### PR TITLE
need to be logged in to download releases

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,10 +24,10 @@ be added in the (currently internal) #tce channel.
 
 1. Download the release.
 
-Make sure you're logged into Github and then go to the [TCE Releases](https://github.com/vmware-tanzu/tce/releases/tag/v0.1.0) page and download the Tanzu CLI for either:
+    Make sure you're logged into Github and then go to the [TCE Releases](https://github.com/vmware-tanzu/tce/releases/tag/v0.1.0) page and download the Tanzu CLI for either
 
-* [linux](https://github.com/vmware-tanzu/tce/releases/download/v0.1.0/dist-linux-v0.1.0.tar.gz)
-* or [Mac](https://github.com/vmware-tanzu/tce/releases/download/v0.1.0/dist-mac-v0.1.0.tar.gz)
+    * [Linux](https://github.com/vmware-tanzu/tce/releases/download/v0.1.0/dist-linux-v0.1.0.tar.gz), or
+    * [Mac](https://github.com/vmware-tanzu/tce/releases/download/v0.1.0/dist-mac-v0.1.0.tar.gz).
 
 1. Unpack the release.
 


### PR DESCRIPTION
You need to be logged in to GH to download files from releases,  unfortunately you can't easily use a Personal Access Token here as you need to use the GH API with tokens which is a whole thing and you need to know [release IDs and stuff](https://gist.github.com/maxim/6e15aa45ba010ab030c4) which is not a user friendly experience.

This changes the doc to just tell people to download the files via their web browser.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>