### PR TITLE
Export args field for Multus CNI DaemonSet

### DIFF
--- a/addons/packages/multus-cni/README.md
+++ b/addons/packages/multus-cni/README.md
@@ -23,6 +23,7 @@ The following configuration values can be set to customize the Multus CNI instal
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
 | `image` | Optional | The image used by Multus CNI DaemonSet. |
+| `args` | Optional | The args for Multus CNI DaemonSet container. |
 
 ## Usage Example
 

--- a/addons/packages/multus-cni/bundle/config/overlays/overlay-multus-cni.yaml
+++ b/addons/packages/multus-cni/bundle/config/overlays/overlay-multus-cni.yaml
@@ -2,6 +2,19 @@
 #@ load("@ytt:data", "data")
 
 #@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "kube-multus-ds-amd64"}})
+#@overlay/match-child-defaults missing_ok=True
+---
+spec:
+  template:
+    spec:
+      containers:
+      #@overlay/match by=overlay.subset({"name": "kube-multus"})
+      - 
+        #@overlay/remove
+        args:
+
+#@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "kube-multus-ds-amd64"}})
+#@overlay/match-child-defaults missing_ok=True
 ---
 metadata:
   namespace: #@ data.values.namespace
@@ -10,7 +23,9 @@ spec:
     spec:
       containers:
       #@overlay/match by=overlay.subset({"name": "kube-multus"})
-      - image: #@ data.values.multus_cni.image
+      - 
+        image: #@ "{}/{}:{}".format(data.values.image.repository, data.values.image.name, data.values.image.tag)
+        args: #@ data.values.daemonset.args
 
 #@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "kube-multus-ds-ppc64le"}})
 #@overlay/remove

--- a/addons/packages/multus-cni/bundle/config/values.yaml
+++ b/addons/packages/multus-cni/bundle/config/values.yaml
@@ -1,7 +1,21 @@
 #@data/values
+#@overlay/match-child-defaults missing_ok=True
 ---
 
 namespace: kube-system
 
-multus_cni:
-  image: docker.io/nfvpe/multus:stable
+image:
+  repository: docker.io/nfvpe
+  name: multus
+  tag: stable
+
+#! DaemonSet related configuration
+#@overlay/replace
+daemonset:
+  #! (OPTIONAL) Args passed via command-line to multus-cni
+  #! Below items are examples same as upstream settings
+  #! For more guide, please refer to
+  #! https://github.com/k8snetworkplumbingwg/multus-cni/tree/master/docs 
+  args:
+    - "--multus-conf-file=auto"
+    - "--cni-version=0.3.1"

--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -83,7 +83,7 @@ package_repository:
     - name: multus-cni
       domain: tce.vmware.com
       version: 3.7.1-vmware0
-      image: projects-stg.registry.vmware.com/tkg/cliu2/multus-cni-extension-templates@sha256:90b0537b4f8965c45eb7ccd29cd35803306a2415631d27330e42efd39ebf3e02
+      image: projects.registry.vmware.com/tce/multus-cni@sha256:8729f0b967224966d5675f34178fd12337fa51e18453310b00c754e80f862c88
       description: Multus CNI enables attaching multiple network interfaces to pods in Kubernetes.
 
     - name: vsphere-cpi


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->
Multus CNI supports different ways to configure how it will configure the network. This PR export the configurable fields through args list to let users can choose different ways like `auto` or a specific ConfigMap contains the configuration to configure the CNI.
## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

1. ytt -f . will give the wanted Daemonset and other resources
2. on a workload cluster, generate a package repository image-type bundle and install it. run tanzu package configure to download the values.yaml and add some wrong paramsthen install it.
Multus CNI failed as expected.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
