### PR TITLE
Fix shell check

### DIFF
--- a/hack/e2e-tests/aws/install-dependencies.sh
+++ b/hack/e2e-tests/aws/install-dependencies.sh
@@ -17,7 +17,7 @@ function error {
 
 # Make sure docker is installed
 echo "Docker check!"
-if [[ -z "$(which docker)" ]]; then
+if [[ -z "$(command -v docker)" ]]; then
     if [[ "$BUILD_OS" == "Linux" ]]; then
         sudo apt-get update > /dev/null
         sudo apt-get install -y \
@@ -51,7 +51,7 @@ if ! sudo docker run hello-world > /dev/null; then
 fi
 
 # Make sure kubectl is installed
-if [[ -z "$(which kubectl)" ]]; then
+if [[ -z "$(command -v kubectl)" ]]; then
     if [[ "$BUILD_OS" == "Linux" ]]; then
         curl -LO https://dl.k8s.io/release/v1.20.1/bin/linux/amd64/kubectl
     elif [[ "$BUILD_OS" == "Darwin" ]]; then


### PR DESCRIPTION
## What this PR does / why we need it
It looks like `make check` has been broken on this github action: https://github.com/vmware-tanzu/tce/runs/2678792375?check_suite_focus=true

The error:
```
hack/check-shell.sh
ShellCheck - shell script analysis tool
version: 0.7.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net

In ./hack/e2e-tests/aws/install-dependencies.sh line 20:
if [[ -z "$(which docker)" ]]; then
            ^---^ SC2230: which is non-standard. Use builtin 'command -v' instead.


In ./hack/e2e-tests/aws/install-dependencies.sh line 54:
if [[ -z "$(which kubectl)" ]]; then
            ^---^ SC2230: which is non-standard. Use builtin 'command -v' instead.

For more information:
  https://www.shellcheck.net/wiki/SC2230 -- which is non-standard. Use builti...
make: *** [Makefile:119: shellcheck] Error 123
Error: Process completed with exit code 2.
```

The error seems to have popped up after merging this PR:
https://github.com/vmware-tanzu/tce/pull/590

It appears running `make check` locally doesn't seem to produce any errors and more. I need to look into why this is in a follow-up PR.

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
NA

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
NA