### PR TITLE
Optimize binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ endif
 CORE_BUILD_VERSION=$$(cat "./hack/CORE_BUILD_VERSION")
 NEW_BUILD_VERSION=$$(cat "./hack/NEW_BUILD_VERSION" 2>/dev/null)
 
-LD_FLAGS = -X "github.com/vmware-tanzu-private/core/pkg/v1/cli.BuildDate=$(BUILD_DATE)"
+LD_FLAGS = -s -w
+LD_FLAGS += -X "github.com/vmware-tanzu-private/core/pkg/v1/cli.BuildDate=$(BUILD_DATE)"
 LD_FLAGS += -X "github.com/vmware-tanzu-private/core/pkg/v1/cli.BuildSHA=$(BUILD_SHA)"
 LD_FLAGS += -X "github.com/vmware-tanzu-private/core/pkg/v1/cli.BuildVersion=$(BUILD_VERSION)"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

This adds the -s and -w flags to strip binaries by default. This matches
what has been done in the core repo. Flags can be dropped locally if
someone has a need to attach a debugger to a running process.
