### PR TITLE
Only trigger signing process once

### DIFF
--- a/.github/workflows/fake-release.yaml
+++ b/.github/workflows/fake-release.yaml
@@ -83,3 +83,15 @@ jobs:
       - name: Commit Next Dev Version
         run: |
           make tag-release
+
+      - name: Upload Cayman Trigger Asset
+        id: upload-cayman-trigger-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./cayman_trigger.txt
+          asset_name: cayman_trigger.txt
+          asset_content_type: text/plain
+          

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -97,3 +97,14 @@ jobs:
       - name: Commit Next Dev Version
         run: |
           make tag-release
+
+      - name: Upload Cayman Trigger Asset
+        id: upload-cayman-trigger-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./cayman_trigger.txt
+          asset_name: cayman_trigger.txt
+          asset_content_type: text/plain

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,3 +98,14 @@ jobs:
       - name: Commit Next Dev Version
         run: |
           make tag-release
+
+      - name: Upload Cayman Trigger Asset
+        id: upload-cayman-trigger-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./cayman_trigger.txt
+          asset_name: cayman_trigger.txt
+          asset_content_type: text/plain

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ _output
 /build
 /offline
 hack/NEW_BUILD_VERSION
+cayman_trigger.txt
 artifacts
 artifacts-admin
 bin

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ else
 	go run ./hack/tags/tags.go -tag $(BUILD_VERSION)
 	BUILD_VERSION=$(CONFIG_VERSION) FAKE_RELEASE=$(shell expr $(BUILD_VERSION) | grep fake) hack/update-tag.sh
 endif
+	echo "$(BUILD_VERSION)" | tee -a ./cayman_trigger.txt
 
 .PHONY: upload-signed-assets
 upload-signed-assets: release-env-check


### PR DESCRIPTION
## What this PR does / why we need it
Since we are going to be watching for draft release to trigger the signing process, we should only ever kick off that process once. The signal that this is a new draft release in which we need to create signed packages will be a text file called `cayman_trigger.txt` attached to the release as an asset.

When the signing process recognizes this is the first time we have seen this draft release and need to kick off the signing process, remove the `cayman_trigger.txt` asset and kick off the build.

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
Manually tested using a build binary and running with and without the `cayman_trigger.txt` file.

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
NA