### PR TITLE
Increase lint job timeout to 10m

### DIFF
--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -35,4 +35,4 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         version: v1.38.0
-        args: --timeout=5m -v
+        args: --timeout=10m -v


### PR DESCRIPTION
This job occasionally fails on merge commits with a timeout error. Not sure why that is happening, but until we can collect more data around it, this just increases the timeout from 5 to 10 minutes.