### PR TITLE
bump contour-operator to 1.15.1

### DIFF
--- a/addons/packages/contour-operator/bundle/.imgpkg/images.yml
+++ b/addons/packages/contour-operator/bundle/.imgpkg/images.yml
@@ -2,8 +2,8 @@
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
-    kbld.carvel.dev/id: docker.io/projectcontour/contour-operator:v1.11.0
-  image: index.docker.io/projectcontour/contour-operator@sha256:fcece509bb2e3386402e29ff37b9309e0d44a82c8ed988fc88416d1e5da5e62c
+    kbld.carvel.dev/id: docker.io/projectcontour/contour-operator:v1.15.1
+  image: index.docker.io/projectcontour/contour-operator@sha256:f48d5f2be1d7d47ec52f14ae93828d25fee664d1802ccf63028518ea82a19a97
 - annotations:
     kbld.carvel.dev/id: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
   image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:e10d1d982dd653db74ca87a1d1ad017bc5ef1aeb651bdea089debf16485b080b

--- a/addons/packages/contour-operator/bundle/config/upstream/operator.yaml
+++ b/addons/packages/contour-operator/bundle/config/upstream/operator.yaml
@@ -9,7 +9,221 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: backendpolicies.networking.x-k8s.io
+spec:
+  group: networking.x-k8s.io
+  names:
+    kind: BackendPolicy
+    listKind: BackendPolicyList
+    plural: backendpolicies
+    shortNames:
+    - bp
+    singular: backendpolicy
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BackendPolicy defines policies associated with backends. For
+          the purpose of this API, a backend is defined as any resource that a route
+          can forward traffic to. A common example of a backend is a Service. Configuration
+          that is implementation specific may be represented with similar implementation
+          specific custom resources.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendPolicy.
+            properties:
+              backendRefs:
+                description: "BackendRefs define which backends this policy should
+                  be applied to. This policy can only apply to backends within the
+                  same namespace. If more than one BackendPolicy targets the same
+                  backend, precedence must be given to the oldest BackendPolicy. \n
+                  Support: Core"
+                items:
+                  description: BackendRef identifies an API object within the same
+                    namespace as the BackendPolicy.
+                  properties:
+                    group:
+                      description: Group is the group of the referent.
+                      maxLength: 253
+                      type: string
+                    kind:
+                      description: Kind is the kind of the referent.
+                      maxLength: 253
+                      type: string
+                    name:
+                      description: Name is the name of the referent.
+                      maxLength: 253
+                      type: string
+                    port:
+                      description: Port is the port of the referent. If unspecified,
+                        this policy applies to all ports on the backend.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                type: array
+              tls:
+                description: "TLS is the TLS configuration for these backends. \n
+                  Support: Extended"
+                properties:
+                  certificateAuthorityRef:
+                    description: "CertificateAuthorityRef is a reference to a resource
+                      that includes trusted CA certificates for the associated backends.
+                      If an entry in this list omits or specifies the empty string
+                      for both the group and the resource, the resource defaults to
+                      \"secrets\". An implementation may support other resources (for
+                      example, resource \"mycertificates\" in group \"networking.acme.io\").
+                      \n When stored in a Secret, certificates must be PEM encoded
+                      and specified within the \"ca.crt\" data field of the Secret.
+                      Multiple certificates can be specified, concatenated by new
+                      lines. \n Support: Extended"
+                    properties:
+                      group:
+                        description: Group is the group of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      kind:
+                        description: Kind is kind of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                    - group
+                    - kind
+                    - name
+                    type: object
+                  options:
+                    additionalProperties:
+                      type: string
+                    description: "Options are a list of key/value pairs to give extended
+                      options to the provider. \n Support: Implementation-specific"
+                    type: object
+                type: object
+            required:
+            - backendRefs
+            type: object
+          status:
+            description: Status defines the current state of BackendPolicy.
+            properties:
+              conditions:
+                description: Conditions describe the current conditions of the BackendPolicy.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: contours.operator.projectcontour.io
 spec:
@@ -48,12 +262,30 @@ spec:
           spec:
             description: Spec defines the desired state of Contour.
             properties:
+              gatewayClassRef:
+                description: GatewayClassRef is a reference to a GatewayClass name
+                  used for managing a Contour.
+                maxLength: 253
+                type: string
+              ingressClassName:
+                description: "IngressClassName is the name of the IngressClass used
+                  by Contour. If unset, Contour will process all ingress objects without
+                  an ingress class annotation or ingress objects with an annotation
+                  matching ingress-class=contour. When specified, Contour will only
+                  process ingress objects that match the provided class. \n For additional
+                  IngressClass details, refer to:   https://projectcontour.io/docs/main/config/annotations/#ingress-class"
+                maxLength: 253
+                minLength: 1
+                type: string
               namespace:
                 default:
                   name: projectcontour
                   removeOnDeletion: false
-                description: Namespace defines the schema of a Contour namespace.
-                  See each field for additional details.
+                description: "Namespace defines the schema of a Contour namespace.
+                  See each field for additional details. Namespace name should be
+                  the same namespace as the Gateway when GatewayClassRef is set. \n
+                  TODO [danehans]: Ignore Namespace when GatewayClassRef is set. xref:
+                  https://github.com/projectcontour/contour-operator/issues/212"
                 properties:
                   name:
                     default: projectcontour
@@ -66,8 +298,195 @@ spec:
                       the Contour is deleted. If set to True, deletion will not occur
                       if any of the following conditions exist: \n 1. The Contour
                       namespace is \"default\", \"kube-system\" or the    contour-operator's
-                      namespace. \n 2. Another Contour exists in the namespace."
+                      namespace. \n 2. Another Contour exists in the namespace. \n
+                      3. The namespace does not contain the Contour owning label."
                     type: boolean
+                type: object
+              networkPublishing:
+                default:
+                  envoy:
+                    containerPorts:
+                    - name: http
+                      portNumber: 8080
+                    - name: https
+                      portNumber: 8443
+                    type: LoadBalancerService
+                description: "NetworkPublishing defines the schema for publishing
+                  Contour to a network. \n See each field for additional details."
+                properties:
+                  envoy:
+                    default:
+                      containerPorts:
+                      - name: http
+                        portNumber: 8080
+                      - name: https
+                        portNumber: 8443
+                      loadBalancer:
+                        providerParameters:
+                          type: AWS
+                        scope: External
+                      type: LoadBalancerService
+                    description: "Envoy provides the schema for publishing the network
+                      endpoints of Envoy. \n If unset, defaults to:   type: LoadBalancerService
+                      \  containerPorts:   - name: http     portNumber: 8080   - name:
+                      https     portNumber: 8443"
+                    properties:
+                      containerPorts:
+                        default:
+                        - name: http
+                          portNumber: 8080
+                        - name: https
+                          portNumber: 8443
+                        description: "ContainerPorts is a list of container ports
+                          to expose from the Envoy container(s). Exposing a port here
+                          gives the system additional information about the network
+                          connections the Envoy container uses, but is primarily informational.
+                          Not specifying a port here DOES NOT prevent that port from
+                          being exposed by Envoy. Any port which is listening on the
+                          default \"0.0.0.0\" address inside the Envoy container will
+                          be accessible from the network. Names and port numbers must
+                          be unique in the list container ports. Two ports must be
+                          specified, one named \"http\" for Envoy's insecure service
+                          and one named \"https\" for Envoy's secure service. \n TODO
+                          [danehans]: Update minItems to 1, requiring only https when
+                          the following issue is fixed: https://github.com/projectcontour/contour/issues/2577.
+                          \n TODO [danehans]: Increase maxItems when https://github.com/projectcontour/contour/pull/3263
+                          is implemented."
+                        items:
+                          description: ContainerPort is the schema to specify a network
+                            port for a container. A container port gives the system
+                            additional information about network connections a container
+                            uses, but is primarily informational.
+                          properties:
+                            name:
+                              description: Name is an IANA_SVC_NAME within the pod.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            portNumber:
+                              description: PortNumber is the network port number to
+                                expose on the envoy pod. The number must be greater
+                                than 0 and less than 65536.
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          required:
+                          - name
+                          - portNumber
+                          type: object
+                        maxItems: 2
+                        minItems: 2
+                        type: array
+                      loadBalancer:
+                        default:
+                          providerParameters:
+                            type: AWS
+                          scope: External
+                        description: "loadBalancer holds parameters for the load balancer.
+                          Present only if type is LoadBalancerService. \n If unspecified,
+                          defaults to an external Classic AWS ELB."
+                        properties:
+                          providerParameters:
+                            default:
+                              type: AWS
+                            description: providerParameters contains load balancer
+                              information specific to the underlying infrastructure
+                              provider.
+                            properties:
+                              type:
+                                default: AWS
+                                description: type is the underlying infrastructure
+                                  provider for the load balancer. Allowed values are
+                                  "AWS", "Azure", and "GCP".
+                                enum:
+                                - AWS
+                                - Azure
+                                - GCP
+                                type: string
+                            type: object
+                          scope:
+                            default: External
+                            description: Scope indicates the scope at which the load
+                              balancer is exposed. Possible values are "External"
+                              and "Internal".
+                            enum:
+                            - Internal
+                            - External
+                            type: string
+                        type: object
+                      nodePorts:
+                        description: "NodePorts is a list of network ports to expose
+                          on each node's IP at a static port number using a NodePort
+                          Service. Present only if type is NodePortService. A ClusterIP
+                          Service, which the NodePort Service routes to, is automatically
+                          created. You'll be able to contact the NodePort Service,
+                          from outside the cluster, by requesting <NodeIP>:<NodePort>.
+                          \n If type is NodePortService and nodePorts is unspecified,
+                          two nodeports will be created, one named \"http\" and the
+                          other named \"https\", with port numbers auto assigned by
+                          Kubernetes API server. For additional information on the
+                          NodePort Service, see: \n  https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+                          \n Names and port numbers must be unique in the list. Two
+                          ports must be specified, one named \"http\" for Envoy's
+                          insecure service and one named \"https\" for Envoy's secure
+                          service."
+                        items:
+                          description: NodePort is the schema to specify a network
+                            port for a NodePort Service.
+                          properties:
+                            name:
+                              description: Name is an IANA_SVC_NAME within the NodePort
+                                Service.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            portNumber:
+                              description: "PortNumber is the network port number
+                                to expose for the NodePort Service. If unspecified,
+                                a port number will be assigned from the the cluster's
+                                nodeport service range, i.e. --service-node-port-range
+                                flag (default: 30000-32767). \n If specified, the
+                                number must: \n 1. Not be used by another NodePort
+                                Service. 2. Be within the cluster's nodeport service
+                                range, i.e. --service-node-port-range    flag (default:
+                                30000-32767). 3. Be a valid network port number, i.e.
+                                greater than 0 and less than 65536."
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          required:
+                          - name
+                          type: object
+                        maxItems: 2
+                        minItems: 2
+                        type: array
+                      type:
+                        default: LoadBalancerService
+                        description: "Type is the type of publishing strategy to use.
+                          Valid values are: \n * LoadBalancerService \n In this configuration,
+                          network endpoints for Envoy use container networking. A
+                          Kubernetes LoadBalancer Service is created to publish Envoy
+                          network endpoints. The Service uses port 80 to publish Envoy's
+                          HTTP network endpoint and port 443 to publish Envoy's HTTPS
+                          network endpoint. \n See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+                          \n * NodePortService \n Publishes Envoy network endpoints
+                          using a Kubernetes NodePort Service. \n In this configuration,
+                          Envoy network endpoints use container networking. A Kubernetes
+                          NodePort Service is created to publish the network endpoints.
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+                          \n * ClusterIPService \n Publishes Envoy network endpoints
+                          using a Kubernetes ClusterIP Service. \n In this configuration,
+                          Envoy network endpoints use container networking. A Kubernetes
+                          ClusterIP Service is created to publish the network endpoints.
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types"
+                        enum:
+                        - LoadBalancerService
+                        - NodePortService
+                        - ClusterIPService
+                        type: string
+                    type: object
                 type: object
               replicas:
                 default: 2
@@ -189,7 +608,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: extensionservices.projectcontour.io
 spec:
@@ -230,19 +649,54 @@ spec:
             properties:
               loadBalancerPolicy:
                 description: The policy for load balancing GRPC service requests.
-                  Note that the `Cookie` load balancing strategy cannot be used here.
+                  Note that the `Cookie` and `RequestHash` load balancing strategies
+                  cannot be used here.
                 properties:
+                  requestHashPolicies:
+                    description: RequestHashPolicies contains a list of hash policies
+                      to apply when the `RequestHash` load balancing strategy is chosen.
+                      If an element of the supplied list of hash policies is invalid,
+                      it will be ignored. If the list of hash policies is empty after
+                      validation, the load balancing strategy will fall back the the
+                      default `RoundRobin`.
+                    items:
+                      description: RequestHashPolicy contains configuration for an
+                        individual hash policy on a request attribute.
+                      properties:
+                        headerHashOptions:
+                          description: HeaderHashOptions should be set when request
+                            header hash based load balancing is desired. It must be
+                            the only hash option field set, otherwise this request
+                            hash policy object will be ignored.
+                          properties:
+                            headerName:
+                              description: HeaderName is the name of the HTTP request
+                                header that will be used to calculate the hash key.
+                                If the header specified is not present on a request,
+                                no hash will be produced.
+                              minLength: 1
+                              type: string
+                          type: object
+                        terminal:
+                          description: Terminal is a flag that allows for short-circuiting
+                            computing of a hash for a given request. If set to true,
+                            and the request attribute specified in the attribute hash
+                            options is present, no further hash policies will be used
+                            to calculate a hash for the request.
+                          type: boolean
+                      type: object
+                    type: array
                   strategy:
                     description: Strategy specifies the policy used to balance requests
                       across the pool of backend pods. Valid policy names are `Random`,
-                      `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`.
+                      `RoundRobin`, `WeightedLeastRequest`, `Cookie`, and `RequestHash`.
                       If an unknown strategy name is specified or no policy is supplied,
                       the default `RoundRobin` policy is used.
                     type: string
                 type: object
               protocol:
                 description: Protocol may be used to specify (or override) the protocol
-                  used to reach this Service. Values may be tls, h2, h2c. If omitted,
+                  used to reach this Service. Values may be h2 or h2c. If omitted,
                   protocol-selection falls back on Service annotations.
                 enum:
                 - h2
@@ -554,7 +1008,897 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: gatewayclasses.networking.x-k8s.io
+spec:
+  group: networking.x-k8s.io
+  names:
+    kind: GatewayClass
+    listKind: GatewayClassList
+    plural: gatewayclasses
+    shortNames:
+    - gc
+    singular: gatewayclass
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.controller
+      name: Controller
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "GatewayClass describes a class of Gateways available to the
+          user for creating Gateway resources. \n GatewayClass is a Cluster level
+          resource."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GatewayClass.
+            properties:
+              controller:
+                description: "Controller is a domain/path string that indicates the
+                  controller that is managing Gateways of this class. \n Example:
+                  \"acme.io/gateway-controller\". \n This field is not mutable and
+                  cannot be empty. \n The format of this field is DOMAIN \"/\" PATH,
+                  where DOMAIN and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                  \n Support: Core"
+                maxLength: 253
+                type: string
+              parametersRef:
+                description: "ParametersRef is a reference to a resource that contains
+                  the configuration parameters corresponding to the GatewayClass.
+                  This is optional if the controller does not require any additional
+                  configuration. \n ParametersRef can reference a standard Kubernetes
+                  resource, i.e. ConfigMap, or an implementation-specific custom resource.
+                  The resource can be cluster-scoped or namespace-scoped. \n If the
+                  referent cannot be found, the GatewayClass's \"InvalidParameters\"
+                  status condition will be true. \n Support: Custom"
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. This
+                      field is required when scope is set to "Namespace" and ignored
+                      when scope is set to "Cluster".
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  scope:
+                    default: Cluster
+                    description: Scope represents if the referent is a Cluster or
+                      Namespace scoped resource. This may be set to "Cluster" or "Namespace".
+                    enum:
+                    - Cluster
+                    - Namespace
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controller
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Waiting
+                status: "False"
+                type: Admitted
+            description: Status defines the current state of GatewayClass.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Waiting
+                  status: "False"
+                  type: Admitted
+                description: "Conditions is the current status from the controller
+                  for this GatewayClass. \n Controllers should prefer to publish conditions
+                  using values of GatewayClassConditionType for the type of each Condition."
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: gateways.networking.x-k8s.io
+spec:
+  group: networking.x-k8s.io
+  names:
+    kind: Gateway
+    listKind: GatewayList
+    plural: gateways
+    shortNames:
+    - gtw
+    singular: gateway
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.gatewayClassName
+      name: Class
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "Gateway represents an instantiation of a service-traffic handling
+          infrastructure by binding Listeners to a set of IP addresses. \n Implementations
+          should add the `gateway-exists-finalizer.networking.x-k8s.io` finalizer
+          on the associated GatewayClass whenever Gateway(s) is running. This ensures
+          that a GatewayClass associated with a Gateway(s) is not deleted while in
+          use."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Gateway.
+            properties:
+              addresses:
+                description: "Addresses requested for this gateway. This is optional
+                  and behavior can depend on the GatewayClass. If a value is set in
+                  the spec and the requested address is invalid, the GatewayClass
+                  MUST indicate this in the associated entry in GatewayStatus.Addresses.
+                  \n If no Addresses are specified, the GatewayClass may schedule
+                  the Gateway in an implementation-defined manner, assigning an appropriate
+                  set of Addresses. \n The GatewayClass MUST bind all Listeners to
+                  every GatewayAddress that it assigns to the Gateway. \n Support:
+                  Core"
+                items:
+                  description: GatewayAddress describes an address that can be bound
+                    to a Gateway.
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: "Type of the address. \n Support: Extended"
+                      enum:
+                      - IPAddress
+                      - NamedAddress
+                      type: string
+                    value:
+                      description: "Value of the address. The validity of the values
+                        will depend on the type and support by the controller. \n
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`."
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                maxItems: 16
+                type: array
+              gatewayClassName:
+                description: GatewayClassName used for this Gateway. This is the name
+                  of a GatewayClass resource.
+                maxLength: 253
+                minLength: 1
+                type: string
+              listeners:
+                description: "Listeners associated with this Gateway. Listeners define
+                  logical endpoints that are bound on this Gateway's addresses. At
+                  least one Listener MUST be specified. \n An implementation MAY group
+                  Listeners by Port and then collapse each group of Listeners into
+                  a single Listener if the implementation determines that the Listeners
+                  in the group are \"compatible\". An implementation MAY also group
+                  together and collapse compatible Listeners belonging to different
+                  Gateways. \n For example, an implementation might consider Listeners
+                  to be compatible with each other if all of the following conditions
+                  are met: \n 1. Either each Listener within the group specifies the
+                  \"HTTP\"    Protocol or each Listener within the group specifies
+                  either    the \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener
+                  within the group specifies a Hostname that is unique    within the
+                  group. \n 3. As a special case, one Listener within a group may
+                  omit Hostname,    in which case this Listener matches when no other
+                  Listener    matches. \n If the implementation does collapse compatible
+                  Listeners, the hostname provided in the incoming client request
+                  MUST be matched to a Listener to find the correct set of Routes.
+                  The incoming hostname MUST be matched using the Hostname field for
+                  each Listener in order of most to least specific. That is, exact
+                  matches must be processed before wildcard matches. \n If this field
+                  specifies multiple Listeners that have the same Port value but are
+                  not compatible, the implementation must raise a \"Conflicted\" condition
+                  in the Listener status. \n Support: Core"
+                items:
+                  description: Listener embodies the concept of a logical endpoint
+                    where a Gateway can accept network connections. Each listener
+                    in a Gateway must have a unique combination of Hostname, Port,
+                    and Protocol. This will be enforced by a validating webhook.
+                  properties:
+                    hostname:
+                      description: "Hostname specifies the virtual hostname to match
+                        for protocol types that define this concept. When unspecified,
+                        \"\", or `*`, all hostnames are matched. This field can be
+                        omitted for protocols that don't require hostname based matching.
+                        \n Hostname is the fully qualified domain name of a network
+                        host, as defined by RFC 3986. Note the following deviations
+                        from the \"host\" part of the URI as defined in the RFC: \n
+                        1. IP literals are not allowed. 2. The `:` delimiter is not
+                        respected because ports are not allowed. \n Hostname can be
+                        \"precise\" which is a domain name without the terminating
+                        dot of a network host (e.g. \"foo.example.com\") or \"wildcard\",
+                        which is a domain name prefixed with a single wildcard label
+                        (e.g. `*.example.com`). The wildcard character `*` must appear
+                        by itself as the first DNS label and matches only a single
+                        label. \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    port:
+                      description: "Port is the network port. Multiple listeners may
+                        use the same port, subject to the Listener compatibility rules.
+                        \n Support: Core"
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: "Protocol specifies the network protocol this listener
+                        expects to receive. The GatewayClass MUST apply the Hostname
+                        match appropriately for each protocol: \n * For the \"TLS\"
+                        protocol, the Hostname match MUST be   applied to the [SNI](https://tools.ietf.org/html/rfc6066#section-3)
+                        \  server name offered by the client. * For the \"HTTP\" protocol,
+                        the Hostname match MUST be   applied to the host portion of
+                        the   [effective request URI](https://tools.ietf.org/html/rfc7230#section-5.5)
+                        \  or the [:authority pseudo-header](https://tools.ietf.org/html/rfc7540#section-8.1.2.3)
+                        * For the \"HTTPS\" protocol, the Hostname match MUST be   applied
+                        at both the TLS and HTTP protocol layers. \n Support: Core"
+                      type: string
+                    routes:
+                      description: "Routes specifies a schema for associating routes
+                        with the Listener using selectors. A Route is a resource capable
+                        of servicing a request and allows a cluster operator to expose
+                        a cluster resource (i.e. Service) by externally-reachable
+                        URL, load-balance traffic and terminate SSL/TLS.  Typically,
+                        a route is a \"HTTPRoute\" or \"TCPRoute\" in group \"networking.x-k8s.io\",
+                        however, an implementation may support other types of resources.
+                        \n The Routes selector MUST select a set of objects that are
+                        compatible with the application protocol specified in the
+                        Protocol field. \n Although a client request may technically
+                        match multiple route rules, only one rule may ultimately receive
+                        the request. Matching precedence MUST be determined in order
+                        of the following criteria: \n * The most specific match. For
+                        example, the most specific HTTPRoute match   is determined
+                        by the longest matching combination of hostname and path.
+                        * The oldest Route based on creation timestamp. For example,
+                        a Route with   a creation timestamp of \"2020-09-08 01:02:03\"
+                        is given precedence over   a Route with a creation timestamp
+                        of \"2020-09-08 01:02:04\". * If everything else is equivalent,
+                        the Route appearing first in   alphabetical order (namespace/name)
+                        should be given precedence. For   example, foo/bar is given
+                        precedence over foo/baz. \n All valid portions of a Route
+                        selected by this field should be supported. Invalid portions
+                        of a Route can be ignored (sometimes that will mean the full
+                        Route). If a portion of a Route transitions from valid to
+                        invalid, support for that portion of the Route should be dropped
+                        to ensure consistency. For example, even if a filter specified
+                        by a Route is invalid, the rest of the Route should still
+                        be supported. \n Support: Core"
+                      properties:
+                        group:
+                          default: networking.x-k8s.io
+                          description: "Group is the group of the route resource to
+                            select. Omitting the value or specifying the empty string
+                            indicates the networking.x-k8s.io API group. For example,
+                            use the following to select an HTTPRoute: \n routes:   kind:
+                            HTTPRoute \n Otherwise, if an alternative API group is
+                            desired, specify the desired group: \n routes:   group:
+                            acme.io   kind: FooRoute \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        kind:
+                          description: "Kind is the kind of the route resource to
+                            select. \n Kind MUST correspond to kinds of routes that
+                            are compatible with the application protocol specified
+                            in the Listener's Protocol field. \n If an implementation
+                            does not support or recognize this resource type, it SHOULD
+                            set the \"ResolvedRefs\" condition to false for this listener
+                            with the \"InvalidRoutesRef\" reason. \n Support: Core"
+                          type: string
+                        namespaces:
+                          default:
+                            from: Same
+                          description: "Namespaces indicates in which namespaces Routes
+                            should be selected for this Gateway. This is restricted
+                            to the namespace of this Gateway by default. \n Support:
+                            Core"
+                          properties:
+                            from:
+                              default: Same
+                              description: "From indicates where Routes will be selected
+                                for this Gateway. Possible values are: * All: Routes
+                                in all namespaces may be used by this Gateway. * Selector:
+                                Routes in namespaces selected by the selector may
+                                be used by   this Gateway. * Same: Only Routes in
+                                the same namespace may be used by this Gateway. \n
+                                Support: Core"
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: "Selector must be specified when From is
+                                set to \"Selector\". In that case, only Routes in
+                                Namespaces matching this Selector will be selected
+                                by this Gateway. This field is ignored for other values
+                                of \"From\". \n Support: Core"
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          type: object
+                        selector:
+                          description: "Selector specifies a set of route labels used
+                            for selecting routes to associate with the Gateway. If
+                            this Selector is defined, only routes matching the Selector
+                            are associated with the Gateway. An empty Selector matches
+                            all routes. \n Support: Core"
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - kind
+                      type: object
+                    tls:
+                      description: "TLS is the TLS configuration for the Listener.
+                        This field is required if the Protocol field is \"HTTPS\"
+                        or \"TLS\" and ignored otherwise. \n The association of SNIs
+                        to Certificate defined in GatewayTLSConfig is defined based
+                        on the Hostname field for this listener. \n The GatewayClass
+                        MUST use the longest matching SNI out of all available certificates
+                        for any TLS handshake. \n Support: Core"
+                      properties:
+                        certificateRef:
+                          description: "CertificateRef is the reference to Kubernetes
+                            object that contain a TLS certificate and private key.
+                            This certificate MUST be used for TLS handshakes for the
+                            domain this GatewayTLSConfig is associated with. \n This
+                            field is required when mode is set to \"Terminate\" (default)
+                            and optional otherwise. \n If an entry in this list omits
+                            or specifies the empty string for both the group and the
+                            resource, the resource defaults to \"secrets\". An implementation
+                            may support other resources (for example, resource \"mycertificates\"
+                            in group \"networking.acme.io\"). \n Support: Core (Kubernetes
+                            Secrets) \n Support: Implementation-specific (Other resource
+                            types)"
+                          properties:
+                            group:
+                              description: Group is the group of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            kind:
+                              description: Kind is kind of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          required:
+                          - group
+                          - kind
+                          - name
+                          type: object
+                        mode:
+                          default: Terminate
+                          description: "Mode defines the TLS behavior for the TLS
+                            session initiated by the client. There are two possible
+                            modes: - Terminate: The TLS session between the downstream
+                            client   and the Gateway is terminated at the Gateway.
+                            This mode requires   certificateRef to be set. - Passthrough:
+                            The TLS session is NOT terminated by the Gateway. This
+                            \  implies that the Gateway can't decipher the TLS stream
+                            except for   the ClientHello message of the TLS protocol.
+                            \  CertificateRef field is ignored in this mode. \n Support:
+                            Core"
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: "Options are a list of key/value pairs to give
+                            extended options to the provider. \n There variation among
+                            providers as to how ciphersuites are expressed. If there
+                            is a common subset for expressing ciphers then it will
+                            make sense to loft that as a core API construct. \n Support:
+                            Implementation-specific"
+                          type: object
+                        routeOverride:
+                          default:
+                            certificate: Deny
+                          description: "RouteOverride dictates if TLS settings can
+                            be configured via Routes or not. \n CertificateRef must
+                            be defined even if `routeOverride.certificate` is set
+                            to 'Allow' as it will be used as the default certificate
+                            for the listener. \n Support: Core"
+                          properties:
+                            certificate:
+                              default: Deny
+                              description: "Certificate dictates if TLS certificates
+                                can be configured via Routes. If set to 'Allow', a
+                                TLS certificate for a hostname defined in a Route
+                                takes precedence over the certificate defined in Gateway.
+                                \n Support: Core"
+                              enum:
+                              - Allow
+                              - Deny
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - port
+                  - protocol
+                  - routes
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+            required:
+            - gatewayClassName
+            - listeners
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: NotReconciled
+                status: "False"
+                type: Scheduled
+            description: Status defines the current state of Gateway.
+            properties:
+              addresses:
+                description: "Addresses lists the IP addresses that have actually
+                  been bound to the Gateway. These addresses may differ from the addresses
+                  in the Spec, e.g. if the Gateway automatically assigns an address
+                  from a reserved pool. \n These addresses should all be of type \"IPAddress\"."
+                items:
+                  description: GatewayAddress describes an address that can be bound
+                    to a Gateway.
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: "Type of the address. \n Support: Extended"
+                      enum:
+                      - IPAddress
+                      - NamedAddress
+                      type: string
+                    value:
+                      description: "Value of the address. The validity of the values
+                        will depend on the type and support by the controller. \n
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`."
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                maxItems: 16
+                type: array
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: NotReconciled
+                  status: "False"
+                  type: Scheduled
+                description: "Conditions describe the current conditions of the Gateway.
+                  \n Implementations should prefer to express Gateway conditions using
+                  the `GatewayConditionType` and `GatewayConditionReason` constants
+                  so that operators and tools can converge on a common vocabulary
+                  to describe Gateway state. \n Known condition types are: \n * \"Scheduled\"
+                  * \"Ready\""
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, type FooStatus struct{
+                          \    // Represents the observations of a foo's current state.
+                          \    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                          \    // +patchStrategy=merge     // +listType=map     //
+                          +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                          patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                          \n     // other fields }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    hostname:
+                      description: Hostname is the Listener hostname value for which
+                        this message is reporting the status.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    port:
+                      description: Port is the unique Listener port value for which
+                        this message is reporting the status.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: Protocol is the Listener protocol value for which
+                        this message is reporting the status.
+                      type: string
+                  required:
+                  - conditions
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - port
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: httpproxies.projectcontour.io
 spec:
@@ -652,6 +1996,12 @@ spec:
                                   value must not be equal to. The condition is true
                                   if the header has any other value.
                                 type: string
+                              notpresent:
+                                description: NotPresent specifies that condition is
+                                  true when the named header is not present. Note
+                                  that setting NotPresent to false does not make the
+                                  condition true if the named header is present.
+                                type: boolean
                               present:
                                 description: Present specifies that condition is true
                                   when the named header is present, regardless of
@@ -739,6 +2089,12 @@ spec:
                                   value must not be equal to. The condition is true
                                   if the header has any other value.
                                 type: string
+                              notpresent:
+                                description: NotPresent specifies that condition is
+                                  true when the named header is not present. Note
+                                  that setting NotPresent to false does not make the
+                                  condition true if the named header is present.
+                                type: boolean
                               present:
                                 description: Present specifies that condition is true
                                   when the named header is present, regardless of
@@ -796,12 +2152,47 @@ spec:
                     loadBalancerPolicy:
                       description: The load balancing policy for this route.
                       properties:
+                        requestHashPolicies:
+                          description: RequestHashPolicies contains a list of hash
+                            policies to apply when the `RequestHash` load balancing
+                            strategy is chosen. If an element of the supplied list
+                            of hash policies is invalid, it will be ignored. If the
+                            list of hash policies is empty after validation, the load
+                            balancing strategy will fall back the the default `RoundRobin`.
+                          items:
+                            description: RequestHashPolicy contains configuration
+                              for an individual hash policy on a request attribute.
+                            properties:
+                              headerHashOptions:
+                                description: HeaderHashOptions should be set when
+                                  request header hash based load balancing is desired.
+                                  It must be the only hash option field set, otherwise
+                                  this request hash policy object will be ignored.
+                                properties:
+                                  headerName:
+                                    description: HeaderName is the name of the HTTP
+                                      request header that will be used to calculate
+                                      the hash key. If the header specified is not
+                                      present on a request, no hash will be produced.
+                                    minLength: 1
+                                    type: string
+                                type: object
+                              terminal:
+                                description: Terminal is a flag that allows for short-circuiting
+                                  computing of a hash for a given request. If set
+                                  to true, and the request attribute specified in
+                                  the attribute hash options is present, no further
+                                  hash policies will be used to calculate a hash for
+                                  the request.
+                                type: boolean
+                            type: object
+                          type: array
                         strategy:
                           description: Strategy specifies the policy used to balance
                             requests across the pool of backend pods. Valid policy
                             names are `Random`, `RoundRobin`, `WeightedLeastRequest`,
-                            `Random` and `Cookie`. If an unknown strategy name is
-                            specified or no policy is supplied, the default `RoundRobin`
+                            `Cookie`, and `RequestHash`. If an unknown strategy name
+                            is specified or no policy is supplied, the default `RoundRobin`
                             policy is used.
                           type: string
                       type: object
@@ -844,6 +2235,229 @@ spec:
                         over HTTP which are normally not permitted when a `virtualhost.tls`
                         block is present.
                       type: boolean
+                    rateLimitPolicy:
+                      description: The policy for rate limiting on the route.
+                      properties:
+                        global:
+                          description: Global defines global rate limiting parameters,
+                            i.e. parameters defining descriptors that are sent to
+                            an external rate limit service (RLS) for a rate limit
+                            decision on each request.
+                          properties:
+                            descriptors:
+                              description: Descriptors defines the list of descriptors
+                                that will be generated and sent to the rate limit
+                                service. Each descriptor contains 1+ key-value pair
+                                entries.
+                              items:
+                                description: RateLimitDescriptor defines a list of
+                                  key-value pair generators.
+                                properties:
+                                  entries:
+                                    description: Entries is the list of key-value
+                                      pair generators.
+                                    items:
+                                      description: RateLimitDescriptorEntry is a key-value
+                                        pair generator. Exactly one field on this
+                                        struct must be non-nil.
+                                      properties:
+                                        genericKey:
+                                          description: GenericKey defines a descriptor
+                                            entry with a static key and value.
+                                          properties:
+                                            key:
+                                              description: Key defines the key of
+                                                the descriptor entry. If not set,
+                                                the key is set to "generic_key".
+                                              type: string
+                                            value:
+                                              description: Value defines the value
+                                                of the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                        remoteAddress:
+                                          description: RemoteAddress defines a descriptor
+                                            entry with a key of "remote_address" and
+                                            a value equal to the client's IP address
+                                            (from x-forwarded-for).
+                                          type: object
+                                        requestHeader:
+                                          description: RequestHeader defines a descriptor
+                                            entry that's populated only if a given
+                                            header is present on the request. The
+                                            descriptor key is static, and the descriptor
+                                            value is equal to the value of the header.
+                                          properties:
+                                            descriptorKey:
+                                              description: DescriptorKey defines the
+                                                key to use on the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                            headerName:
+                                              description: HeaderName defines the
+                                                name of the header to look for on
+                                                the request.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                        requestHeaderValueMatch:
+                                          description: RequestHeaderValueMatch defines
+                                            a descriptor entry that's populated if
+                                            the request's headers match a set of 1+
+                                            match criteria. The descriptor key is
+                                            "header_match", and the descriptor value
+                                            is static.
+                                          properties:
+                                            expectMatch:
+                                              default: true
+                                              description: ExpectMatch defines whether
+                                                the request must positively match
+                                                the match criteria in order to generate
+                                                a descriptor entry (i.e. true), or
+                                                not match the match criteria in order
+                                                to generate a descriptor entry (i.e.
+                                                false). The default is true.
+                                              type: boolean
+                                            headers:
+                                              description: Headers is a list of 1+
+                                                match criteria to apply against the
+                                                request to determine whether to populate
+                                                the descriptor entry or not.
+                                              items:
+                                                description: HeaderMatchCondition
+                                                  specifies how to conditionally match
+                                                  against HTTP headers. The Name field
+                                                  is required, but only one of the
+                                                  remaining fields should be be provided.
+                                                properties:
+                                                  contains:
+                                                    description: Contains specifies
+                                                      a substring that must be present
+                                                      in the header value.
+                                                    type: string
+                                                  exact:
+                                                    description: Exact specifies a
+                                                      string that the header value
+                                                      must be equal to.
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of the header to match against.
+                                                      Name is required. Header names
+                                                      are case insensitive.
+                                                    type: string
+                                                  notcontains:
+                                                    description: NotContains specifies
+                                                      a substring that must not be
+                                                      present in the header value.
+                                                    type: string
+                                                  notexact:
+                                                    description: NoExact specifies
+                                                      a string that the header value
+                                                      must not be equal to. The condition
+                                                      is true if the header has any
+                                                      other value.
+                                                    type: string
+                                                  notpresent:
+                                                    description: NotPresent specifies
+                                                      that condition is true when
+                                                      the named header is not present.
+                                                      Note that setting NotPresent
+                                                      to false does not make the condition
+                                                      true if the named header is
+                                                      present.
+                                                    type: boolean
+                                                  present:
+                                                    description: Present specifies
+                                                      that condition is true when
+                                                      the named header is present,
+                                                      regardless of its value. Note
+                                                      that setting Present to false
+                                                      does not make the condition
+                                                      true if the named header is
+                                                      absent.
+                                                    type: boolean
+                                                required:
+                                                - name
+                                                type: object
+                                              minItems: 1
+                                              type: array
+                                            value:
+                                              description: Value defines the value
+                                                of the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                      type: object
+                                    minItems: 1
+                                    type: array
+                                type: object
+                              minItems: 1
+                              type: array
+                          type: object
+                        local:
+                          description: Local defines local rate limiting parameters,
+                            i.e. parameters for rate limiting that occurs within each
+                            Envoy pod as requests are handled.
+                          properties:
+                            burst:
+                              description: Burst defines the number of requests above
+                                the requests per unit that should be allowed within
+                                a short period of time.
+                              format: int32
+                              type: integer
+                            requests:
+                              description: Requests defines how many requests per
+                                unit of time should be allowed before rate limiting
+                                occurs.
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            responseHeadersToAdd:
+                              description: ResponseHeadersToAdd is an optional list
+                                of response headers to set when a request is rate-limited.
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            responseStatusCode:
+                              description: ResponseStatusCode is the HTTP status code
+                                to use for responses to rate-limited requests. Codes
+                                must be in the 400-599 range (inclusive). If not specified,
+                                the Envoy default of 429 (Too Many Requests) is used.
+                              format: int32
+                              maximum: 599
+                              minimum: 400
+                              type: integer
+                            unit:
+                              description: Unit defines the period of time within
+                                which requests over the limit will be rate limited.
+                                Valid values are "second", "minute" and "hour".
+                              enum:
+                              - second
+                              - minute
+                              - hour
+                              type: string
+                          required:
+                          - requests
+                          - unit
+                          type: object
+                      type: object
                     requestHeadersPolicy:
                       description: The policy for managing request headers during
                         proxying.
@@ -1175,14 +2789,50 @@ spec:
                     type: object
                   loadBalancerPolicy:
                     description: The load balancing policy for the backend services.
+                      Note that the `Cookie` and `RequestHash` load balancing strategies
+                      cannot be used here.
                     properties:
+                      requestHashPolicies:
+                        description: RequestHashPolicies contains a list of hash policies
+                          to apply when the `RequestHash` load balancing strategy
+                          is chosen. If an element of the supplied list of hash policies
+                          is invalid, it will be ignored. If the list of hash policies
+                          is empty after validation, the load balancing strategy will
+                          fall back the the default `RoundRobin`.
+                        items:
+                          description: RequestHashPolicy contains configuration for
+                            an individual hash policy on a request attribute.
+                          properties:
+                            headerHashOptions:
+                              description: HeaderHashOptions should be set when request
+                                header hash based load balancing is desired. It must
+                                be the only hash option field set, otherwise this
+                                request hash policy object will be ignored.
+                              properties:
+                                headerName:
+                                  description: HeaderName is the name of the HTTP
+                                    request header that will be used to calculate
+                                    the hash key. If the header specified is not present
+                                    on a request, no hash will be produced.
+                                  minLength: 1
+                                  type: string
+                              type: object
+                            terminal:
+                              description: Terminal is a flag that allows for short-circuiting
+                                computing of a hash for a given request. If set to
+                                true, and the request attribute specified in the attribute
+                                hash options is present, no further hash policies
+                                will be used to calculate a hash for the request.
+                              type: boolean
+                          type: object
+                        type: array
                       strategy:
                         description: Strategy specifies the policy used to balance
                           requests across the pool of backend pods. Valid policy names
-                          are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random`
-                          and `Cookie`. If an unknown strategy name is specified or
-                          no policy is supplied, the default `RoundRobin` policy is
-                          used.
+                          are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Cookie`,
+                          and `RequestHash`. If an unknown strategy name is specified
+                          or no policy is supplied, the default `RoundRobin` policy
+                          is used.
                         type: string
                     type: object
                   services:
@@ -1321,7 +2971,7 @@ spec:
                     description: This field configures an extension service to perform
                       authorization for this virtual host. Authorization can only
                       be configured on virtual hosts that have TLS enabled. If the
-                      TLS configuration requires client certificate /validation, the
+                      TLS configuration requires client certificate validation, the
                       client certificate is always included in the authentication
                       check request.
                     properties:
@@ -1442,6 +3092,223 @@ spec:
                       ingress tree all leaves of the DAG rooted at this object relate
                       to the fqdn.
                     type: string
+                  rateLimitPolicy:
+                    description: The policy for rate limiting on the virtual host.
+                    properties:
+                      global:
+                        description: Global defines global rate limiting parameters,
+                          i.e. parameters defining descriptors that are sent to an
+                          external rate limit service (RLS) for a rate limit decision
+                          on each request.
+                        properties:
+                          descriptors:
+                            description: Descriptors defines the list of descriptors
+                              that will be generated and sent to the rate limit service.
+                              Each descriptor contains 1+ key-value pair entries.
+                            items:
+                              description: RateLimitDescriptor defines a list of key-value
+                                pair generators.
+                              properties:
+                                entries:
+                                  description: Entries is the list of key-value pair
+                                    generators.
+                                  items:
+                                    description: RateLimitDescriptorEntry is a key-value
+                                      pair generator. Exactly one field on this struct
+                                      must be non-nil.
+                                    properties:
+                                      genericKey:
+                                        description: GenericKey defines a descriptor
+                                          entry with a static key and value.
+                                        properties:
+                                          key:
+                                            description: Key defines the key of the
+                                              descriptor entry. If not set, the key
+                                              is set to "generic_key".
+                                            type: string
+                                          value:
+                                            description: Value defines the value of
+                                              the descriptor entry.
+                                            minLength: 1
+                                            type: string
+                                        type: object
+                                      remoteAddress:
+                                        description: RemoteAddress defines a descriptor
+                                          entry with a key of "remote_address" and
+                                          a value equal to the client's IP address
+                                          (from x-forwarded-for).
+                                        type: object
+                                      requestHeader:
+                                        description: RequestHeader defines a descriptor
+                                          entry that's populated only if a given header
+                                          is present on the request. The descriptor
+                                          key is static, and the descriptor value
+                                          is equal to the value of the header.
+                                        properties:
+                                          descriptorKey:
+                                            description: DescriptorKey defines the
+                                              key to use on the descriptor entry.
+                                            minLength: 1
+                                            type: string
+                                          headerName:
+                                            description: HeaderName defines the name
+                                              of the header to look for on the request.
+                                            minLength: 1
+                                            type: string
+                                        type: object
+                                      requestHeaderValueMatch:
+                                        description: RequestHeaderValueMatch defines
+                                          a descriptor entry that's populated if the
+                                          request's headers match a set of 1+ match
+                                          criteria. The descriptor key is "header_match",
+                                          and the descriptor value is static.
+                                        properties:
+                                          expectMatch:
+                                            default: true
+                                            description: ExpectMatch defines whether
+                                              the request must positively match the
+                                              match criteria in order to generate
+                                              a descriptor entry (i.e. true), or not
+                                              match the match criteria in order to
+                                              generate a descriptor entry (i.e. false).
+                                              The default is true.
+                                            type: boolean
+                                          headers:
+                                            description: Headers is a list of 1+ match
+                                              criteria to apply against the request
+                                              to determine whether to populate the
+                                              descriptor entry or not.
+                                            items:
+                                              description: HeaderMatchCondition specifies
+                                                how to conditionally match against
+                                                HTTP headers. The Name field is required,
+                                                but only one of the remaining fields
+                                                should be be provided.
+                                              properties:
+                                                contains:
+                                                  description: Contains specifies
+                                                    a substring that must be present
+                                                    in the header value.
+                                                  type: string
+                                                exact:
+                                                  description: Exact specifies a string
+                                                    that the header value must be
+                                                    equal to.
+                                                  type: string
+                                                name:
+                                                  description: Name is the name of
+                                                    the header to match against. Name
+                                                    is required. Header names are
+                                                    case insensitive.
+                                                  type: string
+                                                notcontains:
+                                                  description: NotContains specifies
+                                                    a substring that must not be present
+                                                    in the header value.
+                                                  type: string
+                                                notexact:
+                                                  description: NoExact specifies a
+                                                    string that the header value must
+                                                    not be equal to. The condition
+                                                    is true if the header has any
+                                                    other value.
+                                                  type: string
+                                                notpresent:
+                                                  description: NotPresent specifies
+                                                    that condition is true when the
+                                                    named header is not present. Note
+                                                    that setting NotPresent to false
+                                                    does not make the condition true
+                                                    if the named header is present.
+                                                  type: boolean
+                                                present:
+                                                  description: Present specifies that
+                                                    condition is true when the named
+                                                    header is present, regardless
+                                                    of its value. Note that setting
+                                                    Present to false does not make
+                                                    the condition true if the named
+                                                    header is absent.
+                                                  type: boolean
+                                              required:
+                                              - name
+                                              type: object
+                                            minItems: 1
+                                            type: array
+                                          value:
+                                            description: Value defines the value of
+                                              the descriptor entry.
+                                            minLength: 1
+                                            type: string
+                                        type: object
+                                    type: object
+                                  minItems: 1
+                                  type: array
+                              type: object
+                            minItems: 1
+                            type: array
+                        type: object
+                      local:
+                        description: Local defines local rate limiting parameters,
+                          i.e. parameters for rate limiting that occurs within each
+                          Envoy pod as requests are handled.
+                        properties:
+                          burst:
+                            description: Burst defines the number of requests above
+                              the requests per unit that should be allowed within
+                              a short period of time.
+                            format: int32
+                            type: integer
+                          requests:
+                            description: Requests defines how many requests per unit
+                              of time should be allowed before rate limiting occurs.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          responseHeadersToAdd:
+                            description: ResponseHeadersToAdd is an optional list
+                              of response headers to set when a request is rate-limited.
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          responseStatusCode:
+                            description: ResponseStatusCode is the HTTP status code
+                              to use for responses to rate-limited requests. Codes
+                              must be in the 400-599 range (inclusive). If not specified,
+                              the Envoy default of 429 (Too Many Requests) is used.
+                            format: int32
+                            maximum: 599
+                            minimum: 400
+                            type: integer
+                          unit:
+                            description: Unit defines the period of time within which
+                              requests over the limit will be rate limited. Valid
+                              values are "second", "minute" and "hour".
+                            enum:
+                            - second
+                            - minute
+                            - hour
+                            type: string
+                        required:
+                        - requests
+                        - unit
+                        type: object
+                    type: object
                   tls:
                     description: If present the fields describes TLS properties of
                       the virtual host. The SNI names that will be matched on are
@@ -1452,9 +3319,12 @@ spec:
                         description: "ClientValidation defines how to verify the client
                           certificate when an external client establishes a TLS connection
                           to Envoy. \n This setting: \n 1. Enables TLS client certificate
-                          validation. 2. Requires clients to present a TLS certificate
-                          (i.e. not optional validation). 3. Specifies how the client
-                          certificate will be validated."
+                          validation. 2. Specifies how the client certificate will
+                          be validated (i.e.    validation required or skipped). \n
+                          Note: Setting client certificate validation to be skipped
+                          should be only used in conjunction with an external authorization
+                          server that performs client validation as Contour will ensure
+                          client certificates are passed along."
                         properties:
                           caSecret:
                             description: Name of a Kubernetes secret that contains
@@ -1462,8 +3332,17 @@ spec:
                               validate against the certificates in the bundle.
                             minLength: 1
                             type: string
-                        required:
-                        - caSecret
+                          skipClientCertValidation:
+                            description: SkipClientCertValidation disables downstream
+                              client certificate validation. Defaults to false. This
+                              field is intended to be used in conjunction with external
+                              authorization in order to enable the external authorization
+                              server to validate client certificates. When this field
+                              is set to true, client certificates are requested but
+                              not verified by Envoy. If external authorization is
+                              in use, they are presented to the external authorization
+                              server.
+                            type: boolean
                         type: object
                       enableFallbackCertificate:
                         description: EnableFallbackCertificate defines if the vhost
@@ -1471,7 +3350,9 @@ spec:
                           all requests which don't match the SNI defined in this vhost.
                         type: boolean
                       minimumProtocolVersion:
-                        description: Minimum TLS version this vhost should negotiate
+                        description: MinimumProtocolVersion is the minimum TLS version
+                          this vhost should negotiate. Valid options are `1.2` (default)
+                          and `1.3`. Any other value defaults to TLS 1.2.
                         type: string
                       passthrough:
                         description: Passthrough defines whether the encrypted TLS
@@ -1732,6 +3613,41 @@ spec:
                           description: IP is set for load-balancer ingress points
                             that are IP based (typically GCE or OpenStack load-balancers)
                           type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                     type: array
                 type: object
@@ -1755,7 +3671,1288 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: httproutes.networking.x-k8s.io
+spec:
+  group: networking.x-k8s.io
+  names:
+    kind: HTTPRoute
+    listKind: HTTPRouteList
+    plural: httproutes
+    singular: httproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HTTPRoute is the Schema for the HTTPRoute resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of HTTPRoute.
+            properties:
+              gateways:
+                default:
+                  allow: SameNamespace
+                description: Gateways defines which Gateways can use this Route.
+                properties:
+                  allow:
+                    default: SameNamespace
+                    description: 'Allow indicates which Gateways will be allowed to
+                      use this route. Possible values are: * All: Gateways in any
+                      namespace can use this route. * FromList: Only Gateways specified
+                      in GatewayRefs may use this route. * SameNamespace: Only Gateways
+                      in the same namespace may use this route.'
+                    enum:
+                    - All
+                    - FromList
+                    - SameNamespace
+                    type: string
+                  gatewayRefs:
+                    description: GatewayRefs must be specified when Allow is set to
+                      "FromList". In that case, only Gateways referenced in this list
+                      will be allowed to use this route. This field is ignored for
+                      other values of "Allow".
+                    items:
+                      description: GatewayReference identifies a Gateway in a specified
+                        namespace.
+                      properties:
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                    type: array
+                type: object
+              hostnames:
+                description: "Hostnames defines a set of hostname that should match
+                  against the HTTP Host header to select a HTTPRoute to process the
+                  request. Hostname is the fully qualified domain name of a network
+                  host, as defined by RFC 3986. Note the following deviations from
+                  the \"host\" part of the URI as defined in the RFC: \n 1. IPs are
+                  not allowed. 2. The `:` delimiter is not respected because ports
+                  are not allowed. \n Incoming requests are matched against the hostnames
+                  before the HTTPRoute rules. If no hostname is specified, traffic
+                  is routed based on the HTTPRouteRules. \n Hostname can be \"precise\"
+                  which is a domain name without the terminating dot of a network
+                  host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
+                  name prefixed with a single wildcard label (e.g. `*.example.com`).
+                  The wildcard character `*` must appear by itself as the first DNS
+                  label and matches only a single label. You cannot have a wildcard
+                  label by itself (e.g. Host == `*`). Requests will be matched against
+                  the Host field in the following order: \n 1. If Host is precise,
+                  the request matches this rule if    the HTTP Host header is equal
+                  to Host. 2. If Host is a wildcard, then the request matches this
+                  rule if    the HTTP Host header is to equal to the suffix    (removing
+                  the first label) of the wildcard rule. \n Support: Core"
+                items:
+                  description: Hostname is used to specify a hostname that should
+                    be matched.
+                  maxLength: 253
+                  minLength: 1
+                  type: string
+                maxItems: 16
+                type: array
+              rules:
+                default:
+                - matches:
+                  - path:
+                      type: Prefix
+                      value: /
+                description: Rules are a list of HTTP matchers, filters and actions.
+                items:
+                  description: HTTPRouteRule defines semantics for matching an HTTP
+                    request based on conditions, optionally executing additional processing
+                    steps, and forwarding the request to an API object.
+                  properties:
+                    filters:
+                      description: "Filters define the filters that are applied to
+                        requests that match this rule. \n The effects of ordering
+                        of multiple behaviors are currently unspecified. This can
+                        change in the future based on feedback during the alpha stage.
+                        \n Conformance-levels at this level are defined based on the
+                        type of filter: \n - ALL core filters MUST be supported by
+                        all implementations. - Implementers are encouraged to support
+                        extended filters. - Implementation-specific custom filters
+                        have no API guarantees across   implementations. \n Specifying
+                        a core filter multiple times has unspecified or custom conformance.
+                        \n Support: Core"
+                      items:
+                        description: 'HTTPRouteFilter defines additional processing
+                          steps that must be completed during the request or response
+                          lifecycle. HTTPRouteFilters are meant as an extension point
+                          to express additional processing that may be done in Gateway
+                          implementations. Some examples include request or response
+                          modification, implementing authentication strategies, rate-limiting,
+                          and traffic shaping. API guarantee/conformance is defined
+                          based on the type of the filter. TODO(hbagdi): re-render
+                          CRDs once controller-tools supports union tags: - https://github.com/kubernetes-sigs/controller-tools/pull/298
+                          - https://github.com/kubernetes-sigs/controller-tools/issues/461'
+                        properties:
+                          extensionRef:
+                            description: "ExtensionRef is an optional, implementation-specific
+                              extension to the \"filter\" behavior.  For example,
+                              resource \"myroutefilter\" in group \"networking.acme.io\").
+                              ExtensionRef MUST NOT be used for core and extended
+                              filters. \n Support: Implementation-specific"
+                            properties:
+                              group:
+                                description: Group is the group of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: "RequestHeaderModifier defines a schema for
+                              a filter that modifies request headers. \n Support:
+                              Core"
+                            properties:
+                              add:
+                                additionalProperties:
+                                  type: string
+                                description: "Add adds the given header (name, value)
+                                  to the request before the action. It appends to
+                                  any existing values associated with the header name.
+                                  \n Input:   GET /foo HTTP/1.1   my-header: foo \n
+                                  Config:   add: {\"my-header\": \"bar\"} \n Output:
+                                  \  GET /foo HTTP/1.1   my-header: foo   my-header:
+                                  bar \n Support: Extended"
+                                type: object
+                              remove:
+                                description: "Remove the given header(s) from the
+                                  HTTP request before the action. The value of RemoveHeader
+                                  is a list of HTTP header names. Note that the header
+                                  names are case-insensitive [RFC-2616 4.2]. \n Input:
+                                  \  GET /foo HTTP/1.1   my-header1: foo   my-header2:
+                                  bar   my-header3: baz \n Config:   remove: [\"my-header1\",
+                                  \"my-header3\"] \n Output:   GET /foo HTTP/1.1   my-header2:
+                                  bar \n Support: Extended"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                              set:
+                                additionalProperties:
+                                  type: string
+                                description: "Set overwrites the request with the
+                                  given header (name, value) before the action. \n
+                                  Input:   GET /foo HTTP/1.1   my-header: foo \n Config:
+                                  \  set: {\"my-header\": \"bar\"} \n Output:   GET
+                                  /foo HTTP/1.1   my-header: bar \n Support: Extended"
+                                type: object
+                            type: object
+                          requestMirror:
+                            description: "RequestMirror defines a schema for a filter
+                              that mirrors requests. \n Support: Extended"
+                            properties:
+                              backendRef:
+                                description: "BackendRef is a local object reference
+                                  to mirror matched requests to. If both BackendRef
+                                  and ServiceName are specified, ServiceName will
+                                  be given precedence. \n If the referent cannot be
+                                  found, the rule is not included in the route. The
+                                  controller should raise the \"ResolvedRefs\" condition
+                                  on the Gateway with the \"DegradedRoutes\" reason.
+                                  The gateway status for this route should be updated
+                                  with a condition that describes the error more specifically.
+                                  \n Support: Custom"
+                                properties:
+                                  group:
+                                    description: Group is the group of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  kind:
+                                    description: Kind is kind of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - name
+                                type: object
+                              port:
+                                description: "Port specifies the destination port
+                                  number to use for the backend referenced by the
+                                  ServiceName or BackendRef field. \n If unspecified,
+                                  the destination port in the request is used when
+                                  forwarding to a backendRef or serviceName."
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              serviceName:
+                                description: "ServiceName refers to the name of the
+                                  Service to mirror matched requests to. When specified,
+                                  this takes the place of BackendRef. If both BackendRef
+                                  and ServiceName are specified, ServiceName will
+                                  be given precedence. \n If the referent cannot be
+                                  found, the rule is not included in the route. The
+                                  controller should raise the \"ResolvedRefs\" condition
+                                  on the Gateway with the \"DegradedRoutes\" reason.
+                                  The gateway status for this route should be updated
+                                  with a condition that describes the error more specifically.
+                                  \n Support: Core"
+                                maxLength: 253
+                                type: string
+                            type: object
+                          type:
+                            description: "Type identifies the type of filter to apply.
+                              As with other API fields, types are classified into
+                              three conformance levels: \n - Core: Filter types and
+                              their corresponding configuration defined by   \"Support:
+                              Core\" in this package, e.g. \"RequestHeaderModifier\".
+                              All   implementations must support core filters. \n
+                              - Extended: Filter types and their corresponding configuration
+                              defined by   \"Support: Extended\" in this package,
+                              e.g. \"RequestMirror\". Implementers   are encouraged
+                              to support extended filters. \n - Custom: Filters that
+                              are defined and supported by specific vendors.   In
+                              the future, filters showing convergence in behavior
+                              across multiple   implementations will be considered
+                              for inclusion in extended or core   conformance levels.
+                              Filter-specific configuration for such filters   is
+                              specified using the ExtensionRef field. `Type` should
+                              be set to   \"ExtensionRef\" for custom filters. \n
+                              Implementers are encouraged to define custom implementation
+                              types to extend the core API with implementation-specific
+                              behavior."
+                            enum:
+                            - RequestHeaderModifier
+                            - RequestMirror
+                            - ExtensionRef
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      maxItems: 16
+                      type: array
+                    forwardTo:
+                      description: ForwardTo defines the backend(s) where matching
+                        requests should be sent. If unspecified, the rule performs
+                        no forwarding. If unspecified and no filters are specified
+                        that would result in a response being sent, a 503 error code
+                        is returned.
+                      items:
+                        description: HTTPRouteForwardTo defines how a HTTPRoute should
+                          forward a request.
+                        properties:
+                          backendRef:
+                            description: "BackendRef is a reference to a backend to
+                              forward matched requests to. If both BackendRef and
+                              ServiceName are specified, ServiceName will be given
+                              precedence. \n If the referent cannot be found, the
+                              route must be dropped from the Gateway. The controller
+                              should raise the \"ResolvedRefs\" condition on the Gateway
+                              with the \"DegradedRoutes\" reason. The gateway status
+                              for this route should be updated with a condition that
+                              describes the error more specifically. \n Support: Custom"
+                            properties:
+                              group:
+                                description: Group is the group of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          filters:
+                            description: "Filters defined at this-level should be
+                              executed if and only if the request is being forwarded
+                              to the backend defined here. \n Support: Custom (For
+                              broader support of filters, use the Filters field in
+                              HTTPRouteRule.)"
+                            items:
+                              description: 'HTTPRouteFilter defines additional processing
+                                steps that must be completed during the request or
+                                response lifecycle. HTTPRouteFilters are meant as
+                                an extension point to express additional processing
+                                that may be done in Gateway implementations. Some
+                                examples include request or response modification,
+                                implementing authentication strategies, rate-limiting,
+                                and traffic shaping. API guarantee/conformance is
+                                defined based on the type of the filter. TODO(hbagdi):
+                                re-render CRDs once controller-tools supports union
+                                tags: - https://github.com/kubernetes-sigs/controller-tools/pull/298
+                                - https://github.com/kubernetes-sigs/controller-tools/issues/461'
+                              properties:
+                                extensionRef:
+                                  description: "ExtensionRef is an optional, implementation-specific
+                                    extension to the \"filter\" behavior.  For example,
+                                    resource \"myroutefilter\" in group \"networking.acme.io\").
+                                    ExtensionRef MUST NOT be used for core and extended
+                                    filters. \n Support: Implementation-specific"
+                                  properties:
+                                    group:
+                                      description: Group is the group of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: "RequestHeaderModifier defines a schema
+                                    for a filter that modifies request headers. \n
+                                    Support: Core"
+                                  properties:
+                                    add:
+                                      additionalProperties:
+                                        type: string
+                                      description: "Add adds the given header (name,
+                                        value) to the request before the action. It
+                                        appends to any existing values associated
+                                        with the header name. \n Input:   GET /foo
+                                        HTTP/1.1   my-header: foo \n Config:   add:
+                                        {\"my-header\": \"bar\"} \n Output:   GET
+                                        /foo HTTP/1.1   my-header: foo   my-header:
+                                        bar \n Support: Extended"
+                                      type: object
+                                    remove:
+                                      description: "Remove the given header(s) from
+                                        the HTTP request before the action. The value
+                                        of RemoveHeader is a list of HTTP header names.
+                                        Note that the header names are case-insensitive
+                                        [RFC-2616 4.2]. \n Input:   GET /foo HTTP/1.1
+                                        \  my-header1: foo   my-header2: bar   my-header3:
+                                        baz \n Config:   remove: [\"my-header1\",
+                                        \"my-header3\"] \n Output:   GET /foo HTTP/1.1
+                                        \  my-header2: bar \n Support: Extended"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                    set:
+                                      additionalProperties:
+                                        type: string
+                                      description: "Set overwrites the request with
+                                        the given header (name, value) before the
+                                        action. \n Input:   GET /foo HTTP/1.1   my-header:
+                                        foo \n Config:   set: {\"my-header\": \"bar\"}
+                                        \n Output:   GET /foo HTTP/1.1   my-header:
+                                        bar \n Support: Extended"
+                                      type: object
+                                  type: object
+                                requestMirror:
+                                  description: "RequestMirror defines a schema for
+                                    a filter that mirrors requests. \n Support: Extended"
+                                  properties:
+                                    backendRef:
+                                      description: "BackendRef is a local object reference
+                                        to mirror matched requests to. If both BackendRef
+                                        and ServiceName are specified, ServiceName
+                                        will be given precedence. \n If the referent
+                                        cannot be found, the rule is not included
+                                        in the route. The controller should raise
+                                        the \"ResolvedRefs\" condition on the Gateway
+                                        with the \"DegradedRoutes\" reason. The gateway
+                                        status for this route should be updated with
+                                        a condition that describes the error more
+                                        specifically. \n Support: Custom"
+                                      properties:
+                                        group:
+                                          description: Group is the group of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        kind:
+                                          description: Kind is kind of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - group
+                                      - kind
+                                      - name
+                                      type: object
+                                    port:
+                                      description: "Port specifies the destination
+                                        port number to use for the backend referenced
+                                        by the ServiceName or BackendRef field. \n
+                                        If unspecified, the destination port in the
+                                        request is used when forwarding to a backendRef
+                                        or serviceName."
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    serviceName:
+                                      description: "ServiceName refers to the name
+                                        of the Service to mirror matched requests
+                                        to. When specified, this takes the place of
+                                        BackendRef. If both BackendRef and ServiceName
+                                        are specified, ServiceName will be given precedence.
+                                        \n If the referent cannot be found, the rule
+                                        is not included in the route. The controller
+                                        should raise the \"ResolvedRefs\" condition
+                                        on the Gateway with the \"DegradedRoutes\"
+                                        reason. The gateway status for this route
+                                        should be updated with a condition that describes
+                                        the error more specifically. \n Support: Core"
+                                      maxLength: 253
+                                      type: string
+                                  type: object
+                                type:
+                                  description: "Type identifies the type of filter
+                                    to apply. As with other API fields, types are
+                                    classified into three conformance levels: \n -
+                                    Core: Filter types and their corresponding configuration
+                                    defined by   \"Support: Core\" in this package,
+                                    e.g. \"RequestHeaderModifier\". All   implementations
+                                    must support core filters. \n - Extended: Filter
+                                    types and their corresponding configuration defined
+                                    by   \"Support: Extended\" in this package, e.g.
+                                    \"RequestMirror\". Implementers   are encouraged
+                                    to support extended filters. \n - Custom: Filters
+                                    that are defined and supported by specific vendors.
+                                    \  In the future, filters showing convergence
+                                    in behavior across multiple   implementations
+                                    will be considered for inclusion in extended or
+                                    core   conformance levels. Filter-specific configuration
+                                    for such filters   is specified using the ExtensionRef
+                                    field. `Type` should be set to   \"ExtensionRef\"
+                                    for custom filters. \n Implementers are encouraged
+                                    to define custom implementation types to extend
+                                    the core API with implementation-specific behavior."
+                                  enum:
+                                  - RequestHeaderModifier
+                                  - RequestMirror
+                                  - ExtensionRef
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            maxItems: 16
+                            type: array
+                          port:
+                            description: "Port specifies the destination port number
+                              to use for the backend referenced by the ServiceName
+                              or BackendRef field. If unspecified, the destination
+                              port in the request is used when forwarding to a backendRef
+                              or serviceName. \n Support: Core"
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          serviceName:
+                            description: "ServiceName refers to the name of the Service
+                              to forward matched requests to. When specified, this
+                              takes the place of BackendRef. If both BackendRef and
+                              ServiceName are specified, ServiceName will be given
+                              precedence. \n If the referent cannot be found, the
+                              route must be dropped from the Gateway. The controller
+                              should raise the \"ResolvedRefs\" condition on the Gateway
+                              with the \"DegradedRoutes\" reason. The gateway status
+                              for this route should be updated with a condition that
+                              describes the error more specifically. \n The protocol
+                              to use should be specified with the AppProtocol field
+                              on Service resources. This field was introduced in Kubernetes
+                              1.18. If using an earlier version of Kubernetes, a `networking.x-k8s.io/app-protocol`
+                              annotation on the BackendPolicy resource may be used
+                              to define the protocol. If the AppProtocol field is
+                              available, this annotation should not be used. The AppProtocol
+                              field, when populated, takes precedence over the annotation
+                              in the BackendPolicy resource. For custom backends,
+                              it is encouraged to add a semantically-equivalent field
+                              in the Custom Resource Definition. \n Support: Core"
+                            maxLength: 253
+                            type: string
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of HTTP
+                              requests forwarded to the backend referenced by the
+                              ServiceName or BackendRef field. This is computed as
+                              weight/(sum of all weights in this ForwardTo list).
+                              For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision
+                              an implementation supports. Weight is not a percentage
+                              and the sum of weights does not need to equal 100. \n
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100% of the traffic is forwarded to
+                              that backend. If weight is set to 0, no traffic should
+                              be forwarded for this entry. If unspecified, weight
+                              defaults to 1. \n Support: Core"
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        type: object
+                      maxItems: 16
+                      type: array
+                    matches:
+                      default:
+                      - path:
+                          type: Prefix
+                          value: /
+                      description: "Matches define conditions used for matching the
+                        rule against incoming HTTP requests. Each match is independent,
+                        i.e. this rule will be matched if **any** one of the matches
+                        is satisfied. \n For example, take the following matches configuration:
+                        \n ``` matches: - path:     value: \"/foo\"   headers:     values:
+                        \      version: \"2\" - path:     value: \"/v2/foo\" ``` \n
+                        For a request to match against this rule, a request should
+                        satisfy EITHER of the two conditions: \n - path prefixed with
+                        `/foo` AND contains the header `version: \"2\"` - path prefix
+                        of `/v2/foo` \n See the documentation for HTTPRouteMatch on
+                        how to specify multiple match conditions that should be ANDed
+                        together. \n If no matches are specified, the default is a
+                        prefix path match on \"/\", which has the effect of matching
+                        every HTTP request. \n A client request may match multiple
+                        HTTP route rules. Matching precedence MUST be determined in
+                        order of the following criteria, continuing on ties: \n *
+                        The longest matching hostname. * The longest matching path.
+                        * The largest number of header matches * The oldest Route
+                        based on creation timestamp. For example, a Route with   a
+                        creation timestamp of \"2020-09-08 01:02:03\" is given precedence
+                        over   a Route with a creation timestamp of \"2020-09-08 01:02:04\".
+                        * The Route appearing first in alphabetical order (namespace/name)
+                        for   example, foo/bar is given precedence over foo/baz."
+                      items:
+                        description: "HTTPRouteMatch defines the predicate used to
+                          match requests to a given action. Multiple match types are
+                          ANDed together, i.e. the match will evaluate to true only
+                          if all conditions are satisfied. \n For example, the match
+                          below will match a HTTP request only if its path starts
+                          with `/foo` AND it contains the `version: \"1\"` header:
+                          \n ``` match:   path:     value: \"/foo\"   headers:     values:
+                          \      version: \"1\" ```"
+                        properties:
+                          extensionRef:
+                            description: "ExtensionRef is an optional, implementation-specific
+                              extension to the \"match\" behavior. For example, resource
+                              \"myroutematcher\" in group \"networking.acme.io\".
+                              If the referent cannot be found, the rule is not included
+                              in the route. The controller should raise the \"ResolvedRefs\"
+                              condition on the Gateway with the \"DegradedRoutes\"
+                              reason. The gateway status for this route should be
+                              updated with a condition that describes the error more
+                              specifically. \n Support: Custom"
+                            properties:
+                              group:
+                                description: Group is the group of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          headers:
+                            description: Headers specifies a HTTP request header matcher.
+                            properties:
+                              type:
+                                default: Exact
+                                description: "Type specifies how to match against
+                                  the value of the header. \n Support: Core (Exact)
+                                  \n Support: Custom (RegularExpression, ImplementationSpecific)
+                                  \n Since RegularExpression PathType has custom conformance,
+                                  implementations can support POSIX, PCRE or any other
+                                  dialects of regular expressions. Please read the
+                                  implementation's documentation to determine the
+                                  supported dialect. \n HTTP Header name matching
+                                  MUST be case-insensitive (RFC 2616 - section 4.2)."
+                                enum:
+                                - Exact
+                                - RegularExpression
+                                - ImplementationSpecific
+                                type: string
+                              values:
+                                additionalProperties:
+                                  type: string
+                                description: "Values is a map of HTTP Headers to be
+                                  matched. It MUST contain at least one entry. \n
+                                  The HTTP header field name to match is the map key,
+                                  and the value of the HTTP header is the map value.
+                                  HTTP header field name matching MUST be case-insensitive.
+                                  \n Multiple match values are ANDed together, meaning,
+                                  a request must match all the specified headers to
+                                  select the route."
+                                type: object
+                            required:
+                            - values
+                            type: object
+                          path:
+                            default:
+                              type: Prefix
+                              value: /
+                            description: Path specifies a HTTP request path matcher.
+                              If this field is not specified, a default prefix match
+                              on the "/" path is provided.
+                            properties:
+                              type:
+                                default: Prefix
+                                description: "Type specifies how to match against
+                                  the path Value. \n Support: Core (Exact, Prefix)
+                                  \n Support: Custom (RegularExpression, ImplementationSpecific)
+                                  \n Since RegularExpression PathType has custom conformance,
+                                  implementations can support POSIX, PCRE or any other
+                                  dialects of regular expressions. Please read the
+                                  implementation's documentation to determine the
+                                  supported dialect."
+                                enum:
+                                - Exact
+                                - Prefix
+                                - RegularExpression
+                                - ImplementationSpecific
+                                type: string
+                              value:
+                                description: Value of the HTTP path to match against.
+                                minLength: 1
+                                type: string
+                            required:
+                            - value
+                            type: object
+                        type: object
+                      maxItems: 8
+                      type: array
+                  type: object
+                maxItems: 16
+                type: array
+              tls:
+                description: "TLS defines the TLS certificate to use for Hostnames
+                  defined in this Route. This configuration only takes effect if the
+                  AllowRouteOverride field is set to true in the associated Gateway
+                  resource. \n Collisions can happen if multiple HTTPRoutes define
+                  a TLS certificate for the same hostname. In such a case, conflict
+                  resolution guiding principles apply, specifically, if hostnames
+                  are same and two different certificates are specified then the certificate
+                  in the oldest resource wins. \n Please note that HTTP Route-selection
+                  takes place after the TLS Handshake (ClientHello). Due to this,
+                  TLS certificate defined here will take precedence even if the request
+                  has the potential to match multiple routes (in case multiple HTTPRoutes
+                  share the same hostname). \n Support: Core"
+                properties:
+                  certificateRef:
+                    description: "CertificateRef refers to a Kubernetes object that
+                      contains a TLS certificate and private key. This certificate
+                      MUST be used for TLS handshakes for the domain this RouteTLSConfig
+                      is associated with. If an entry in this list omits or specifies
+                      the empty string for both the group and kind, the resource defaults
+                      to \"secrets\". An implementation may support other resources
+                      (for example, resource \"mycertificates\" in group \"networking.acme.io\").
+                      \n Support: Core (Kubernetes Secrets) \n Support: Implementation-specific
+                      (Other resource types)"
+                    properties:
+                      group:
+                        description: Group is the group of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      kind:
+                        description: Kind is kind of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                    - group
+                    - kind
+                    - name
+                    type: object
+                required:
+                - certificateRef
+                type: object
+            type: object
+          status:
+            description: Status defines the current state of HTTPRoute.
+            properties:
+              gateways:
+                description: "Gateways is a list of Gateways that are associated with
+                  the route, and the status of the route with respect to each Gateway.
+                  When a Gateway selects this route, the controller that manages the
+                  Gateway must add an entry to this list when the controller first
+                  sees the route and should update the entry as appropriate when the
+                  route is modified. \n A maximum of 100 Gateways will be represented
+                  in this list. If this list is full, there may be additional Gateways
+                  using this Route that are not included in the list. An empty list
+                  means the route has not been admitted by any Gateway."
+                items:
+                  description: RouteGatewayStatus describes the status of a route
+                    with respect to an associated Gateway.
+                  properties:
+                    conditions:
+                      description: Conditions describes the status of the route with
+                        respect to the Gateway. The "Admitted" condition must always
+                        be specified by controllers to indicate whether the route
+                        has been admitted or rejected by the Gateway, and why. Note
+                        that the route's availability is also subject to the Gateway's
+                        own status conditions and listener status.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, type FooStatus struct{
+                          \    // Represents the observations of a foo's current state.
+                          \    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                          \    // +patchStrategy=merge     // +listType=map     //
+                          +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                          patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                          \n     // other fields }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    gatewayRef:
+                      description: GatewayRef is a reference to a Gateway object that
+                        is associated with the route.
+                      properties:
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                  required:
+                  - gatewayRef
+                  type: object
+                maxItems: 100
+                type: array
+            required:
+            - gateways
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: tcproutes.networking.x-k8s.io
+spec:
+  group: networking.x-k8s.io
+  names:
+    kind: TCPRoute
+    listKind: TCPRouteList
+    plural: tcproutes
+    singular: tcproute
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TCPRoute is the Schema for the TCPRoute resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TCPRoute.
+            properties:
+              gateways:
+                default:
+                  allow: SameNamespace
+                description: Gateways defines which Gateways can use this Route.
+                properties:
+                  allow:
+                    default: SameNamespace
+                    description: 'Allow indicates which Gateways will be allowed to
+                      use this route. Possible values are: * All: Gateways in any
+                      namespace can use this route. * FromList: Only Gateways specified
+                      in GatewayRefs may use this route. * SameNamespace: Only Gateways
+                      in the same namespace may use this route.'
+                    enum:
+                    - All
+                    - FromList
+                    - SameNamespace
+                    type: string
+                  gatewayRefs:
+                    description: GatewayRefs must be specified when Allow is set to
+                      "FromList". In that case, only Gateways referenced in this list
+                      will be allowed to use this route. This field is ignored for
+                      other values of "Allow".
+                    items:
+                      description: GatewayReference identifies a Gateway in a specified
+                        namespace.
+                      properties:
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                    type: array
+                type: object
+              rules:
+                description: Rules are a list of TCP matchers and actions.
+                items:
+                  description: TCPRouteRule is the configuration for a given rule.
+                  properties:
+                    forwardTo:
+                      description: ForwardTo defines the backend(s) where matching
+                        requests should be sent.
+                      items:
+                        description: RouteForwardTo defines how a Route should forward
+                          a request.
+                        properties:
+                          backendRef:
+                            description: "BackendRef is a reference to a backend to
+                              forward matched requests to. If both BackendRef and
+                              ServiceName are specified, ServiceName will be given
+                              precedence. \n If the referent cannot be found, the
+                              rule is not included in the route. The controller should
+                              raise the \"ResolvedRefs\" condition on the Gateway
+                              with the \"DegradedRoutes\" reason. The gateway status
+                              for this route should be updated with a condition that
+                              describes the error more specifically. \n Support: Custom"
+                            properties:
+                              group:
+                                description: Group is the group of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          port:
+                            description: "Port specifies the destination port number
+                              to use for the backend referenced by the ServiceName
+                              or BackendRef field. If unspecified, the destination
+                              port in the request is used when forwarding to a backendRef
+                              or serviceName. \n Support: Core"
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          serviceName:
+                            description: "ServiceName refers to the name of the Service
+                              to forward matched requests to. When specified, this
+                              takes the place of BackendRef. If both BackendRef and
+                              ServiceName are specified, ServiceName will be given
+                              precedence. \n If the referent cannot be found, the
+                              rule is not included in the route. The controller should
+                              raise the \"ResolvedRefs\" condition on the Gateway
+                              with the \"DegradedRoutes\" reason. The gateway status
+                              for this route should be updated with a condition that
+                              describes the error more specifically. \n The protocol
+                              to use is defined using AppProtocol field (introduced
+                              in Kubernetes 1.18) in the Service resource. In the
+                              absence of the AppProtocol field a `networking.x-k8s.io/app-protocol`
+                              annotation on the BackendPolicy resource may be used
+                              to define the protocol. If the AppProtocol field is
+                              available, this annotation should not be used. The AppProtocol
+                              field, when populated, takes precedence over the annotation
+                              in the BackendPolicy resource. For custom backends,
+                              it is encouraged to add a semantically-equivalent field
+                              in the Custom Resource Definition. \n Support: Core"
+                            maxLength: 253
+                            type: string
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of HTTP
+                              requests forwarded to the backend referenced by the
+                              ServiceName or BackendRef field. This is computed as
+                              weight/(sum of all weights in this ForwardTo list).
+                              For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision
+                              an implementation supports. Weight is not a percentage
+                              and the sum of weights does not need to equal 100. \n
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100% of the traffic is forwarded to
+                              that backend. If weight is set to 0, no traffic should
+                              be forwarded for this entry. If unspecified, weight
+                              defaults to 1. \n Support: Extended"
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        type: object
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                    matches:
+                      description: Matches define conditions used for matching the
+                        rule against incoming TCP connections. Each match is independent,
+                        i.e. this rule will be matched if **any** one of the matches
+                        is satisfied. If unspecified, all requests from the associated
+                        gateway TCP listener will match.
+                      items:
+                        description: TCPRouteMatch defines the predicate used to match
+                          connections to a given action.
+                        properties:
+                          extensionRef:
+                            description: "ExtensionRef is an optional, implementation-specific
+                              extension to the \"match\" behavior.  For example, resource
+                              \"mytcproutematcher\" in group \"networking.acme.io\".
+                              If the referent cannot be found, the rule is not included
+                              in the route. The controller should raise the \"ResolvedRefs\"
+                              condition on the Gateway with the \"DegradedRoutes\"
+                              reason. The gateway status for this route should be
+                              updated with a condition that describes the error more
+                              specifically. \n Support: Custom"
+                            properties:
+                              group:
+                                description: Group is the group of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                        type: object
+                      maxItems: 8
+                      type: array
+                  required:
+                  - forwardTo
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TCPRoute.
+            properties:
+              gateways:
+                description: "Gateways is a list of Gateways that are associated with
+                  the route, and the status of the route with respect to each Gateway.
+                  When a Gateway selects this route, the controller that manages the
+                  Gateway must add an entry to this list when the controller first
+                  sees the route and should update the entry as appropriate when the
+                  route is modified. \n A maximum of 100 Gateways will be represented
+                  in this list. If this list is full, there may be additional Gateways
+                  using this Route that are not included in the list. An empty list
+                  means the route has not been admitted by any Gateway."
+                items:
+                  description: RouteGatewayStatus describes the status of a route
+                    with respect to an associated Gateway.
+                  properties:
+                    conditions:
+                      description: Conditions describes the status of the route with
+                        respect to the Gateway. The "Admitted" condition must always
+                        be specified by controllers to indicate whether the route
+                        has been admitted or rejected by the Gateway, and why. Note
+                        that the route's availability is also subject to the Gateway's
+                        own status conditions and listener status.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, type FooStatus struct{
+                          \    // Represents the observations of a foo's current state.
+                          \    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                          \    // +patchStrategy=merge     // +listType=map     //
+                          +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                          patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                          \n     // other fields }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    gatewayRef:
+                      description: GatewayRef is a reference to a Gateway object that
+                        is associated with the route.
+                      properties:
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                  required:
+                  - gatewayRef
+                  type: object
+                maxItems: 100
+                type: array
+            required:
+            - gateways
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: tlscertificatedelegations.projectcontour.io
 spec:
@@ -2048,6 +5245,776 @@ status:
   conditions: []
   storedVersions: []
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: tlsroutes.networking.x-k8s.io
+spec:
+  group: networking.x-k8s.io
+  names:
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "The TLSRoute resource is similar to TCPRoute, but can be configured
+          to match against TLS-specific metadata. This allows more flexibility in
+          matching streams for a given TLS listener. \n If you need to forward traffic
+          to a single target for a TLS listener, you could choose to use a TCPRoute
+          with a TLS listener."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              gateways:
+                default:
+                  allow: SameNamespace
+                description: Gateways defines which Gateways can use this Route.
+                properties:
+                  allow:
+                    default: SameNamespace
+                    description: 'Allow indicates which Gateways will be allowed to
+                      use this route. Possible values are: * All: Gateways in any
+                      namespace can use this route. * FromList: Only Gateways specified
+                      in GatewayRefs may use this route. * SameNamespace: Only Gateways
+                      in the same namespace may use this route.'
+                    enum:
+                    - All
+                    - FromList
+                    - SameNamespace
+                    type: string
+                  gatewayRefs:
+                    description: GatewayRefs must be specified when Allow is set to
+                      "FromList". In that case, only Gateways referenced in this list
+                      will be allowed to use this route. This field is ignored for
+                      other values of "Allow".
+                    items:
+                      description: GatewayReference identifies a Gateway in a specified
+                        namespace.
+                      properties:
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                    type: array
+                type: object
+              rules:
+                description: Rules are a list of TLS matchers and actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    forwardTo:
+                      description: ForwardTo defines the backend(s) where matching
+                        requests should be sent.
+                      items:
+                        description: RouteForwardTo defines how a Route should forward
+                          a request.
+                        properties:
+                          backendRef:
+                            description: "BackendRef is a reference to a backend to
+                              forward matched requests to. If both BackendRef and
+                              ServiceName are specified, ServiceName will be given
+                              precedence. \n If the referent cannot be found, the
+                              rule is not included in the route. The controller should
+                              raise the \"ResolvedRefs\" condition on the Gateway
+                              with the \"DegradedRoutes\" reason. The gateway status
+                              for this route should be updated with a condition that
+                              describes the error more specifically. \n Support: Custom"
+                            properties:
+                              group:
+                                description: Group is the group of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          port:
+                            description: "Port specifies the destination port number
+                              to use for the backend referenced by the ServiceName
+                              or BackendRef field. If unspecified, the destination
+                              port in the request is used when forwarding to a backendRef
+                              or serviceName. \n Support: Core"
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          serviceName:
+                            description: "ServiceName refers to the name of the Service
+                              to forward matched requests to. When specified, this
+                              takes the place of BackendRef. If both BackendRef and
+                              ServiceName are specified, ServiceName will be given
+                              precedence. \n If the referent cannot be found, the
+                              rule is not included in the route. The controller should
+                              raise the \"ResolvedRefs\" condition on the Gateway
+                              with the \"DegradedRoutes\" reason. The gateway status
+                              for this route should be updated with a condition that
+                              describes the error more specifically. \n The protocol
+                              to use is defined using AppProtocol field (introduced
+                              in Kubernetes 1.18) in the Service resource. In the
+                              absence of the AppProtocol field a `networking.x-k8s.io/app-protocol`
+                              annotation on the BackendPolicy resource may be used
+                              to define the protocol. If the AppProtocol field is
+                              available, this annotation should not be used. The AppProtocol
+                              field, when populated, takes precedence over the annotation
+                              in the BackendPolicy resource. For custom backends,
+                              it is encouraged to add a semantically-equivalent field
+                              in the Custom Resource Definition. \n Support: Core"
+                            maxLength: 253
+                            type: string
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of HTTP
+                              requests forwarded to the backend referenced by the
+                              ServiceName or BackendRef field. This is computed as
+                              weight/(sum of all weights in this ForwardTo list).
+                              For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision
+                              an implementation supports. Weight is not a percentage
+                              and the sum of weights does not need to equal 100. \n
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100% of the traffic is forwarded to
+                              that backend. If weight is set to 0, no traffic should
+                              be forwarded for this entry. If unspecified, weight
+                              defaults to 1. \n Support: Extended"
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        type: object
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                    matches:
+                      description: Matches define conditions used for matching the
+                        rule against an incoming TLS handshake. Each match is independent,
+                        i.e. this rule will be matched if **any** one of the matches
+                        is satisfied. If unspecified, all requests from the associated
+                        gateway TLS listener will match.
+                      items:
+                        description: TLSRouteMatch defines the predicate used to match
+                          connections to a given action.
+                        properties:
+                          extensionRef:
+                            description: "ExtensionRef is an optional, implementation-specific
+                              extension to the \"match\" behavior.  For example, resource
+                              \"mytlsroutematcher\" in group \"networking.acme.io\".
+                              If the referent cannot be found, the rule is not included
+                              in the route. The controller should raise the \"ResolvedRefs\"
+                              condition on the Gateway with the \"DegradedRoutes\"
+                              reason. The gateway status for this route should be
+                              updated with a condition that describes the error more
+                              specifically. \n Support: Custom"
+                            properties:
+                              group:
+                                description: Group is the group of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          snis:
+                            description: "SNIs defines a set of SNI names that should
+                              match against the SNI attribute of TLS ClientHello message
+                              in TLS handshake. \n SNI can be \"precise\" which is
+                              a domain name without the terminating dot of a network
+                              host (e.g. \"foo.example.com\") or \"wildcard\", which
+                              is a domain name prefixed with a single wildcard label
+                              (e.g. `*.example.com`). The wildcard character `*` must
+                              appear by itself as the first DNS label and matches
+                              only a single label. You cannot have a wildcard label
+                              by itself (e.g. Host == `*`). \n Requests will be matched
+                              against the Host field in the following order: \n 1.
+                              If SNI is precise, the request matches this rule if
+                              the SNI in    ClientHello is equal to one of the defined
+                              SNIs. 2. If SNI is a wildcard, then the request matches
+                              this rule if the    SNI is to equal to the suffix (removing
+                              the first label) of the    wildcard rule. 3. If SNIs
+                              is unspecified, all requests associated with the gateway
+                              TLS    listener will match. This can be used to define
+                              a default backend    for a TLS listener. \n Support:
+                              Core"
+                            items:
+                              description: Hostname is used to specify a hostname
+                                that should be matched.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            maxItems: 16
+                            type: array
+                        type: object
+                      maxItems: 8
+                      type: array
+                  required:
+                  - forwardTo
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              gateways:
+                description: "Gateways is a list of Gateways that are associated with
+                  the route, and the status of the route with respect to each Gateway.
+                  When a Gateway selects this route, the controller that manages the
+                  Gateway must add an entry to this list when the controller first
+                  sees the route and should update the entry as appropriate when the
+                  route is modified. \n A maximum of 100 Gateways will be represented
+                  in this list. If this list is full, there may be additional Gateways
+                  using this Route that are not included in the list. An empty list
+                  means the route has not been admitted by any Gateway."
+                items:
+                  description: RouteGatewayStatus describes the status of a route
+                    with respect to an associated Gateway.
+                  properties:
+                    conditions:
+                      description: Conditions describes the status of the route with
+                        respect to the Gateway. The "Admitted" condition must always
+                        be specified by controllers to indicate whether the route
+                        has been admitted or rejected by the Gateway, and why. Note
+                        that the route's availability is also subject to the Gateway's
+                        own status conditions and listener status.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, type FooStatus struct{
+                          \    // Represents the observations of a foo's current state.
+                          \    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                          \    // +patchStrategy=merge     // +listType=map     //
+                          +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                          patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                          \n     // other fields }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    gatewayRef:
+                      description: GatewayRef is a reference to a Gateway object that
+                        is associated with the route.
+                      properties:
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                  required:
+                  - gatewayRef
+                  type: object
+                maxItems: 100
+                type: array
+            required:
+            - gateways
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: udproutes.networking.x-k8s.io
+spec:
+  group: networking.x-k8s.io
+  names:
+    kind: UDPRoute
+    listKind: UDPRouteList
+    plural: udproutes
+    singular: udproute
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: UDPRoute is a resource that specifies how a Gateway should forward
+          UDP traffic.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of UDPRoute.
+            properties:
+              gateways:
+                default:
+                  allow: SameNamespace
+                description: Gateways defines which Gateways can use this Route.
+                properties:
+                  allow:
+                    default: SameNamespace
+                    description: 'Allow indicates which Gateways will be allowed to
+                      use this route. Possible values are: * All: Gateways in any
+                      namespace can use this route. * FromList: Only Gateways specified
+                      in GatewayRefs may use this route. * SameNamespace: Only Gateways
+                      in the same namespace may use this route.'
+                    enum:
+                    - All
+                    - FromList
+                    - SameNamespace
+                    type: string
+                  gatewayRefs:
+                    description: GatewayRefs must be specified when Allow is set to
+                      "FromList". In that case, only Gateways referenced in this list
+                      will be allowed to use this route. This field is ignored for
+                      other values of "Allow".
+                    items:
+                      description: GatewayReference identifies a Gateway in a specified
+                        namespace.
+                      properties:
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                    type: array
+                type: object
+              rules:
+                description: Rules are a list of UDP matchers and actions.
+                items:
+                  description: UDPRouteRule is the configuration for a given rule.
+                  properties:
+                    forwardTo:
+                      description: ForwardTo defines the backend(s) where matching
+                        requests should be sent.
+                      items:
+                        description: RouteForwardTo defines how a Route should forward
+                          a request.
+                        properties:
+                          backendRef:
+                            description: "BackendRef is a reference to a backend to
+                              forward matched requests to. If both BackendRef and
+                              ServiceName are specified, ServiceName will be given
+                              precedence. \n If the referent cannot be found, the
+                              rule is not included in the route. The controller should
+                              raise the \"ResolvedRefs\" condition on the Gateway
+                              with the \"DegradedRoutes\" reason. The gateway status
+                              for this route should be updated with a condition that
+                              describes the error more specifically. \n Support: Custom"
+                            properties:
+                              group:
+                                description: Group is the group of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          port:
+                            description: "Port specifies the destination port number
+                              to use for the backend referenced by the ServiceName
+                              or BackendRef field. If unspecified, the destination
+                              port in the request is used when forwarding to a backendRef
+                              or serviceName. \n Support: Core"
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          serviceName:
+                            description: "ServiceName refers to the name of the Service
+                              to forward matched requests to. When specified, this
+                              takes the place of BackendRef. If both BackendRef and
+                              ServiceName are specified, ServiceName will be given
+                              precedence. \n If the referent cannot be found, the
+                              rule is not included in the route. The controller should
+                              raise the \"ResolvedRefs\" condition on the Gateway
+                              with the \"DegradedRoutes\" reason. The gateway status
+                              for this route should be updated with a condition that
+                              describes the error more specifically. \n The protocol
+                              to use is defined using AppProtocol field (introduced
+                              in Kubernetes 1.18) in the Service resource. In the
+                              absence of the AppProtocol field a `networking.x-k8s.io/app-protocol`
+                              annotation on the BackendPolicy resource may be used
+                              to define the protocol. If the AppProtocol field is
+                              available, this annotation should not be used. The AppProtocol
+                              field, when populated, takes precedence over the annotation
+                              in the BackendPolicy resource. For custom backends,
+                              it is encouraged to add a semantically-equivalent field
+                              in the Custom Resource Definition. \n Support: Core"
+                            maxLength: 253
+                            type: string
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of HTTP
+                              requests forwarded to the backend referenced by the
+                              ServiceName or BackendRef field. This is computed as
+                              weight/(sum of all weights in this ForwardTo list).
+                              For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision
+                              an implementation supports. Weight is not a percentage
+                              and the sum of weights does not need to equal 100. \n
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100% of the traffic is forwarded to
+                              that backend. If weight is set to 0, no traffic should
+                              be forwarded for this entry. If unspecified, weight
+                              defaults to 1. \n Support: Extended"
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        type: object
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                    matches:
+                      description: Matches define conditions used for matching the
+                        rule against incoming UDP connections. Each match is independent,
+                        i.e. this rule will be matched if **any** one of the matches
+                        is satisfied. If unspecified, all requests from the associated
+                        gateway UDP listener will match.
+                      items:
+                        description: UDPRouteMatch defines the predicate used to match
+                          packets to a given action.
+                        properties:
+                          extensionRef:
+                            description: "ExtensionRef is an optional, implementation-specific
+                              extension to the \"match\" behavior.  For example, resource
+                              \"myudproutematcher\" in group \"networking.acme.io\".
+                              If the referent cannot be found, the rule is not included
+                              in the route. The controller should raise the \"ResolvedRefs\"
+                              condition on the Gateway with the \"DegradedRoutes\"
+                              reason. The gateway status for this route should be
+                              updated with a condition that describes the error more
+                              specifically. \n Support: Custom"
+                            properties:
+                              group:
+                                description: Group is the group of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                        type: object
+                      maxItems: 8
+                      type: array
+                  required:
+                  - forwardTo
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of UDPRoute.
+            properties:
+              gateways:
+                description: "Gateways is a list of Gateways that are associated with
+                  the route, and the status of the route with respect to each Gateway.
+                  When a Gateway selects this route, the controller that manages the
+                  Gateway must add an entry to this list when the controller first
+                  sees the route and should update the entry as appropriate when the
+                  route is modified. \n A maximum of 100 Gateways will be represented
+                  in this list. If this list is full, there may be additional Gateways
+                  using this Route that are not included in the list. An empty list
+                  means the route has not been admitted by any Gateway."
+                items:
+                  description: RouteGatewayStatus describes the status of a route
+                    with respect to an associated Gateway.
+                  properties:
+                    conditions:
+                      description: Conditions describes the status of the route with
+                        respect to the Gateway. The "Admitted" condition must always
+                        be specified by controllers to indicate whether the route
+                        has been admitted or rejected by the Gateway, and why. Note
+                        that the route's availability is also subject to the Gateway's
+                        own status conditions and listener status.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, type FooStatus struct{
+                          \    // Represents the observations of a foo's current state.
+                          \    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                          \    // +patchStrategy=merge     // +listType=map     //
+                          +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                          patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                          \n     // other fields }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    gatewayRef:
+                      description: GatewayRef is a reference to a Gateway object that
+                        is associated with the route.
+                      properties:
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                  required:
+                  - gatewayRef
+                  type: object
+                maxItems: 100
+                type: array
+            required:
+            - gateways
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -2125,6 +6092,7 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
+  - get
   - list
 - apiGroups:
   - apps
@@ -2160,13 +6128,20 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
-  - gatewayclasses
-  - gateways
-  - httproutes
+  - ingressclasses
   - ingresses
-  - tcproutes
   verbs:
   - get
   - list
@@ -2178,6 +6153,47 @@ rules:
   verbs:
   - create
   - get
+  - update
+- apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - backendpolicies
+  - gatewayclasses
+  - gateways
+  - httproutes
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - backendpolicies/status
+  - gatewayclasses/status
+  - gateways/status
+  - httproutes/status
+  - tlsroutes/status
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - tcproutes
+  - udproutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - tcproutes/status
+  - udproutes/status
+  verbs:
   - update
 - apiGroups:
   - operator.projectcontour.io
@@ -2248,7 +6264,7 @@ rules:
   verbs:
   - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: contour-operator-metrics-reader
@@ -2346,11 +6362,7 @@ spec:
         - --enable-leader-election
         command:
         - /contour-operator
-        - --contour-image
-        - docker.io/projectcontour/contour:v1.11.0
-        - --envoy-image
-        - docker.io/envoyproxy/envoy:v1.16.2
-        image: docker.io/projectcontour/contour-operator:v1.11.0
+        image: docker.io/projectcontour/contour-operator:v1.15.1
         imagePullPolicy: IfNotPresent
         name: contour-operator
         resources:

--- a/addons/packages/contour-operator/bundle/vendir.lock.yml
+++ b/addons/packages/contour-operator/bundle/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Update Contour Docker image to v1.11.0....
-      sha: 4b4ab1f9380567bda8f19cf441da7656a28988ca
+      commitTitle: Update Contour Docker image to v1.15.1....
+      sha: 7ea1a380e3ebd9953d77080d3bf7439d92fc3b10
       tags:
-      - v1.11.0
+      - v1.15.1
     path: .
   path: config/upstream
 kind: LockConfig

--- a/addons/packages/contour-operator/bundle/vendir.yml
+++ b/addons/packages/contour-operator/bundle/vendir.yml
@@ -7,5 +7,5 @@ directories:
   - path: .
     git:
       url: https://github.com/projectcontour/contour-operator
-      ref: v1.11.0
+      ref: v1.15.1
     newRootPath: examples/operator

--- a/addons/packages/contour-operator/installedpackage.yaml
+++ b/addons/packages/contour-operator/installedpackage.yaml
@@ -12,5 +12,5 @@ spec:
   packageRef:
     publicName: contour-operator.tce.vmware.com
     versionSelection:
-      constraints: "1.11.0-vmware0"
+      constraints: "1.15.1-vmware0"
       prereleases: {}

--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -28,8 +28,8 @@ package_repository:
     
     - name: contour-operator
       domain: tce.vmware.com
-      version: 1.11.0-vmware0
-      image: projects.registry.vmware.com/tce/contour-operator@sha256:db7a9ba6dd060c4f77835f09d83b27de5c20b6ae67e1bc1088903c08320ac0cf
+      version: 1.15.1-vmware0
+      image: projects.registry.vmware.com/tce/contour-operator@sha256:<!!!TODO!!!>
       description: This package provides an ingress controller.
 
     - name: external-dns


### PR DESCRIPTION
Updates contour-operator to v1.15.1 to match the Contour version.

Closes #693.

Signed-off-by: Steve Kriss <krisss@vmware.com>

## What this PR does / why we need it
Updates contour-operator to v1.15.1 to match the Contour version.

## Which issue(s) this PR fixes
Fixes: #693

## Describe testing done for PR
Basic YAML generation.

## Special notes for your reviewer
Not 100% sure this is the right process for bumping versions, so let me know if I did this incorrectly.

Will need the bundle pushed to the registry once this PR looks good.

## Does this PR introduce a user-facing change?
```release-note
Updates contour-operator to v1.15.1.
```
