### PR TITLE
Fixing tag update script

### DIFF
--- a/.github/workflows/fake-release.yaml
+++ b/.github/workflows/fake-release.yaml
@@ -77,10 +77,6 @@ jobs:
           asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
 
-      - name: Reset repo
-        run: |
-          git reset --hard
-
       - name: Checkout for Update
         uses: actions/checkout@v2
 

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -91,10 +91,6 @@ jobs:
           destination: tce-cli-plugins
           credentials: ${{ secrets.GCP_BUCKET_SA }}
 
-      - name: Reset repo
-        run: |
-          git reset --hard
-
       - name: Checkout for Update
         uses: actions/checkout@v2
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,10 +92,6 @@ jobs:
           destination: tce-cli-plugins
           credentials: ${{ secrets.GCP_BUCKET_SA }}
 
-      - name: Reset repo
-        run: |
-          git reset --hard
-
       - name: Checkout for Update
         uses: actions/checkout@v2
 

--- a/hack/update-tag.sh
+++ b/hack/update-tag.sh
@@ -23,6 +23,11 @@ fi
 
 git config user.name github-actions
 git config user.email github-actions@github.com
+# putting in the reset, checkout, reset below because doing a checkout in a github action
+# doesnt seem to do a fresh clone/checkout of the repo
+git reset --hard
+git checkout main
+git reset --hard
 
 if [[ "${FAKE_RELEASE}" != "" ]]; then
 


### PR DESCRIPTION
## What this PR does / why we need it
In testing a fake release, the run yielded the following error:
```
+ NEW_BUILD_VERSION=v0.2.2-dev.1001
+ echo 'NEW_BUILD_VERSION: v0.2.2-dev.1001'
+ git add hack/FAKE_BUILD_VERSION.yaml
+ git commit -m 'auto-generated - update fake version'
[detached HEAD c7e494b] auto-generated - update fake version
 1 file changed, 1 insertion(+), 1 deletion(-)
+ git push origin main
error: src refspec main does not match any
error: failed to push some refs to 'https://github.com/vmware-tanzu/tce'
```
Added a reset, checkout, reset in the script because performing a checkout in a GitHub action before executing this script doesn't seem to do a fresh clone/checkout of the repo. This should fix this...

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
NA

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
NA