### PR TITLE
Optional get --force to redownload plugin again

### DIFF
--- a/pkg/common/github/github.go
+++ b/pkg/common/github/github.go
@@ -48,7 +48,7 @@ func (m *Manager) GetInternalRepo() bool {
 }
 
 // DownloadExtension download extension on github
-func (m *Manager) DownloadExtension(extensionName string) error {
+func (m *Manager) DownloadExtension(extensionName string, force bool) error {
 
 	klog.V(6).Infof("DownloadExtension(%s)", extensionName)
 
@@ -65,23 +65,30 @@ func (m *Manager) DownloadExtension(extensionName string) error {
 	}
 	klog.V(2).Infof("Extension found %s", extension.Name)
 
+	extensionDirectory := filepath.Join(m.extensionDirectory, extension.Name)
+	if force {
+		err = os.RemoveAll(extensionDirectory)
+		if err != nil {
+			klog.Errorf("RemoveAll failed. Err: %v", err)
+			return err
+		}
+	}
+
 	if m.GetInternalRepo() {
 		klog.V(2).Infof("Using internal GitHub repo")
 		extensionFolder := filepath.Join(m.cfg.ExtensionDirectory, extension.Name)
-		extensionDirectory := filepath.Join(m.extensionDirectory, extension.Name)
 
 		return m.dl.DownloadGitHubFilesToDir(m.cfg.GitHubBranchTag, extensionFolder, extension.GetFileList(), extensionDirectory, m.cfg.Token)
 	}
 
 	klog.V(2).Infof("Using external GitHub repo")
 	extensionFolder := m.cfg.GitHubURI + "/" + extension.Name
-	extensionDirectory := filepath.Join(m.extensionDirectory, extension.Name)
 
 	return m.dl.DownloadFilesToDir(extensionFolder, extension.GetFileList(), extensionDirectory)
 }
 
 // PrintExtension print extension on github
-func (m *Manager) PrintExtension(extensionName string) error {
+func (m *Manager) PrintExtension(extensionName string, force bool) error {
 
 	klog.V(6).Infof("PrintExtension(%s)", extensionName)
 
@@ -98,17 +105,24 @@ func (m *Manager) PrintExtension(extensionName string) error {
 	}
 	klog.V(2).Infof("Extension found %s", extension.Name)
 
+	extensionDirectory := filepath.Join(m.extensionDirectory, extension.Name)
+	if force {
+		err = os.RemoveAll(extensionDirectory)
+		if err != nil {
+			klog.Errorf("RemoveAll failed. Err: %v", err)
+			return err
+		}
+	}
+
 	if m.GetInternalRepo() {
 		klog.V(2).Infof("Using internal GitHub repo")
 		extensionFolder := filepath.Join(m.cfg.ExtensionDirectory, extension.Name)
-		extensionDirectory := filepath.Join(m.extensionDirectory, extension.Name)
 
 		return m.dl.PrintGitHubFiles(m.cfg.GitHubBranchTag, extensionFolder, extension.GetFileList(), extensionDirectory, m.cfg.Token)
 	}
 
 	klog.V(2).Infof("Using external GitHub repo")
 	extensionFolder := m.cfg.GitHubURI + "/" + extension.Name
-	extensionDirectory := filepath.Join(m.extensionDirectory, extension.Name)
 
 	return m.dl.PrintFiles(extensionFolder, extension.GetFileList(), extensionDirectory)
 }
@@ -121,7 +135,7 @@ func (m *Manager) StageFiles(workingDir string, extensionName string) error {
 	if _, err := os.Stat(extensionFileCheck); os.IsNotExist(err) {
 		klog.V(4).Infof("Local file does not exist. Downloading from repo.")
 
-		err = m.DownloadExtension(extensionName)
+		err = m.DownloadExtension(extensionName, false)
 		if err != nil {
 			klog.Errorf("DownloadFilesToDir failed. Err: %v", err)
 			return err

--- a/pkg/extension/get.go
+++ b/pkg/extension/get.go
@@ -12,6 +12,7 @@ import (
 
 var printAlso bool
 var getName string
+var getForce bool
 
 // GetCmd represents the get command
 var GetCmd = &cobra.Command{
@@ -29,13 +30,15 @@ var GetCmd = &cobra.Command{
 
 func init() {
 	GetCmd.Flags().BoolVarP(&printAlso, "print", "p", false, "Print extension files")
+	GetCmd.Flags().BoolVarP(&getForce, "force", "f", false, "Force downloading a new copy of the extension")
 }
 
 func getExtension(cmd *cobra.Command, args []string) error {
 
-	klog.V(6).Infof("getExtension(%s)", getName)
+	klog.V(6).Infof("getExtension = %s", getName)
+	klog.V(6).Infof("force download = %t", getForce)
 
-	err := mgr.gh.DownloadExtension(getName)
+	err := mgr.gh.DownloadExtension(getName, getForce)
 	if err != nil {
 		fmt.Printf("DownloadExtension failed. Err: %v\n", err)
 		return err
@@ -46,9 +49,10 @@ func getExtension(cmd *cobra.Command, args []string) error {
 
 func printExtension(cmd *cobra.Command, args []string) error {
 
-	klog.V(6).Infof("printExtension(%s)", getName)
+	klog.V(6).Infof("printExtension = %s", getName)
+	klog.V(6).Infof("force download = %t", getForce)
 
-	err := mgr.gh.PrintExtension(getName)
+	err := mgr.gh.PrintExtension(getName, getForce)
 	if err != nil {
 		fmt.Printf("DownloadExtension failed. Err: %v\n", err)
 		return err

--- a/pkg/extension/reset.go
+++ b/pkg/extension/reset.go
@@ -55,6 +55,6 @@ func reset(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Extension plugin reset successful")
+	fmt.Printf("Extension plugin reset successful\n")
 	return nil
 }


### PR DESCRIPTION
This option mainly handles these use-cases:
- current release is pointed to `latest` since that's the only version that can change (aka tip of main branch)
- all other releases point to tagged versions as they exist in the repo. if the local copy is corrupt or has been modified, this should restore the extension to original