### PR TITLE
Trigger on vX.Y.Z releases only

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,8 @@ name: Create Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '!**-**'
     branches:
       - main
 


### PR DESCRIPTION
We only want to trigger on full releases `vX.Y.Z` and not on any other intermediate build which contains a trailing `vX.Y.Z-ABC`