### PR TITLE
Address linting issues in scripts

### DIFF
--- a/docs/designs/tanzu-addon-packaging.md
+++ b/docs/designs/tanzu-addon-packaging.md
@@ -858,4 +858,3 @@ are going to handle the ever growing number of package instances
 
 * Do we maintain a `default` repo with all the latest packages?
 * How to we offer older packages?
-

--- a/hack/create-addon-dir.sh
+++ b/hack/create-addon-dir.sh
@@ -19,18 +19,18 @@ EXT_CONFIG_DIR="config"
 EXT_OVERLAY_DIR="overlay"
 EXT_UPSTREAM_DIR="upstream"
 EXT_IMGPKG_DIR=".imgpkg"
-EXT_DIR=${EXT_ROOT_DIR}/${EXT_NAME}
+EXT_DIR="${EXT_ROOT_DIR}/${EXT_NAME}"
 
 # create directory structure for extension
-mkdir -vp ${EXT_DIR}/${EXT_BUNDLE_DIR}/{${EXT_CONFIG_DIR},${EXT_IMGPKG_DIR}}
-mkdir -v ${EXT_DIR}/${EXT_BUNDLE_DIR}/${EXT_CONFIG_DIR}/{${EXT_OVERLAY_DIR},${EXT_UPSTREAM_DIR}}
+mkdir -vp "${EXT_DIR}/${EXT_BUNDLE_DIR}/{${EXT_CONFIG_DIR},${EXT_IMGPKG_DIR}}"
+mkdir -v "${EXT_DIR}/${EXT_BUNDLE_DIR}/${EXT_CONFIG_DIR}/{${EXT_OVERLAY_DIR},${EXT_UPSTREAM_DIR}}"
 
 # create README and fill with name of extension
-cp docs/extension-readme-template.md ${EXT_DIR}/README.md
-sed -i "s/EXT_NAME/${EXT_NAME}/g" ${EXT_DIR}/README.md
+cp docs/extension-readme-template.md "${EXT_DIR}/README.md"
+sed -i "s/EXT_NAME/${EXT_NAME}/g" "${EXT_DIR}/README.md"
 
 # create addon yaml
-cp docs/app-cr-template.yaml ${EXT_DIR}/addon.yaml
+cp docs/app-cr-template.yaml "${EXT_DIR}/addon.yaml"
 
 echo
 echo "add-on boostrapped at ${EXT_DIR}"


### PR DESCRIPTION
Some scripts that were merged before we had our linting check running on
PRs are now erroring on some of the existing code. This does minor
cleanup to address those issues.