### PR TITLE
add standardized configuration options for fluent-bit addon

### DIFF
--- a/addons/packages/fluent-bit/README.md
+++ b/addons/packages/fluent-bit/README.md
@@ -32,13 +32,16 @@ of Fluent Bit are available, the addon's configuration is intentionally a lightw
 
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
-|`fluent_bit.service`|Optional|custom configuration for Fluent Bit service, as a multiline `yaml` string.|
-|`fluent_bit.outputs`|Optional|configuration for Fluent Bit outputs, as a multiline `yaml` string.|
-|`fluent_bit.inputs`|Optional|configuration for Fluent Bit inputs, as a multiline `yaml` string.|
-|`fluent_bit.filters`|Optional|configuration for Fluent Bit filters, as a multiline `yaml` string.|
-|`fluent_bit.parsers`|Optional|configuration for Fluent Bit parsers, as a multiline `yaml` string.|
-|`fluent_bit.streams`|Optional|content for Fluent Bit streams file, as a multiline `yaml` string.|
-|`fluent_bit.plugins`|Optional|content for a Fluent Bit plugins configuration file, as a multiline `yaml` string.|
+|`fluent_bit.config.service`|Optional|custom configuration for Fluent Bit service, as a multiline `yaml` string.|
+|`fluent_bit.config.outputs`|Optional|configuration for Fluent Bit outputs, as a multiline `yaml` string.|
+|`fluent_bit.config.inputs`|Optional|configuration for Fluent Bit inputs, as a multiline `yaml` string.|
+|`fluent_bit.config.filters`|Optional|configuration for Fluent Bit filters, as a multiline `yaml` string.|
+|`fluent_bit.config.parsers`|Optional|configuration for Fluent Bit parsers, as a multiline `yaml` string.|
+|`fluent_bit.config.streams`|Optional|content for Fluent Bit streams file, as a multiline `yaml` string.|
+|`fluent_bit.config.plugins`|Optional|content for a Fluent Bit plugins configuration file, as a multiline `yaml` string.|
+|`fluent_bit.daemonset.resources`|Optional|resource limits and/or requests for the `fluent-bit` container within the daemonset's pods  |
+|`fluent_bit.daemonset.podAnnotations`|Optional|metadata annotations for the daemonset pods|
+|`fluent_bit.daemonset.podLabels`|Optional|metadata labels for the daemonset pods|
 
 ## Usage Example
 

--- a/addons/packages/fluent-bit/bundle/config/overlays/overlay-configmap.yaml
+++ b/addons/packages/fluent-bit/bundle/config/overlays/overlay-configmap.yaml
@@ -7,30 +7,30 @@ data:
   #@yaml/text-templated-strings
   #@overlay/replace
   fluent-bit.conf: |
-    (@= data.values.fluent_bit.service @)
+    (@= data.values.fluent_bit.config.service @)
 
       Parsers_File  parsers.conf
-      (@= "Plugins_File  plugins.conf" if data.values.fluent_bit.plugins else ""@)
-      (@= "Streams_File  streams.conf" if data.values.fluent_bit.streams else ""@)
+      (@= "Plugins_File  plugins.conf" if data.values.fluent_bit.config.plugins else ""@)
+      (@= "Streams_File  streams.conf" if data.values.fluent_bit.config.streams else ""@)
 
     @INCLUDE inputs.conf
     @INCLUDE filters.conf
     @INCLUDE outputs.conf
   #@yaml/text-templated-strings
   #@overlay/replace
-  outputs.conf: (@= data.values.fluent_bit.outputs @)
+  outputs.conf: (@= data.values.fluent_bit.config.outputs @)
   #@yaml/text-templated-strings
   #@overlay/replace
-  inputs.conf: (@= data.values.fluent_bit.inputs @)
+  inputs.conf: (@= data.values.fluent_bit.config.inputs @)
   #@yaml/text-templated-strings
   #@overlay/replace
-  filters.conf: (@= data.values.fluent_bit.filters @)
+  filters.conf: (@= data.values.fluent_bit.config.filters @)
   #@yaml/text-templated-strings
   #@overlay/replace
-  parsers.conf: (@= data.values.fluent_bit.parsers @)
+  parsers.conf: (@= data.values.fluent_bit.config.parsers @)
   #@yaml/text-templated-strings
   #@overlay/replace
-  streams.conf: (@= data.values.fluent_bit.streams @)
+  streams.conf: (@= data.values.fluent_bit.config.streams @)
   #@yaml/text-templated-strings
   #@overlay/replace
-  plugins.conf: (@= data.values.fluent_bit.plugins @)
+  plugins.conf: (@= data.values.fluent_bit.config.plugins @)

--- a/addons/packages/fluent-bit/bundle/config/overlays/overlay-daemonset.yaml
+++ b/addons/packages/fluent-bit/bundle/config/overlays/overlay-daemonset.yaml
@@ -1,0 +1,16 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet", "metadata": {"name": "fluent-bit"}}), expects=1
+---
+spec:
+  updateStrategy: #@ data.values.fluent_bit.daemonset.updateStrategy
+  template:
+    metadata:
+      labels: #@ data.values.fluent_bit.daemonset.podLabels
+      annotations: #@ data.values.fluent_bit.daemonset.podAnnotations
+    spec:
+      containers:
+       #@overlay/match by="name"
+        - name: fluent-bit
+          resources: #@ data.values.fluent_bit.daemonset.resources

--- a/addons/packages/fluent-bit/bundle/config/upstream/fluentbit/daemonset.yaml
+++ b/addons/packages/fluent-bit/bundle/config/upstream/fluentbit/daemonset.yaml
@@ -31,13 +31,8 @@ spec:
             httpGet:
               path: /
               port: http
-          resources:
-            requests:
-              cpu: 5m
-              memory: 10Mi
-            limits:
-              cpu: 50m
-              memory: 60Mi
+          resources: {}
+          securityContext: {}
           volumeMounts:
             - name: var-log
               mountPath: /var/log

--- a/addons/packages/fluent-bit/bundle/config/values.yaml
+++ b/addons/packages/fluent-bit/bundle/config/values.yaml
@@ -2,27 +2,25 @@
 #@overlay/match-child-defaults missing_ok=True
 ---
 namespace: "fluent-bit"
-
 #! Required params for supported output plugins
 fluent_bit:
-  #! https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/variables
-  service: |
-    [Service]
-      Flush         1
-      Log_Level     info
-      Daemon        off
-      Parsers_File  parsers.conf
-      HTTP_Server   On
-      HTTP_Listen   0.0.0.0
-      HTTP_Port     2020
-
-  outputs: |
-    [OUTPUT]
-      Name              stdout
-      Match             *
-
-  inputs: |
-    [INPUT]
+  config:
+    #! https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/variables
+    service: |
+      [Service]
+        Flush         1
+        Log_Level     info
+        Daemon        off
+        Parsers_File  parsers.conf
+        HTTP_Server   On
+        HTTP_Listen   0.0.0.0
+        HTTP_Port     2020
+    outputs: |
+      [OUTPUT]
+        Name              stdout
+        Match             *
+    inputs: |
+      [INPUT]
         Name tail
         Path /var/log/containers/*.log
         Parser docker
@@ -30,33 +28,44 @@ fluent_bit:
         Mem_Buf_Limit 5MB
         Skip_Long_Lines On
 
-    [INPUT]
+      [INPUT]
         Name systemd
         Tag host.*
         Systemd_Filter _SYSTEMD_UNIT=kubelet.service
         Read_From_Tail On
-  filters: |
-    [FILTER]
-      Name                kubernetes
-      Match               kube.*
-      Kube_URL            https://kubernetes.default.svc:443
-      Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-      Kube_Tag_Prefix     kube.var.log.containers.
-      Merge_Log           On
-      Merge_Log_Key       log_processed
-      K8S-Logging.Parser  On
-      K8S-Logging.Exclude Off
+    filters: |
+      [FILTER]
+        Name                kubernetes
+        Match               kube.*
+        Kube_URL            https://kubernetes.default.svc:443
+        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+        Kube_Tag_Prefix     kube.var.log.containers.
+        Merge_Log           On
+        Merge_Log_Key       log_processed
+        K8S-Logging.Parser  On
+        K8S-Logging.Exclude Off
 
-    [FILTER]
-      Name                modify
-      Match               *
-      Rename message text
-  parsers: |
-    [PARSER]
-      Name   json
-      Format json
-      Time_Key time
-      Time_Format %d/%b/%Y:%H:%M:%S %z
-  streams: ""
-  plugins: ""
+      [FILTER]
+        Name                modify
+        Match               *
+        Rename message text
+    parsers: |
+      [PARSER]
+        Name   json
+        Format json
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+    streams: ""
+    plugins: ""
+  #! optional configuration for the daemonset
+  daemonset:
+    resources: { }
+    #! limits:
+    #!   cpu: 100m
+    #!   memory: 128Mi
+    #! requests:
+    #!   cpu: 100m
+    #!   memory: 128Mi
+    podAnnotations: { }
+    podLabels: { }


### PR DESCRIPTION
## What this PR does / why we need it

This adds a handful of customization options for the `fluent-bit` Daemonset along with a script that we'd like to use to inject the same configuration for other daemonsets in other packages we maintain.
