### PR TITLE
Fix condition check for presence of carvel tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ create-channel: # Stub out new channel values file. Usage: make create-channel N
 
 check-carvel:
 	$(foreach exec,$(REQUIRED_BINARIES),\
-		$(if $(shell which $(exec)),placeholder,$(error "'$(exec)' not found. Carvel toolset is required. See instructions at https://carvel.dev/#install")))
+		$(if $(shell which $(exec)),,$(error "'$(exec)' not found. Carvel toolset is required. See instructions at https://carvel.dev/#install")))
 
 vendir-sync-all: check-carvel # Performs a `vendir sync` for each package
 	@cd addons/packages && for package in *; do\


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

The format used by using a "placeholder" string in the check did not
work everywhere. Since this is comparing the location of each tool we
are looking for, it actually should be an empty string.

Correct changes introduced in https://github.com/vmware-tanzu/tce/pull/515/

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

Ran `make check-carvel` on macOS and Linux, with carvel toolset present and not.