### PR TITLE
Tce capd managed and workload cluster automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script: ./hack/e2e-tests/aws/build-tce.sh
 after_success:
 - ./hack/e2e-tests/aws/deploy-tce.sh
 - ./test-automation/run-tce-capd-standalone.sh
+- ./test-automation/run-tce-capd-managed.sh

--- a/test-automation/install-jq.sh
+++ b/test-automation/install-jq.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -x
+
+curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o jq
+chmod +x jq
+sudo mv jq /usr/local/bin/

--- a/test-automation/run-tce-capd-managed.sh
+++ b/test-automation/run-tce-capd-managed.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -x
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+"${MY_DIR}"/install-jq.sh
+
+random_id="${RANDOM}"
+
+export MGMT_CLUSTER_NAME="management-cluster-${random_id}"
+export GUEST_CLUSTER_NAME="guest-cluster-${random_id}"
+
+tanzu management-cluster create -i docker --name ${MGMT_CLUSTER_NAME} -v 10 --plan dev --ceip-participation=false
+
+# Check management cluster details
+tanzu management-cluster get
+
+# Get kube config of management cluster
+tanzu management-cluster kubeconfig get ${MGMT_CLUSTER_NAME} --admin
+
+"${MY_DIR}"/check-tce-cluster-creation.sh ${MGMT_CLUSTER_NAME}-admin@${MGMT_CLUSTER_NAME}
+
+tanzu cluster create ${GUEST_CLUSTER_NAME} --plan dev
+
+tanzu cluster list
+
+tanzu cluster kubeconfig get ${GUEST_CLUSTER_NAME} --admin
+
+"${MY_DIR}"/check-tce-cluster-creation.sh ${GUEST_CLUSTER_NAME}-admin@${GUEST_CLUSTER_NAME}
+
+tanzu package repository install --default
+
+# wait for packages to be available
+sleep 10
+
+tanzu package list
+
+tanzu package install fluent-bit.tce.vmware.com
+
+kubectl -n fluent-bit get all
+
+kubectl get installedpackage,apps --all-namespaces
+
+tanzu cluster delete ${GUEST_CLUSTER_NAME} --yes
+
+num_of_clusters=$(tanzu cluster list -o json | jq 'length')
+
+while [ "$num_of_clusters" != "0" ]
+do
+    echo "Waiting for workload cluster to get deleted..."
+    sleep 2;
+    num_of_clusters=$(tanzu cluster list -o json | jq 'length')
+done
+
+echo "Workload cluster ${GUEST_CLUSTER_NAME} successfully deleted"
+
+tanzu management-cluster delete ${MGMT_CLUSTER_NAME} --yes
+
+echo "Management cluster ${GUEST_CLUSTER_NAME} successfully deleted"


### PR DESCRIPTION
## What this PR does / why we need it

This is to run TCE CAPD managed and workload clusters automatically using a script with no manual human intervention. This is a precursor to our next step of running end to end (E2E) tests for TCE in an automated manner. So, in order to run E2E tests in an automated manner we first need a cluster up and running using TCE

## Which issue(s) this PR fixes
Fixes: #594 

## Describe testing done for PR
- I manually ran the script locally
- I also tested it in an automated manner by running script automatically using Travis CI job. See build logs https://travis-ci.com/github/karuppiah7890/tce/builds/226664101 (please let me know if you have issues accessing the CI log, I can help give you access)

Note that there were quite some failures - due to resource issues I believe, which made things slower, and lead to timeout issues. You can see the different build logs here - https://travis-ci.com/github/karuppiah7890/tce/builds , for branch level - https://travis-ci.com/github/karuppiah7890/tce/branches , look for `tce-capd-managed-and-workload-cluster-automation` from where this PR has been raised

## Special notes for your reviewer

Assumptions - Same as #583 as mentioned here - https://github.com/vmware-tanzu/tce/pull/583#issue-647296073

## Does this PR introduce a user-facing change?
```release-note
NONE
```