### PR TITLE
Increase `make lint` timeout to 5 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ fmt:
 	hack/check-format.sh
 
 lint: tools
-	$(GOLANGCI_LINT) run -v
+	$(GOLANGCI_LINT) run -v --timeout=5m
 
 mdlint:
 	hack/check-mdlint.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

The `make lint` target calls golangci-lint to perform various linting.
On development machines, resources are usually pretty good and this
linting is performed fairly fast. But in the GitHub Actions there are a
lot less resources available and things take a bit longer to run.

The default timeout for golangci-lint is 1 minute. This is overridden in
our Check job configuration, so when run on normal PRs, this check has
plenty of time to run.

We run into issues with the job that is run on new commits being pushed
to main. This job configuration wants to run all of our checks, so
rather than using the golangci-lint action, it just calls `make check`,
which pulls in the lint target and other checks.

Because we had been calling golangci-lint there without passing in a
--timeout, it falls back to the 1 minute default timeout and ends up
failing when run in this Action.

This increases the timeout in the Makefile to 5 minutes to avoid hitting
this on merge commits.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #334

**Describe testing done for PR**:

Difficult to test the actual scenario, but I at least ran `make lint` locally
and made sure golangci-lint picked up the new argument.

**Special notes for your reviewer**:
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
