### PR TITLE
Update release script to get user's group

### DIFF
--- a/hack/package-release.sh
+++ b/hack/package-release.sh
@@ -102,8 +102,8 @@ cp -rf "${ROOT_REPO_DIR}/offline/." "${PACKAGE_DARWIN_AMD64_DIR}/extensions"
 chmod +x "${ROOT_REPO_DIR}/hack/install.sh"
 cp -f "${ROOT_REPO_DIR}/hack/install.sh" "${PACKAGE_LINUX_AMD64_DIR}"
 cp -f "${ROOT_REPO_DIR}/hack/install.sh" "${PACKAGE_DARWIN_AMD64_DIR}"
-chown -R "$USER":"$USER" "${PACKAGE_LINUX_AMD64_DIR}"
-chown -R "$USER":"$USER" "${PACKAGE_DARWIN_AMD64_DIR}"
+chown -R "$USER":"$(id -g -n "$USER")" "${PACKAGE_LINUX_AMD64_DIR}"
+chown -R "$USER":"$(id -g -n "$USER")" "${PACKAGE_DARWIN_AMD64_DIR}"
 
 # packaging
 rm -f tce-linux-amd64-*.tar.gz


### PR DESCRIPTION
The release script was calling `chown` to set ownership to $USER:$USER.
Group name is not always the same as the user name, especially on macOS.

To make sure the correct primary group is always set, this updates the
call to look up the users primary group and use that for setting the
group ownership.