### PR TITLE
Fix for empty config being loaded on gcp bucket creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ vet: ## Run go vet
 lint: tools ## Run linting checks
 	$(GOLANGCI_LINT) run -v
 	$(GOLINT) -set_exit_status ./...
+
+test: ## Run go tests
+	$(GO) test ./...
+
 ##### COMMON TARGETS #####
 
 ##### BUILD TARGETS #####

--- a/pkg/common/gcp/config.go
+++ b/pkg/common/gcp/config.go
@@ -70,6 +70,10 @@ func InitBucketConfig(byConfig []byte) (*Config, error) {
 		return nil, err
 	}
 
+	if cfg == nil {
+		cfg = NewConfig()
+	}
+
 	// Env Vars should override config file entries if present
 	if err := cfg.FromEnv(); err != nil {
 		klog.Errorf("FromEnv failed: %s", err)

--- a/pkg/common/gcp/config_test.go
+++ b/pkg/common/gcp/config_test.go
@@ -1,0 +1,13 @@
+package gcp
+
+import "testing"
+
+func TestInitBucketConfigEmpty(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("InitBucket should not panic: %v", r)
+		}
+	}()
+
+	InitBucketConfig([]byte(""))
+}


### PR DESCRIPTION
There is an edge case where `FromEnv` will panic if the config file is empty. The edge case may have been fixed in #170 just a few hours ago, but this PR catches the panic that will happen in `FromEnv` in the case that the config file is empty.

Let me know if this needs anything else!!