### PR TITLE
Update build scripts to exit on failure

### DIFF
--- a/hack/build-tanzu.sh
+++ b/hack/build-tanzu.sh
@@ -18,7 +18,7 @@ fi
 ROOT_REPO_DIR="/tmp/tce-release"
 rm -fr "${ROOT_REPO_DIR}"
 mkdir -p "${ROOT_REPO_DIR}"
-cd "${ROOT_REPO_DIR}" || return 1
+cd "${ROOT_REPO_DIR}" || exit 1
 
 if [[ -z "${BUILD_VERSION}" ]]; then
     echo "BUILD_VERSION is not set"
@@ -34,37 +34,37 @@ TANZU_TKG_CLI_PLUGINS_REPO_BRANCH=${BUILD_VERSION}
 # set +x
 # git clone --depth 1 --branch "${TKG_CLI_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/tkg-cli.git"
 # set -x
-# pushd "${ROOT_REPO_DIR}/tkg-cli" || return 1
+# pushd "${ROOT_REPO_DIR}/tkg-cli" || exit 1
 # git reset --hard
-# popd || return 1
+# popd || exit 1
 
 rm -rf "${ROOT_REPO_DIR}/tkg-providers"
 set +x
 git clone --depth 1 --branch "${TKG_PROVIDERS_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/tkg-providers.git"
 set -x
-pushd "${ROOT_REPO_DIR}/tkg-providers" || return 1
+pushd "${ROOT_REPO_DIR}/tkg-providers" || exit 1
 git reset --hard
-popd || return 1
+popd || exit 1
 
 rm -rf "${ROOT_REPO_DIR}/core"
 mv -f "${HOME}/.tanzu" "${HOME}/.tanzu-$(date +"%Y-%m-%d_%H:%M")"
 set +x
 git clone --depth 1 --branch "${TANZU_CORE_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/core.git"
 set -x
-pushd "${ROOT_REPO_DIR}/core" || return 1
+pushd "${ROOT_REPO_DIR}/core" || exit 1
 git reset --hard
 # go mod edit --replace github.com/vmware-tanzu-private/tkg-cli=../tkg-cli
 go mod edit --replace github.com/vmware-tanzu-private/tkg-providers=../tkg-providers
 sed "$SEDARGS" "s/ --dirty//g" ./Makefile
 sed "$SEDARGS" "s/\$(shell git describe --tags --abbrev=0 2>\$(NUL))/${TANZU_CORE_REPO_BRANCH}/g" ./Makefile
 make build-install-cli-all
-popd || return 1
+popd || exit 1
 
 rm -rf "${ROOT_REPO_DIR}/tanzu-cli-tkg-plugins"
 set +x
 git clone --depth 1 --branch "${TANZU_TKG_CLI_PLUGINS_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/tanzu-cli-tkg-plugins.git"
 set -x
-pushd "${ROOT_REPO_DIR}/tanzu-cli-tkg-plugins" || return 1
+pushd "${ROOT_REPO_DIR}/tanzu-cli-tkg-plugins" || exit 1
 git reset --hard
 # go mod edit --replace github.com/vmware-tanzu-private/tkg-cli=../tkg-cli
 go mod edit --replace github.com/vmware-tanzu-private/tkg-providers=../tkg-providers
@@ -74,4 +74,4 @@ sed "$SEDARGS" "s/\$(shell git describe --tags --abbrev=0 2>\$(NUL))/${TANZU_TKG
 sed "$SEDARGS" "s/tanzu plugin install all --local \$(ARTIFACTS_DIR)/TANZU_CLI_NO_INIT=true \$(GO) run -ldflags \"\$(LD_FLAGS)\" github.com\/vmware-tanzu-private\/core\/cmd\/cli\/tanzu plugin install all --local \$(ARTIFACTS_DIR)/g" ./Makefile
 make build
 make install-cli-plugins
-popd || return 1
+popd || exit 1

--- a/hack/package-release.sh
+++ b/hack/package-release.sh
@@ -11,7 +11,7 @@ set -o xtrace
 # Change directories to the parent directory of the one in which this
 # script is located.
 ROOT_REPO_DIR="$(dirname "${BASH_SOURCE[0]}")/.."
-cd "${ROOT_REPO_DIR}" || return 1
+cd "${ROOT_REPO_DIR}" || exit 1
 
 if [[ -z "${BUILD_VERSION}" ]]; then
     echo "BUILD_VERSION is not set"
@@ -109,7 +109,7 @@ chown -R "$USER":"$(id -g -n "$USER")" "${PACKAGE_DARWIN_AMD64_DIR}"
 # packaging
 rm -f tce-linux-amd64-*.tar.gz
 rm -f tce-darwin-amd64-*.tar.gz
-pushd "${BUILD_ROOT_DIR}" || return 1
+pushd "${BUILD_ROOT_DIR}" || exit 1
 tar -czvf "tce-linux-amd64-${EXTENSION_BUILD_VERSION}.tar.gz" "tce-linux-amd64-${BUILD_VERSION}"
 tar -czvf "tce-darwin-amd64-${EXTENSION_BUILD_VERSION}.tar.gz" "tce-darwin-amd64-${BUILD_VERSION}"
-popd || return 1
+popd || exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Some scripts were calling return on failure, which would then error due
to not being in a function from which to return. The scripts are
currently set to continue, so unless you saw it in the logs, you
wouldn't know there was an issue.

This updates the scripts to `exit` rather than `return` when not running
in a function.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #332

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change. 
-->

See repro steps in linked issue.

**Special notes for your reviewer**:
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
