### PR TITLE
DNM: Check if cert-manager e2e test runs using gh workflow

### DIFF
--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -34,3 +34,6 @@ jobs:
 
       - name: Build
         run: make build
+      - name: cert-manager-e2e
+        run: docker run -v /var/run/docker.sock:/var/run/docker.sock --privileged --network host projects-stg.registry.vmware.com/tkg/cert-manager-e2e-test/e2e-test:v1.1.0-dirty.1
+


### PR DESCRIPTION
## What this PR does / why we need it
Adds e2e test for cert-manager

## Which issue(s) this PR fixes

Fixes: N/A

## Describe testing done for PR
Adding test for existing package

## Special notes for your reviewer
Draft


## Does this PR introduce a user-facing change?
```release-note
NONE
```
