### PR TITLE
Fix tag script and intro fake releases for automation testing

### DIFF
--- a/.github/workflows/fake-release.yaml
+++ b/.github/workflows/fake-release.yaml
@@ -1,0 +1,78 @@
+name: Create Pre-Release
+
+on:
+  push:
+    branches:
+      - "!not_activated_on_branches!*"
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+-fake.[0-9]+"
+
+jobs:
+  build:
+    name: Pre-Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
+        id: go
+
+      - name: Config credentials
+        env:
+          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: |
+          git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Get the Tag
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+
+      - name: Generate release
+        env:
+          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: make release
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Changelog:
+            - TODO: First Change
+            - TODO: Second Change
+          draft: true
+          prerelease: true
+
+      - name: Upload Linux AMD64 Asset
+        id: upload-linux-amd64-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build/tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_name: tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload Darwin AMD64 Asset
+        id: upload-darwin-amd64-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build/tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
+          asset_content_type: application/gzip

--- a/hack/update-tag.sh
+++ b/hack/update-tag.sh
@@ -20,6 +20,6 @@ git config user.name github-actions
 git config user.email github-actions@github.com
 git add hack/DEV_BUILD_VERSION.yaml
 git commit -m "auto-generated - update dev version"
-git push -f origin HEAD:main
-git tag -f -m "${NEW_BUILD_VERSION}" "${NEW_BUILD_VERSION}"
-git push -f origin "${NEW_BUILD_VERSION}"
+git push origin main
+git tag -m "${NEW_BUILD_VERSION}" "${NEW_BUILD_VERSION}"
+git push origin "${NEW_BUILD_VERSION}"


### PR DESCRIPTION
## What this PR does / why we need it
This activates a mock release process for pushing tags like `v0.5.0-fake.1` but doesnt upload or execute the update tag functionality that bonked the repo.

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
NA

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
NA