### PR TITLE
Fix offline bundle for dev/staging build

### DIFF
--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -42,7 +42,7 @@ jobs:
     - name: Generate metadata
       env:
         GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-      run: make gen-metadata-staging
+      run: make gen-metadata
 
     - id: upload-cli-metadata
       uses: google-github-actions/upload-cloud-storage@main

--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,9 @@ build: build-plugin
 build-all: version clean copy-release tag-release install-cli install-cli-plugins
 build-plugin: version clean-plugin copy-release tag-release install-cli-plugins
 
-release: build-all gen-metadata-release package-release
+release: build-all gen-metadata package-release
 
-clean: clean-plugin clean-core
+clean: clean-release clean-plugin clean-core
 
 # RELEASE MANAGEMENT
 version:
@@ -95,15 +95,14 @@ version:
 	@echo "CONFIG_VERSION:" ${CONFIG_VERSION}
 	@echo "CORE_BUILD_VERSION:" ${CORE_BUILD_VERSION}
 
-PHONY: gen-metadata-staging
-gen-metadata-staging:
+PHONY: gen-metadata
+gen-metadata:
 	go run ./hack/release/release.go
-	go run ./hack/metadata/metadata.go -tag $(CONFIG_VERSION)
-
-PHONY: gen-metadata-release
-gen-metadata-release:
-	go run ./hack/release/release.go
+ifeq ($(shell expr $(BUILD_VERSION)), $(shell expr $(CONFIG_VERSION)))
 	go run ./hack/metadata/metadata.go -tag $(CONFIG_VERSION) -release
+else
+	go run ./hack/metadata/metadata.go -tag $(CONFIG_VERSION)
+endif
 
 PHONY: copy-release
 copy-release:
@@ -120,6 +119,11 @@ endif
 .PHONY: package-release
 package-release:
 	CORE_BUILD_VERSION=${CORE_BUILD_VERSION} BUILD_VERSION=${BUILD_VERSION} hack/package-release.sh
+
+clean-release:
+	rm -rf ./build
+	rm -rf ./metadata
+	rm -rf ./offline
 # RELEASE MANAGEMENT
 
 # TANZU CLI

--- a/hack/build-tanzu.sh
+++ b/hack/build-tanzu.sh
@@ -36,7 +36,7 @@ git reset --hard
 popd || return 1
 
 rm -rf "${ROOT_REPO_DIR}/core"
-rm -rf ~/.tanzu
+mv -f ~/.tanzu ~/.tanzu-old
 git clone --depth 1 --branch "${TANZU_CORE_REPO_BRANCH}" git@github.com:vmware-tanzu-private/core.git
 pushd "${ROOT_REPO_DIR}/core" || return 1
 git reset --hard

--- a/hack/metadata/metadata.go
+++ b/hack/metadata/metadata.go
@@ -83,7 +83,7 @@ func fetchDirectoryList(token string) ([]string, error) {
 	var extensions []string
 	for _, item := range dirGH {
 		if strings.EqualFold(*item.Type, "file") {
-			//fmt.Printf("skip file: %s\n", *item.Name)
+			fmt.Printf("skip file: %s\n", *item.Name)
 			continue
 		}
 		fmt.Printf("add extension: %s\n", *item.Name)
@@ -178,12 +178,16 @@ func copyFile(source, destination string) error {
 	return nil
 }
 
-func saveForOffline(md *Metadata) error {
+func saveForOffline(md *Metadata, release bool) error {
 
 	// copy all the extensions
 	for _, extension := range md.Extensions {
+		fmt.Printf("Saving App CRD Extension: %s\n", extension.Name)
 
-		offlineDir := filepath.Join(OfflineDirectory, md.Version, extension.Name)
+		offlineDir := filepath.Join(OfflineDirectory, LatestKeyword, extension.Name)
+		if release {
+			offlineDir = filepath.Join(OfflineDirectory, md.Version, extension.Name)
+		}
 
 		err := os.MkdirAll(offlineDir, 0755)
 		if err != nil {
@@ -244,14 +248,12 @@ func main() {
 		return
 	}
 
-	// if release, save extensions
-	if release {
-		err = saveForOffline(md)
-		if err != nil {
-			fmt.Printf("saveForOffline failed. Err: %v", err)
-			return
-		}
-	} 
+	// save extensions
+	err = saveForOffline(md, release)
+	if err != nil {
+		fmt.Printf("saveForOffline failed. Err: %v", err)
+		return
+	}
 
 	fmt.Printf("Succeeded\n")
 }


### PR DESCRIPTION
Changes:
- Copies extensions into offline folder for bundling
- clean certain folders on build relating to tarball
- move the `.tanzu` folder instead of deleting it when doing a local developer build

