### PR TITLE
Disable tag on branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,8 @@ name: Create Release
 
 on:
   push:
+    branches:
+      - "!not_activated_on_branches!*"
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - '!*-*'


### PR DESCRIPTION
Just trigger off the tag and not the branch...  it isn't an and operation, it's an or which is why the branch needs to be disabled