### PR TITLE
Update getting started guide to drop tkg cli

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,8 +30,8 @@ be added in the (currently internal) #tanzu-community-edition channel.
 
     Make sure you're logged into GitHub and then go to the [TCE Releases](https://github.com/vmware-tanzu/tce/releases/tag/v0.2.0) page and download the Tanzu CLI for either
 
-    * [Linux](https://github.com/vmware-tanzu/tce/releases/download/v0.2.0/dist-linux-v0.2.0.tar.gz), or
-    * [Mac](https://github.com/vmware-tanzu/tce/releases/download/v0.2.0/dist-mac-v0.2.0.tar.gz)
+    * [Linux](https://github.com/vmware-tanzu/tce/releases/download/v0.2.0/tce-darwin-amd64-v0.2.0.tar.gz), or
+    * [Mac](https://github.com/vmware-tanzu/tce/releases/download/v0.2.0/tce-linux-amd64-v0.2.0.tar.gz)
 
 1. Unpack the release.
 


### PR DESCRIPTION
We should now be able to do everything with the tanzu CLI. This updates
installation instructions to move over to use the tanzu commands.

Also updates the download instructions with the expected version of the
next release. This may need to be updated, but I thought it would be
better to have invalid links than to have someone download the old
version that would not work with the current instructions.