### PR TITLE
Fix 0.5.0 download links

### DIFF
--- a/docs/site/content/docs/assets/cli-install-linux.md
+++ b/docs/site/content/docs/assets/cli-install-linux.md
@@ -1,4 +1,4 @@
-1. Download the release for [Linux](https://github.com/vmware-tanzu/tce/releases/download/v0.4.0/tce-linux-amd64-v0.4.0.tar.gz).
+1. Download the release for [Linux](https://github.com/vmware-tanzu/tce/releases/download/v0.5.0/tce-linux-amd64-v0.5.0.tar.gz).
 
 1. Unpack the release.
 

--- a/docs/site/content/docs/assets/cli-install-mac.md
+++ b/docs/site/content/docs/assets/cli-install-mac.md
@@ -1,4 +1,4 @@
-1. Download the release for [macOS](https://github.com/vmware-tanzu/tce/releases/download/v0.4.0/tce-darwin-amd64-v0.4.0.tar.gz).
+1. Download the release for [macOS](https://github.com/vmware-tanzu/tce/releases/download/v0.5.0/tce-darwin-amd64-v0.5.0.tar.gz).
 
 1. Unpack the release.
 


### PR DESCRIPTION
## What this PR does / why we need it
 Currently, the download links get the v0.4.0 release tarballs. This should be updated to v0.5.0.

## Describe testing done for PR

Ran site locally and verified links went to the correct address.

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
