### PR TITLE
Update contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,19 +5,59 @@ These guidelines will help you get started. Please note that we require [DCO sig
 
 ## Building from source
 
-This section describes how to build TCE from source.
+This section describes how to build TCE from source. Build and test is driven by our [Makefile](Makefile).
+Commands meant to be used directly by developers feature help text. You can see this by running `make help`.
 
 ### Fetch the source
 
-( Placeholder )
+```shell
+git clone https://github.com/vmware-tanzu/tce
+```
 
-### Building
+### Building the CLI and all plugins from source
 
-( Placeholder )
+TCE consists of the `tanzu` CLI and multiple CLI plugins that facilitate functionality from cluster management to authentication.
+The CLI and some of its plugins live in different repositories. To build the CLI and all plugins, including those
+hosted in the TCE repository, run the following.
 
-### Running tests
+```shell
+make build-all
+```
 
-( Placeholder )
+After build and install, you'll see an output similar to the following.
+
+```text
+[COMPLETE] installed plugins at /home/josh/.local/share/tanzu-cli/. These plugins will be automatically detected by tanzu CLI.
+
+[COMPLETE] installed tanzu CLI at /home/josh/bin/tanzu. Move this binary to a location in your path!
+```
+
+As seen in the message above, you can now move `tanzu` from the location it was installed into a location in your path (such as `/usr/local/bin`).
+Plugins are automatically installed in the correctly location, so when calling `tanzu`, the plugins functionality is picked up automatically.
+
+### Building only TCE-specific plugins from source
+
+If you already have `taznu` CLI installed and wish to only compile and install TCE-specific plugins, run the following.
+
+```shell
+make build-plugin
+```
+
+After build and install, you'll see an output similar to the following.
+
+```text
+[COMPLETE] installed TCE-specific plugins at /home/josh/.local/share/tanzu-cli/. These plugins will be automatically detected by your tanzu CLI.
+```
+
+Now that the TCE-specifc plugins are installed on your system, you will see their command when running `tanzu`.
+
+### Running TCE-specific plugin tests
+
+To run tests on TCE-specific CLU plugins, run the following.
+
+```shell
+make test-plugins
+```
 
 ## Contribution workflow
 

--- a/hack/build-tanzu.sh
+++ b/hack/build-tanzu.sh
@@ -30,17 +30,9 @@ TKG_PROVIDERS_REPO_BRANCH=${BUILD_VERSION}
 TANZU_CORE_REPO_BRANCH=${BUILD_VERSION}
 TANZU_TKG_CLI_PLUGINS_REPO_BRANCH=${BUILD_VERSION}
 
-# rm -rf "${ROOT_REPO_DIR}/tkg-cli"
-# set +x
-# git clone --depth 1 --branch "${TKG_CLI_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/tkg-cli.git"
-# set -x
-# pushd "${ROOT_REPO_DIR}/tkg-cli" || exit 1
-# git reset --hard
-# popd || exit 1
-
 rm -rf "${ROOT_REPO_DIR}/tkg-providers"
 set +x
-git clone --depth 1 --branch "${TKG_PROVIDERS_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/tkg-providers.git"
+git clone --depth 1 --branch "${TKG_PROVIDERS_REPO_BRANCH}" "ssh://git@github.com/vmware-tanzu-private/tkg-providers.git"
 set -x
 pushd "${ROOT_REPO_DIR}/tkg-providers" || exit 1
 git reset --hard
@@ -49,7 +41,7 @@ popd || exit 1
 rm -rf "${ROOT_REPO_DIR}/core"
 mv -f "${HOME}/.tanzu" "${HOME}/.tanzu-$(date +"%Y-%m-%d_%H:%M")"
 set +x
-git clone --depth 1 --branch "${TANZU_CORE_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/core.git"
+git clone --depth 1 --branch "${TANZU_CORE_REPO_BRANCH}" "ssh://git@github.com/vmware-tanzu-private/core.git"
 set -x
 pushd "${ROOT_REPO_DIR}/core" || exit 1
 git reset --hard
@@ -62,7 +54,7 @@ popd || exit 1
 
 rm -rf "${ROOT_REPO_DIR}/tanzu-cli-tkg-plugins"
 set +x
-git clone --depth 1 --branch "${TANZU_TKG_CLI_PLUGINS_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/tanzu-cli-tkg-plugins.git"
+git clone --depth 1 --branch "${TANZU_TKG_CLI_PLUGINS_REPO_BRANCH}" "ssh://git@github.com/vmware-tanzu-private/tanzu-cli-tkg-plugins.git"
 set -x
 pushd "${ROOT_REPO_DIR}/tanzu-cli-tkg-plugins" || exit 1
 git reset --hard


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds details for a developer to contribute to TCE. Namely
building and installing the CLI and plugins.

This commit also updates the Makefile with the following changes.

* Help text (make help) is only presented for commands that are meant to
  be run locally by developers. All other commands are considered
  "private".
* Targets that install plugins or the tanzu CLI now tell the user where
  they were installed (assuming successful completion)

**Which issue(s) this PR fixes**:

Fixes: #16 