### PR TITLE
Changed package namespace to tce.vmware.com

### DIFF
--- a/addons/packages/cert-manager/installedpackage.yaml
+++ b/addons/packages/cert-manager/installedpackage.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   serviceAccountName: cert-manager-extension-sa
   packageRef:
-    publicName: cert-manager
+    publicName: cert-manager.tce.vmware.com
     versionSelection:
       constraints: "1.1.0-vmware0"
       prereleases: {}

--- a/addons/packages/contour-operator/installedpackage.yaml
+++ b/addons/packages/contour-operator/installedpackage.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   serviceAccountName: contour-extension-sa
   packageRef:
-    publicName: contour-operator
+    publicName: contour-operator.tce.vmware.com
     versionSelection:
       constraints: "1.11.0-vmware0"
       prereleases: {}

--- a/addons/packages/fluentbit/installedpackage.yaml
+++ b/addons/packages/fluentbit/installedpackage.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   serviceAccountName: fluent-bit-extension-sa
   packageRef:
-    publicName: fluent-bit
+    publicName: fluent-bit.tce.vmware.com
     versionSelection:
       constraints: "1.7.2-vmware0"
       prereleases: {}

--- a/addons/packages/gatekeeper/installedpackage.yaml
+++ b/addons/packages/gatekeeper/installedpackage.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   serviceAccountName: gatekeeper-extension-sa
   packageRef:
-    publicName: gatekeeper
+    publicName: gatekeeper.tce.vmware.com
     versionSelection:
       constraints: "3.2.3-vmware0"
       prereleases: {}

--- a/addons/packages/grafana/installedpackage.yaml
+++ b/addons/packages/grafana/installedpackage.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   serviceAccountName: grafana-addon-sa
   packageRef:
-    publicName: grafana
+    publicName: grafana.tce.vmware.com
     versionSelection:
       constraints: "7.4.3-vmware0"
       prereleases: {}

--- a/addons/packages/knative-serving/installedpackage.yaml
+++ b/addons/packages/knative-serving/installedpackage.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   serviceAccountName: knative-serving-extension-sa
   packageRef:
-    publicName: knative-serving
+    publicName: knative-serving.tce.vmware.com
     versionSelection:
       constraints: "0.21.0-vmware0"
       prereleases: {}

--- a/addons/packages/prometheus/installedpackage.yaml
+++ b/addons/packages/prometheus/installedpackage.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   serviceAccountName: prometheus-extension-sa
   packageRef:
-    publicName: prometheus
+    publicName: prometheus.tce.vmware.com
     versionSelection:
       constraints: "2.25.0-vmware0"
       prereleases: {}

--- a/addons/packages/velero/installedpackage.yaml
+++ b/addons/packages/velero/installedpackage.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   serviceAccountName: velero-extension-sa
   packageRef:
-    publicName: velero
+    publicName: velero.tce.vmware.com
     versionSelection:
       constraints: "1.5.2-vmware0"
       prereleases: {}

--- a/addons/repos/main/packages/cert-manager-1.1.0_vmware0.yaml
+++ b/addons/repos/main/packages/cert-manager-1.1.0_vmware0.yaml
@@ -1,9 +1,9 @@
 apiVersion: package.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: cert-manager.1.1.0-vmware0
+  name: cert-manager.tce.vmware.com.1.1.0-vmware0
 spec:
-  publicName: cert-manager
+  publicName: cert-manager.tce.vmware.com
   version: 1.1.0-vmware0
   template:
     spec:

--- a/addons/repos/main/packages/contour-operator.1.11.0_vmware.0.yaml
+++ b/addons/repos/main/packages/contour-operator.1.11.0_vmware.0.yaml
@@ -1,9 +1,9 @@
 apiVersion: package.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: contour-operator.1.11.0-vmware0
+  name: contour-operator.tce.vmware.com.1.11.0-vmware0
 spec:
-  publicName: contour-operator
+  publicName: contour-operator.tce.vmware.com
   version: 1.11.0-vmware0
   template:
     spec:

--- a/addons/repos/main/packages/fluent-bit-1.7.2_vmware0.yaml
+++ b/addons/repos/main/packages/fluent-bit-1.7.2_vmware0.yaml
@@ -3,13 +3,13 @@ kind: Package
 metadata:
   # Kubernetes name is not used for anything specific but is still required.
   # Use ${spec.publicName}.#{spec.version} as a convetion
-  name: fluent-bit.1.7.2-vmware0
+  name: fluent-bit.tce.vmware.com.1.7.2-vmware0
 spec:
   # publicName will be used by consumers of this package.
   # publicName should be unique across all packages, hence we
   # recommend to use fully qualified name similar to what
   # would be used as a name for a CRD.
-  publicName: fluent-bit
+  publicName: fluent-bit.tce.vmware.com
   # version will be used by consumers of this package.
   # must be a valid semantic version string.
   version: "1.7.2-vmware0"

--- a/addons/repos/main/packages/gatekeeper.3.2.3-vmware0.yaml
+++ b/addons/repos/main/packages/gatekeeper.3.2.3-vmware0.yaml
@@ -3,13 +3,13 @@ kind: Package
 metadata:
   # Kubernetes name is not used for anything specific but is still required.
   # Use ${spec.publicName}.#{spec.version} as a convetion
-  name: gatekeeper.3.2.3-vmware0
+  name: gatekeeper.tce.vmware.com.3.2.3-vmware0
 spec:
   # publicName will be used by consumers of this package.
   # publicName should be unique across all packages, hence we
   # recommend to use fully qualified name similar to what
   # would be used as a name for a CRD.
-  publicName: gatekeeper
+  publicName: gatekeeper.tce.vmware.com
   # version will be used by consumers of this package.
   # must be a valid semantic version string.
   version: "3.2.3-vmware0"

--- a/addons/repos/main/packages/grafana-7.4.3_vmware0.yaml
+++ b/addons/repos/main/packages/grafana-7.4.3_vmware0.yaml
@@ -1,9 +1,9 @@
 apiVersion: package.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: grafana.7.4.3-vmware0
+  name: grafana.tce.vmware.com.7.4.3-vmware0
 spec:
-  publicName: grafana
+  publicName: grafana.tce.vmware.com
   version: 7.4.3-vmware0
   template:
     spec:

--- a/addons/repos/main/packages/knative-0.21.0_vmware0.yaml
+++ b/addons/repos/main/packages/knative-0.21.0_vmware0.yaml
@@ -1,9 +1,9 @@
 apiVersion: package.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: knative-serving.0.21.0-vmware0
+  name: knative-serving.tce.vmware.com.0.21.0-vmware0
 spec:
-  publicName: knative-serving
+  publicName: knative-serving.tce.vmware.com
   version: 0.21.0-vmware0
   template:
     spec:

--- a/addons/repos/main/packages/prometheus-2.25.0_vmware0.yaml
+++ b/addons/repos/main/packages/prometheus-2.25.0_vmware0.yaml
@@ -1,9 +1,9 @@
 apiVersion: package.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: prometheus.2.25.0-vmware0
+  name: prometheus.tce.vmware.com.2.25.0-vmware0
 spec:
-  publicName: prometheus
+  publicName: prometheus.tce.vmware.com
   version: 2.25.0-vmware0
   template:
     spec:

--- a/addons/repos/main/packages/velero-1.5.2_vmware0.yaml
+++ b/addons/repos/main/packages/velero-1.5.2_vmware0.yaml
@@ -1,9 +1,9 @@
 apiVersion: package.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: velero.1.5.2-vmware0
+  name: velero.tce.vmware.com.1.5.2-vmware0
 spec:
-  publicName: velero
+  publicName: velero.tce.vmware.com
   version: 1.5.2-vmware0
   template:
     spec:

--- a/docs/designs/tanzu-addon-management.md
+++ b/docs/designs/tanzu-addon-management.md
@@ -78,10 +78,10 @@ possible.
 ```sh
 tanzu package list
 
-NAME               VERSION    REPO
-knative-serving    1.12       tce-main
-contour            2.32       tce-main
-nvidia-driver      1.11       nvidia-main
+NAME                              VERSION    REPO
+knative-serving.tce.vmware.com    1.12       tce-main
+contour.tce.vmware.com            2.32       tce-main
+nvidia-driver.tce.vmware.com      1.11       nvidia-main
 ```
 
 In the above, the `tanzu` CLI is aggregating and listing metadata from
@@ -145,25 +145,25 @@ packages in a cluster.
 ```sh
 tanzu package list
 
-NAME               VERSION    REPO
-knative-serving    1.12       tce-main
-contour            2.32       tce-main
-nvidia-driver      1.11       nvidia-main
+NAME                              VERSION    REPO
+knative-serving.tce.vmware.com    0.21       tce-main
+contour.tce.vmware.com            2.32       tce-main
+nvidia-driver.tce.vmware.com      1.11       nvidia-main
 ```
 
-Should the user want to install the `knative-serving:1.12` package, they can run
-the following command.
+Should the user want to install the `knative-serving.tce.vmware.com:0.21.0-vmware0` package, 
+they can run the following command.
 
 ```sh
-tanzu package install knative-serving
+tanzu package install knative-serving.tce.vmware.com
 
-knative-serving 1.12 installed in cluster
-reference: kubectl get InstalledPackage knative-serving-1-12
+Looking up package to install: knative-serving.tce.vmware.com:
+Installed package in default/knative-serving.tce.vmware.com:0.21.0-vmware0
 ```
 
 In running this command, the `tanzu` client will have done the following.
 
-1. Read the contents of the `knative-serving:1.12` `Package`.
+1. Read the contents of the `knative-serving.tce.vmware.com:0.21.0-vmware0` `Package`.
 
     The following is an example of what the Package contents might be.
 
@@ -175,14 +175,14 @@ In running this command, the `tanzu` client will have done the following.
       # Should only be populated to comply with Kubernetes resource schema.
       # spec.publicName/spec.version fields are primary identifiers
       # used in references from InstalledPackage
-      name: knative.vmware.com.1.12
+      name: knative.tce.vmware.com.0.21.0-vmware0
       # Package is a cluster scoped resource, so no namespace
     spec:
       # Name of the package; Referenced by InstalledPackage (required)
-      publicName: knative.vmware.com
+      publicName: knative.tce.vmware.com
       # Package version; Referenced by InstalledPackage;
       # Must be valid semver (required)
-      version: 1.12
+      version: 0.21.0-vmware0
       # App template used to create the underlying App CR.
       # See 'App CR Spec' docs for more info
       template:
@@ -203,7 +203,7 @@ In running this command, the `tanzu` client will have done the following.
           - kapp: {}
     ```
 
-1. Created a `knative-serving-1-12` `InstalledPackage`.
+1. Created a `knative-serving-0-21` `InstalledPackage`.
 
     The following is an example of what the `InstalledPackage` contents might be.
 
@@ -211,31 +211,31 @@ In running this command, the `tanzu` client will have done the following.
     apiVersion: install.package.carvel.dev/v1alpha1
     kind: InstalledPackage
     metadata:
-      name: knative
+      name: knative-serving-0-21
       namespace: my-ns
     spec:
       # specifies service account that will be used to install underlying package contents
       serviceAccountName: knative-sa
       packageRef:
         # Public name of the package to install. (required)
-        publicName: knative
+        publicName: knative.tce.vmware.com
         # Specifies a specific version of a package to install (optional)
         # Either version or versionSelection is required.
-        version: 1.12
+        version: 0.21.0-vmware0
         # Selects version of a package based on constraints provided (optional)
         # Either version or versionSelection is required.
         versionSelection:
           # Constraint to limit acceptable versions of a package;
           # Latest version satisying the contraint is chosen;
           # Newly available, acceptable later versions are picked up and installed automatically. (optional)
-          constraint: ">v1.12"
+          constraint: ">0.20"
           # Include prereleases when selecting version. (optional)
           prereleases: {}
     # Populated by the controller
     status:
       packageRef:
         # Kubernetes resource name of the package chosen against the constraints
-        name: knative.tkg.vmware.com.v1.12
+        name: knative.tce.vmware.com.0.21.0-vmware0
       # Derived from the underlying App's Status
       conditions:
       - type: ValuesSchemaCheckFailed
@@ -259,10 +259,10 @@ install `--config`/`-c`. The above example could be run again with the
 following.
 
 ```sh
-tanzu package install knative-serving --config knative-serving-config.yaml
+tanzu package install knative-serving.tce.vmware.com --config knative-serving-config.yaml
 
-knative-serving 1.12 installed in cluster
-reference: kubectl get InstalledPackage knative-serving-1-12
+Looking up package to install: knative-serving.tce.vmware.com:
+Installed package in default/knative-serving.tce.vmware.com:0.21.0-vmware0
 ```
 
 The implication of including this configuration would do the following.

--- a/docs/designs/tanzu-addon-packaging.md
+++ b/docs/designs/tanzu-addon-packaging.md
@@ -565,12 +565,12 @@ Then you can validate the packages become available in the cluster.
 ```sh
 $ k get package
 
-NAME                              PUBLIC-NAME        VERSION          AGE
-cert-manager.1.11.0-vmware0       cert-manager       1.1.0-vmware0    39h
-contour-operator.1.11.0-vmware0   contour-operator   1.11.0-vmware0   39h
-gatekeeper.3.2.3-vmware0          gatekeeper         3.2.3-vmware0    39h
-knative-serving.0.21.0-vmware0    knative-serving    0.21.0-vmware0   39h
-velero.1.5.2-vmware0              velero             1.5.2-vmware0    39h
+NAME                                             PUBLIC-NAME                       VERSION          AGE
+cert-manager.tce.vmware.com.1.2.0-vmware0        cert-manager.tce.vmware.com       1.2.0-vmware0    39h
+contour-operator.tce.vmware.com.1.11.0-vmware0   contour-operator.tce.vmware.com   1.11.0-vmware0   39h
+gatekeeper.tce.vmware.com.3.2.3-vmware0          gatekeeper.tce.vmware.com         3.2.3-vmware0    39h
+knative-serving.tce.vmware.com.0.21.0-vmware0    knative-serving.tce.vmware.com    0.21.0-vmware0   39h
+velero.tce.vmware.com.1.5.2-vmware0              velero.tce.vmware.com             1.5.2-vmware0    39h
 ```
 
 Next, to run a package in the cluster an `InstalledPackage` must be introduced.
@@ -587,7 +587,7 @@ metadata:
 spec:
   serviceAccountName: contour-extension-sa
   packageRef:
-    publicName: contour-operator
+    publicName: contour-operator.tce.vmware.com
     versionSelection:
       constraints: "1.11.0-vmware0"
       prereleases: {}

--- a/docs/package-templates/installedpackage.yaml
+++ b/docs/package-templates/installedpackage.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   serviceAccountName: PACKAGE_NAME-extension-sa
   packageRef:
-    publicName: PACKAGE_NAME
+    publicName: PACKAGE_NAME.tce.vmware.com
     versionSelection:
       constraints: INFO_NEEDED
       prereleases: {}

--- a/docs/package-templates/package.yaml
+++ b/docs/package-templates/package.yaml
@@ -1,9 +1,9 @@
 apiVersion: package.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: PACKAGE_NAME.INFO_NEEDED
+  name: PACKAGE_NAME.tce.vmware.com.INFO_NEEDED
 spec:
-  publicName: PACKAGE_NAME
+  publicName: PACKAGE_NAME.tce.vmware.com
   version: INFO_NEEDED
   template:
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
It creates a namespace for the TCE packages.

**Which issue(s) this PR fixes**:
Fixes #372 

**Describe testing done for PR**:
- Created a TKG cluster. 
- Replaced the kapp-controller as instructed via the getting started guide
- NO need for a packagerepository, so not installed one.
- Deployed the repos/main/packages (with the new namespaces) 
- Installed each and every package (tanzu package install xyz.tce.vmware.com)
- Verified the installedpackages where properly reconciled
- Verified docs
- Verified template that makefile uses to create new package

**Does this PR introduce a user-facing change?**:
```release-note
Package names now include FQDN with suffix of `tce.vmware.com`
```
