### PR TITLE
Add pointer to docs to old getting started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,13 @@
-# Getting Started with TCE
+# Getting Started with TCE (Legacy)
+
+---
+
+___This getting started guide has been superseded by the published
+[Getting Started Guides](https://quirky-franklin-8969be.netlify.app/docs/latest)
+(password `ExpectedBirthdayIndirectBinary`). It is kept here for historical
+reference and will be removed soon.___
+
+---
 
 This guide walks you through standing up a management and guest cluster using
 Tanzu CLI. It then demonstrates how you can deploy add-ons into the cluster.


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

We now have new getting started guides published using Hugo that folks
should be using when trying out TCE. Our old getting started guide has
been mostly superseded by this, but until we are ready to clean up docs
and get this old information fully cleaned up, we should at least add a
note to it pointing people to the newer correct location to avoid
confusion.