### PR TITLE
add kapp-controller.yaml file that uses custom build of kapp-controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,11 @@ help: ## display help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 deploy-kapp-controller: ## deploys the latest version of kapp-controller
-	kubectl create ns kapp-controller || true
-	kubectl --namespace kapp-controller apply --file https://github.com/k14s/kapp-controller/releases/latest/download/release.yml
+	#kubectl create ns kapp-controller || true
+	#kubectl --namespace kapp-controller apply --file https://github.com/k14s/kapp-controller/releases/latest/download/release.yml
+
+	# Use custom build of kapp-controller
+	kubectl apply --filename kapp-controller.yaml
 
 push-extensions: ## build and push extension templates
 	imgpkg push --bundle $(OCI_REGISTRY)/velero-extension-templates:dev --file extensions/velero/bundle/

--- a/kapp-controller.yaml
+++ b/kapp-controller.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kapp-controller
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: apps.kappctrl.k14s.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.friendlyDescription
+    description: Friendly description
+    name: Description
+    type: string
+  - JSONPath: .status.deploy.startedAt
+    description: Last time app started being deployed. Does not mean anything was changed.
+    name: Since-Deploy
+    type: date
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created.
+      It is not guaranteed to be set in happens-before order across separate operations.
+      Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      Populated by the system. Read-only. Null for lists.
+      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
+  group: kappctrl.k14s.io
+  names:
+    kind: App
+    listKind: AppList
+    plural: apps
+    singular: app
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kapp-controller
+  namespace: kapp-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kapp-controller
+  template:
+    metadata:
+      labels:
+        app: kapp-controller
+    spec:
+      containers:
+      - args: []
+        env:
+        - name: KAPPCTRL_MEM_TMP_DIR
+          value: /etc/kappctrl-mem-tmp
+        image: projects.registry.vmware.com/tce/kapp-controller@sha256:a67be43fc41fce6fcf015e10c70a403b8e61c7d5d4412ac825002c8a53dadf73
+        name: kapp-controller
+        resources:
+          requests:
+            cpu: 120m
+            memory: 100Mi
+        securityContext:
+          runAsGroup: 2000
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /etc/kappctrl-mem-tmp
+          name: template-fs
+      securityContext:
+        fsGroup: 3000
+      serviceAccount: kapp-controller-sa
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: template-fs
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kapp-controller-sa
+  namespace: kapp-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kapp-controller-cluster-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - secrets
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - kappctrl.k14s.io
+  resources:
+  - apps
+  - apps/status
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kapp-controller-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kapp-controller-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: kapp-controller-sa
+  namespace: kapp-controller
+


### PR DESCRIPTION
Adds a kapp-controller.yaml file that deploys the custom build of kapp-controller with experimental imgpkg bundle support.

Also updates the `deploy-kapp-controller` make target to use the file instead of the latest kapp-controller release. 

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>