### PR TITLE
WIP: Update to build with go 1.16

### DIFF
--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
       id: go
 
     - name: Config credentials

--- a/.github/workflows/check-fmt.yaml
+++ b/.github/workflows/check-fmt.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
       id: go
 
     - name: Config credentials

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
       id: go
 
     - name: Config credentials

--- a/.github/workflows/check-mdlint.yaml
+++ b/.github/workflows/check-mdlint.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
       id: go
 
     - name: Config credentials

--- a/.github/workflows/check-shell.yaml
+++ b/.github/workflows/check-shell.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
       id: go
 
     - name: Config credentials

--- a/.github/workflows/check-static.yaml
+++ b/.github/workflows/check-static.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
       id: go
 
     - name: Config credentials

--- a/.github/workflows/check-vet.yaml
+++ b/.github/workflows/check-vet.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
       id: go
 
     - name: Config credentials

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
       id: go
 
     - name: Config credentials

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
       id: go
 
     - name: Config credentials

--- a/.github/workflows/push-packages.yml
+++ b/.github/workflows/push-packages.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
       id: go
 
     - name: Config credentials

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
       id: go
 
     - name: Config credentials

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
       id: go
 
     - name: Config credentials

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tce
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go/storage v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -934,8 +934,6 @@ github.com/vmware-tanzu-private/tkg-cli v1.3.0-pre-alpha-1.0.20210114003033-285a
 github.com/vmware-tanzu-private/tkg-cli v1.3.0-pre-alpha-1.0.20210114003033-285a8c9131d4/go.mod h1:Wz1ZH1vUB0IM63Cm9LNUWs8dNf9C/Fvz5O4N0n1k408=
 github.com/vmware-tanzu-private/tkg-providers v1.3.0-pre-alpha-1.0.20210113202657-eb07b4e0558d h1:G9vsZoETI+qxrpk+KtUXuFCskYUjyIo2pcNqa2hy1CI=
 github.com/vmware-tanzu-private/tkg-providers v1.3.0-pre-alpha-1.0.20210113202657-eb07b4e0558d/go.mod h1:njTZCd8EgOpYmLSOxyuQJGcP5oISTRK7/FwqF0g/qW0=
-github.com/vmware-tanzu/carvel-kapp-controller v0.16.1-0.20210308212453-d12c40dd11f1 h1:acw9+5jV8StK926EnFVAQqp5CHPUaMJk1n5IF1n7MSo=
-github.com/vmware-tanzu/carvel-kapp-controller v0.16.1-0.20210308212453-d12c40dd11f1/go.mod h1:JWjOXCt2p4/Dsx/JPDMyCJt9rqpqelaYPSaO4Zl6J7k=
 github.com/vmware-tanzu/carvel-kapp-controller v0.16.1-0.20210311153426-867eef4d6913 h1:WD5hTQb4ICxNzY7qLBYmm1PKHy49GYh2JFq43kRqK+8=
 github.com/vmware-tanzu/carvel-kapp-controller v0.16.1-0.20210311153426-867eef4d6913/go.mod h1:JWjOXCt2p4/Dsx/JPDMyCJt9rqpqelaYPSaO4Zl6J7k=
 github.com/vmware-tanzu/carvel-vendir v0.16.0 h1:1vpXXQQJ7ObjaZglVEzKACDqysbT13H1olNHxm6evPU=


### PR DESCRIPTION
This updates our build process to use go 1.16.

The core repo should move first before the TCE repo.