### PR TITLE
Add copyright/license header to source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 ##### BUILD #####

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
This adds the header to the last couple files missing it. We could
potentially also add to yaml files, but I don't think we want to go
there.

Closes #115