### PR TITLE
Get config dir from tanzu client

### DIFF
--- a/cli/pkg/standalone-cluster/create.go
+++ b/cli/pkg/standalone-cluster/create.go
@@ -4,11 +4,9 @@
 package standalone
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 
+	"github.com/vmware-tanzu-private/core/pkg/v1/client"
 	"github.com/vmware-tanzu-private/tkg-cli/pkg/tkgctl"
 	"github.com/vmware-tanzu-private/tkg-cli/pkg/types"
 
@@ -40,16 +38,16 @@ func init() {
 func create(cmd *cobra.Command, args []string) error {
 	cmd.Println(tkgctl.CreateClusterOptions{})
 
-	homedir, err := os.UserHomeDir()
+	configDir, err := client.LocalDir()
 	if err != nil {
-		return utils.NonUsageError(cmd, err, "unable to determine user home directory.")
+		return utils.NonUsageError(cmd, err, "unable to determine Tanzu configuration directory.")
 	}
 
 	// setup client options
 	opt := tkgctl.Options{
 		KubeConfig:        "",
 		KubeContext:       "",
-		ConfigDir:         fmt.Sprintf("%s/.tanzu", homedir),
+		ConfigDir:         configDir,
 		LogOptions:        tkgctl.LoggingOptions{Verbosity: 10},
 		ProviderGetter:    nil,
 		CustomizerOptions: types.CustomizerOptions{},

--- a/cli/pkg/standalone-cluster/delete.go
+++ b/cli/pkg/standalone-cluster/delete.go
@@ -5,12 +5,14 @@ package standalone
 
 import (
 	"fmt"
-	"os/user"
 
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu-private/core/pkg/v1/client"
 	"github.com/vmware-tanzu-private/tkg-cli/pkg/tkgctl"
 	"github.com/vmware-tanzu-private/tkg-cli/pkg/types"
 
-	"github.com/spf13/cobra"
+	"github.com/vmware-tanzu/tce/cli/pkg/utils"
 )
 
 type teardownStandaloneOptions struct {
@@ -45,18 +47,16 @@ func teardown(cmd *cobra.Command, args []string) error {
 	}
 	clusterName := args[0]
 
-	fmt.Println(tkgctl.CreateClusterOptions{})
-
-	usr, err := user.Current()
+	configDir, err := client.LocalDir()
 	if err != nil {
-		return err
+		return utils.NonUsageError(cmd, err, "unable to determine Tanzu configuration directory.")
 	}
 
 	// setup client options
 	opt := tkgctl.Options{
 		KubeConfig:        "",
 		KubeContext:       "",
-		ConfigDir:         usr.HomeDir + "/.tanzu",
+		ConfigDir:         configDir,
 		LogOptions:        tkgctl.LoggingOptions{Verbosity: 10},
 		ProviderGetter:    nil,
 		CustomizerOptions: types.CustomizerOptions{},


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

This updates the standalone cluster plugin to get the configuration
directory to use from the client rather than trying to determine it on
its own.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #489

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

Ran tests and compiled. Made sure running command didn't error.

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
