### PR TITLE
expand the avaiable configuration values for fluent-bit

### DIFF
--- a/addons/packages/fluent-bit/README.md
+++ b/addons/packages/fluent-bit/README.md
@@ -21,9 +21,22 @@ The following configuration values can be set to customize the Fluent Bit instal
 
 ### Fluent Bit Configuration
 
+Fluent-bit's primary configuration interface is its config file, which is documented on Fluent's documentation page:
+
+https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
+
+In order to ensure that any supported inputs, outputs, filters, parsers, or other capabilities of the deployed version
+of Fluent Bit are available, the addon's configuration is intentionally a lightweight pass-through of the Fluent Bit config file format.
+
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
-|`fluent_bit.outputs`|Optional|configuration for Fluent Bit outputs, as a multiline `yaml` string. See the Fluent Bit config file [documentation](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_output) for detailed configuration guidance.|
+|`fluent_bit.service`|Optional|custom configuration for Fluent Bit service, as a multiline `yaml` string.|
+|`fluent_bit.outputs`|Optional|configuration for Fluent Bit outputs, as a multiline `yaml` string.|
+|`fluent_bit.inputs`|Optional|configuration for Fluent Bit inputs, as a multiline `yaml` string.|
+|`fluent_bit.filters`|Optional|configuration for Fluent Bit filters, as a multiline `yaml` string.|
+|`fluent_bit.parsers`|Optional|configuration for Fluent Bit parsers, as a multiline `yaml` string.|
+|`fluent_bit.streams`|Optional|content for Fluent Bit streams file, as a multiline `yaml` string.|
+|`fluent_bit.plugins`|Optional|content for a Fluent Bit plugins configuration file, as a multiline `yaml` string.|
 
 ## Usage Example
 

--- a/addons/packages/fluent-bit/bundle/config/overlays/overlay-configmap.yaml
+++ b/addons/packages/fluent-bit/bundle/config/overlays/overlay-configmap.yaml
@@ -6,4 +6,31 @@
 data:
   #@yaml/text-templated-strings
   #@overlay/replace
+  fluent-bit.conf: |
+    (@= data.values.fluent_bit.service @)
+
+      Parsers_File  parsers.conf
+      (@= "Plugins_File  plugins.conf" if data.values.fluent_bit.plugins else ""@)
+      (@= "Streams_File  streams.conf" if data.values.fluent_bit.streams else ""@)
+
+    @INCLUDE inputs.conf
+    @INCLUDE filters.conf
+    @INCLUDE outputs.conf
+  #@yaml/text-templated-strings
+  #@overlay/replace
   outputs.conf: (@= data.values.fluent_bit.outputs @)
+  #@yaml/text-templated-strings
+  #@overlay/replace
+  inputs.conf: (@= data.values.fluent_bit.inputs @)
+  #@yaml/text-templated-strings
+  #@overlay/replace
+  filters.conf: (@= data.values.fluent_bit.filters @)
+  #@yaml/text-templated-strings
+  #@overlay/replace
+  parsers.conf: (@= data.values.fluent_bit.parsers @)
+  #@yaml/text-templated-strings
+  #@overlay/replace
+  streams.conf: (@= data.values.fluent_bit.streams @)
+  #@yaml/text-templated-strings
+  #@overlay/replace
+  plugins.conf: (@= data.values.fluent_bit.plugins @)

--- a/addons/packages/fluent-bit/bundle/config/upstream/fluentbit/configmap.yaml
+++ b/addons/packages/fluent-bit/bundle/config/upstream/fluentbit/configmap.yaml
@@ -61,3 +61,5 @@ data:
       Format json
       Time_Key time
       Time_Format %d/%b/%Y:%H:%M:%S %z
+  plugins.conf: ""
+  streams.conf: ""

--- a/addons/packages/fluent-bit/bundle/config/values.yaml
+++ b/addons/packages/fluent-bit/bundle/config/values.yaml
@@ -5,7 +5,58 @@ namespace: "fluent-bit"
 
 #! Required params for supported output plugins
 fluent_bit:
+  #! https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/variables
+  service: |
+    [Service]
+      Flush         1
+      Log_Level     info
+      Daemon        off
+      Parsers_File  parsers.conf
+      HTTP_Server   On
+      HTTP_Listen   0.0.0.0
+      HTTP_Port     2020
+
   outputs: |
     [OUTPUT]
       Name              stdout
       Match             *
+
+  inputs: |
+    [INPUT]
+        Name tail
+        Path /var/log/containers/*.log
+        Parser docker
+        Tag kube.*
+        Mem_Buf_Limit 5MB
+        Skip_Long_Lines On
+
+    [INPUT]
+        Name systemd
+        Tag host.*
+        Systemd_Filter _SYSTEMD_UNIT=kubelet.service
+        Read_From_Tail On
+  filters: |
+    [FILTER]
+      Name                kubernetes
+      Match               kube.*
+      Kube_URL            https://kubernetes.default.svc:443
+      Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+      Kube_Tag_Prefix     kube.var.log.containers.
+      Merge_Log           On
+      Merge_Log_Key       log_processed
+      K8S-Logging.Parser  On
+      K8S-Logging.Exclude Off
+
+    [FILTER]
+      Name                modify
+      Match               *
+      Rename message text
+  parsers: |
+    [PARSER]
+      Name   json
+      Format json
+      Time_Key time
+      Time_Format %d/%b/%Y:%H:%M:%S %z
+  streams: ""
+  plugins: ""


### PR DESCRIPTION
## What this PR does / why we need it
The existing fluent-bit addon only allows for easy configuration of outputs using the `values.yaml` file. Outputs are the most critical configuration need for fluent-bit, but inputs, parsers, plugins, and other settings are all reasonable to expose for configuration.

This PR adds additional configuration hooks to provide easy and reasonably comprehensive customization for the fluent-bit addon using `values.yaml` alone.

## Describe testing done for PR
validated `ytt` output using `ytt -f config/*` in the bundle directory for the addon.

## Special notes for your reviewer

## Does this PR introduce a user-facing change?
```release-note
Expanded configuration options for Fluent Bit addon
```
