### PR TITLE
add script to run TCE CAPD standalone cluster + travis CI job config to run script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install: ./hack/e2e-tests/aws/install-dependencies.sh
 script: ./hack/e2e-tests/aws/build-tce.sh
 after_success:
 - ./hack/e2e-tests/aws/deploy-tce.sh
- 
+- ./test-automation/run-tce-capd-standalone.sh

--- a/test-automation/check-tce-cluster-creation.sh
+++ b/test-automation/check-tce-cluster-creation.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e # Fail on errors
+set -x # See what commands are running
+
+kube_context=$1
+
+if [ -z "$kube_context" ]; then
+    echo "Error: Kube context name not provided. Please provide kube context name"
+    exit 1
+fi
+
+kubectl config use-context "$kube_context"
+
+kubectl cluster-info
+
+kubectl get nodes
+
+kubectl get pods -A

--- a/test-automation/run-tce-capd-standalone.sh
+++ b/test-automation/run-tce-capd-standalone.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -x
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+guest_cluster_name="guest-cluster-${RANDOM}"
+
+CLUSTER_PLAN=dev CLUSTER_NAME="$guest_cluster_name" tanzu standalone-cluster create ${guest_cluster_name} -i docker -v 10
+
+"${MY_DIR}"/check-tce-cluster-creation.sh ${guest_cluster_name}-admin@${guest_cluster_name}


### PR DESCRIPTION

## What this PR does / why we need it

This is to run TCE CAPD standalone cluster automatically using a script with no manual human intervention. This is a precursor to our next step of running end to end (E2E) tests for TCE in an automated manner. So, in order to run E2E tests in an automated manner we first need a cluster up and running using TCE

## Which issue(s) this PR fixes

Fixes: #582 

## Describe testing done for PR
- Manually ran the script
- Also tested it in an automated manner by running script automatically using Travis CI job

## Special notes for your reviewer

Assumptions
1. Docker Engine is running locally and accessible
2. TCE is not installed
3. Kubectl is not installed

Do we need to use the below cleanup commands in CI? Especially if CI is gonna kill / cleanup the machine? As that will kill the containers too and remove the containers and all other resources like networks, volumes, images
`docker kill $(docker ps -q)`

`docker system prune --volumes` - TODO: This is an interactive command and not automatic. Needs some changes

Also, above command assume that all containers are related to TCE. Or we need to use labels or the name of the containers which container cluster name prefix. I can see labels provided by the kind cluster -

```bash
$ docker inspect <container>
...
"Labels": {
                "io.x-k8s.kind.cluster": "guest-cluster-26185",
                "io.x-k8s.kind.role": "worker"
            }
...
```

## Does this PR introduce a user-facing change?
```release-note
NONE
```
