### PR TITLE
Overlay namespace for config map in Fluent-Bit package #370

### DIFF
--- a/addons/packages/fluentbit/bundle/config/overlays/overlay-namespace.yaml
+++ b/addons/packages/fluentbit/bundle/config/overlays/overlay-namespace.yaml
@@ -6,16 +6,9 @@
 metadata:
   name: #@ data.values.namespace
 
-#@ ds=overlay.subset({"kind": "DaemonSet"})
-#@ deployment=overlay.subset({"kind": "Deployment"})
-#@ role=overlay.subset({"kind": "Role"})
-#@ rb=overlay.subset({"kind":"RoleBinding"})
-#@ svc=overlay.subset({"kind":"Service"})
-#@ sa=overlay.subset({"kind":"ServiceAccount"})
-#@overlay/match by=overlay.or_op(ds, deployment, role, rb, svc, sa), expects=2
+#@overlay/match by=overlay.subset({"metadata":{"namespace": "fluent-bit"}}), expects=3
 ---
 metadata:
-  #@overlay/match missing_ok=True
   namespace: #@ data.values.namespace
 
 #@ crb=overlay.subset({"kind":"ClusterRoleBinding"})


### PR DESCRIPTION
Signed-off-by: Nicholas Seemiller <nseemiller@vmware.com>

**What this PR does / why we need it**:
The namespace for the ConfigMap for the Fluent-Bit package was not being overlaid.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #370 

**Describe testing done for PR**:
When running `ytt` and modifying the namespace to a value of `foooooent-bit`, I originally saw this:
```sh
ytt -f fluent-bit-values.yaml -f overlays/overlay-namespace.yaml -f upstream/rbac.yml -f upstream/configmap.yaml -f upstream/daemonset.yaml -f upstream/namespace.yaml | grep namespace
  - namespaces
  namespace: foooooent-bit
  namespace: foooooent-bit
  namespace: fluent-bit
  namespace: foooooent-bit
```
Traced this back to the ConfigMap. Updated the namespace overlay, now get this:
```sh
ytt -f fluent-bit-values.yaml -f overlays/overlay-namespace.yaml -f upstream/rbac.yml -f upstream/configmap.yaml -f upstream/daemonset.yaml -f upstream/namespace.yaml | grep namespace
  - namespaces
  namespace: foooooent-bit
  namespace: foooooent-bit
  namespace: foooooent-bit
  namespace: foooooent-bit
```

**Special notes for your reviewer**:
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
