### PR TITLE
Implements Offline Support on Release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,11 +33,10 @@ jobs:
       run: |
         go get -v -t -d ./...
 
-    - name: Build All Components
-      run: make build-all
-
-    - name: Package TCE Release
-      run: make package-release
+    - name: Generate release
+      env:
+        GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      run: make release
 
     # - name: Test
     #   run: make test
@@ -78,11 +77,6 @@ jobs:
         asset_path: ./build/tce-darwin-amd64-${{ github.ref }}.tar.gz
         asset_name: tce-darwin-amd64-${{ github.ref }}.tar.gz
         asset_content_type: application/gzip
-
-    - name: Generate metadata
-      env:
-        GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-      run: make gen-metadata-release
 
     - id: upload-cli-artifacts
       uses: google-github-actions/upload-cloud-storage@main

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ _test
 _output
 /build
 /metadata
+/offline
 /core
 /tanzu-cli-tkg-plugins
 /tkg-cli

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ help: ## display help
 ### GLOBAL ###
 
 ##### BUILD #####
-BUILD_VERSION ?= $$(git describe --tags --dirty=-dev --abbrev=0)
+BUILD_VERSION ?= $$(git describe --tags --abbrev=0)
 BUILD_SHA ?= $$(git rev-parse --short HEAD)
 BUILD_DATE ?= $$(date -u +"%Y-%m-%d")
 CONFIG_VERSION ?= $$(echo "$(BUILD_VERSION)" | cut -d "-" -f1)
@@ -85,7 +85,7 @@ build: build-plugin
 build-all: version clean copy-release tag-release install-cli install-cli-plugins
 build-plugin: version clean-plugin copy-release tag-release install-cli-plugins
 
-release: build-all package-release
+release: build-all gen-metadata-release package-release
 
 clean: clean-plugin clean-core
 

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -44,7 +44,6 @@ esac
 
 install "${MY_DIR}/bin/tanzu-plugin-alpha" "${XDG_DATA_HOME}/tanzu-cli"
 install "${MY_DIR}/bin/tanzu-plugin-cluster" "${XDG_DATA_HOME}/tanzu-cli"
-# install "${MY_DIR}/bin/tanzu-plugin-clustergroup" "${XDG_DATA_HOME}/tanzu-cli"
 install "${MY_DIR}/bin/tanzu-plugin-management-cluster" "${XDG_DATA_HOME}/tanzu-cli"
 install "${MY_DIR}/bin/tanzu-plugin-kubernetes-release" "${XDG_DATA_HOME}/tanzu-cli"
 install "${MY_DIR}/bin/tanzu-plugin-login" "${XDG_DATA_HOME}/tanzu-cli"
@@ -57,7 +56,6 @@ if [[ "$BUILD_OS" == "Darwin" ]] ;  then
   xattr -d com.apple.quarantine /usr/local/bin/tanzu
   xattr -d com.apple.quarantine "${XDG_DATA_HOME}/tanzu-cli/tanzu-plugin-alpha"
   xattr -d com.apple.quarantine "${XDG_DATA_HOME}/tanzu-cli/tanzu-plugin-cluster"
-  # xattr -d com.apple.quarantine "${XDG_DATA_HOME}/tanzu-cli/tanzu-plugin-clustergroup"
   xattr -d com.apple.quarantine "${XDG_DATA_HOME}/tanzu-cli/tanzu-plugin-management-cluster"
   xattr -d com.apple.quarantine "${XDG_DATA_HOME}/tanzu-cli/tanzu-plugin-kubernetes-release"
   xattr -d com.apple.quarantine "${XDG_DATA_HOME}/tanzu-cli/tanzu-plugin-login"
@@ -70,5 +68,9 @@ fi
 # repo config
 rm -rf "${XDG_DATA_HOME}/tanzu-repository"
 mkdir -p "${XDG_DATA_HOME}/tanzu-repository"
+mkdir -p "${XDG_DATA_HOME}/tanzu-repository/metadata"
+mkdir -p "${XDG_DATA_HOME}/tanzu-repository/extensions"
 
 cp -f "${MY_DIR}/config.yaml" "${XDG_DATA_HOME}/tanzu-repository"
+cp -rf "${MY_DIR}/metadata/." "${XDG_DATA_HOME}/tanzu-repository/metadata"
+cp -rf "${MY_DIR}/extensions/." "${XDG_DATA_HOME}/tanzu-repository/extensions"

--- a/hack/metadata/metadata.go
+++ b/hack/metadata/metadata.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"bufio"
 	"path/filepath"
+	"errors"
+	"io/ioutil"
 
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
@@ -21,10 +23,16 @@ const (
 	MainBranchKeyword string = "main"
 	// LatestKeyword latest
 	LatestKeyword string = "latest"
+
 	// MetadataDirectory filename
 	MetadataDirectory string = "metadata"
 	// MetadataFilename filename
 	MetadataFilename string = "metadata.yaml"
+
+	// ExtensionDirectory filename
+	ExtensionDirectory string = "extensions"
+	// OfflineDirectory filename
+	OfflineDirectory string = "offline"
 	// AppCrdFilename filename
 	AppCrdFilename string = "extension.yaml"
 )
@@ -66,7 +74,7 @@ func fetchDirectoryList(token string) ([]string, error) {
 	// 	klog.V(6).Infof("Update Ref = %s", branch)
 	// 	opts.Ref = branch
 	// }
-	_, dirGH, _, err := client.Repositories.GetContents(ctx, "vmware-tanzu", "tce", "extensions", opts)
+	_, dirGH, _, err := client.Repositories.GetContents(ctx, "vmware-tanzu", "tce", ExtensionDirectory, opts)
 	if err != nil {
 		fmt.Printf("client.Repositories failed. Err: %v", err)
 		return nil, err
@@ -85,32 +93,11 @@ func fetchDirectoryList(token string) ([]string, error) {
 	return extensions, nil
 }
 
-func main() {
-
-	var token string
-	if v := os.Getenv("GH_ACCESS_TOKEN"); v != "" {
-		token = v
-	}
-
-	var tag string
-    flag.StringVar(&tag, "tag", "", "The latest tag")
-	var release bool
-	flag.BoolVar(&release, "release", false, "Is this a release")
-	flag.Parse()
-
-	if token == "" {
-		fmt.Printf("token is empty\n")
-		return
-	}
-	if tag == "" {
-		fmt.Printf("tag is empty\n")
-		return
-	}
-
+func saveMetadata(metadataDir string, token string, tag string, release bool) (*Metadata, error) {
 	list, err := fetchDirectoryList(token)
 	if err != nil {
 		fmt.Printf("fetchDirectoryList failed: %v\n", err)
-		return
+		return nil, err
 	}
 
 	metadata := &Metadata{
@@ -141,45 +128,29 @@ func main() {
 	byRaw, err := yaml.Marshal(metadata)
 	if err != nil {
 		fmt.Printf("yaml.Marshal error. Err: %v\n", err)
-		return
+		return nil, err
 	}
 	fmt.Printf("BYTES:\n\n")
 	fmt.Printf("%s\n", string(byRaw))
-
-	// make dir
-	dirToMake := filepath.Join(MetadataDirectory, LatestKeyword)
-	if release {
-		dirToMake = filepath.Join(MetadataDirectory, tag)
-	}
-	// err = os.RemoveAll(dirToMake)
-	// if err != nil {
-	// 	fmt.Printf("RemoveAll failed. Err: %v", err)
-	// 	return
-	// }
-	err = os.MkdirAll(dirToMake, 0755)
-	if err != nil {
-		fmt.Printf("MkdirAll failed. Err: %v", err)
-		return
-	}
 	
 	// write the file
-	fileToWrite := filepath.Join(dirToMake, MetadataFilename)
+	fileToWrite := filepath.Join(metadataDir, MetadataFilename)
 	fileWrite, err := os.OpenFile(fileToWrite, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {
 		fmt.Printf("Open Config for write failed. Err: %v\n", err)
-		return
+		return nil, err
 	}
 
 	datawriter := bufio.NewWriter(fileWrite)
 	if datawriter == nil {
 		fmt.Printf("Datawriter creation failed\n")
-		return
+		return nil, errors.New("Datawriter creation failed")
 	}
 
 	_, err = datawriter.Write(byRaw)
 	if err != nil {
 		fmt.Printf("datawriter.Write error. Err: %v\n", err)
-		return
+		return nil, err
 	}
 	datawriter.Flush()
 
@@ -187,8 +158,100 @@ func main() {
 	err = fileWrite.Close()
 	if err != nil {
 		fmt.Printf("fileWrite.Close failed. Err: %v", err)
+		return nil, err
+	}
+
+	return metadata, nil
+}
+
+func copyFile(source, destination string) error {
+	input, err := ioutil.ReadFile(source)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(destination, input, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func saveForOffline(md *Metadata) error {
+
+	// copy all the extensions
+	for _, extension := range md.Extensions {
+
+		offlineDir := filepath.Join(OfflineDirectory, md.Version, extension.Name)
+
+		err := os.MkdirAll(offlineDir, 0755)
+		if err != nil {
+			fmt.Printf("MkdirAll failed. Err: %v", err)
+			return err
+		}
+
+		srcCrdToCopy := filepath.Join(ExtensionDirectory, extension.Name, AppCrdFilename)
+		dstCrdToCopy := filepath.Join(offlineDir, AppCrdFilename)
+
+		err = copyFile(srcCrdToCopy, dstCrdToCopy)
+		if err != nil {
+			fmt.Printf("copyFile failed. Err: %v", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func main() {
+
+	var token string
+	if v := os.Getenv("GH_ACCESS_TOKEN"); v != "" {
+		token = v
+	}
+
+	var tag string
+    flag.StringVar(&tag, "tag", "", "The latest tag")
+	var release bool
+	flag.BoolVar(&release, "release", false, "Is this a release")
+	flag.Parse()
+
+	if token == "" {
+		fmt.Printf("token is empty\n")
 		return
 	}
+	if tag == "" {
+		fmt.Printf("tag is empty\n")
+		return
+	}
+
+	// make metadata dir
+	metadataDir := filepath.Join(MetadataDirectory, LatestKeyword)
+	if release {
+		metadataDir = filepath.Join(MetadataDirectory, tag)
+	}
+	err := os.MkdirAll(metadataDir, 0755)
+	if err != nil {
+		fmt.Printf("MkdirAll failed. Err: %v", err)
+		return
+	}
+
+	// save metadata
+	md, err := saveMetadata(metadataDir, token, tag, release)
+	if err != nil {
+		fmt.Printf("saveMetadata failed. Err: %v", err)
+		return
+	}
+
+	// if release, save extensions
+	if release {
+		err = saveForOffline(md)
+		if err != nil {
+			fmt.Printf("saveForOffline failed. Err: %v", err)
+			return
+		}
+	} 
 
 	fmt.Printf("Succeeded\n")
 }

--- a/hack/package-release.sh
+++ b/hack/package-release.sh
@@ -40,6 +40,10 @@ rm -rf "${PACKAGE_DARWIN_AMD64_DIR}"
 mkdir -p "${BUILD_ROOT_DIR}"
 mkdir -p "${PACKAGE_LINUX_AMD64_DIR}/bin"
 mkdir -p "${PACKAGE_DARWIN_AMD64_DIR}/bin"
+mkdir -p "${PACKAGE_LINUX_AMD64_DIR}/extensions"
+mkdir -p "${PACKAGE_DARWIN_AMD64_DIR}/extensions"
+mkdir -p "${PACKAGE_LINUX_AMD64_DIR}/metadata"
+mkdir -p "${PACKAGE_DARWIN_AMD64_DIR}/metadata"
 
 # config
 cp -f "${ROOT_REPO_DIR}/hack/config.yaml" "${PACKAGE_LINUX_AMD64_DIR}"
@@ -88,6 +92,11 @@ cp -f "${ROOT_TKG_PLUGINS_ARTIFACTS_DIR}/management-cluster/${CORE_BUILD_VERSION
 # TCE bits
 cp -f "${ROOT_EXTENSION_ARTIFACTS_DIR}/extension/${EXTENSION_BUILD_VERSION}/tanzu-extension-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-extension"
 
+# copy extensions/metadata for offline use
+cp -rf "${ROOT_REPO_DIR}/metadata/." "${PACKAGE_LINUX_AMD64_DIR}/metadata"
+cp -rf "${ROOT_REPO_DIR}/metadata/." "${PACKAGE_DARWIN_AMD64_DIR}/metadata"
+cp -rf "${ROOT_REPO_DIR}/offline/." "${PACKAGE_LINUX_AMD64_DIR}/extensions"
+cp -rf "${ROOT_REPO_DIR}/offline/." "${PACKAGE_DARWIN_AMD64_DIR}/extensions"
 
 # change settings
 chmod +x "${ROOT_REPO_DIR}/hack/install.sh"

--- a/hack/release/release.go
+++ b/hack/release/release.go
@@ -60,9 +60,13 @@ func getTags(token string) ([]*Version, error) {
 	for _, tag := range tagsGH {
 		fmt.Printf("Found: %s\n", *tag.TagName)
 
+		if tag.PublishedAt == nil {
+			continue
+		}
+
 		tags = append(tags, &Version{
 			Version: *tag.TagName,
-			Date: (*tag.PublishedAt).Format(layoutISO),
+			Date: tag.PublishedAt.Format(layoutISO),
 		})
 	}
 


### PR DESCRIPTION
On a tagged release, this implements a fully offline distribution of TCE by pre-packaging all the metadata and extensions. As long as you don't use any of the `tanzu extension release` actions, the plugin will only use the packaged release and stay offline.

Other changes:
- a build issue on staging
- consolidate the GH action for release into a simple single step