### PR TITLE
Prometheus: Add monitoring dependencies to gather cluster health metrics

### DIFF
--- a/addons/packages/prometheus/bundle/.imgpkg/images.yml
+++ b/addons/packages/prometheus/bundle/.imgpkg/images.yml
@@ -7,4 +7,16 @@ images:
 - annotations:
     kbld.carvel.dev/id: prom/prometheus:v2.26.0
   image: index.docker.io/prom/prometheus@sha256:38d40a760569b1c5aec4a36e8a7f11e86299e9191b9233672a5d41296d8fa74e
+    kbld.carvel.dev/id: gcr.io/cadvisor/cadvisor:v0.37.5
+  image: gcr.io/cadvisor/cadvisor@sha256:071f30c4fed3c733336c5fe5b260c12a0352be7b943625a067902b2b7551fab6
+- annotations:
+    kbld.carvel.dev/id: prom/pushgateway:v1.4.0
+  image: index.docker.io/prom/pushgateway@sha256:ca32c7864bb2573bf27ff6628a03d17b37b1aa3dc367b5d86831e6c0f0761376
+- annotations:
+    kbld.carvel.dev/id: quay.io/coreos/kube-state-metrics:v1.9.8
+  image: quay.io/coreos/kube-state-metrics@sha256:ace842fc85031688d06c4aa000b5b1e58ba3b9dd13d26e7c8f2547f7ee0bcc84
+- annotations:
+    kbld.carvel.dev/id: quay.io/prometheus/node-exporter:v1.1.2
+  image: quay.io/prometheus/node-exporter@sha256:22fbde17ab647ddf89841e5e464464eece111402b7d599882c2a3393bc0d2810
+
 kind: ImagesLock

--- a/addons/packages/prometheus/bundle/config/overlays/overlay-cadvisor.yaml
+++ b/addons/packages/prometheus/bundle/config/overlays/overlay-cadvisor.yaml
@@ -1,0 +1,21 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "prometheus-cadvisor"}})
+#@overlay/match-child-defaults missing_ok=True
+---
+spec:
+  updateStrategy:
+    type: #@ data.values.cadvisor.daemonset.updatestrategy
+  template:
+    spec:
+      serviceAccountName: prometheus-cadvisor
+      containers:
+        #@overlay/match by=overlay.subset({"name": "prometheus-cadvisor"})
+        - resources:
+            requests:
+              memory: #@ data.values.cadvisor.daemonset.containers.resources.requests.memory
+              cpu: #@ data.values.cadvisor.daemonset.containers.resources.requests.cpu
+            limits:
+              memory: #@ data.values.cadvisor.daemonset.containers.resources.limits.memory
+              cpu: #@ data.values.cadvisor.daemonset.containers.resources.limits.cpu

--- a/addons/packages/prometheus/bundle/config/overlays/overlay-kube-state-metrics.yaml
+++ b/addons/packages/prometheus/bundle/config/overlays/overlay-kube-state-metrics.yaml
@@ -1,0 +1,7 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name":"prometheus-kube-state-metrics"}})
+---
+spec:
+  replicas: #@ data.values.kube_state_metrics.deployment.replicas

--- a/addons/packages/prometheus/bundle/config/overlays/overlay-namespace.yaml
+++ b/addons/packages/prometheus/bundle/config/overlays/overlay-namespace.yaml
@@ -6,12 +6,12 @@
 metadata:
   name: #@ data.values.namespace
 
-#@overlay/match by=overlay.subset({"metadata":{"namespace": "default"}}), expects=10
+#@overlay/match by=overlay.subset({"metadata":{"namespace": "default"}}), expects=22
 ---
 metadata:
   namespace: #@ data.values.namespace
 
-#@overlay/match by=overlay.subset({"kind":"ClusterRoleBinding"}), expects=2
+#@overlay/match by=overlay.subset({"kind":"ClusterRoleBinding"}), expects=6
 ---
 subjects:
 #@overlay/match by=overlay.subset({"namespace": "default"})

--- a/addons/packages/prometheus/bundle/config/overlays/overlay-node-exporter.yaml
+++ b/addons/packages/prometheus/bundle/config/overlays/overlay-node-exporter.yaml
@@ -1,0 +1,12 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "prometheus-node-exporter"}})
+---
+spec:
+  updateStrategy:
+    type: #@ data.values.node_exporter.daemonset.updatestrategy
+  template:
+    spec:
+      hostNetwork: #@ data.values.node_exporter.hostNetwork
+

--- a/addons/packages/prometheus/bundle/config/overlays/overlay-pushgateway.yaml
+++ b/addons/packages/prometheus/bundle/config/overlays/overlay-pushgateway.yaml
@@ -1,0 +1,7 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name":"prometheus-pushgateway"}})
+---
+spec:
+  replicas: #@ data.values.pushgateway.deployment.replicas

--- a/addons/packages/prometheus/bundle/config/upstream/cadvisor/clusterrole.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/cadvisor/clusterrole.yaml
@@ -1,0 +1,36 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    component: "cadvisor"
+    app: prometheus
+  name: prometheus-cadvisor
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - nodes
+  - nodes/stats
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - policy
+  resources:
+    - podsecuritypolicies
+  verbs:
+    - use

--- a/addons/packages/prometheus/bundle/config/upstream/cadvisor/clusterrolebinding.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/cadvisor/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: cadvisor
+    app: prometheus
+  name: prometheus-cadvisor
+subjects:
+- kind: ServiceAccount
+  name: prometheus-cadvisor
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-cadvisor

--- a/addons/packages/prometheus/bundle/config/upstream/cadvisor/daemonset.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/cadvisor/daemonset.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    component: cadvisor
+    app: prometheus
+  name: prometheus-cadvisor
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      component: cadvisor
+      app: prometheus
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        component: cadvisor
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus-cadvisor
+      containers:
+      - name: prometheus-cadvisor
+        image: gcr.io/cadvisor/cadvisor:v0.37.5
+        imagePullPolicy: "IfNotPresent"
+        volumeMounts:
+        - name: rootfs
+          mountPath: /rootfs
+          readOnly: true
+        - name: var-run
+          mountPath: /var/run
+          readOnly: true
+        - name: sys
+          mountPath: /sys
+          readOnly: true
+        - name: docker
+          mountPath: /var/lib/docker
+          readOnly: true
+        - name: disk
+          mountPath: /dev/disk
+          readOnly: true
+        ports:
+          - name: http
+            containerPort: 8080
+            protocol: TCP
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+      - name: var-run
+        hostPath:
+          path: /var/run
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: docker
+        hostPath:
+          path: /var/lib/docker
+      - name: disk
+        hostPath:
+          path: /dev/disk

--- a/addons/packages/prometheus/bundle/config/upstream/cadvisor/serviceaccount.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/cadvisor/serviceaccount.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: cadvisor
+    app: prometheus
+  name: prometheus-cadvisor
+  namespace: default

--- a/addons/packages/prometheus/bundle/config/upstream/kube-state-metrics/clusterrole.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/kube-state-metrics/clusterrole.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: "kube-state-metrics"
+    app: prometheus
+  name: prometheus-kube-state-metrics
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - pods
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - endpoints
+      - secrets
+      - configmaps
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - ingresses
+      - replicasets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - statefulsets
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+    - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use

--- a/addons/packages/prometheus/bundle/config/upstream/kube-state-metrics/clusterrolebinding.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/kube-state-metrics/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: "kube-state-metrics"
+    app: prometheus
+  name: prometheus-kube-state-metrics
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-kube-state-metrics
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-kube-state-metrics

--- a/addons/packages/prometheus/bundle/config/upstream/kube-state-metrics/deployment.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/kube-state-metrics/deployment.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: "kube-state-metrics"
+    app: prometheus
+  name: prometheus-kube-state-metrics
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      component: "kube-state-metrics"
+      app: prometheus
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: "kube-state-metrics"
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus-kube-state-metrics
+      containers:
+        - name: prometheus-kube-state-metrics
+          image: "quay.io/coreos/kube-state-metrics:v1.9.8"
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: telemetry
+              containerPort: 8081
+          resources:
+            {}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/addons/packages/prometheus/bundle/config/upstream/kube-state-metrics/service.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/kube-state-metrics/service.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+  labels:
+    component: "kube-state-metrics"
+    app: prometheus
+  name: prometheus-kube-state-metrics
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: telemetry
+      port: 81
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    component: "kube-state-metrics"
+    app: prometheus
+  type: "ClusterIP"

--- a/addons/packages/prometheus/bundle/config/upstream/kube-state-metrics/serviceaccount.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/kube-state-metrics/serviceaccount.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: "kube-state-metrics"
+    app: prometheus
+  name: prometheus-kube-state-metrics
+  namespace: default

--- a/addons/packages/prometheus/bundle/config/upstream/node-exporter/clusterolebinding.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/node-exporter/clusterolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-node-exporter
+  labels:
+    component: node-exporter
+    app: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-node-exporter-sa
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-node-exporter

--- a/addons/packages/prometheus/bundle/config/upstream/node-exporter/clusterrole.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/node-exporter/clusterrole.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: node-exporter
+    app: prometheus
+  name: prometheus-node-exporter
+rules:
+- apiGroups: ['']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - node-exporter

--- a/addons/packages/prometheus/bundle/config/upstream/node-exporter/daemonset.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/node-exporter/daemonset.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    component: node-exporter
+    app: prometheus
+  name: prometheus-node-exporter
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      component: node-exporter
+      app: prometheus
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        component: node-exporter
+        app: prometheus
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "9100"
+    spec:
+      serviceAccountName: prometheus-node-exporter-sa
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      containers:
+        - name: prometheus-node-exporter
+          image: "quay.io/prometheus/node-exporter:v1.1.2"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --web.listen-address=$(HOST_IP):9100
+          env:
+          - name: HOST_IP
+            value: 0.0.0.0
+          ports:
+            - name: metrics
+              containerPort: 9100
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9100
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9100
+          resources:
+            {}
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly:  true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
+              readOnly: true
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: root
+          hostPath:
+            path: /

--- a/addons/packages/prometheus/bundle/config/upstream/node-exporter/psp.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/node-exporter/psp.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: prometheus-node-exporter
+  namespace: default
+  labels:     
+    component: node-exporter
+    app: prometheus
+spec:
+  privileged: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+    - 'hostPath'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: true
+  hostPorts:
+    - min: 0
+      max: 65535
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      #! Forbid adding the root group.
+      - min: 0
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      #! Forbid adding the root group.
+      - min: 0
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/addons/packages/prometheus/bundle/config/upstream/node-exporter/service.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/node-exporter/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-node-exporter
+  namespace: default
+  labels:
+    component: node-exporter
+    app: prometheus
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9100
+      targetPort: 9100
+      protocol: TCP
+      name: metrics
+  selector:
+    component: node-exporter
+    app: prometheus

--- a/addons/packages/prometheus/bundle/config/upstream/node-exporter/serviceaccount.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/node-exporter/serviceaccount.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-node-exporter-sa
+  namespace: default
+  labels:
+    component: node-exporter
+    app: prometheus

--- a/addons/packages/prometheus/bundle/config/upstream/pushgateway/clusterrole.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/pushgateway/clusterrole.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: "pushgateway"
+    app: prometheus
+  name: prometheus-pushgateway
+rules:
+  - apiGroups:
+    - policy
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use

--- a/addons/packages/prometheus/bundle/config/upstream/pushgateway/clusterrolebinding.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/pushgateway/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: "pushgateway"
+    app: prometheus
+  name: prometheus-pushgateway
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-pushgateway
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-pushgateway

--- a/addons/packages/prometheus/bundle/config/upstream/pushgateway/deployment.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/pushgateway/deployment.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: "pushgateway"
+    app: prometheus
+  name: prometheus-pushgateway
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      component: "pushgateway"
+      app: prometheus
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: "pushgateway"
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus-pushgateway
+      containers:
+        - name: prometheus-pushgateway
+          image: "prom/pushgateway:v1.4.0"
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 9091
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9091
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9091
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+          resources:
+            {}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534

--- a/addons/packages/prometheus/bundle/config/upstream/pushgateway/service.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/pushgateway/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/probe: pushgateway
+  labels:
+    component: "pushgateway"
+    app: prometheus
+  name: prometheus-pushgateway
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 9091
+      protocol: TCP
+      targetPort: 9091
+  selector:
+    component: "pushgateway"
+    app: prometheus
+  type: "ClusterIP"

--- a/addons/packages/prometheus/bundle/config/upstream/pushgateway/serviceaccount.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/pushgateway/serviceaccount.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: "pushgateway"
+    app: prometheus
+  name: prometheus-pushgateway
+  namespace: default

--- a/addons/packages/prometheus/bundle/config/values.yaml
+++ b/addons/packages/prometheus/bundle/config/values.yaml
@@ -25,6 +25,14 @@ prometheus:
         scrape_interval: 5s
         static_configs:
         - targets: ['localhost:9090']
+      - job_name: 'kube-state-metrics'
+        static_configs:
+        - targets: ['prometheus-kube-state-metrics.prometheus-addon.svc.cluster.local:8080']
+
+      - job_name: 'node-exporter'
+        static_configs:
+        - targets: ['prometheus-node-exporter.prometheus-addon.svc.cluster.local:9100']
+
       - job_name: 'kubernetes-pods'
         kubernetes_sd_configs:
         - role: pod
@@ -49,6 +57,24 @@ prometheus:
         - source_labels: [__meta_kubernetes_pod_name]
           action: replace
           target_label: kubernetes_pod_name
+      - job_name: kubernetes-nodes-cadvisor
+        kubernetes_sd_configs:
+        - role: node
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - replacement: kubernetes.default.svc:443
+          target_label: __address__
+        - regex: (.+)
+          replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+          source_labels:
+          - __meta_kubernetes_node_name
+          target_label: __metrics_path__
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       alerting:
         alertmanagers:
         - scheme: http
@@ -99,3 +125,29 @@ alertmanager:
         group_wait: 10s
         receiver: default-receiver
         repeat_interval: 3h
+
+
+kube_state_metrics:
+  deployment:
+    replicas: 1
+
+node_exporter:
+  daemonset:
+    updatestrategy: RollingUpdate
+  hostNetwork: false
+
+pushgateway:
+  deployment:
+    replicas: 1
+
+cadvisor:
+  daemonset:
+    updatestrategy: RollingUpdate
+    containers:
+      resources:
+        requests:
+          memory: 200Mi
+          cpu: 150m
+        limits:
+          memory: 2000Mi
+          cpu: 300m

--- a/addons/packages/prometheus/bundle/vendir.lock.yml
+++ b/addons/packages/prometheus/bundle/vendir.lock.yml
@@ -5,5 +5,13 @@ directories:
     path: alertmanager
   - manual: {}
     path: prometheus
+  - manual: {}
+    path: node-exporter
+  - manual: {}
+    path: pushgateway
+  - manual: {}
+    path: kube-state-metrics
+  - manual: {}
+    path: cadvisor
   path: config/upstream
 kind: LockConfig

--- a/addons/packages/prometheus/bundle/vendir.yml
+++ b/addons/packages/prometheus/bundle/vendir.yml
@@ -8,3 +8,11 @@ directories:
     manual: {}
   - path: prometheus
     manual: {}
+  - path: node-exporter
+    manual: {}
+  - path: pushgateway
+    manual: {}
+  - path: kube-state-metrics
+    manual: {}
+  - path: cadvisor
+    manual: {}


### PR DESCRIPTION
## What this PR does / why we need it
This PR introduces the monitoring components that are needed to gather metrics to monitor the health of a cluster.  This would help us move forward our goal of having opinionated dashboards for cluster health needed by the operator.

## Which issue(s) this PR fixes
NONE

## Describe testing done for PR
Ran `make check`
```
$ make check
make -C hack/tools golangci-lint
make[1]: Nothing to be done for `golangci-lint'.
hack/tools/bin/golangci-lint run -v --timeout=5m
INFO [config_reader] Config search paths: [./ /Users/akodali/workspace/akodali18/tce /Users/akodali/workspace/akodali18 /Users/akodali/workspace /Users/akodali /Users /]
INFO [config_reader] Used config file .golangci.yaml
INFO [lintersdb] Active 35 linters: [bodyclose deadcode depguard dogsled dupl errcheck funlen goconst gocritic gocyclo gofmt goheader goimports golint gomnd goprintffuncname gosec gosimple govet ineffassign maligned misspell nakedret noctx nolintlint rowserrcheck staticcheck structcheck stylecheck typecheck unconvert unparam unused varcheck whitespace]
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|types_sizes|files|imports|name) took 2.490609366s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 3.442379ms
INFO [linters context/goanalysis] analyzers took 0s with no stages
INFO [linters context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 89, after processing: 0
INFO [runner] Processors filtering stat (out/in): nolint: 0/4, autogenerated_exclude: 89/89, identifier_marker: 89/89, exclude-rules: 4/89, cgo: 89/89, filename_unadjuster: 89/89, path_prettifier: 89/89, skip_files: 89/89, skip_dirs: 89/89, exclude: 89/89
INFO [runner] processing took 7.787518ms with stages: autogenerated_exclude: 2.290599ms, path_prettifier: 1.467163ms, identifier_marker: 1.201319ms, nolint: 1.185597ms, exclude-rules: 1.076976ms, exclude: 373.385µs, skip_dirs: 149.696µs, max_same_issues: 22.812µs, cgo: 9.728µs, filename_unadjuster: 7.71µs, uniq_by_line: 408ns, max_from_linter: 369ns, sort_results: 284ns, source_code: 272ns, skip_files: 257ns, diff: 233ns, max_per_file_from_linter: 213ns, severity-rules: 195ns, path_shortener: 182ns, path_prefixer: 120ns
INFO [runner] linters took 887.728671ms with stages: goanalysis_metalinter: 878.74438ms, unused: 1.058735ms
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 35 samples, avg is 90.2MB, max is 141.1MB
INFO Execution took 3.393740877s
hack/check-mdlint.sh
hack/check-shell.sh
```

Used the `hack/addon-dev/dev-deploy-addon.sh` script to successfully upload and deploy the new bundle successfully.
Port forwarded prometheus and verified that prometheus contains all expected metrics, verified `up` status for all new targets.

## Special notes for your reviewer
NONE

## Does this PR introduce a user-facing change?
NONE

Cc: @LukeWinikates 