### PR TITLE
Use `wheel` group for macOS instead of root

### DIFF
--- a/docs/site/content/docs/assets/cli-install-mac.md
+++ b/docs/site/content/docs/assets/cli-install-mac.md
@@ -20,5 +20,5 @@
 
     ```sh
     curl -LO https://dl.k8s.io/release/v1.20.1/bin/darwin/amd64/kubectl
-    sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+    sudo install -o root -g wheel -m 0755 kubectl /usr/local/bin/kubectl
     ```


### PR DESCRIPTION
## What this PR does / why we need it
When copying the provided kubectl command from the current docs on macOS, the following error is returned:

```shell
mbp16 in /Users/nrb/projects/tce (git) fix-kubectl-mac-group
% sudo install -o root -g root kubectl /usr/local/bin/kubectl
install: root: Invalid argument
```

## Describe testing done for PR

Verified the groups that root belongs to on macOS (Catalina, not Big Sur):

```shell
mbp16 in /Users/nrb/projects/tce (git) fix-kubectl-mac-group
% groups root
wheel daemon kmem sys tty operator procview procmod everyone staff certusers localaccounts admin _appstore _lpadmin _lpoperator _developer _analyticsusers com.apple.access_ftp com.apple.access_screensharing com.apple.access_ssh com.apple.access_remote_ae com.apple.sharepoint.group.1
```

Tried the `wheel` group, which is what I believe to be closest to the intent of the original command, and got no error.

```shell
mbp16 in /Users/nrb/projects/tce (git) fix-kubectl-mac-group
% sudo install -o root -g wheel kubectl /usr/local/bin/kubectl
```

Verified ownership

```shell
% ls -al $(which kubectl)
-rwxr-xr-x  1 root  wheel  46226800 Jun  8 16:01 /usr/local/bin/kubectl*
```

Verified version, with no running cluster.

```shell
mbp16 in /Users/nrb/projects/tce (git) fix-kubectl-mac-group
%  kubectl version
Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.1", GitCommit:"c4d752765b3bbac2237bf87cf0b1c2e307844666", GitTreeState:"clean", BuildDate:"2020-12-18T12:09:25Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"darwin/amd64"}
The connection to the server localhost:8080 was refused - did you specify the right host or port?
```

## Special notes for your reviewer
I have not tried this against any macOS version except Catalina, so other versions might have different groups.

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
