### PR TITLE
fix infinite log recursion in the fluent-bit plugin with default configuration

### DIFF
--- a/extensions/fluentbit/README.md
+++ b/extensions/fluentbit/README.md
@@ -2,8 +2,8 @@
 
 > Fluent Bit is an open source Log Processor and Forwarder which allows you to collect any data like metrics and logs from different sources, enrich them with filters and send them to multiple destinations.
 
-This addon deploys Fluent Bit as a DaemonSet, with one Fluent Bit `pod` on each Kubernetes `node`, collecting and forwarding logs from each `pod` running on that `node`.
-The provided default configuration will print forwarded logs to `stdout` on the `fluent-bit`.
+This addon deploys Fluent Bit as a DaemonSet, with one Fluent Bit `pod` on each Kubernetes `node`, collecting logs from `systemd` and from each `pod` on the `node`.
+The provided default configuration uses the `stdout` output plugin to forward `systemd` logs to the `fluent-bit` pod for illustrative purposes.
 The `stdout` output plugin is useful for testing, but typically not appropriate for production use.
 Instead, Fluent Bit supports configurations for a number of different output types, such as open-source software like `postgresql` or `loki`, cloud platform-provided services like `CloudWatch`, `S3`, or `Stackdriver`, or generic protocols like `http` and `syslog`.
 
@@ -27,4 +27,4 @@ The following configuration values can be set to customize the Fluent Bit instal
 
 ## Usage Example
 
-Once the addon has been deployed, tail the logs from the fluent-bit DaemonSet using `kubectl logs daemonset/fluent-bit -n fluent-bit`. You should see a large volume of logs from all pods.
+Once the addon has been deployed, tail the logs from the fluent-bit DaemonSet using `kubectl logs daemonset/fluent-bit -n fluent-bit`. You should see a handful of log messages from `systemd`.

--- a/extensions/fluentbit/bundle/config/values.yaml
+++ b/extensions/fluentbit/bundle/config/values.yaml
@@ -8,4 +8,4 @@ fluent_bit:
   outputs: |
     [OUTPUT]
       Name              stdout
-      Match             *
+      Match             host.*


### PR DESCRIPTION
It's a bit tricky to provide a default fluent-bit configuration that doesn't have external dependencies. Stdout is the easiest output to demonstrate with, but since fluent-bit is also scraping the stdout logs for all containers, if we print container logs to the stdout of the fluent-bit pod, we get infinite recursion. This pr makes the default configuration only print `systemd` logs. It still *collects* all the container logs, but it only prints the `systemd` ones. It makes the OOTB experience less interesting, but it's less broken.

There's not inherently much value in just deploying fluent-bit. If we wanted to make the addon more interesting, we might provide instructions for how to install a log store like `loki`.