### PR TITLE
Update Tanzu Addon Packaging Design Docs

### DIFF
--- a/docs/designs/tanzu-addon-packaging.md
+++ b/docs/designs/tanzu-addon-packaging.md
@@ -409,90 +409,193 @@ subjects:
     namespace: tanzu-extensions
 ```
 
-### 9. Create App CR
+### 9. Create a Package CR
 
-The bundles (created by `imgpkg`) are pulled down, processed, and deployed by
-kapp-controller. In order to instruct kapp-controller on what bundles to pull on
-reconcile, an App Custom Resource (CR) must be created.
+A `Package` is used to define metadata and templating information about a piece
+of software. A `Package` CR is created for every addon and points to the OCI
+registry where the `imgpkg` bundle can be found. The `Package` CR is put into
+a directory structure with other packages to eventually form a
+`PackageRepository`. The `Package` CR is **not** deployed to the cluster,
+instead the `PackageRepsoitory` bundle, containing many `Package`s is. Once
+the `PackageRepository` is in place, `kapp-controller` will make `Package` CRs
+in the cluster. This relationship can be seen as follows.
 
-The application CR, named `addon.yaml` should be added to `extensions/foo/`. The
-file will look as follows.
+![Package and Package Repository](../images/tanzu-carvel-new-apis.png)
+
+An example `Package` for `foo` would read as follows.
 
 ```yaml
-apiVersion: kappctrl.k14s.io/v1alpha1
-kind: App
+apiVersion: package.carvel.dev/v1alpha1
+kind: Package
 metadata:
-  name: todo
-  namespace: tanzu-extensions
+  name: foo.tanzu.vmware.com.1.0.0-vmware0,
 spec:
-  syncPeriod: 5m
-  serviceAccountName: todo
-  fetch:
-    - imgpkgBundle:
-        image: todo
+  publicName: foo.tanzu.vmware.com
+  version: "1.0.0-vmware0"
   template:
-    - ytt:
-        ignoreUnknownComments: true
-        paths:
-          - config/
-    - kbld: {}
-  deploy:
-    - kapp:
-        rawOptions: ["--wait-timeout=5m"]
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: registry.corp.com/packages/simple-app:1.0.0
+      template:
+        - ytt:
+            ignoreUnknownComments: true
+            paths:
+              - config/
+        - kbld: {}
+      deploy:
+        - kapp:
+            rawOptions: ["--wait-timeout=5m"]
 ```
 
-Each `todo` field above must be customized for your add-ons, the fields
-definitions are as follows.
+* `name`: Concatenation of `spec.publicName` and `version` (see below).
+* `spec.publicName`: Name that will show up to consumers. **Must be unique across
+packages**.
+* `version`: version number of this package instance, must use semver. The
+version used should reflect the version of the packaged software. For example,
+if `simple-app`'s main container image is version `1.0.0`, this
+package should be the same. We add a suffix `-vmware0` to enable versioned
+changes to just the package or template when needed.
+* `spec.template.spec.fetch[0].imgpkgBundle.image`: reference to the
+configuration/manifest bundle described in [this
+section](#6-bundle-configuration-and-deploy-to-registry).
 
-* `metadata.name`: Name of the App CR that is deployed into the cluster
-* `spec.serviceAccountName`: Name of the ServiceAccount used to instantiate the
-objects via kapp-controller. (see section above)
-* `spec.fetch[0].imagepkgBundle.image`: name of the add-on bundle stored in the
-registry.`
+This file belongs in a repository directory stored in the TCE GitHub repo.
+Assuming it is part of the TCE `main` repository, it would go in
+`addons/repos/main/packages`. An example of the contents of this directory are as
+follows.
+
+```txt
+addons/repos/main
+└── packages
+    ├── cert-manager-1.1.0_vmware0.yaml
+    ├── contour-operator.1.11.0_vmware.0.yaml
+    ├── gatekeeper.3.2.3-vmware0.yaml
+    ├── knative-0.21.0_vmware0.yaml
+    └── velero-1.5.2_vmware0.yaml
+```
 
 ### 10. Update repository metadata
 
-Today, for an add-on to show up in the `tanzu` CLI for TCE, you need to open an
-issue inside of the TCE repository. If approved, a TCE member can then update
-our existing repository metadata and update it so that the add-ons shows up in
-the `tanzu` CLI.
+As described in the above section, `Package` manifests are stored in this
+repository at `addons/repos/${REPO_NAME}`. The directory structure that holds
+the main repo packages and main `PackageRepository` manifest is as follows.
 
-Add-on metadata is kept in a GCP bucket. This acts as repository metadata that
-powers the `tanzu` CLI plugin. The metadata looks as follows.
-
-```yaml
-version: latest
-branch: main
-extensions:
-  - name: velero
-    version: v0.2.0-pre-alpha-1
-    minsupported: v0.2.0-pre-alpha-1
-    maxsupported: v0.2.0-pre-alpha-1
-    files:
-      - filename: extension.yaml
-  - name: gatekeeper
-    version: v0.2.0-pre-alpha-1
-    minsupported: v0.2.0-pre-alpha-1
-    maxsupported: v0.2.0-pre-alpha-1
-    files:
-      - filename: extension.yaml
-  - name: contour
-    version: v0.2.0-pre-alpha-1
-    minsupported: v0.2.0-pre-alpha-1
-    maxsupported: v0.2.0-pre-alpha-1
-    files:
-      - filename: extension.yaml
-  - name: cert-manager
-    version: v0.2.0-pre-alpha-1
-    minsupported: v0.2.0-pre-alpha-1
-    maxsupported: v0.2.0-pre-alpha-1
-    files:
-      - filename: extension.yaml
+```txt
+addons/repos/
+├── main
+│   └── packages
+│       ├── cert-manager-1.1.0_vmware0.yaml
+│       ├── contour-operator.1.11.0_vmware.0.yaml
+│       ├── gatekeeper.3.2.3-vmware0.yaml
+│       ├── knative-0.21.0_vmware0.yaml
+│       └── velero-1.5.2_vmware0.yaml
+└── main.yaml
 ```
 
-This is a temporary solution until new Carvel APIs
-around packaging are integrated with TCE. You can [read about our planned work
-for the new APIs here](#package-repository-and-installedpackage-apis).
+With the directory structure in place, the repository can be uploaded to a
+container registry, as follows.
+
+```sh
+imgpkg push -i projects.registry.vmware.com/tce/main:dev -f addons/repos/main
+```
+
+The `main.yaml` contains the `PackageRepository` that is deployed to the
+cluster. This manifest contains a reference to the repository bundle pushed to
+the repo. For this example, it would read as follow.
+
+```yaml
+apiVersion: install.package.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: tce-main.tanzu.vmware
+spec:
+  fetch:
+    image:
+      url: projects.registry.vmware.com/tce/main:dev
+```
+
+### 11. Create a sample `InstalledPackage`
+
+`InstalledPackage` is the declaration of intent to install a package, which
+kapp-controller will act on. This file is generally created by a client (such as
+`tanzu` CLI and applied to the cluster. However, for testing purposes, we
+maintain a sample `InstalledPackage` in the file
+`addons/packages/${package_name}/installedpackage.yaml`. For the `foo` example
+above, the `InstalledPackage` would look as follows.
+
+```yaml
+# This InstalledPackage resource is used for testing purposes.
+# Namely it's for manual installation when tooling such as the
+# tanzu CLI is not in play.
+---
+apiVersion: install.package.carvel.dev/v1alpha1
+kind: InstalledPackage
+metadata:
+  name: foo-sample
+  namespace: tanzu-extensions
+spec:
+  serviceAccountName: foo-extension-sa
+  packageRef:
+    publicName: foo-operator
+    versionSelection:
+      constraints: "1.11.0-vmware0"
+      prereleases: {}
+```
+
+### 12. (Optional) Validating Package Installation
+
+This section describes how you can manually (using `kubectl`) validate the
+installation of a package. For TCE users, this flow will happen through `tanzu`
+CLI. You can read about that implementation in the [Tanzu Add-on Management
+design doc](./tanzu-addon-management.md).
+
+While the APIs are still alpha, you **must** follow [this
+guide](../test-package-apis.md) to update your `kapp-controller instance`.
+
+Once `kapp-controller` is configured, you can deploy the `PackageRepository`
+your package is bundled within. Assuming this is main, you would do the
+following.
+
+```sh
+kubectl apply -f addons/repos/main.yaml
+```
+
+Then you can validate the packages become available in the cluster.
+
+```sh
+$ k get package
+
+NAME                              PUBLIC-NAME        VERSION          AGE
+cert-manager.1.11.0-vmware0       cert-manager       1.1.0-vmware0    39h
+contour-operator.1.11.0-vmware0   contour-operator   1.11.0-vmware0   39h
+gatekeeper.3.2.3-vmware0          gatekeeper         3.2.3-vmware0    39h
+knative-serving.0.21.0-vmware0    knative-serving    0.21.0-vmware0   39h
+velero.1.5.2-vmware0              velero             1.5.2-vmware0    39h
+```
+
+Next, to run a package in the cluster an `InstalledPackage` must be introduced.
+To install `contour-operator` above, the following `InstalledPackage` contents
+can be used.
+
+```yaml
+---
+apiVersion: install.package.carvel.dev/v1alpha1
+kind: InstalledPackage
+metadata:
+  name: contour-operator-sample
+  namespace: tanzu-extensions
+spec:
+  serviceAccountName: contour-extension-sa
+  packageRef:
+    publicName: contour-operator
+    versionSelection:
+      constraints: "1.11.0-vmware0"
+      prereleases: {}
+```
+
+> An example `InstalledPackage` is kept at
+`addons/packages/contour-operator/installedpackage.yaml`.
 
 ## Common Packaging Considerations
 
@@ -638,202 +741,6 @@ applied until the Deployment is healthy.
 
 For more details on this annotation, see the [kapp Apply Ordering
 documentation](https://carvel.dev/kapp/docs/latest/apply-ordering).
-
-## Planned to Implement
-
-The following sections include changes to this design that are either planned to
-be implemented in TCE or currently in-flight.
-
-### Package, Repository, and InstalledPackage APIs
-
-**status:** planned
-
-**impacts:**
-
-* [Create App CR](#8-create-app-cr)
-
-* [Update Respository Metadata](#9-update-repository-metadata)
-
-The introduction of the [Package, PackageRepository, and InstalledPackage
-APIs](https://carvel.dev/kapp-controller/docs/latest/packaging/#package-cr)
-changes aspects of TCE's packaging approach. At a high-level, we move away from
-the existing [App CR](#8-create-app-cr) and convert them to `Package` manifests.
-These `Package` manifests are then bundled using `imgpkg`, creating a repository
-bundle that can be stored in an OCI registry. In a TCE cluster (which is running
-kapp-controller) a `PackageRepository` object is added. This object references
-the registry bundle stored in the registry. With knowledge of this
-`PackageRepository`, kapp-controller makes a `Package` CR for each package in
-the bundle. This looks as follows.
-
-![Package and Package Repository](../images/tanzu-carvel-new-apis.png)
-
-With the above in place, a user can see all the packages using `kubectl`.
-
-```sh
-$ kubectl get packages
-NAME                              PUBLIC-NAME            VERSION      AGE
-pkg.test.carvel.dev.1.0.0         pkg.test.carvel.dev   1.0.0        7s
-pkg.test.carvel.dev.2.0.0         pkg.test.carvel.dev   2.0.0        7s
-pkg.test.carvel.dev.3.0.0-rc.1    pkg.test.carvel.dev   3.0.0-rc.1   7s
-```
-
-> example taken from [https://carvel.dev/kapp-controller/docs/latest/package-consumption](https://carvel.dev/kapp-controller/docs/latest/package-consumption)
-
-Once a user determines which package they'd like installed, they instruct
-kapp-controller to install it by applying a `InstalledPackage` object. The flow
-looks as follows.
-
-![InstalledPackage Flow](../images/tanzu-carvel-installed-package.png)
-
-The following sections cover each API and the changes we need to make to this
-current design to integrate/implement them.
-
-#### Package API
-
-Creating our add-on bundles remains largely unchanged. However, our declaration
-of the add-on is no longer done in the App API. Instead it is done using a
-`Package`. The `spec.template` is the same schema as the App API. Thus, TCE can
-take existing App CRs and put their contents in `spec.template`. The `spec` also
-includes the following fields packages need to propagate.
-
-* `publicName`: Name that will show up to consumers. **Must be unique across
-packages**.
-* `version`: version number of this package instance, must use semver.
-
-An example `Package` for `foo` (seen [here](#8-create-app-cr)) would read as follows.
-
-```yaml
-apiVersion: package.carvel.dev/v1alpha1
-kind: Package
-metadata:
-  name: foo.tanzu.vmware.com.1.0.0,
-spec:
-  publicName: foo.tanzu.vmware.com
-  version: "1.0.0"
-  template:
-    spec:
-      fetch:
-      - imgpkgBundle:
-          image: registry.corp.com/packages/simple-app:1.0.0
-      template:
-        - ytt:
-            ignoreUnknownComments: true
-            paths:
-              - config/
-        - kbld: {}
-      deploy:
-        - kapp:
-            rawOptions: ["--wait-timeout=5m"]
-```
-
-The work needed to covert to this API is _roughly_ the following for each add-on.
-
-* [ ] Create a new Package manifest
-* [ ] Add the existing App CR `spec` to `spec.template`
-* [ ] Set the metadata values including `spec.publicName` and `spec.version`
-* [ ] Update `metadata.name` to be `spec.publicName`.`spec.version`
-* [ ] Delete the App CR related to the add-on
-* [ ] Update this design doc to include this model rather than the App CR
-
-#### PackageRepository API
-
-Unlike `App`, a `Package` is not deployed into the cluster. Instead multiple
-packages are bundled together and stored in an OCI registry. A
-`PackageRepository` object is then added to the cluster and points at the OCI
-bundle. The expected directory structure looks as follows.
-
-```txt
-tce-main
-└── packages
-    └── gatekeeper.tanzu.vmware.1.0.0.yml
-    └── velero.tanzu.vmware.1.2.0.yml
-    └── knative.tanzu.vmware.2.1.0.yml
-```
-
-The above directories and files should be stored in the TCE repository under
-`extensions/repo`. Packages should be versioned independent of the underlying
-software. To ensure a change to a package can occur even when an container
-image versions don't change.
-
-With the directory structure in place, the repository can be uploading to a
-container registry, as follows.
-
-```sh
-imgpkg push -i projects.registry.vmware.com/tce/repo:main -f extensions/repo/tce-main
-```
-
-In order for a TCE cluster to recognize the packages in this bundle, a
-`PackageRepository` object must be created and (eventually) deployed into the
-cluster. In the `extensions/repo` directory a YAML file should be created
-reflecting the package repo. With the example above, the file would be
-`extensions/repo/tce-main.yaml` and would look as follows.
-
-```yaml
-apiVersion: install.package.carvel.dev/v1alpha1
-kind: PackageRepository
-metadata:
-  name: tce-main.tanzu.vmware
-spec:
-  fetch:
-    image:
-      url: projects.registry.vmware.com/tce/repo:main
-```
-
-We will eventually update the `tanzu` CLI to be able to init this into the
-cluster.
-
-The work needed to covert to this API is _roughly_ the following.
-
-* [ ] Create a new directory structure as described above
-* [ ] For each add-on, add a Package CR (`.yaml`)
-* [ ] Use imgpkg to bundle and push to a container registry
-* [ ] Create/Update TCE's default `PackageRepository` manifest to point to the
-    bundle
-* [ ] Update `tanzu` CLI tooling to init this default `PackageRepository`.
-
-#### InstalledPackage API
-
-`InstalledPackage` is the declaration of intent to install a package, which
-kapp-controller will act on. There are no changes that need to happen from a
-packaging perspective. However, we do need to introduce tooling changes to
-ensure users can install these packages. The current design uses `tanzu` CLI to
-add packages/add-ons. In order to continue this experience, the CLI must be able
-to read available packages (Package CRDs) in the cluster and generate
-`InstalledPackage` objects that are applied to the cluster. An example of this
-declaration is as follows.
-
-```yaml
----
-apiVersion: install.package.carvel.dev/v1alpha1
-kind: InstalledPackage
-metadata:
-  name: pkg-demo
-  namespace: default
-spec:
-  serviceAccountName: default-ns-sa
-  packageRef:
-    publicName: pkg.test.carvel.dev
-    version: 1.0.0
-  values:
-  - secretRef:
-      name: pkg-demo-values
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: pkg-demo-values
-stringData:
-  values.yml: |
-    #@data/values
-    ---
-    hello_msg: "hi"
-```
-
-> example copied from [https://carvel.dev/kapp-controller/docs/latest/package-consumption/#installing-a-package](https://carvel.dev/kapp-controller/docs/latest/package-consumption/#installing-a-package)
-
-This design goes beyond the scope of this Packaging document. It is (or will)
-instead be detailed in our [Tanzu Add-on
-Management](./tanzu-addon-management.md) document.
 
 ## Designed Pending Details
 

--- a/docs/test-package-apis.md
+++ b/docs/test-package-apis.md
@@ -1,4 +1,4 @@
-THIS IS A TEMPORARY DOC THAT SHOULD BE MOVED INTO THE GETTING STARTED GUIDE
+# Temporary Testing Doc for Packaging APIs
 
 To validate the packaging APIs, TCE requires an alpha build of kapp-controller
 [imgpkg bundle
@@ -84,4 +84,3 @@ version of kapp-controller on the guest cluster.
    ```sh
    kubectl get packagerepositories,packages,installedpackages -A
    ```
-


### PR DESCRIPTION
Now that we've re-packed the majority of our addons using the Tanzu Addon Packaging design doc, this PR updates it to include the new packaging bits throughout the guide.