### PR TITLE
Docs: Adds copy to clipboard buttons to all code-blocks

### DIFF
--- a/docs/site/themes/template/assets/js/main.js
+++ b/docs/site/themes/template/assets/js/main.js
@@ -45,18 +45,27 @@ function addCopyButtons(clipboard) {
         button.innerText = 'Copy';
 
         button.addEventListener('click', function () {
-            clipboard.writeText(codeBlock.innerText).then(function () {
+            clipboard.writeText(codeBlock.innerText.trim()).then(function () {
                 /* Chrome doesn't seem to blur automatically,
                    leaving the button in a focused state. */
                 button.blur();
+                button.innerText = 'Copied!';
                 button.classList.add('copy-code-button-copied')
 
                 setTimeout(function () {
+                    button.innerText = 'Copy';
                     button.classList.remove('copy-code-button-copied');
                 }, 500);
             }, function (error) {
+                button.innerText = 'Error!';
+                button.classList.add('copy-code-button-error')
                 console.error("could not copy to clipboard");
                 console.error(error)
+
+                setTimeout(function () {
+                    button.innerText = 'Copy';
+                    button.classList.remove('copy-code-button-error');
+                }, 500);
             });
         });
 

--- a/docs/site/themes/template/assets/scss/_components.scss
+++ b/docs/site/themes/template/assets/scss/_components.scss
@@ -731,6 +731,10 @@
             color: white;
             background-color: $mainblue;
         }
+        .copy-code-button-error {
+            color: white;
+            background-color: red;
+        }
         .highlight pre {
             /* Avoid pushing up the copy buttons. */
             margin: 0;


### PR DESCRIPTION
## What this PR does / why we need it
Adds copy to clipboard buttons to all code blocks. 

This was [well documented by a hugo user](https://github.com/dguo/dannyguo.com/blob/main/content/blog/how-to-add-copy-to-clipboard-buttons-to-code-blocks-in-hugo.md) with how to accomplish this in a rendered hugo site. I used their examples in the `main.js` library for our hugo theme.

Once the DOM has loaded, check for the presence of the `navigator` and `navigator.clipboard` browser APIs. Internet explorer is the only browser this is not supported in. If a user is using IE, they will not see the buttons. Next, create the button elements and add the classes, also injecting them to the `pre code` parent elements. The button callback functions handle the actual functionality for copying the text to the system clipboard.

![image](https://user-images.githubusercontent.com/23109390/121088827-87fc7d00-c7a3-11eb-9370-e015de34db94.png)

## Which issue(s) this PR fixes
Fixes: #700 

## Describe testing done for PR
Deployed via `hugo serve` and tried on Firefox and Chrome. Works!

## Special notes for your reviewer
Not sure if we want the "success" blue color class that indicates to the user that the block was copied correctly. Open to anything and everything for how this should look.
