### PR TITLE
Release tidy and clean up

### DIFF
--- a/hack/metadata/metadata.go
+++ b/hack/metadata/metadata.go
@@ -210,6 +210,7 @@ func saveForOffline(md *Metadata, release bool) error {
 
 func main() {
 
+	//flags
 	var token string
 	if v := os.Getenv("GH_ACCESS_TOKEN"); v != "" {
 		token = v
@@ -217,9 +218,12 @@ func main() {
 
 	var tag string
     flag.StringVar(&tag, "tag", "", "The latest tag")
+
 	var release bool
 	flag.BoolVar(&release, "release", false, "Is this a release")
+
 	flag.Parse()
+	//flags
 
 	if token == "" {
 		fmt.Printf("token is empty\n")

--- a/pkg/common/download/constants.go
+++ b/pkg/common/download/constants.go
@@ -4,6 +4,11 @@
 package download
 
 const (
+	// HTTPSuccessCodeLower is 200
+	HTTPSuccessCodeLower int = 200
+	// HTTPSuccessCodeUpper is 299
+	HTTPSuccessCodeUpper int = 299
+
 	// DefaultGitHubOrg default is vmware-tanzu
 	DefaultGitHubOrg string = "vmware-tanzu"
 	// DefaultGitHubRepo default is tce

--- a/pkg/common/download/github.go
+++ b/pkg/common/download/github.go
@@ -5,6 +5,7 @@ package download
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -66,6 +67,12 @@ func (m *Manager) DownloadGitHubFile(branch string, fromURI string, toDirFile st
 			return err
 		}
 		defer response.Body.Close()
+
+		if response.StatusCode < HTTPSuccessCodeLower || response.StatusCode > HTTPSuccessCodeUpper {
+			errMsg := fmt.Sprintf("Http Response Code failed. Code: %d", response.StatusCode)
+			klog.Errorf(errMsg)
+			return errors.New(errMsg)
+		}
 
 		file, err := os.Create(toDirFile)
 		if err != nil {

--- a/pkg/common/download/http.go
+++ b/pkg/common/download/http.go
@@ -4,6 +4,7 @@
 package download
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -38,6 +39,12 @@ func (m *Manager) DownloadFile(fromURI string, toDirFile string) error {
 			return err
 		}
 		defer response.Body.Close()
+
+		if response.StatusCode < HTTPSuccessCodeLower || response.StatusCode > HTTPSuccessCodeUpper {
+			errMsg := fmt.Sprintf("Http Response Code failed. Code: %d", response.StatusCode)
+			klog.Errorf(errMsg)
+			return errors.New(errMsg)
+		}
 
 		file, err := os.Create(toDirFile)
 		if err != nil {


### PR DESCRIPTION
Some make and CI clean up ahead of the release

Changes:
- allow user override for build version for release testing
- enable rebuild targets without clobbering things
- if calling `make release`, have a check for providing the github token
- chicken and the egg problem: need to add the "final" release tag in the metadata.yaml before the release is published
- Error on the failure of downloading an extension and don't write the extension file