### PR TITLE
Pin packages to SHAs instead of the dev tag. #393

### DIFF
--- a/addons/repos/main/packages/cert-manager-1.1.0_vmware0.yaml
+++ b/addons/repos/main/packages/cert-manager-1.1.0_vmware0.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/cert-manager-extension-templates:dev
+            image: projects.registry.vmware.com/tce/cert-manager-extension-templates@sha256:178cb084167e2a5f53912bc987a40626a9c2470dcf45c611b02f3ba18cae8572
       template:
         - ytt:
             ignoreUnknownComments: true

--- a/addons/repos/main/packages/contour-operator.1.11.0_vmware.0.yaml
+++ b/addons/repos/main/packages/contour-operator.1.11.0_vmware.0.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/contour-extension-templates:dev
+            image: projects.registry.vmware.com/tce/contour-extension-templates@sha256:fef1d4b7bb3378bee3a6a8b0cd217a4f94a1db6cb0760c941fa0aa846d0ba6f0
       template:
         - ytt:
             ignoreUnknownComments: true

--- a/addons/repos/main/packages/fluent-bit-1.7.2_vmware0.yaml
+++ b/addons/repos/main/packages/fluent-bit-1.7.2_vmware0.yaml
@@ -18,7 +18,7 @@ spec:
       fetch:
         - imgpkgBundle:
             # replace image registry and repo with one you are using
-            image: projects.registry.vmware.com/tce/fluent-bit-extension-templates:dev
+            image: projects.registry.vmware.com/tce/fluent-bit-extension-templates@sha256:59a4be20e539ebc511c1185f741bbfe74dee93211b224b21950b532cb3b69ea4
       template:
         - ytt:
             paths:

--- a/addons/repos/main/packages/gatekeeper.3.2.3-vmware0.yaml
+++ b/addons/repos/main/packages/gatekeeper.3.2.3-vmware0.yaml
@@ -18,7 +18,7 @@ spec:
       fetch:
         - imgpkgBundle:
             # replace image registry and repo with one you are using
-            image: projects.registry.vmware.com/tce/gatekeeper-extension-templates:dev
+            image: projects.registry.vmware.com/tce/gatekeeper-extension-templates@sha256:2865b316b738edaf9bc9c72deaa250298b5a7a4e38990a86f024414ba448821c
       template:
         - ytt:
             paths:

--- a/addons/repos/main/packages/grafana-7.4.3_vmware0.yaml
+++ b/addons/repos/main/packages/grafana-7.4.3_vmware0.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/grafana-extension-templates:dev
+            image: projects.registry.vmware.com/tce/grafana-extension-templates@sha256:bd7722c1cd4ab7443dd5d79384987a811b1e4827e713dda4b3e6752ad6c408ad
       template:
         - ytt:
             ignoreUnknownComments: true

--- a/addons/repos/main/packages/knative-0.21.0_vmware0.yaml
+++ b/addons/repos/main/packages/knative-0.21.0_vmware0.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/knative-serving-extension-templates:dev
+            image: projects.registry.vmware.com/tce/knative-serving-extension-templates@sha256:ffe26733500e7e722bbfa2cce0a3fd3010d43c5f8bffa98763729eefb53bbd44
       template:
         - ytt:
             ignoreUnknownComments: true

--- a/addons/repos/main/packages/prometheus-2.25.0_vmware0.yaml
+++ b/addons/repos/main/packages/prometheus-2.25.0_vmware0.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/prometheus-extension-templates:dev
+            image: projects.registry.vmware.com/tce/prometheus-extension-templates@sha256:1e6bee9cf8f1c838e928fc0280b8d8921d1b4f7253f9571842e5681b8b2cfb1b
       template:
         - ytt:
             ignoreUnknownComments: true

--- a/addons/repos/main/packages/velero-1.5.2_vmware0.yaml
+++ b/addons/repos/main/packages/velero-1.5.2_vmware0.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/velero-extension-templates:dev
+            image: projects.registry.vmware.com/tce/velero-extension-templates@sha256:41b18bf81628b2b4195f208d3780b7dccbc10d0fc74738183b1495324ea59177
       template:
         - ytt:
             ignoreUnknownComments: true


### PR DESCRIPTION
Signed-off-by: Nicholas Seemiller <nseemiller@vmware.com>

**What this PR does / why we need it**:
Use SHAs in the repo packages instead of the `dev` tag

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #393 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change. 
-->

**Special notes for your reviewer**:
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
