### PR TITLE
Doc: Standalone include description - 511

### DIFF
--- a/docs/site/content/docs/latest/getting-started-standalone.md
+++ b/docs/site/content/docs/latest/getting-started-standalone.md
@@ -6,6 +6,7 @@ CLI.
 {{% include "/docs/assets/standalone-warning.md" %}}
 {{% include "/docs/assets/tce-feedback.md" %}}
 {{% include "/docs/assets/pre-reqs.md" %}}
+{{% include "/docs/assets/standalone-desc.md" %}}
 
 ## CLI Installation
 


### PR DESCRIPTION
Created an include for standalone cluster description that is used in
both Planning you installation and Getting Started>Standalone Clusters topics
based on point 7 in feedback in issue 511: 