### PR TITLE
Add annotation kapp.k14s.io/versioned to vsphere-cpi's ConfigMap resource

### DIFF
--- a/addons/packages/vsphere-cpi/bundle/config/overlays/update-config.yaml
+++ b/addons/packages/vsphere-cpi/bundle/config/overlays/update-config.yaml
@@ -4,6 +4,10 @@
 
 #@overlay/match by=overlay.subset({"kind": "ConfigMap", "metadata": {"name": "vsphere-cloud-config"}})
 ---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    kapp.k14s.io/versioned: ""
 #@overlay/replace
 data:
   vsphere.conf: #@ vsphere_conf(values)


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->
Add versioned annotation to vsphere-cpi's ConfigMap resource.
Adding versioned annotation to Secret will not work. Because there is a value in the data of ConfigMap points to the Secret name, when add versioned annotation for both this ConfigMap and Secret, the original secret name in the ConfigMap will not be found.
Updating the vcenter credential in that Secret is supported by TKG CLI.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

- ytt generates the expected ConfigMap template
- target configmap is versioned on a tce 0.5.0 cluster with kapp-controller to 0.19.0-alpha.7
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
