### PR TITLE
Remove expection to load config file

### DIFF
--- a/cli/pkg/addon/addon.go
+++ b/cli/pkg/addon/addon.go
@@ -7,11 +7,9 @@ import (
 	"flag"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"strconv"
 	"time"
 
-	"github.com/adrg/xdg"
 	"k8s.io/klog/v2"
 
 	"github.com/vmware-tanzu/tce/cli/pkg/common/kapp"
@@ -55,17 +53,9 @@ func NewManager() (*Manager, error) {
 	_ = flag.Set("v", level)
 	flag.Parse()
 
-	// read config
-	configFile := filepath.Join(xdg.DataHome, "tanzu-repository", DefaultConfigFile)
-	byFile, err := os.ReadFile(configFile)
-	if err != nil {
-		klog.Errorf("ReadFile failed. Err: %v", err)
-		return nil, err
-	}
-
 	mngr := &Manager{}
 
-	kap, err := kapp.NewKapp(byFile)
+	kap, err := kapp.NewKapp()
 	if err != nil {
 		klog.Errorf("NewYtt failed. Err: %v", err)
 		return nil, err

--- a/cli/pkg/common/kapp/config.go
+++ b/cli/pkg/common/kapp/config.go
@@ -7,16 +7,13 @@ import (
 	"os"
 	"path/filepath"
 
-	yaml "github.com/ghodss/yaml"
 	"k8s.io/client-go/util/homedir"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 )
 
 // NewConfig generates a Config object
 func NewConfig() *Config {
 	cfg := &Config{
-		ExtensionNamespace:             DefaultAppCrdNamespace,
-		WorkingDirectory:               DefaultWorkingDirectory,
 		ExtensionServiceAccountPostfix: DefaultServiceAccountPostfix,
 		ExtensionRoleBindingPostfix:    DefaultRoleBindingPostfix,
 	}
@@ -29,12 +26,6 @@ func NewConfig() *Config {
 // for a property that's already initialized, the environment variable's value
 // takes precedence.
 func (cfg *Config) FromEnv() error {
-	if v := os.Getenv("TCE_EXTENSION_WORKING"); v != "" {
-		cfg.WorkingDirectory = v
-	}
-	if v := os.Getenv("TCE_EXTENSION_NAMESPACE"); v != "" {
-		cfg.ExtensionNamespace = v
-	}
 	if v := os.Getenv("TCE_EXTENSION_SERVICEACCOUNT_POSTFIX"); v != "" {
 		cfg.ExtensionServiceAccountPostfix = v
 	}
@@ -58,8 +49,6 @@ func (cfg *Config) FromEnv() error {
 	}
 
 	klog.V(4).Infof("Kubeconfig = %s", cfg.Kubeconfig)
-	klog.V(4).Infof("WorkingDirectory = %s", cfg.WorkingDirectory)
-	klog.V(4).Infof("ExtensionNamespace = %s", cfg.ExtensionNamespace)
 	klog.V(4).Infof("ExtensionServiceAccountPostfix = %s", cfg.ExtensionServiceAccountPostfix)
 	klog.V(4).Infof("ExtensionRoleBindingPostfix = %s", cfg.ExtensionRoleBindingPostfix)
 
@@ -67,18 +56,8 @@ func (cfg *Config) FromEnv() error {
 }
 
 // InitKappConfig inits the Config and also checks Environment variables
-func InitKappConfig(byConfig []byte) (*Config, error) {
-	klog.V(4).Infof("Config Data:")
-	klog.V(4).Infof("%s", string(byConfig))
-
+func InitKappConfig() (*Config, error) {
 	cfg := NewConfig()
-
-	// pull the version from the config.yaml
-	err := yaml.Unmarshal(byConfig, &cfg)
-	if err != nil {
-		klog.Errorf("Unmarshal failed. Err: ", err)
-		return nil, err
-	}
 
 	// Env Vars should override config file entries if present
 	if err := cfg.FromEnv(); err != nil {

--- a/cli/pkg/common/kapp/kapp.go
+++ b/cli/pkg/common/kapp/kapp.go
@@ -6,12 +6,9 @@ package kapp
 import (
 	"context"
 	"fmt"
-	"path/filepath"
-
-	"github.com/adrg/xdg"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -40,16 +37,15 @@ func init() {
 }
 
 // NewKapp generates a Kapp object
-func NewKapp(byConfig []byte) (*Kapp, error) {
-	cfg, err := InitKappConfig(byConfig)
+func NewKapp() (*Kapp, error) {
+	cfg, err := InitKappConfig()
 	if err != nil {
 		klog.Errorf("InitKappConfig failed. Err: %v", err)
 		return nil, err
 	}
 
 	kapp := &Kapp{
-		config:                cfg,
-		localWorkingDirectory: filepath.Join(xdg.DataHome, "tanzu-repository", cfg.WorkingDirectory),
+		config: cfg,
 	}
 
 	klog.V(4).Infof("localWorkingDirectory = %s", kapp.localWorkingDirectory)

--- a/cli/pkg/common/kapp/types.go
+++ b/cli/pkg/common/kapp/types.go
@@ -14,10 +14,6 @@ type Config struct {
 	// Kubeconfig is the users kubeconfig
 	Kubeconfig string
 
-	// WorkingDirectory is the users working directory
-	WorkingDirectory string
-	// ExtensionNamespace is the extension namespace to install into
-	ExtensionNamespace string
 	// ExtensionServiceAccountPostfix is the extension postfix for service account
 	ExtensionServiceAccountPostfix string
 	// ExtensionRoleBindingPostfix is the extension postfix for role binding

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	cloud.google.com/go/storage v1.12.0 // indirect
-	github.com/adrg/xdg v0.3.0
+	github.com/adrg/xdg v0.3.0 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/joshrosso/image/v5 v5.10.2-0.20210331180716-71545f2b27af


### PR DESCRIPTION
This commit removes the old-expected config file that would hold
information about extensions.

Without this change, assuming the config file is not there (it should no longer be there) calls to the `package` plugin will fail.