### PR TITLE
Fix sed calls on Linux hosts

### DIFF
--- a/hack/build-tanzu.sh
+++ b/hack/build-tanzu.sh
@@ -9,9 +9,9 @@ set -o pipefail
 set -o xtrace
 
 # Handle differences in MacOS sed
-SEDARGS=
+SEDARGS="-i"
 if [[ "$(uname -s)" == "Darwin" ]]; then
-    SEDARGS="'' -e"
+    SEDARGS="-i '' -e"
 fi
 
 # Change directories to a clean build space
@@ -49,8 +49,8 @@ pushd "${ROOT_REPO_DIR}/core" || return 1
 git reset --hard
 # go mod edit --replace github.com/vmware-tanzu-private/tkg-cli=../tkg-cli
 go mod edit --replace github.com/vmware-tanzu-private/tkg-providers=../tkg-providers
-sed -i "$SEDARGS" "s/ --dirty//g" ./Makefile
-sed -i "$SEDARGS" "s/\$(shell git describe --tags --abbrev=0 2>\$(NUL))/${TANZU_CORE_REPO_BRANCH}/g" ./Makefile
+sed "$SEDARGS" "s/ --dirty//g" ./Makefile
+sed "$SEDARGS" "s/\$(shell git describe --tags --abbrev=0 2>\$(NUL))/${TANZU_CORE_REPO_BRANCH}/g" ./Makefile
 make build-install-cli-all
 popd || return 1
 
@@ -61,9 +61,9 @@ git reset --hard
 # go mod edit --replace github.com/vmware-tanzu-private/tkg-cli=../tkg-cli
 go mod edit --replace github.com/vmware-tanzu-private/tkg-providers=../tkg-providers
 go mod edit --replace github.com/vmware-tanzu-private/core=../core
-sed -i "$SEDARGS" "s/ --dirty//g" ./Makefile
-sed -i "$SEDARGS" "s/\$(shell git describe --tags --abbrev=0 2>\$(NUL))/${TANZU_TKG_CLI_PLUGINS_REPO_BRANCH}/g" ./Makefile
-sed -i "$SEDARGS" "s/tanzu plugin install all --local \$(ARTIFACTS_DIR)/TANZU_CLI_NO_INIT=true \$(GO) run -ldflags \"\$(LD_FLAGS)\" github.com\/vmware-tanzu-private\/core\/cmd\/cli\/tanzu plugin install all --local \$(ARTIFACTS_DIR)/g" ./Makefile
+sed "$SEDARGS" "s/ --dirty//g" ./Makefile
+sed "$SEDARGS" "s/\$(shell git describe --tags --abbrev=0 2>\$(NUL))/${TANZU_TKG_CLI_PLUGINS_REPO_BRANCH}/g" ./Makefile
+sed "$SEDARGS" "s/tanzu plugin install all --local \$(ARTIFACTS_DIR)/TANZU_CLI_NO_INIT=true \$(GO) run -ldflags \"\$(LD_FLAGS)\" github.com\/vmware-tanzu-private\/core\/cmd\/cli\/tanzu plugin install all --local \$(ARTIFACTS_DIR)/g" ./Makefile
 make build
 make install-cli-plugins
 popd || return 1

--- a/hack/create-addon-dir.sh
+++ b/hack/create-addon-dir.sh
@@ -14,9 +14,9 @@ then
 fi
 
 # Handle differences in MacOS sed
-SEDARGS=
+SEDARGS="-i"
 if [ "$(uname -s)" = "Darwin" ]; then
-    SEDARGS="'' -e"
+    SEDARGS="-i '' -e"
 fi
 
 EXT_ROOT_DIR="extensions"
@@ -33,7 +33,7 @@ mkdir -v "${EXT_DIR}/${EXT_BUNDLE_DIR}/${EXT_CONFIG_DIR}/{${EXT_OVERLAY_DIR},${E
 
 # create README and fill with name of extension
 cp docs/extension-readme-template.md "${EXT_DIR}/README.md"
-sed -i "$SEDARGS" "s/EXT_NAME/${EXT_NAME}/g" "${EXT_DIR}/README.md"
+sed "$SEDARGS" "s/EXT_NAME/${EXT_NAME}/g" "${EXT_DIR}/README.md"
 
 # create addon yaml
 cp docs/app-cr-template.yaml "${EXT_DIR}/addon.yaml"


### PR DESCRIPTION
The changes in 42e3272 caused sed commands in Linux to include unwanted
quotes, causing sed calls to fail during the release build process. This
fixes the way sed arguments are passed to make it work on both mac and
linux.