### PR TITLE
Automate the Release

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -1,4 +1,4 @@
-name: Check PR
+name: Pull Request Checks
 
 on:
   pull_request:
@@ -37,12 +37,6 @@ jobs:
     - name: Get dependencies
       run: |
         go get -v -t -d ./...
-      # env
-      # tanzu init
-      # tanzu plugin repo add -b tanzu-cli-admin-plugins -n admin -r artifacts-admin
-      # tanzu plugin install builder
-      # tanzu plugin install test
-      # tanzu plugin list
 
     - name: Build
       run: make build

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,4 @@
-name: Main
+name: Verifications on Main
 
 on:
   push:

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -1,11 +1,11 @@
-name: Release Staging
+name: Create Dev Build
 
 on:
   push:
     branches:
       - main
     tags-ignore:
-     - "**"
+     - '**'
 
 jobs:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
-name: Release
+name: Create Release
 
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
     branches:
       - main
 
@@ -33,11 +33,51 @@ jobs:
       run: |
         go get -v -t -d ./...
 
-    - name: Build
-      run: make build
+    - name: Build All Components
+      run: make build-all
+
+    - name: Package TCE Release
+      run: make package-release
 
     # - name: Test
     #   run: make test
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        body: |
+          Changelog:
+          - TODO: First Change
+          - TODO: Second Change
+        draft: true
+        prerelease: false
+
+    - name: Upload Linux AMD64 Asset
+      id: upload-linux-amd64-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./build/tce-linux-amd64-${{ github.ref }}.tar.gz
+        asset_name: tce-linux-amd64-${{ github.ref }}.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload Darwin AMD64 Asset
+      id: upload-darwin-amd64-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./build/tce-darwin-amd64-${{ github.ref }}.tar.gz
+        asset_name: tce-darwin-amd64-${{ github.ref }}.tar.gz
+        asset_content_type: application/gzip
 
     - name: Generate metadata
       env:


### PR DESCRIPTION
Changes:
- When a tag is pushed to main, the GH action will create a draft release and upload the artifacts from that build
- Minor: Renamed actions to something a little more descriptive

NOTE: I'm probably going to push a (hopefully small number of) release(s) marked as -rc1, -rc2, etc in order to test this.