### PR TITLE
Address install.sh issues

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -53,13 +53,13 @@ fi
 # check if ~/bin is in PATH if so use that and don't sudo
 # fall back to /usr/local/bin with sudo
 TANZU_BIN_PATH="/usr/local/bin"
-if [[ ":$PATH:" == *":$HOME/bin:"* && -d "${HOME}/bin" ]]; then
+if [[ ":${PATH}:" == *":$HOME/bin:"* && -d "${HOME}/bin" ]]; then
   TANZU_BIN_PATH="${HOME}/bin"
   echo Installing tanzu cli to "${TANZU_BIN_PATH}"
   install "${MY_DIR}/bin/tanzu" "${TANZU_BIN_PATH}"
 else
-  echo Installing tanzu cli to /usr/local/bin
-  sudo install "${MY_DIR}/bin/tanzu" /usr/local/bin
+  echo Installing tanzu cli to "${TANZU_BIN_PATH}"
+  sudo install "${MY_DIR}/bin/tanzu" "${TANZU_BIN_PATH}"
 fi
 
 install "${MY_DIR}/bin/tanzu-plugin-alpha" "${XDG_DATA_HOME}/tanzu-cli"


### PR DESCRIPTION
This addresses a couple things we have seen with the install.sh script
used for official release installation.

If the tanzu binary is installed into the system-wide /usr/local/bin we
use sudo to do so. To try to avoid using sudo, we check for ~/bin being
on the user's path. This works well to avoid calling sudo - and
potentially causing the user to have to enter their password. But then
later, if we are running on macOS we need to call xattr -d to remove the
quarantine of the files. To avoid needing to check twice to determine if
we need to sudo, this removes the quarantine on the packaged file before
trying to install it.

Another issue was if ~/bin is on the path, but an earlier version of
tanzu is already installed to a location that is earlier on the user's
PATH. This adds a check for an existing tanzu executable and deletes it
attempts to delete it if found before installing the current one to try
to avoid this.

Finally, it's possible ~/bin is on the PATH, but the directory doesn't
actually exist. This makes sure it is actually a directory before
attempting to install to it.

Closes: #273 