### PR TITLE
updates to package install

### DIFF
--- a/docs/site/content/docs/assets/package-installation.md
+++ b/docs/site/content/docs/assets/package-installation.md
@@ -1,5 +1,5 @@
 ## Installing and Managing Packages
-You can discover and deploy packages through the Tanzu CLI. Packages extend the functionality of Tivoli Community Edition. <!--KOR: wanted to use the package description include from docs\site\content\docs\assets\package-description so we could have a consistent description in different topics, but I can't add in include in an include? -->
+You can discover and deploy packages through the Tanzu CLI. Packages extend the functionality of Tivoli Community Edition. <!--KOR: wanted to use the package description include from docs\site\content\docs\assets\package-description so we could have a consistent description in different topics, but I can't add an include in an include? -->
 
 ### Before you begin
 Ensure you have deployed either a management/guest cluster or a standalone cluster.


### PR DESCRIPTION
- [ ] as package-installation.md is used for both mgmt and standalone Getting Started topic, made some changes to make it generic to both

- [ ] made some changes so that I can reuse package-installation.md in the Packages section of doc - added Getting Started and Procedure headings - this is better than duplicating I think

- [ ] Added a description for packages - as mentioned in a comment  - wanted to use the package description include from docs\site\content\docs\assets\package-description.md so we could have a consistent description of packages in different topics, but I can't add an include in an include? -->