### PR TITLE
Fix main so github actions pass

### DIFF
--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -34,11 +34,6 @@ jobs:
       - name: Build
         run: make build
 
-      - name: Generate metadata
-        env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: make gen-metadata
-
       - id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main
         with:

--- a/addons/packages/fluent-bit/README.md
+++ b/addons/packages/fluent-bit/README.md
@@ -21,9 +21,7 @@ The following configuration values can be set to customize the Fluent Bit instal
 
 ### Fluent Bit Configuration
 
-Fluent-bit's primary configuration interface is its config file, which is documented on Fluent's documentation page:
-
-https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
+Fluent-bit's primary configuration interface is its config file, which is documented on Fluent's [documentation](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file) page.
 
 In order to ensure that any supported inputs, outputs, filters, parsers, or other capabilities of the deployed version
 of Fluent Bit are available, the addon's configuration is intentionally a lightweight pass-through of the Fluent Bit config file format.


### PR DESCRIPTION
## What this PR does / why we need it
Main is broken with `make check` and the staging uploads are broken because we removed the metadata generation
