### PR TITLE
Remove GitHub Actions not needed for docs

### DIFF
--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -2,6 +2,8 @@ name: Check build
 
 on:
   pull_request:
+    branches:
+      - main
     types:
       - assigned
       - opened


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

Right now, the main branch is the only one where we need to perform a
full build on PRs to validate. There is a lot of work happening in the
docs branch. These doc-only changes are not touching code, so waiting on
builds to complete is unnecessary and consuming Action time.

We may have something like release branches in the future, in which case
we can add them or change how this is handled.