### PR TITLE
Fix XDG_DATA_HOME on darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ SED := sed -i
 endif
 ifeq ($(XDG_DATA_HOME),)
 ifeq ($(build_OS), Darwin)
-XDG_DATA_HOME := "$${HOME}/Library/Application Support"
+XDG_DATA_HOME := "${HOME}/Library/Application Support"
 SED := sed -i '' -e
 endif
 endif


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

Extra `$` in defining the `XDG_DATA_HOME` variable results in the literal
string `${HOME}` being output when running `make build-all`.