### PR TITLE
Add annotation kapp.k14s.io/versioned to ConfigMaps and Secrets in some core packages

### DIFF
--- a/addons/packages/antrea/bundle/config/overlay/antrea_overlay.yaml
+++ b/addons/packages/antrea/bundle/config/overlay/antrea_overlay.yaml
@@ -152,11 +152,23 @@ selfSignedCert: true
 
 #@ end
 
+#@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-ca"}})
+---
+kind: ConfigMap
+metadata:
+  name: antrea-ca
+  #@overlay/match missing_ok=True
+  annotations:
+    kapp.k14s.io/versioned: ""
+
 #@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-config-b59fc7d2b4"}})
 ---
 kind: ConfigMap
 metadata:
   name: antrea-config-b59fc7d2b4
+  annotations:
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/versioned: ""
 data:
   antrea-agent.conf: #@ yaml.encode(antrea_agent_conf())
   antrea-controller.conf: #@ yaml.encode(antrea_controller_conf())

--- a/addons/packages/calico/bundle/config/overlay/calico_overlay.yaml
+++ b/addons/packages/calico/bundle/config/overlay/calico_overlay.yaml
@@ -53,6 +53,10 @@ metadata:
 
 #@overlay/match by=overlay.subset({"kind":"ConfigMap"})
 ---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    kapp.k14s.io/versioned: ""
 data:
   #@ if/end values.infraProvider == "azure":
   calico_backend: "vxlan"

--- a/addons/packages/vsphere-csi/bundle/config/overlays/add-secret.yaml
+++ b/addons/packages/vsphere-csi/bundle/config/overlays/add-secret.yaml
@@ -7,6 +7,8 @@ kind: Secret
 metadata:
   name: vsphere-config-secret
   namespace: kube-system
+  annotations:
+    kapp.k14s.io/versioned: ""
 stringData:
   csi-vsphere.conf: #@ vsphere_conf(values)
 type: Opaque

--- a/addons/packages/vsphere-csi/bundle/config/overlays/update-vsphere-csi-controller-deployment.yaml
+++ b/addons/packages/vsphere-csi/bundle/config/overlays/update-vsphere-csi-controller-deployment.yaml
@@ -66,3 +66,10 @@ spec:
               name: socket-dir
           imagePullPolicy: IfNotPresent
         #@ end
+
+#@overlay/match by=overlay.subset({"kind":"ConfigMap"})
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    kapp.k14s.io/versioned: ""


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->
The users may modify some configmaps or secrets used by the Deployment/DaemonSet/etc. in the packages, and expect the changes to take effect as soon as possible without manually restarting the Deployment/DaemonSet.

This PR add the annotation `kapp.k14s.io/versioned: ""` to all configmaps and secrets to achieve it.
## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: Reconfiguration in core addons secret does not take effect.

This PR fixes the issue in Calico/Antrea/CSI packages, but not CPI package. 
CPI uses the ConfigMap in which there is a reference to the secret name and kapp's annotation `kapp.k14s.io/versioned` doesn't work in this case, as kapp update the configmap/secret name in the DS/Deployment to something like 'original-secret-name-ver-N'.

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
`ytt -f .` locally produces the expected result and tests the changes based on kapp-controller 0.19.0-alpha.7 TCE cluster. And modify one secret then new versioned secret is created and resources that refers the secret is restarted and refers the newly created resource which follows naming rule `-ver-n`
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
