### PR TITLE
pull new versions of grafana, fluent-bit, and prometheus dependencies

### DIFF
--- a/addons/packages/fluent-bit/bundle/.imgpkg/images.yml
+++ b/addons/packages/fluent-bit/bundle/.imgpkg/images.yml
@@ -2,6 +2,6 @@
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
-    kbld.carvel.dev/id: fluent/fluent-bit:1.7.4
-  image: index.docker.io/fluent/fluent-bit@sha256:f1d45c18d2b43cfaf275b5e9d5f7638f46e3b5d504fa8cbb4c315e58540454da
+    kbld.carvel.dev/id: fluent/fluent-bit:1.7.5
+  image: index.docker.io/fluent/fluent-bit@sha256:63745ff3b3ced72611f31b9998435721405573a3239d79974f0e3a60e4903d02
 kind: ImagesLock

--- a/addons/packages/fluent-bit/bundle/config/upstream/fluentbit/daemonset.yaml
+++ b/addons/packages/fluent-bit/bundle/config/upstream/fluentbit/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: fluent-bit
-          image: fluent/fluent-bit:1.7.4
+          image: fluent/fluent-bit:1.7.5
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: http

--- a/addons/packages/grafana/bundle/.imgpkg/images.yml
+++ b/addons/packages/grafana/bundle/.imgpkg/images.yml
@@ -2,6 +2,6 @@
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
-    kbld.carvel.dev/id: grafana/grafana:7.5.5
-  image: index.docker.io/grafana/grafana@sha256:075819791b43f30aab18497fff217d3aec918d7d55bf873818de6a916da04d54
+    kbld.carvel.dev/id: grafana/grafana:7.5.7
+  image: index.docker.io/grafana/grafana@sha256:4e5835bcfd55cf72563a06932f10c75d9d92a0e1334a4c83eaa9c5b897370b25
 kind: ImagesLock

--- a/addons/packages/grafana/bundle/config/upstream/grafana/deployment.yaml
+++ b/addons/packages/grafana/bundle/config/upstream/grafana/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         runAsUser: 472
       containers:
         - name: grafana
-          image: grafana/grafana:7.5.5
+          image: grafana/grafana:7.5.7
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/addons/packages/grafana/bundle/config/values.yaml
+++ b/addons/packages/grafana/bundle/config/values.yaml
@@ -8,7 +8,7 @@ grafana:
   deployment:
     replicas: 1
     image:
-      name: "grafana/grafana:7.5.5"
+      name: "grafana/grafana:7.5.7"
       pullPolicy: "IfNotPresent"
   #! The grafana configuration.
   config:

--- a/addons/packages/prometheus/bundle/.imgpkg/images.yml
+++ b/addons/packages/prometheus/bundle/.imgpkg/images.yml
@@ -2,14 +2,14 @@
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
-    kbld.carvel.dev/id: gcr.io/cadvisor/cadvisor:v0.37.5
-  image: gcr.io/cadvisor/cadvisor@sha256:071f30c4fed3c733336c5fe5b260c12a0352be7b943625a067902b2b7551fab6
+    kbld.carvel.dev/id: gcr.io/cadvisor/cadvisor:v0.39.1
+  image: gcr.io/cadvisor/cadvisor@sha256:10638ceca79c01f4045f4a645242e763fe62eeb71d859ff93b09b0854a0d2220
 - annotations:
     kbld.carvel.dev/id: prom/alertmanager:v0.21.0
   image: index.docker.io/prom/alertmanager@sha256:7e4e9f7a0954b45736d149c40e9620a6664036bb05f0dce447bef5042b139f5d
 - annotations:
-    kbld.carvel.dev/id: prom/prometheus:v2.26.0
-  image: index.docker.io/prom/prometheus@sha256:38d40a760569b1c5aec4a36e8a7f11e86299e9191b9233672a5d41296d8fa74e
+    kbld.carvel.dev/id: prom/prometheus:v2.27.0
+  image: index.docker.io/prom/prometheus@sha256:d1a9a86b9a3e60a9ea3cde141bdc936847456acc497e0affe7e288234383efa5
 - annotations:
     kbld.carvel.dev/id: prom/pushgateway:v1.4.0
   image: index.docker.io/prom/pushgateway@sha256:ca32c7864bb2573bf27ff6628a03d17b37b1aa3dc367b5d86831e6c0f0761376

--- a/addons/packages/prometheus/bundle/config/upstream/cadvisor/daemonset.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/cadvisor/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: prometheus-cadvisor
       containers:
       - name: prometheus-cadvisor
-        image: gcr.io/cadvisor/cadvisor:v0.37.5
+        image: gcr.io/cadvisor/cadvisor:v0.39.1
         imagePullPolicy: "IfNotPresent"
         volumeMounts:
         - name: rootfs

--- a/addons/packages/prometheus/bundle/config/upstream/prometheus/deployment.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/prometheus/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: prometheus-server-sa
       containers:
         - name: prometheus-server
-          image: prom/prometheus:v2.26.0
+          image: prom/prometheus:v2.27.0
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d


### PR DESCRIPTION
## What this PR does / why we need it

Pulling in a few newly available image versions ahead of an upcoming internal milestone.

Most notably, the v0.39.1 release of cadvisor fixes a CVE in runc.

