### PR TITLE
[bug-fix] remove ako add-on image info section to aligin with tce add-on format

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/bundle/config/overlays/overlay-statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/bundle/config/overlays/overlay-statefulset.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: #@ values.loadBalancerAndIngressService.namespace
   labels:
     app.kubernetes.io/name: #@ values.loadBalancerAndIngressService.name
-    app.kubernetes.io/version: #@ values.imageInfo.images.loadBalancerAndIngressServiceImage.tag
 spec:
   replicas: #@ values.loadBalancerAndIngressService.config.replica_count
   selector:
@@ -115,8 +114,6 @@ spec:
             - mountPath: #@ values.loadBalancerAndIngressService.config.mount_path
               name: ako-pv-storage
 #@ end 
-          image: #@ "{}/{}:{}".format(values.imageInfo.imageRepository,values.imageInfo.images.loadBalancerAndIngressServiceImage.imagePath,values.imageInfo.images.loadBalancerAndIngressServiceImage.tag)
-          imagePullPolicy: #@ values.imageInfo.imagePullPolicy
           env:
 #@ if values.loadBalancerAndIngressService.config.network_settings.node_network_list:
 #@overlay/append

--- a/addons/packages/load-balancer-and-ingress-service/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
@@ -88,7 +88,7 @@ metadata:
   namespace: avi-system
   labels:
     app.kubernetes.io/name: wc-ako
-    app.kubernetes.io/version: v1.3.2
+    app.kubernetes.io/version: 1.3.1
 spec:
   replicas: 1
   serviceName: ako

--- a/addons/packages/load-balancer-and-ingress-service/bundle/config/values.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/bundle/config/values.yaml
@@ -1,13 +1,6 @@
 #@data/values
 #@overlay/match-child-defaults missing_ok=True
 ---
-imageInfo:
-  imageRepository: avinetworks
-  imagePullPolicy: IfNotPresent
-  images:
-    loadBalancerAndIngressServiceImage:
-      imagePath: ako
-      tag: 1.3.1
 loadBalancerAndIngressService:
   name: ako-default-wc-1
   namespace: avi-system


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->
Since there should be no imageinfo section in tce add-on format, remove it for ako(load-balancer-and-ingress-service) add-on.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
