### PR TITLE
Handle case for commit before pushing dev tag

### DIFF
--- a/.github/workflows/fake-release.yaml
+++ b/.github/workflows/fake-release.yaml
@@ -22,6 +22,7 @@ jobs:
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: |
+          git config --global pull.rebase true
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -22,6 +22,7 @@ jobs:
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: |
+          git config --global pull.rebase true
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: |
+          git config --global pull.rebase true
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
       - name: Check out code into the Go module directory

--- a/hack/update-tag.sh
+++ b/hack/update-tag.sh
@@ -24,6 +24,12 @@ fi
 git config user.name github-actions
 git config user.email github-actions@github.com
 
+# handle the case when a PR is merged before the commit/tag can complete
+git stash
+git fetch
+git pull origin main
+git stash pop
+
 if [[ "${FAKE_RELEASE}" != "" ]]; then
 
 DEV_VERSION=$(awk '{print $2}' < ./hack/FAKE_BUILD_VERSION.yaml)


### PR DESCRIPTION
## What this PR does / why we need it
If there is a commit that happens before we bump the tag, we might need to rebase before committing the dev file and dev tag. This can happen because the build takes forever (because we rebuild the world) but will go away when we start consuming pure Core bits. Never the less, we should probably handle that use case. As happened in this run:
https://github.com/vmware-tanzu/tce/actions/runs/886798898

Error:
```
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
make: *** [Makefile:191: tag-release] Error 1
```