### PR TITLE
Update standalone-cluster create using --ui flag to not require clustname

### DIFF
--- a/docs/site/content/docs/assets/aws-standalone-clusters.md
+++ b/docs/site/content/docs/assets/aws-standalone-clusters.md
@@ -3,17 +3,10 @@
 This section covers setting up a standalone cluster in AWS. This provides you
 a workload cluster that is **not** managed by a centralized management cluster.
 
-1. Store the name of your cluster (set in the configuration file) to a
-   `GUEST_CLUSTER_NAME` environment variable.
-
-    ```sh
-    export GUEST_CLUSTER_NAME="<INSERT_GUEST_CLUSTER_NAME_HERE>"
-    ```
-
 1. Initialize the Tanzu kickstart UI.
 
     ```sh
-    tanzu standalone-cluster create ${GUEST_CLUSTER_NAME} --ui
+    tanzu standalone-cluster create --ui
     ```
 
 1. Go through the configuration steps, considering the following.
@@ -26,6 +19,13 @@ a workload cluster that is **not** managed by a centralized management cluster.
     > We will have more complete `tanzu` cluster bootstrapping documentation available here in the near future.
 
 1. At the end of the UI, deploy the cluster.
+
+1. Store the name of your cluster (set during configuration or automatically generated) to a
+   `GUEST_CLUSTER_NAME` environment variable.
+
+    ```sh
+    export GUEST_CLUSTER_NAME="<INSERT_GUEST_CLUSTER_NAME_HERE>"
+    ```
 
 1. Set your kubectl context to the cluster.
 

--- a/docs/site/content/docs/assets/vsphere-standalone-clusters.md
+++ b/docs/site/content/docs/assets/vsphere-standalone-clusters.md
@@ -28,17 +28,10 @@ vSphere. These clusters are not managed by a management cluster.
 
 1. After importing, right-click and covert to a template.
 
-1. Store the name of your cluster (set in the configuration file) to a
-   `GUEST_CLUSTER_NAME` environment variable.
-
-    ```sh
-    export GUEST_CLUSTER_NAME="<INSERT_GUEST_CLUSTER_NAME_HERE>"
-    ```
-
 1. Initialize the Tanzu kickstart UI.
 
     ```sh
-    tanzu standalone-cluster create ${GUEST_CLUSTER_NAME} --ui
+    tanzu standalone-cluster create --ui
     ```
 
 1. Go through the configuration steps, considering the following.
@@ -59,6 +52,12 @@ vSphere. These clusters are not managed by a management cluster.
 
 1. At the end of the UI, create the standalone cluster.
 
+1. Store the name of your cluster (set during configuration or generated) to a
+   `GUEST_CLUSTER_NAME` environment variable.
+
+    ```sh
+    export GUEST_CLUSTER_NAME="<INSERT_GUEST_CLUSTER_NAME_HERE>"
+    ```
 1. Set your kubectl context to the cluster.
 
     ```sh


### PR DESCRIPTION
## What this PR does / why we need it
Updates the docs for standalone-cluster create to reflect the newest UX to not require the cluster name filed. Also shuffles around where the user would set that environment variable (after the fact)

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
Ran `make check` and `hugo serve` locally to verify
