### PR TITLE
rename contour-operator Bundle to contour-operator

### DIFF
--- a/addons/packages/contour-operator/bundle/.imgpkg/bundle.yml
+++ b/addons/packages/contour-operator/bundle/.imgpkg/bundle.yml
@@ -1,7 +1,7 @@
 apiVersion: imgpkg.carvel.dev/v1alpha1
 kind: Bundle
 metadata:
-  name: contour
+  name: contour-operator
 authors:
   - name: Nicholas Seemiller
     email: nseemiller@vmware.com


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

## What this PR does / why we need it
Renames the `contour-operator` Bundle to `contour-operator` so the upcoming `Contour` add-on can use the `contour` name.

## Which issue(s) this PR fixes
N/A

## Describe testing done for PR
none

## Special notes for your reviewer
cc @seemiller (xref https://github.com/vmware-tanzu/tce/pull/514#issuecomment-840090285)

## Does this PR introduce a user-facing change?
not sure?