### PR TITLE
check-shell default to docker image & ensure deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,10 @@ TAG := latest
 
 ##### LINTING TARGETS #####
 .PHONY: lint mdlint shellcheck check
-check: lint mdlint shellcheck
+check: ensure-deps lint mdlint shellcheck
+
+ensure-deps:
+	hack/ensure-dependencies.sh
 
 lint: tools
 	$(GOLANGCI_LINT) run -v --timeout=5m

--- a/hack/check-shell.sh
+++ b/hack/check-shell.sh
@@ -25,18 +25,18 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 usage() {
   cat <<EOF
 usage: ${0} [FLAGS]
-  Lints the project's shell scripts.
+  Lints the project's shell scripts using Docker.
 
 FLAGS
-  -d    use the docker image
+  -l    use your local shellcheck (warning - errors may differ from docker!)
   -h    prints this help screen
 EOF
 }
 
-while getopts ':dh' opt; do
+while getopts ':lh' opt; do
   case "${opt}" in
-  d)
-    DO_DOCKER=1
+  l)
+    DO_DOCKER=0
     ;;
   h)
     usage 1>&2; exit 1
@@ -51,9 +51,10 @@ while getopts ':dh' opt; do
 done
 shift $((OPTIND-1))
 
-if [ ! "${DO_DOCKER-}" ] && command -v shellcheck >/dev/null 2>&1; then
+if [ "${DO_DOCKER-}" ]; then
   shellcheck --version
   find . -path ./vendor -prune -o -name "*.*sh" -type f -print0 | xargs -0 shellcheck
 else
+  docker run --rm -t -v "$(pwd)":/build:ro gcr.io/cluster-api-provider-vsphere/extra/shellcheck --version
   docker run --rm -t -v "$(pwd)":/build:ro gcr.io/cluster-api-provider-vsphere/extra/shellcheck
 fi

--- a/hack/ensure-dependencies.sh
+++ b/hack/ensure-dependencies.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script can be used to check your local development environment
+# for necessary dependencies used in TCE
+
+i=0
+
+if [[ -z "$(command -v go)" ]]; then
+    echo "Missing go"
+    ((i=i+1))
+fi
+
+if [[ -z "$(command -v imgpkg)" ]]; then
+    echo "Missing imgpkg"
+    ((i=i+1))
+fi
+
+if [[ -z "$(command -v kbld)" ]]; then
+    echo "Missing kbld"
+    ((i=i+1))
+fi
+
+if [[ -z "$(command -v ytt)" ]]; then
+    echo "Missing ytt"
+    ((i=i+1))
+fi
+
+if [[ -z "$(command -v shellcheck)" ]]; then
+    echo "Missing shellcheck"
+    ((i=i+1))
+fi
+
+if [[ -z "$(command -v docker)" ]]; then
+    echo "Missing docker"
+    ((i=i+1))
+fi
+
+if [[ -z "$(command -v kubectl)" ]]; then
+    echo "Missing kubectl"
+    ((i=i+1))
+fi
+
+if [[ $i -gt 0 ]]; then
+    echo "Total missing: $i"
+    echo "Please install dependencies to continue"
+    exit 1
+fi
+
+echo "No missing dependencies!"
+exit 0
+


### PR DESCRIPTION
`hack/check-shell.sh` now defaults to using the docker image. This came up since different minor versions of shellcheck may have different "errors" vs the one used in CI. This came up during conversation in https://github.com/vmware-tanzu/tce/pull/620. So now, a local user can be assured that their shellcheck is the same as the one that is run in CI.

A user must now specify `./hack/check-shell.sh -l` to run the script _with a local_ shellcheck binary 

Also includes a script to ensure development dependencies on the system. This is run before `make check` and will fail if various binaries are not installed.

## What this PR does / why we need it
Fixes discrepancies between CI and local shellcheck

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
Shellcheck now passes locally using docker. Need to ensure this also still works in CI.

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
```release-note
NONE
```
