### PR TITLE
Skip hugo site files for mdlint checking

### DIFF
--- a/hack/check-mdlint.sh
+++ b/hack/check-mdlint.sh
@@ -23,4 +23,5 @@ set -o pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 docker run --rm -v "$(pwd)":/build \
-  gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.17.0 /md/lint -i vendor -i LICENSE.md .
+  gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.17.0 /md/lint \
+  -i docs/site -i LICENSE.md .


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

Various files under the hugo site do not pass our mdlint checks. Since
this site is still in flux with a lot more changes likely to come, this
just skips the entire subdirectory until we are ready to start enforcing
and cleaning up issues there. It does still check other files under the
docs directory.
