### PR TITLE
Fix incorrect action named in standalone delete failure

### DIFF
--- a/cli/pkg/standalone-cluster/delete.go
+++ b/cli/pkg/standalone-cluster/delete.go
@@ -92,7 +92,7 @@ func teardown(cmd *cobra.Command, args []string) error {
 
 	err = c.DeleteStandalone(teardownRegionOpts)
 	if err != nil {
-		return utils.Error(err, "standalone cluster creation failed")
+		return utils.Error(err, "standalone cluster deletion failed")
 	}
 
 	err = removeStandaloneClusterConfig(clusterName)


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

When deletion of a standalone cluster would fail, the error printed on
the command line would state "Error: standalone cluster creation failed"
rather than "standalone cluster deletion failed". Trivial fix to
reference the right action.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #661