### PR TITLE
Support for signing binaries in cayman

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build/tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
-          asset_name: tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_name: tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload Darwin AMD64 Asset
@@ -74,7 +74,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build/tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
-          asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
 
       - id: upload-artifacts-staging

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build/tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
-          asset_name: tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_name: tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload Darwin AMD64 Asset
@@ -75,7 +75,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build/tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
-          asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
 
       - id: upload-artifacts-staging

--- a/hack/asset/asset.go
+++ b/hack/asset/asset.go
@@ -1,0 +1,149 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+func getClientWithEnvToken() (*github.Client, error) {
+	var token string
+	if v := os.Getenv("GH_ACCESS_TOKEN"); v != "" {
+		token = v
+	}
+
+	if token == "" {
+		return nil, fmt.Errorf("token is empty")
+	}
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	client := github.NewClient(tc)
+	return client, nil
+}
+
+func getDraftRelease(tag string) (*github.RepositoryRelease, error) {
+	client, err := getClientWithEnvToken()
+	if err != nil {
+		fmt.Printf("getClientWithEnvToken returned error: %v\n", err)
+		return nil, err
+	}
+
+	opt := &github.ListOptions{}
+	releasesGH, _, err := client.Repositories.ListReleases(context.Background(), "vmware-tanzu", "tce", opt)
+	if err != nil {
+		fmt.Printf("Repositories.ListReleases returned error: %v\n", err)
+		return nil, err
+	}
+
+	for _, release := range releasesGH {
+		fmt.Printf("Check: %s\n", *release.TagName)
+
+		if !strings.EqualFold(tag, *release.TagName) {
+			continue
+		}
+
+		if release.PublishedAt == nil {
+			fmt.Printf("Draft Release Found: %s\n", *release.TagName)
+			return release, nil
+		}
+
+		fmt.Printf("Release already published: %s\n", *release.TagName)
+		return nil, fmt.Errorf("release already published")
+	}
+
+	return nil, fmt.Errorf("unable to find a draft release")
+}
+
+func uploadToDraftRelease(release *github.RepositoryRelease, fullPathFilename string) error {
+	filename := filepath.Base(fullPathFilename)
+	fileAsset, err := os.OpenFile(fullPathFilename, os.O_RDONLY, 0755)
+	if err != nil {
+		fmt.Printf("OpenFile returned error: %v\n", err)
+		return err
+	}
+
+	client, err := getClientWithEnvToken()
+	if err != nil {
+		fmt.Printf("getClientWithEnvToken returned error: %v\n", err)
+		return err
+	}
+
+	opt := &github.UploadOptions{
+		Name: filename,
+	}
+	_, _, err = client.Repositories.UploadReleaseAsset(context.Background(), "vmware-tanzu", "tce", *release.ID, opt, fileAsset)
+	if err != nil {
+		fmt.Printf("Repositories.UploadReleaseAsset returned error: %v\n", err)
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	var tag string
+	flag.StringVar(&tag, "tag", "", "The release tag to add")
+
+	flag.Parse()
+
+	if tag == "" {
+		fmt.Printf("A tag must be provided\n")
+		return
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Printf("Getwd failed: %v\n", err)
+		return
+	}
+
+	draftRelease, err := getDraftRelease(tag)
+	if err != nil {
+		fmt.Printf("getDraftRelease failed: %v\n", err)
+		return
+	}
+
+	darwinAssetFilename := fmt.Sprintf("tce-darwin-amd64-%s.tar.gz", tag)
+	darwinAsset := filepath.Join(cwd, "build", darwinAssetFilename)
+	err = uploadToDraftRelease(draftRelease, darwinAsset)
+	if err != nil {
+		fmt.Printf("uploadToDraftRelease(darwin) failed: %v\n", err)
+		return
+	}
+
+	linuxAssetFilename := fmt.Sprintf("tce-linux-amd64-%s.tar.gz", tag)
+	linuxAsset := filepath.Join(cwd, "build", linuxAssetFilename)
+	err = uploadToDraftRelease(draftRelease, linuxAsset)
+	if err != nil {
+		fmt.Printf("uploadToDraftRelease(linux) failed: %v\n", err)
+		return
+	}
+
+	/*
+		TODO: this is for windows
+
+		windowsAssetFilename := fmt.Sprintf("tce-windows-amd64-%s.tar.gz", tag)
+		windowsAsset := filepath.Join(cwd, "build", windowsAssetFilename)
+		err = uploadToDraftRelease(draftRelease, windowsAsset)
+		if err != nil {
+			fmt.Printf("uploadToDraftRelease(windows) failed: %v\n", err)
+			return
+		}
+	*/
+
+	fmt.Printf("Succeeded\n")
+}

--- a/hack/build-tanzu.sh
+++ b/hack/build-tanzu.sh
@@ -29,6 +29,10 @@ TKG_PROVIDERS_REPO_BRANCH=${TKG_PROVIDERS_REPO_BRANCH:-$BUILD_VERSION}
 if [[ "${TKG_PROVIDERS_REPO_BRANCH}" != "${BUILD_VERSION}" ]]; then
     echo "**************** WARNING - TKG_PROVIDERS_REPO_BRANCH = ${TKG_PROVIDERS_REPO_BRANCH} ****************"
 fi
+TKG_CLI_REPO_BRANCH=${TKG_CLI_REPO_BRANCH:-$BUILD_VERSION}
+if [[ "${TKG_CLI_REPO_BRANCH}" != "${BUILD_VERSION}" ]]; then
+    echo "**************** WARNING - TKG_CLI_REPO_BRANCH = ${TKG_CLI_REPO_BRANCH} ****************"
+fi
 TANZU_CORE_REPO_BRANCH=${TANZU_CORE_REPO_BRANCH:-$BUILD_VERSION}
 if [[ "${TANZU_CORE_REPO_BRANCH}" != "${BUILD_VERSION}" ]]; then
     echo "**************** WARNING - TANZU_CORE_REPO_BRANCH = ${TANZU_CORE_REPO_BRANCH} ****************"
@@ -40,20 +44,28 @@ fi
 
 rm -rf "${ROOT_REPO_DIR}/tkg-providers"
 set +x
-git clone --depth 1 --branch "${TKG_PROVIDERS_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/tkg-providers.git"
+git clone --depth 1 --branch "${TKG_PROVIDERS_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/tkg-providers.git" "tkg-providers"
 set -x
 pushd "${ROOT_REPO_DIR}/tkg-providers" || exit 1
+git reset --hard
+popd || exit 1
+
+rm -rf "${ROOT_REPO_DIR}/tkg-cli"
+set +x
+git clone --depth 1 --branch "${TKG_CLI_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/tkg-cli.git" "tkg-cli"
+set -x
+pushd "${ROOT_REPO_DIR}/tkg-cli" || exit 1
 git reset --hard
 popd || exit 1
 
 rm -rf "${ROOT_REPO_DIR}/core"
 mv -f "${HOME}/.tanzu" "${HOME}/.tanzu-$(date +"%Y-%m-%d_%H:%M")"
 set +x
-git clone --depth 1 --branch "${TANZU_CORE_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/core.git"
+git clone --depth 1 --branch "${TANZU_CORE_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/core.git" "core"
 set -x
 pushd "${ROOT_REPO_DIR}/core" || exit 1
 git reset --hard
-# go mod edit --replace github.com/vmware-tanzu-private/tkg-cli=../tkg-cli
+go mod edit --replace github.com/vmware-tanzu-private/tkg-cli=../tkg-cli
 go mod edit --replace github.com/vmware-tanzu-private/tkg-providers=../tkg-providers
 sed "$SEDARGS" "s/ --dirty//g" ./Makefile
 sed "$SEDARGS" "s/\$(shell git describe --tags --abbrev=0 2>\$(NUL))/${TANZU_CORE_REPO_BRANCH}/g" ./Makefile
@@ -62,15 +74,16 @@ popd || exit 1
 
 rm -rf "${ROOT_REPO_DIR}/tanzu-cli-tkg-plugins"
 set +x
-git clone --depth 1 --branch "${TANZU_TKG_CLI_PLUGINS_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/tanzu-cli-tkg-plugins.git"
+git clone --depth 1 --branch "${TANZU_TKG_CLI_PLUGINS_REPO_BRANCH}" "https://git:${GH_ACCESS_TOKEN}@github.com/vmware-tanzu-private/tanzu-cli-tkg-plugins.git" "tanzu-cli-tkg-plugins"
 set -x
 pushd "${ROOT_REPO_DIR}/tanzu-cli-tkg-plugins" || exit 1
 git reset --hard
-# go mod edit --replace github.com/vmware-tanzu-private/tkg-cli=../tkg-cli
+go mod edit --replace github.com/vmware-tanzu-private/tkg-cli=../tkg-cli
 go mod edit --replace github.com/vmware-tanzu-private/tkg-providers=../tkg-providers
 go mod edit --replace github.com/vmware-tanzu-private/core=../core
 sed "$SEDARGS" "s/ --dirty//g" ./Makefile
 sed "$SEDARGS" "s/\$(shell git describe --tags --abbrev=0 2>\$(NUL))/${TANZU_TKG_CLI_PLUGINS_REPO_BRANCH}/g" ./Makefile
+sed "$SEDARGS" "s/tanzu builder cli compile --version \$(BUILD_VERSION) --ldflags \"\$(LD_FLAGS)\" --path .\/cmd\/plugin/\$(GO) run github.com\/vmware-tanzu-private\/core\/cmd\/cli\/plugin-admin\/builder cli compile --version \$(BUILD_VERSION) --ldflags \"\$(LD_FLAGS)\" --path .\/cmd\/plugin --artifacts \$(ARTIFACTS_DIR)/g" ./Makefile
 sed "$SEDARGS" "s/tanzu plugin install all --local \$(ARTIFACTS_DIR)/TANZU_CLI_NO_INIT=true \$(GO) run -ldflags \"\$(LD_FLAGS)\" github.com\/vmware-tanzu-private\/core\/cmd\/cli\/tanzu plugin install all --local \$(ARTIFACTS_DIR)/g" ./Makefile
 make build
 make install-cli-plugins

--- a/hack/fix-for-ci-build.sh
+++ b/hack/fix-for-ci-build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# Handle differences in MacOS sed
+SEDARGS="-i"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    SEDARGS="-i '' -e"
+fi
+
+# override https
+git config --global url."https://git:${GH_ACCESS_TOKEN}@github.com".insteadOf "https://github.com"
+
+# skip the token because we are using gitlab mirrors
+sed "$SEDARGS" "s/https:\/\/git:\${GH_ACCESS_TOKEN}@github.com\/vmware-tanzu-private\/tkg-providers.git/git@gitlab.eng.vmware.com:TKG\/tkg-cli-providers/g" ./hack/build-tanzu.sh
+sed "$SEDARGS" "s/https:\/\/git:\${GH_ACCESS_TOKEN}@github.com\/vmware-tanzu-private\/tkg-cli.git/git@gitlab.eng.vmware.com:core-build\/mirrors_github_vmware-tanzu-private_tkg-cli.git/g" ./hack/build-tanzu.sh
+sed "$SEDARGS" "s/https:\/\/git:\${GH_ACCESS_TOKEN}@github.com\/vmware-tanzu-private\/core.git/git@gitlab.eng.vmware.com:core-build\/mirrors_github_vmware-tanzu-private_core.git/g" ./hack/build-tanzu.sh
+sed "$SEDARGS" "s/https:\/\/git:\${GH_ACCESS_TOKEN}@github.com\/vmware-tanzu-private\/tanzu-cli-tkg-plugins.git/git@gitlab.eng.vmware.com:core-build\/mirrors_github_vmware-tanzu-private_tanzu-cli-tkg-plugins.git/g" ./hack/build-tanzu.sh
+
+# docker container has no user account
+sed "$SEDARGS" "s/\"\$(id -g -n \"\$USER\")\"/\$(id -g)/g" ./hack/package-release.sh
+sed "$SEDARGS" "s/\"\$USER\"/\$(id -u)/g" ./hack/package-release.sh
+
+# TCE overrides for gitlab
+go mod edit --replace github.com/vmware-tanzu-private/tkg-providers=/tmp/tce-release/tkg-providers
+go mod edit --replace github.com/vmware-tanzu-private/tkg-cli=/tmp/tce-release/tkg-cli
+go mod edit --replace github.com/vmware-tanzu-private/core=/tmp/tce-release/core

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -30,12 +30,6 @@ mv -f "${HOME}/.tanzu" "${HOME}/.tanzu-$(date +"%Y-%m-%d_%H:%M")"
 rm -rf "${XDG_DATA_HOME}/tanzu-cli"
 mkdir -p "${XDG_DATA_HOME}/tanzu-cli"
 
-if [[ "$BUILD_OS" == "Darwin" ]] ;  then
-  for bin in bin/tanzu*; do
-    xattr -d com.apple.quarantine "${bin}"
-  done
-fi
-
 # check if the tanzu CLI already exists and remove it to avoid conflicts
 TANZU_BIN_PATH=$(command -v tanzu)
 if [[ -n "${TANZU_BIN_PATH}" ]]; then


### PR DESCRIPTION
Changes:
- change the assets created by github actions to "-unsigned". On the publish of the release, these assets can be deleted.
- put in some plumbing so that we can build using the golang container
- asset.go used to upload the signed asset to the draft release
- add in `tkg-cli` repo because tanzu cli repo depends on it. needed for building in cayman
- remove the unsigned workaround
