### PR TITLE
Use Current Release on Empty Config File

### DIFF
--- a/cmd/plugin/extension/main.go
+++ b/cmd/plugin/extension/main.go
@@ -4,20 +4,25 @@
 package main
 
 import (
+	"bufio"
 	"os"
+	"path/filepath"
 
+	"github.com/adrg/xdg"
 	klog "k8s.io/klog/v2"
+	yaml "github.com/ghodss/yaml"
 
 	"github.com/vmware-tanzu-private/core/pkg/v1/cli"
 	"github.com/vmware-tanzu-private/core/pkg/v1/cli/command/plugin"
 
+	cfg "github.com/vmware-tanzu/tce/pkg/common/config"
 	extension "github.com/vmware-tanzu/tce/pkg/extension"
 )
 
 var descriptor = cli.PluginDescriptor{
 	Name:        "extension",
 	Description: "Extension management",
-	Version:     "v0.2.0-pre-alpha-1", //TODO: Workaround for build breaking. Was: cli.BuildVersion,
+	Version:     cli.BuildVersion,
 	BuildSHA:    "",
 	Group:       cli.ManageCmdGroup,
 }
@@ -26,10 +31,47 @@ var descriptor = cli.PluginDescriptor{
 // var logFile string
 
 func main() {
+	
+	// checks for config file existence
+	configFile := filepath.Join(xdg.DataHome, "tanzu-repository", cfg.DefaultConfigFile)
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		klog.Error("Config file does not exist")
+
+		c := cfg.NewConfig()
+		c.ReleaseVersion = cli.BuildVersion
+
+		fileWrite, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+		if err != nil {
+			klog.Fatalf("Open Config for write failed. Err: %v", err)
+		}
+
+		datawriter := bufio.NewWriter(fileWrite)
+		if datawriter == nil {
+			klog.Fatalf("Datawriter creation failed")
+		}
+
+		byRaw, err := yaml.Marshal(c)
+		if err != nil {
+			klog.Fatalf("yaml.Marshal error. Err: %v", err)
+		}
+		klog.V(6).Infof("byRaw = %v", byRaw)
+
+		_, err = datawriter.Write(byRaw)
+		if err != nil {
+			klog.Fatalf("datawriter.Write error. Err: %v", err)
+		}
+		datawriter.Flush()
+
+		err = fileWrite.Close()
+		if err != nil {
+			klog.Fatalf("fileWrite.Close failed. Err: %v", err)
+		}
+	}
+
 	// plugin!
 	p, err := plugin.NewPlugin(&descriptor)
 	if err != nil {
-		klog.Fatal(err)
+		klog.Fatalf("%v", err)
 	}
 
 	// p.Cmd.PersistentFlags().Int32VarP(&logLevel, "v", "v", 0, "Number for the log level verbosity(0-9)")

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,12 @@
 module github.com/vmware-tanzu/tce
 
-go 1.14
+go 1.15
 
 require (
 	cloud.google.com/go/storage v1.12.0
 	github.com/adrg/xdg v0.3.0
-	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/google/go-github/v33 v33.0.0
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/spf13/cobra v1.1.1
 	github.com/vmware-tanzu-private/core v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,6 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmatcuk/doublestar v1.2.1/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
-github.com/bradleyfalzon/ghinstallation v1.1.1 h1:pmBXkxgM1WeF8QYvDLT5kuQiHMcmf+X015GI0KM/E3I=
-github.com/bradleyfalzon/ghinstallation v1.1.1/go.mod h1:vyCmHTciHx/uuyN82Zc3rXN3X2KTK8nUTCrTMwAhcug=
 github.com/caarlos0/spin v1.1.0 h1:EjsfGbZJejib25BPnDqf7iL2z9RUna7refvUf+AN9UE=
 github.com/caarlos0/spin v1.1.0/go.mod h1:HOC4pUvfhjXR2yDt+sEY9dRc2m4CCaK5z5oQYAbzXSA=
 github.com/caddyserver/caddy v1.0.3 h1:i9gRhBgvc5ifchwWtSe7pDpsdS9+Q0Rw9oYQmYUTw1w=
@@ -391,10 +389,6 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-containerregistry v0.0.0-20190412005658-1d38b9cfdb9d/go.mod h1:yZAFP63pRshzrEYLXLGPmUt0Ay+2zdjmMN1loCnRLUk=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
-github.com/google/go-github/v29 v29.0.2 h1:opYN6Wc7DOz7Ku3Oh4l7prmkOMwEcQxpFtxdU8N8Pts=
-github.com/google/go-github/v29 v29.0.2/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
-github.com/google/go-github/v33 v33.0.0 h1:qAf9yP0qc54ufQxzwv+u9H0tiVOnPJxo0lI/JXqw3ZM=
-github.com/google/go-github/v33 v33.0.0/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/goexpect v0.0.0-20200703111054-623d5ca06f56/go.mod h1:qtE5aAEkt0vOSA84DBh8aJsz6riL8ONfqfULY7lBjqc=
@@ -501,7 +495,6 @@ github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/istio/istio v0.0.0-20210126190117-f78b449aa4ba h1:pfnRx7C9W1v8RIxpxyshe5jJCW5QzKJn1naIRezEP4U=
 github.com/jedib0t/go-pretty v4.3.0+incompatible h1:CGs8AVhEKg/n9YbUenWmNStRW2PHJzaeDodcfvRAbIo=
 github.com/jedib0t/go-pretty v4.3.0+incompatible/go.mod h1:XemHduiw8R651AF9Pt4FwCTKeG3oo7hrHJAoznj9nag=
 github.com/jeremywohl/flatten v1.0.1 h1:LrsxmB3hfwJuE+ptGOijix1PIfOoKLJ3Uee/mzbgtrs=
@@ -798,8 +791,6 @@ github.com/vmware-tanzu-private/tkg-cli v1.3.0-pre-alpha-1.0.20210114003033-285a
 github.com/vmware-tanzu-private/tkg-cli v1.3.0-pre-alpha-1.0.20210114003033-285a8c9131d4/go.mod h1:Wz1ZH1vUB0IM63Cm9LNUWs8dNf9C/Fvz5O4N0n1k408=
 github.com/vmware-tanzu-private/tkg-providers v1.3.0-pre-alpha-1.0.20210113202657-eb07b4e0558d h1:G9vsZoETI+qxrpk+KtUXuFCskYUjyIo2pcNqa2hy1CI=
 github.com/vmware-tanzu-private/tkg-providers v1.3.0-pre-alpha-1.0.20210113202657-eb07b4e0558d/go.mod h1:njTZCd8EgOpYmLSOxyuQJGcP5oISTRK7/FwqF0g/qW0=
-github.com/vmware-tanzu/carvel-kapp-controller v0.13.0 h1:+0w4iH+zE7l/FCk8cce8j9TMEay6aomCy4KAcGzTeGY=
-github.com/vmware-tanzu/carvel-kapp-controller v0.13.0/go.mod h1:dIUnNsV5VgCMzA/B5Bi3nubSNtgHe/215STMBaACGqw=
 github.com/vmware-tanzu/carvel-vendir v0.15.1-0.20210125232012-da0fe75e8194/go.mod h1:FxmviIYibdN+Z7GTJgtlZZtFsYfLpvsFcrhpi3oRZqc=
 github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
 github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=

--- a/pkg/common/github/config.go
+++ b/pkg/common/github/config.go
@@ -8,6 +8,8 @@ import (
 
 	yaml "github.com/ghodss/yaml"
 	klog "k8s.io/klog/v2"
+
+	types "github.com/vmware-tanzu/tce/pkg/common/types"
 )
 
 // NewGitHubConfig generates a Config object
@@ -46,8 +48,8 @@ func (cfg *Config) FromEnv() error {
 	cfg.originalBranchTag = cfg.GitHubBranchTag
 	klog.V(4).Infof("cfg.originalBranchTag = %s", cfg.originalBranchTag)
 	klog.V(4).Infof("cfg.GitHubBranchTag = %s", cfg.GitHubBranchTag)
-	if cfg.GitHubBranchTag == DefaultGitHubLatest {
-		klog.V(4).Infof("Replacing %s with %s", DefaultGitHubLatest, DefaultGitHubBranchTagMain)
+	if cfg.GitHubBranchTag == types.DefaultReleaseLatest {
+		klog.V(4).Infof("Replacing %s with %s", types.DefaultReleaseLatest, DefaultGitHubBranchTagMain)
 		cfg.GitHubBranchTag = DefaultGitHubBranchTagMain
 	}
 

--- a/pkg/common/github/constants.go
+++ b/pkg/common/github/constants.go
@@ -17,7 +17,4 @@ const (
 	DefaultGitHubBlob string = "blob"
 	// DefaultGitHubTree - tree for directory
 	DefaultGitHubTree string = "tree"
-
-	// DefaultGitHubLatest switch for human-readable
-	DefaultGitHubLatest string = "latest"
 )

--- a/pkg/common/kapp/config.go
+++ b/pkg/common/kapp/config.go
@@ -10,8 +10,6 @@ import (
 	yaml "github.com/ghodss/yaml"
 	"k8s.io/client-go/util/homedir"
 	klog "k8s.io/klog/v2"
-
-	types "github.com/vmware-tanzu/tce/pkg/common/types"
 )
 
 // NewConfig generates a Config object
@@ -19,7 +17,7 @@ func NewConfig() *Config {
 
 	cfg := &Config{
 		ExtensionNamespace:             DefaultAppCrdNamespace,
-		WorkingDirectory:               types.DefaultWorkingDirectory,
+		WorkingDirectory:               DefaultWorkingDirectory,
 		ExtensionServiceAccountPostfix: DefaultServiceAccountPostfix,
 		ExtensionRoleBindingPostfix:    DefaultRoleBindingPostfix,
 	}

--- a/pkg/common/kapp/constants.go
+++ b/pkg/common/kapp/constants.go
@@ -4,6 +4,9 @@
 package kapp
 
 const (
+	// DefaultWorkingDirectory is the working directory
+	DefaultWorkingDirectory string = "working"
+	
 	// DefaultAppCrdNamespace is the default App Crd namespace
 	DefaultAppCrdNamespace string = "tanzu-extensions"
 	// DefaultServiceAccountPostfix is the default Service Account postfix name

--- a/pkg/common/types/constants.go
+++ b/pkg/common/types/constants.go
@@ -3,9 +3,16 @@
 
 package types
 
+// Addon related constants
 const (
-	// DefaultWorkingDirectory is the working directory
-	DefaultWorkingDirectory string = "working"
 	// DefaultAppCrdFilename is the default App Crd filename
 	DefaultAppCrdFilename string = "extension.yaml"
+)
+
+// Release related constants
+const (
+	// DefaultReleaseLatest switch for human-readable
+	DefaultReleaseLatest string = "latest"
+	// DefaultReleaseStable switch for human-readable
+	DefaultReleaseStable string = "stable"
 )

--- a/pkg/extension/constants.go
+++ b/pkg/extension/constants.go
@@ -7,11 +7,6 @@ const (
 	// DefaultConfigFile is config filename
 	DefaultConfigFile string = "config.yaml"
 
-	// DefaultReleaseLatest switch for human-readable
-	DefaultReleaseLatest string = "latest"
-	// DefaultReleaseStable switch for human-readable
-	DefaultReleaseStable string = "stable"
-
 	// TokenMinLength is 24
 	TokenMinLength int = 24
 

--- a/pkg/extension/release.go
+++ b/pkg/extension/release.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 	klog "k8s.io/klog/v2"
+
+	types "github.com/vmware-tanzu/tce/pkg/common/types"
 )
 
 var printRelease bool
@@ -79,7 +81,7 @@ func setRelease(cmd *cobra.Command, args []string) error {
 	}
 
 	// check to see if version is valid
-	if !strings.EqualFold(releaseName, DefaultReleaseLatest) && !strings.EqualFold(releaseName, DefaultReleaseStable) {
+	if !strings.EqualFold(releaseName, types.DefaultReleaseLatest) && !strings.EqualFold(releaseName, types.DefaultReleaseStable) {
 		_, err := release.GetVersion(releaseName)
 		if err != nil {
 			klog.Errorf("Invalid version")
@@ -87,9 +89,9 @@ func setRelease(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if releaseName == DefaultReleaseLatest {
+	if releaseName == types.DefaultReleaseLatest {
 		klog.V(2).Infof("Setting to %s", releaseName)
-	} else if releaseName == DefaultReleaseStable {
+	} else if releaseName == types.DefaultReleaseStable {
 		klog.V(2).Infof("Setting to %s", releaseName)
 		releaseName = release.Stable
 	}


### PR DESCRIPTION
If the config.yaml file is missing (a required file), the plugin will create one based on the current build of the plugin (defined by `cli.BuildVersion`).

Other changes:
- Makefile updates (currently commented out) for upcoming core repo PR changes
- ran `go mod tidy`
- Consolidate the `const` values needed for this PR

Feedback weclome!