### PR TITLE
Doc: Update pkg readmes

### DIFF
--- a/addons/packages/cert-manager/README.md
+++ b/addons/packages/cert-manager/README.md
@@ -1,6 +1,7 @@
-**THIS CONTENT HAS MOVED TO THE DOCS BRANCH IN:  
-``docs\site\content\docs\latest\cert-manager-config``  
-PLEASE MAKE ANY FURTHER UPDATES THERE**
+# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
+
+File is available here on docs branch: ``docs\site\content\docs\latest\cert-manager-config``
+
 ## cert-manager
 
 This package provides certificate management functionality using [cert-manager](https://cert-manager.io/docs/).

--- a/addons/packages/contour-operator/README.md
+++ b/addons/packages/contour-operator/README.md
@@ -1,7 +1,3 @@
-**THIS CONTENT HAS MOVED TO THE DOCS BRANCH IN:  
-``docs\site\content\docs\latest\contour-config``  
-PLEASE MAKE ANY FURTHER UPDATES THERE**
-
 # Contour
 
 This package provides an ingress controller using [Contour](https://projectcontour.io/). The contour-operator is used.

--- a/addons/packages/contour/README.md
+++ b/addons/packages/contour/README.md
@@ -1,4 +1,8 @@
-# Contour Package
+# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
+
+File is available here on docs branch: ``docs\site\content\docs\latest\contour-config``
+
+## Contour Package
 
 This package provides an ingress controller using [Contour](https://projectcontour.io/).
 

--- a/addons/packages/external-dns/README.md
+++ b/addons/packages/external-dns/README.md
@@ -1,8 +1,8 @@
-THIS CONTENT HAS MOVED TO THE DOCS BRANCH IN:  
-``docs\site\content\docs\latest\externaldns-config``  
-PLEASE MAKE ANY FURTHER UPDATES THERE**
+# THIS CONTENT HAS MOVED TO THE DOCS BRANCH: PLEASE MAKE ANY FURTHER UPDATES THERE**
 
-# ExternalDNS
+File is available here on docs branch: ``docs\site\content\docs\latest\externaldns-config``
+
+## ExternalDNS
 
 [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 

--- a/addons/packages/fluent-bit/README.md
+++ b/addons/packages/fluent-bit/README.md
@@ -1,7 +1,8 @@
-**THIS CONTENT HAS MOVED TO THE DOCS BRANCH IN:  
-``docs\site\content\docs\latest\fluentbit-config``  
-PLEASE MAKE ANY FURTHER UPDATES THERE**
-# Fluent Bit
+# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
+
+File is available here on docs branch: ``docs\site\content\docs\latest\fluentbit-config``
+
+## Fluent Bit
 
 > Fluent Bit is an open source Log Processor and Forwarder which allows you to collect any data like metrics and logs from different sources, enrich them with filters and send them to multiple destinations.
 

--- a/addons/packages/gatekeeper/README.md
+++ b/addons/packages/gatekeeper/README.md
@@ -1,8 +1,8 @@
-**THIS CONTENT HAS MOVED TO THE DOCS BRANCH IN:  
-``docs\site\content\docs\latest\gatekeeper-config``  
-PLEASE MAKE ANY FURTHER UPDATES THERE**
+# THIS CONTENT HAS MOVED TO THE DOCS BRANCH IN:  PLEASE MAKE ANY FURTHER UPDATES THERE
 
-# Gatekeeper
+File is available here on docs branch: ``docs\site\content\docs\latest\gatekeeper-config``
+
+## Gatekeeper
 
 This package provides custom admission control using
 [gatekeeper](https://github.com/open-policy-agent/gatekeeper). Under the hood,

--- a/addons/packages/grafana/README.md
+++ b/addons/packages/grafana/README.md
@@ -1,7 +1,8 @@
-**THIS CONTENT HAS MOVED TO THE DOCS BRANCH IN:  
-``docs\site\content\docs\latest\grafana-config``  
-PLEASE MAKE ANY FURTHER UPDATES THERE**
-# Grafana
+# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
+
+File is available here on docs branch: ``docs\site\content\docs\latest\grafana-config``  
+
+## Grafana
 
 Grafana is open source visualization and analytics software. It allows you to query, visualize, alert on, and explore your metrics no matter where they are stored. In plain English, it provides you with tools to turn your time-series database (TSDB) data into beautiful graphs and visualizations.
 

--- a/addons/packages/knative-serving/README.md
+++ b/addons/packages/knative-serving/README.md
@@ -1,7 +1,8 @@
-**THIS CONTENT HAS MOVED TO THE DOCS BRANCH IN:  
-``docs\site\content\docs\latest\knative-config``  
-PLEASE MAKE ANY FURTHER UPDATES THERE**
-# Knative Serving
+# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
+
+File is available here on docs branch: ``docs\site\content\docs\latest\knative-config``  
+
+## Knative Serving
 
 This package provides serverless functionality using [Knative](https://knative.dev/).
 

--- a/addons/packages/prometheus/README.md
+++ b/addons/packages/prometheus/README.md
@@ -1,7 +1,8 @@
-**THIS CONTENT HAS MOVED TO THE DOCS BRANCH IN:  
-``docs\site\content\docs\latest\prometheus-config``  
-PLEASE MAKE ANY FURTHER UPDATES THERE**
-# Prometheus
+# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
+
+File is available here on docs branch: ``docs\site\content\docs\latest\prometheus-config``  
+
+## Prometheus
 
 A time series database for your metrics.
 

--- a/addons/packages/velero/README.md
+++ b/addons/packages/velero/README.md
@@ -1,7 +1,8 @@
-**THIS CONTENT HAS MOVED TO THE DOCS BRANCH IN:  
-``docs\site\content\docs\latest\velero-config``  
-PLEASE MAKE ANY FURTHER UPDATES THERE**
-# Velero
+# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
+
+File is available here on docs branch: ``docs\site\content\docs\latest\velero-config``  
+
+## Velero
 
 This package provides disaster recovery capabilities using [velero](https://velero.io/). At the moment, it leverages [minio](https://github.com/minio/minio) for object storage.
 


### PR DESCRIPTION
readmes for packages have moved to docs folder so they can be displayed as procedures on the website
To avoid divergence/duplication - updating readmes with a note at the top to indicate any updates should be made in docs 