### PR TITLE
Bump external-dns addon to v0.8.0

### DIFF
--- a/addons/packages/external-dns/README.md
+++ b/addons/packages/external-dns/README.md
@@ -74,7 +74,7 @@ deployment:
 
 ### Configuring with Contour HTTPProxy
 
-Follow [this tutorial](https://github.com/kubernetes-sigs/external-dns/blob/v0.7.6/docs/tutorials/contour.md)
+Follow [this tutorial](https://github.com/kubernetes-sigs/external-dns/blob/v0.8.0/docs/tutorials/contour.md)
 for guidance on providing arguments to ExternalDNS to enable HTTPProxy support. The ExternalDNS package is
 preconfigured with the correct RBAC permissions to watch for HTTPProxies, so this part of the tutorial
 may be skipped.

--- a/addons/packages/external-dns/bundle/.imgpkg/bundle.yml
+++ b/addons/packages/external-dns/bundle/.imgpkg/bundle.yml
@@ -7,8 +7,6 @@ authors:
   email: exie@vmware.com
 - name: Christian Ang
   email: angc@vmware.com
-- name: Larry Hamel
-  email: larryh@vmware.com
 - name: Gabriel Rosenhouse
   email: grosenhouse@vmware.com
 - name: Tyler Schultz

--- a/addons/packages/external-dns/bundle/.imgpkg/images.yml
+++ b/addons/packages/external-dns/bundle/.imgpkg/images.yml
@@ -3,5 +3,5 @@ apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/external-dns/external-dns
-  image: k8s.gcr.io/external-dns/external-dns@sha256:3556894d90108857075033ecbce23b9fe24de4a2075da640cee2050ac74cf74d
+  image: k8s.gcr.io/external-dns/external-dns@sha256:e49f63e07498ce8484c9e9050c1dfbc2584f4c9c262433d80387e855725e6bce
 kind: ImagesLock

--- a/addons/packages/external-dns/bundle/vendir.lock.yml
+++ b/addons/packages/external-dns/bundle/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: 'Merge pull request #1919 from kubernetes-sigs/raffo/release-script-update...'
-      sha: 3aed4c0d4a302f25e4fdc29dcd49b4c82d03164a
+      commitTitle: 'Merge pull request #2070 from kubernetes-sigs/raffo/bump-ci-timeout...'
+      sha: b5f9d789743113f6af3d4f20f9439842e73a1110
       tags:
-      - v0.7.6
+      - v0.8.0
     path: .
   path: config/upstream
 kind: LockConfig

--- a/addons/packages/external-dns/bundle/vendir.yml
+++ b/addons/packages/external-dns/bundle/vendir.yml
@@ -6,6 +6,6 @@ directories:
   - path: .
     git:
       url: https://github.com/kubernetes-sigs/external-dns
-      ref: v0.7.6
+      ref: v0.8.0
     newRootPath: kustomize
     excludePaths: ["kustomize/kustomization.yaml"]

--- a/addons/packages/external-dns/installedpackage.yaml
+++ b/addons/packages/external-dns/installedpackage.yaml
@@ -12,5 +12,5 @@ spec:
   packageRef:
     publicName: external-dns.tce.vmware.com
     versionSelection:
-      constraints: "0.7.6-vmware0"
+      constraints: "0.8.0-vmware0"
       prereleases: {}


### PR DESCRIPTION
## What this PR does / why we need it
This PR bumps the version of the image used by the external-dns deployment to v0.8.0.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #756 

## Describe testing done for PR
We deployed the package to a standalone-cluster and ran the e2e tests in #753 to validate the package is functional.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

We didn't bump the version in addons/repos/main.yaml since we assume it's bumped as part of the release engineering pipeline.

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
external-dns addon is updated to v0.8.0
```
