### PR TITLE
Fix go.sum for build

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1742,12 +1742,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7Zo
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vito/go-interact v0.0.0-20171111012221-fa338ed9e9ec h1:Klu98tQ9Z1t23gvC7p7sCmvxkZxLhBHLNyrUPsWsYFg=
 github.com/vito/go-interact v0.0.0-20171111012221-fa338ed9e9ec/go.mod h1:wPlfmglZmRWMYv/qJy3P+fK/UnoQB5ISk4txfNd9tDo=
-github.com/vmware-tanzu-private/core v1.3.1-0.20210524181536-6510d9ff7974 h1:yX8XKPIY0A/2FqGy4JzVSyabO7sj6jyOMotTAWNyjwo=
-github.com/vmware-tanzu-private/core v1.3.1-0.20210524181536-6510d9ff7974/go.mod h1:w7vyUrDtTZWYIyxOG5DqQuNQLbo40lGqr99LPJfJnj8=
 github.com/vmware-tanzu-private/core v1.3.1-0.20210524231710-aaa4fe81d0e3 h1:oKVJvWNUjrHVBaAF5sTv9GXEHDhsYVjRKIfbGqXRGRI=
 github.com/vmware-tanzu-private/core v1.3.1-0.20210524231710-aaa4fe81d0e3/go.mod h1:bFSx4RPTeC/8ha6G/sIV6kWr0tpHgfShHVLI50YdRl4=
-github.com/vmware-tanzu-private/tkg-cli v1.3.1-0.20210524231343-b0dd61093e8d h1:aHjP5bkCwIefZidMEzQjl+4q8y8zVi9f78aZE/+CJJQ=
-github.com/vmware-tanzu-private/tkg-cli v1.3.1-0.20210524231343-b0dd61093e8d/go.mod h1:o1RK/zC9s2WAcsIqhZWNDiJPmXg4SLBHkOlXG95A6Gs=
 github.com/vmware-tanzu-private/tkg-cli v1.3.1-0.20210525051804-aecf8ddffda7 h1:6aaIGoW3QEMTarQIHmtRbEc5deRoZKJ80vIcC6KRx/8=
 github.com/vmware-tanzu-private/tkg-cli v1.3.1-0.20210525051804-aecf8ddffda7/go.mod h1:o1RK/zC9s2WAcsIqhZWNDiJPmXg4SLBHkOlXG95A6Gs=
 github.com/vmware-tanzu-private/tkg-providers v1.3.1-0.20210422215837-027482ef8765 h1:COlCwxflxhePl5PbV8BGtItfru4odCcqj9amYi64Bbo=


### PR DESCRIPTION
## What this PR does / why we need it
It appears that go.mod may not have been updated in the latest rounds of updating go.mod. When you run a `make build-plugin` on the current code in `main`, a new go.sum gets generated. Since we need to update the go.sum file, I ran a `go mod tidy` and verified `make build-plugin` works. Making sure that isn't the hang up when building the release.

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
NA

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
No
