### PR TITLE
Revert ensure check

### DIFF
--- a/hack/ensure-dependencies.sh
+++ b/hack/ensure-dependencies.sh
@@ -13,35 +13,35 @@ if [[ -z "$(command -v go)" ]]; then
     ((i=i+1))
 fi
 
-if [[ -z "$(command -v imgpkg)" ]]; then
-    echo "Missing imgpkg"
-    ((i=i+1))
-fi
+# if [[ -z "$(command -v imgpkg)" ]]; then
+#     echo "Missing imgpkg"
+#     ((i=i+1))
+# fi
 
-if [[ -z "$(command -v kbld)" ]]; then
-    echo "Missing kbld"
-    ((i=i+1))
-fi
+# if [[ -z "$(command -v kbld)" ]]; then
+#     echo "Missing kbld"
+#     ((i=i+1))
+# fi
 
-if [[ -z "$(command -v ytt)" ]]; then
-    echo "Missing ytt"
-    ((i=i+1))
-fi
+# if [[ -z "$(command -v ytt)" ]]; then
+#     echo "Missing ytt"
+#     ((i=i+1))
+# fi
 
-if [[ -z "$(command -v shellcheck)" ]]; then
-    echo "Missing shellcheck"
-    ((i=i+1))
-fi
+# if [[ -z "$(command -v shellcheck)" ]]; then
+#     echo "Missing shellcheck"
+#     ((i=i+1))
+# fi
 
 if [[ -z "$(command -v docker)" ]]; then
     echo "Missing docker"
     ((i=i+1))
 fi
 
-if [[ -z "$(command -v kubectl)" ]]; then
-    echo "Missing kubectl"
-    ((i=i+1))
-fi
+# if [[ -z "$(command -v kubectl)" ]]; then
+#     echo "Missing kubectl"
+#     ((i=i+1))
+# fi
 
 if [[ $i -gt 0 ]]; then
     echo "Total missing: $i"


### PR DESCRIPTION
## What this PR does / why we need it
Need to revert the ensure check. There are a number of places in which we would need to pre-bake utilities like ytt, imgpkg, and etc. If these components are required, then we need to ensure the dependencies via a dynamic download. This reverts some checks just so we can get GitHub build nodes and Cayman build nodes to pass this check for now until the dynamic download is implemented.
