### PR TITLE
Add standalone-cluster to release package

### DIFF
--- a/hack/package-release.sh
+++ b/hack/package-release.sh
@@ -65,6 +65,7 @@ cp -f "${ROOT_TKG_PLUGINS_ARTIFACTS_DIR}/management-cluster/${CORE_BUILD_VERSION
 
 # TCE bits
 cp -f "${ROOT_EXTENSION_ARTIFACTS_DIR}/package/${EXTENSION_BUILD_VERSION}/tanzu-package-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu-plugin-package"
+cp -f "${ROOT_EXTENSION_ARTIFACTS_DIR}/standalone-cluster/${EXTENSION_BUILD_VERSION}/tanzu-standalone-cluster-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu-plugin-standalone-cluster"
 
 
 # copy tanzu cli bits Darwin AMD64
@@ -84,6 +85,7 @@ cp -f "${ROOT_TKG_PLUGINS_ARTIFACTS_DIR}/management-cluster/${CORE_BUILD_VERSION
 
 # TCE bits
 cp -f "${ROOT_EXTENSION_ARTIFACTS_DIR}/package/${EXTENSION_BUILD_VERSION}/tanzu-package-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-package"
+cp -f "${ROOT_EXTENSION_ARTIFACTS_DIR}/standalone-cluster/${EXTENSION_BUILD_VERSION}/tanzu-standalone-cluster-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-standalone-cluster"
 
 # change settings
 chmod +x "${ROOT_REPO_DIR}/hack/install.sh"


### PR DESCRIPTION
**What this PR does / why we need it**:
When the install package is created, this will add in the standalone-cluster plugin.

**Which issue(s) this PR fixes**:
NA

**Describe testing done for PR**:
Installed fine for me

**Special notes for your reviewer**:
This will require manually bypassing the signing restriction with:
```
xattr -d com.apple.quarantine "/Users/<USER>/Library/Application Support/tanzu-cli/tanzu-plugin-standalone-cluster"
```
Until we have a release. This is new functionality, so that would totally be expected.

**Does this PR introduce a user-facing change?**:
NA
