### PR TITLE
Doc: Troubleshooting doc template

### DIFF
--- a/.github/ISSUE_TEMPLATE/troubleshooting-doc.md
+++ b/.github/ISSUE_TEMPLATE/troubleshooting-doc.md
@@ -2,7 +2,7 @@
 name: Troubleshooting doc entry
 about: Use this template to describe an issue and the associated solution/workaround that you encountered installing/deploying TCE clusters/packages. Troubleshooting entries will be listed in a section in the TCE docs.
 title: ''
-labels: kind/docs
+labels: kind/docs-troubleshoot
 assignees: ''
 
 ---


### PR DESCRIPTION
I've created a troubleshooting doc template intending to capture some of the common issues new TCE users are encountering.
I've also created an associated label.  My hope is to not clutter up the procedural content in the docs with notes on things that could go wrong at a particular step, but instead to keep this content in a Troubleshooting doc section probably as the last section in the TCE docs. 


