### PR TITLE
Docs: Update fluent-bit naming in package docs

### DIFF
--- a/docs/site/content/docs/assets/package-installation.md
+++ b/docs/site/content/docs/assets/package-installation.md
@@ -18,7 +18,7 @@ With a cluster bootstrapped, you're ready to configure and install packages to t
 
 1. List the available packages.
 
-    ```txt
+    ```sh
     tanzu package list
 
     NAME                             VERSION         
@@ -34,7 +34,6 @@ With a cluster bootstrapped, you're ready to configure and install packages to t
     ```
 
 1. [Optional]: Download the configuration for a package.
-
 
    ```sh
    tanzu package configure fluent-bit.tce.vmware.com
@@ -53,7 +52,6 @@ With a cluster bootstrapped, you're ready to configure and install packages to t
 
     ```sh
     tanzu package install fluent-bit.tce.vmware.com --config fluent-bit.tce.vmware.com-values.yaml
-
 
     Looking up package to install: fluent-bit.tce.vmware.com:
     Installed package in default/fluent-bit.tce.vmware.com:1.7.2-vmware0


### PR DESCRIPTION
## What this PR does / why we need it
Uses the correct names for packages in docs. For example, instead of 
`fluent-bit`
use the fully qualified package name (as it shows up in the CLI)
`fluent-bit.tce.vmware.com`

## Which issue(s) this PR fixes

Fixes: #561
