### PR TITLE
install script: fix plugin installation failure when installing from outside release tar ball directory

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -50,7 +50,7 @@ else
 fi
 
 # install all plugins present in the bundle
-for plugin in bin/tanzu-plugin*; do
+for plugin in "${MY_DIR}"/bin/tanzu-plugin*; do
   install "${plugin}" "${XDG_DATA_HOME}/tanzu-cli"
 done
 


### PR DESCRIPTION
Fixes #548

Signed-off-by: Karuppiah Natarajan <karuppiahn@vmware.com>

## What this PR does / why we need it

It's needed to fix installation issues in the case where the user installs / invokes the install script from outside release tar ball directory

## Which issue(s) this PR fixes

Fixes #548 

## Describe testing done for PR

Manually downloaded https://github.com/vmware-tanzu/tce/releases/download/v0.4.0/tce-darwin-amd64-v0.4.0.tar.gz from the browser and ran the below commands:

```
$ tar xzvf ~/Downloads/tce-darwin-amd64-v0.4.0.tar.gz
$ ./tce-darwin-amd64-v0.4.0/install.sh
+++ dirname ./tce-darwin-amd64-v0.4.0/install.sh
++ cd ./tce-darwin-amd64-v0.4.0
++ pwd
+ MY_DIR=/Users/karuppiahn/projects/github.com/karuppiah/tce-run-automation/tce-installation/tce-darwin-amd64-v0.4.0
++ uname
+ BUILD_OS=Darwin
+ case "${BUILD_OS}" in
+ XDG_DATA_HOME='/Users/karuppiahn/Library/Application Support'
+ echo '/Users/karuppiahn/Library/Application Support'
/Users/karuppiahn/Library/Application Support
++ date +%Y-%m-%d_%H:%M
+ mv -f /Users/karuppiahn/.tanzu /Users/karuppiahn/.tanzu-2021-05-13_18:51
+ rm -rf '/Users/karuppiahn/Library/Application Support/tanzu-cli'
+ mkdir -p '/Users/karuppiahn/Library/Application Support/tanzu-cli'
++ command -v tanzu
+ TANZU_BIN_PATH=/usr/local/bin/tanzu
+ [[ -n /usr/local/bin/tanzu ]]
+ rm -f /usr/local/bin/tanzu
+ TANZU_BIN_PATH=/usr/local/bin
+ [[ :/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/opt/fzf/bin: == *\:\/\U\s\e\r\s\/\k\a\r\u\p\p\i\a\h\n\/\b\i\n\:* ]]
+ echo Installing tanzu cli to /usr/local/bin
Installing tanzu cli to /usr/local/bin
+ sudo install /Users/karuppiahn/projects/github.com/karuppiah/tce-run-automation/tce-installation/tce-darwin-amd64-v0.4.0/bin/tanzu /usr/local/bin
Password:
Sorry, try again.
Password:
+ for plugin in '${MY_DIR}/bin/tanzu-plugin*'
+ install /Users/karuppiahn/projects/github.com/karuppiah/tce-run-automation/tce-installation/tce-darwin-amd64-v0.4.0/bin/tanzu-plugin-alpha '/Users/karuppiahn/Library/Application Support/tanzu-cli'
+ for plugin in '${MY_DIR}/bin/tanzu-plugin*'
+ install /Users/karuppiahn/projects/github.com/karuppiah/tce-run-automation/tce-installation/tce-darwin-amd64-v0.4.0/bin/tanzu-plugin-builder '/Users/karuppiahn/Library/Application Support/tanzu-cli'
+ for plugin in '${MY_DIR}/bin/tanzu-plugin*'
+ install /Users/karuppiahn/projects/github.com/karuppiah/tce-run-automation/tce-installation/tce-darwin-amd64-v0.4.0/bin/tanzu-plugin-cluster '/Users/karuppiahn/Library/Application Support/tanzu-cli'
+ for plugin in '${MY_DIR}/bin/tanzu-plugin*'
+ install /Users/karuppiahn/projects/github.com/karuppiah/tce-run-automation/tce-installation/tce-darwin-amd64-v0.4.0/bin/tanzu-plugin-kubernetes-release '/Users/karuppiahn/Library/Application Support/tanzu-cli'
+ for plugin in '${MY_DIR}/bin/tanzu-plugin*'
+ install /Users/karuppiahn/projects/github.com/karuppiah/tce-run-automation/tce-installation/tce-darwin-amd64-v0.4.0/bin/tanzu-plugin-login '/Users/karuppiahn/Library/Application Support/tanzu-cli'
+ for plugin in '${MY_DIR}/bin/tanzu-plugin*'
+ install /Users/karuppiahn/projects/github.com/karuppiah/tce-run-automation/tce-installation/tce-darwin-amd64-v0.4.0/bin/tanzu-plugin-management-cluster '/Users/karuppiahn/Library/Application Support/tanzu-cli'
+ for plugin in '${MY_DIR}/bin/tanzu-plugin*'
+ install /Users/karuppiahn/projects/github.com/karuppiah/tce-run-automation/tce-installation/tce-darwin-amd64-v0.4.0/bin/tanzu-plugin-package '/Users/karuppiahn/Library/Application Support/tanzu-cli'
+ for plugin in '${MY_DIR}/bin/tanzu-plugin*'
+ install /Users/karuppiahn/projects/github.com/karuppiah/tce-run-automation/tce-installation/tce-darwin-amd64-v0.4.0/bin/tanzu-plugin-pinniped-auth '/Users/karuppiahn/Library/Application Support/tanzu-cli'
+ for plugin in '${MY_DIR}/bin/tanzu-plugin*'
+ install /Users/karuppiahn/projects/github.com/karuppiah/tce-run-automation/tce-installation/tce-darwin-amd64-v0.4.0/bin/tanzu-plugin-standalone-cluster '/Users/karuppiahn/Library/Application Support/tanzu-cli'
+ for plugin in '${MY_DIR}/bin/tanzu-plugin*'
+ install /Users/karuppiahn/projects/github.com/karuppiah/tce-run-automation/tce-installation/tce-darwin-amd64-v0.4.0/bin/tanzu-plugin-test '/Users/karuppiahn/Library/Application Support/tanzu-cli'
+ TANZU_CLI_NO_INIT=true
+ tanzu init
✔  Successfully initialized Tanzu CLI 
+ tanzu plugin repo add --name tce --gcp-bucket-name tce-cli-plugins --gcp-root-path artifacts
```

## Special notes for your reviewer

Question: Should we try to add some sort of test for the installation? Actually the Automation that me and @rajaskakodkar are working on to run TCE has this installation as part of it. That's how this issue was discovered. Maybe that can also be considered like a test for this issue, in which case we don't need to add any test now. And Automation is meant to run first to setup a cluster for E2E tests, so the Automation will be run as part of it

## Does this PR introduce a user-facing change?
```release-note
Fix install script not installing plugins when running it from outside the release tar ball directory
```
