### PR TITLE
Fix broken build with missing cluster-api dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ build-cli: install-cli
 
 .PHONY: install-cli
 install-cli:
-	TANZU_CORE_REPO_BRANCH="tce-v1.3.0" TKG_CLI_REPO_BRANCH="tce-v1.3.0-saui" TKG_PROVIDERS_REPO_BRANCH="tce-v1.3.0" TANZU_TKG_CLI_PLUGINS_REPO_BRANCH="tce-v1.3.0" BUILD_VERSION=${CORE_BUILD_VERSION} hack/build-tanzu.sh
+	TANZU_CORE_REPO_BRANCH="tce-v1.3.0" TKG_CLI_REPO_BRANCH="tce-v1.3.0-saui" CLUSTER_API_REPO_BRANCH="tce-v0.3.14" TKG_PROVIDERS_REPO_BRANCH="tce-v1.3.0" TANZU_TKG_CLI_PLUGINS_REPO_BRANCH="tce-v1.3.0" BUILD_VERSION=${CORE_BUILD_VERSION} hack/build-tanzu.sh
 
 .PHONY: clean-core
 clean-core: clean-cli-metadata


### PR DESCRIPTION
## What this PR does / why we need it
Fixes broken builds when building _all_ plugins. There were changes in the cluster-api made in #751. This now captures those changes for dependent repos when building everything

## Which issue(s) this PR fixes
Fixes #759 

## Describe testing done for PR
Able to locally run `make build-all` (which _should_ encompass everything)