### PR TITLE
Fix reading environment variable

### DIFF
--- a/hack/fix-for-ci-build.sh
+++ b/hack/fix-for-ci-build.sh
@@ -8,11 +8,13 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+SKIP_GITLAB_REDIRECT="${SKIP_GITLAB_REDIRECT:-false}"
+
 # override https
 git config --global url."https://git:${GH_ACCESS_TOKEN}@github.com".insteadOf "https://github.com"
 
 # skip the token because we are using gitlab mirrors
-if [[ -z ${SKIP_GITLAB_REDIRECT} ]]; then
+if [[ "${SKIP_GITLAB_REDIRECT}" != "true" ]]; then
 sed -i.bak -e "s/https:\/\/git:\${GH_ACCESS_TOKEN}@github.com\/vmware-tanzu-private\/tkg-providers.git/git@gitlab.eng.vmware.com:TKG\/tkg-cli-providers/g" ./hack/build-tanzu.sh && rm ./hack/build-tanzu.sh.bak
 sed -i.bak -e "s/https:\/\/git:\${GH_ACCESS_TOKEN}@github.com\/vmware-tanzu-private\/tkg-cli.git/git@gitlab.eng.vmware.com:core-build\/mirrors_github_vmware-tanzu-private_tkg-cli.git/g" ./hack/build-tanzu.sh && rm ./hack/build-tanzu.sh.bak
 sed -i.bak -e "s/https:\/\/git:\${GH_ACCESS_TOKEN}@github.com\/vmware-tanzu-private\/core.git/git@gitlab.eng.vmware.com:core-build\/mirrors_github_vmware-tanzu-private_core.git/g" ./hack/build-tanzu.sh && rm ./hack/build-tanzu.sh.bak
@@ -24,7 +26,7 @@ sed -i.bak -e "s/\"\$(id -g -n \"\$USER\")\"/\$(id -g)/g" ./hack/package-release
 sed -i.bak -e "s/\"\$USER\"/\$(id -u)/g" ./hack/package-release.sh && rm ./hack/package-release.sh.bak
 
 # TCE overrides for gitlab
-if [[ -z ${SKIP_GITLAB_REDIRECT} ]]; then
+if [[ "${SKIP_GITLAB_REDIRECT}" != "true" ]]; then
 go mod edit --replace github.com/vmware-tanzu-private/tkg-providers=/tmp/tce-release/tkg-providers
 go mod edit --replace github.com/vmware-tanzu-private/tkg-cli=/tmp/tce-release/tkg-cli
 go mod edit --replace github.com/vmware-tanzu-private/core=/tmp/tce-release/core


### PR DESCRIPTION
## What this PR does / why we need it
Addresses an issue in signing... produced this error in the signing step:
```
build      INFO         ./hack/fix-for-ci-build.sh: line 15: SKIP_GITLAB_REDIRECT: unbound variable
```

If we do a local docker build, we set `SKIP_GITLAB_REDIRECT` to `true`. If we are in an official build, we set `SKIP_GITLAB_REDIRECT` to `false` which is the default. This script should only be run within the `make release-docker` or in the signing process.

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
NA

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
NA