### PR TITLE
Add mutate function for controllerutil.CreateOrUpdate

### DIFF
--- a/cli/pkg/common/kapp/kapp.go
+++ b/cli/pkg/common/kapp/kapp.go
@@ -231,7 +231,7 @@ func (k *Kapp) installServiceAccount(kClient client.Client, input *AppCrdInput) 
 	klog.V(6).Infof("serviceAccount.Name = %s", serviceAccount.ObjectMeta.Name)
 	klog.V(6).Infof("sa.Namespace = %s", serviceAccount.ObjectMeta.Namespace)
 
-	_, err := controllerutil.CreateOrUpdate(context.TODO(), kClient, serviceAccount, nil)
+	_, err := controllerutil.CreateOrUpdate(context.TODO(), kClient, serviceAccount, mutate)
 	if err != nil {
 		klog.Errorf("Error creating or patching addon service account. Err: %v", err)
 		return err
@@ -265,7 +265,7 @@ func (k *Kapp) installRoleBinding(kClient client.Client, input *AppCrdInput) err
 	klog.V(6).Infof("roleBinding.Subjects.Name = %s", roleBinding.Subjects[0].Name)
 	klog.V(6).Infof("roleBinding.Subjects.Namespace = %s", roleBinding.Subjects[0].Namespace)
 
-	_, err := controllerutil.CreateOrUpdate(context.TODO(), kClient, roleBinding, nil)
+	_, err := controllerutil.CreateOrUpdate(context.TODO(), kClient, roleBinding, mutate)
 	if err != nil {
 		klog.Errorf("Error creating or patching addon role binding. Err: %v", err)
 		return err
@@ -348,7 +348,7 @@ func (k *Kapp) installInstalledPackage(kClient client.Client, input *AppCrdInput
 	}
 
 	klog.V(6).Infof("Deploying installed package: %s", ip)
-	_, err := controllerutil.CreateOrUpdate(context.TODO(), kClient, ip, nil)
+	_, err := controllerutil.CreateOrUpdate(context.TODO(), kClient, ip, mutate)
 	if err != nil {
 		return err
 	}
@@ -486,7 +486,7 @@ func (k *Kapp) installConfigSecret(kClient client.Client, input *AppCrdInput) (*
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(context.TODO(), kClient, config, nil)
+	_, err := controllerutil.CreateOrUpdate(context.TODO(), kClient, config, mutate)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/pkg/common/kapp/repository.go
+++ b/cli/pkg/common/kapp/repository.go
@@ -89,7 +89,7 @@ func (k *Kapp) InstallRepository(name, url string) error {
 		},
 	}
 
-	_, err = controllerutil.CreateOrUpdate(context.TODO(), client, repo, nil)
+	_, err = controllerutil.CreateOrUpdate(context.TODO(), client, repo, mutate)
 	if err != nil {
 		klog.Errorf("Create failed. Err: %v", err)
 		return err
@@ -116,7 +116,7 @@ func (k *Kapp) InstallRepositoryFromFile(filename string) error {
 		return err
 	}
 
-	_, err = controllerutil.CreateOrUpdate(context.TODO(), client, repo, nil)
+	_, err = controllerutil.CreateOrUpdate(context.TODO(), client, repo, mutate)
 	if err != nil {
 		klog.Errorf("Create failed. Err: %v", err)
 		return err

--- a/cli/pkg/common/kapp/types.go
+++ b/cli/pkg/common/kapp/types.go
@@ -52,3 +52,13 @@ type Kapp struct {
 	// localWorkingDirectory is where all modification based on user overrides is defined
 	localWorkingDirectory string
 }
+
+// mutate is used to pass in to controllerutil calls to mutate an object into
+// its desired state. For now it is just a noop since we don't need to do
+// anything, but some calls expect a function to be passed in and will panic if
+// nil. If we don't find a need for mutating, this can be cleaned up once
+// https://github.com/kubernetes-sigs/controller-runtime/issues/1476 is
+// resolved.
+func mutate() error {
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

These calls require a MutateFn to be passed in. This is normally used to
mutate the API object, but we do not have a need to do that right now.

In case we do have a need in the future, and to have something to make
the controllerutil calls happy, this defines a noop function that can be
used for these instances.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #442

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change. 
-->

Ran failing command locally with development build and verified it succeeded.

**Special notes for your reviewer**:
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
