### PR TITLE
Give User an Error When Delete Non-existent Add-on

### DIFF
--- a/pkg/common/kapp/errors.go
+++ b/pkg/common/kapp/errors.go
@@ -8,6 +8,6 @@ import (
 )
 
 var (
-	// ErrTodo is returned when the provided username is empty.
-	ErrTodo = errors.New("TODO")
+	// ErrAppNotPresentOrInstalled is Application is not present/installed
+	ErrAppNotPresentOrInstalled = errors.New("Application is not present/installed")
 )

--- a/pkg/common/kapp/kapp.go
+++ b/pkg/common/kapp/kapp.go
@@ -365,13 +365,13 @@ func (k *Kapp) deleteAppCrd(client *client.Client, extensionName string, force b
 	}
 	klog.V(4).Info("\n%v\n\n", app)
 
-	if err := (*client).Delete(context.TODO(), app); err != nil {
-		if apierrors.IsNotFound(err) {
-			klog.V(2).Info("Addon app not found")
-			return nil
-		}
+	var errRet error
+	if errRet = (*client).Delete(context.TODO(), app); err != nil {
 		klog.Errorf("Error deleting App CRD. Err: %v", err)
-		return err
+		if apierrors.IsNotFound(err) {
+			klog.Warningf("App CRD is not present/installed")
+			errRet = ErrAppNotPresentOrInstalled
+		}
 	}
 
 	if force {
@@ -422,8 +422,12 @@ func (k *Kapp) deleteAppCrd(client *client.Client, extensionName string, force b
 		}
 	}
 
-	klog.V(2).Infof("deleteAppCrd(%s) succeeded", extensionName)
-	return nil
+	if errRet == nil {
+		klog.V(2).Infof("deleteAppCrd(%s) succeeded", extensionName)
+	} else {
+		klog.V(2).Infof("deleteAppCrd(%s) failed. Err: %v", extensionName, errRet)
+	}
+	return errRet
 }
 
 // DeleteFromFile delete extension from file

--- a/pkg/extension/delete.go
+++ b/pkg/extension/delete.go
@@ -82,7 +82,7 @@ func delete(cmd *cobra.Command, args []string) error {
 
 	err = mgr.kapp.DeleteFromFile(inputAppCrd)
 	if err != nil {
-		fmt.Printf("kclient delete failed. Err: %v\n", err)
+		fmt.Printf("Delete failed. Err: %v\n", err)
 		return err
 	}
 


### PR DESCRIPTION
This addresses issue https://github.com/vmware-tanzu/tce/issues/145 

This will throw an error if the add-on is not installed and also enables the `--force` option to execute even if the add-on is not present.

Feedback weclome. Otherwise, will leave open for a couple of days.