### PR TITLE
Update adopter text to use TCE instead of Velero

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -8,6 +8,6 @@ If you're using TCE and want to add your organization to this list, follow these
 
 Below is a list of solutions where TCE is being used as a component.
 
-## Adding your organization to the list of Velero Adopters
+## Adding your organization to the list of Tanzu Community Edition Adopters
 
 ## Adding a logo to XXXX


### PR DESCRIPTION
Signed-off-by: Nolan Brubaker <brubakern@vmware.com>

## What this PR does / why we need it
The ADOPTERS.md shouldn't reference Velero, though I assume it was copied from the Velero ADOPTERS.md.

## Describe testing done for PR
Previewed Markdown on Github fork

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
None
