### PR TITLE
Align RC and GA builds, Fix Dev Tagging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,12 +108,13 @@ jobs:
         destination: tce-cli-plugins
         credentials: ${{ secrets.GCP_BUCKET_SA }}
 
-  post-build:
-    steps:
+    - name: Reset repo
+      run: |
+        git reset --hard
     
     - name: Checkout for Update
       uses: actions/checkout@v2
 
-    - name: Commit New Version 
+    - name: Commit Next Dev Version 
       run: |
         make tag-release

--- a/hack/update-tag.sh
+++ b/hack/update-tag.sh
@@ -20,6 +20,6 @@ git config user.name github-actions
 git config user.email github-actions@github.com
 git add hack/DEV_BUILD_VERSION.yaml
 git commit -m "auto-generated - update dev version"
-git push origin HEAD:main --force
-git tag -m "${NEW_BUILD_VERSION}" "${NEW_BUILD_VERSION}"
-git push --tags
+git push -f origin HEAD:main
+git tag -f -m "${NEW_BUILD_VERSION}" "${NEW_BUILD_VERSION}"
+git push -f origin "${NEW_BUILD_VERSION}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Need to eliminate the error when attempting to tag. The process partially worked in the last build (https://github.com/vmware-tanzu/tce/runs/2145385000?check_suite_focus=true), but we need to suppress the error by only pushing the new dev tag.

**Which issue(s) this PR fixes**:
NA

**Describe testing done for PR**:
It partially worked in the last release, this just suppresses the error

**Special notes for your reviewer**:
NA

**Does this PR introduce a user-facing change?**:
No