### PR TITLE
Run build-all in check-build github action

### DIFF
--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -33,4 +33,6 @@ jobs:
           go get -v -t -d ./...
 
       - name: Build
+        env:
+          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: make build-all


### PR DESCRIPTION
## What this PR does / why we need it
Runs `make build-all` in the check-build github action instead of `make build`. This will prevent dependency changes from being merged that may break the core build (like what happened in https://github.com/vmware-tanzu/tce/issues/759 and was fixed with https://github.com/vmware-tanzu/tce/pull/768)

## Which issue(s) this PR fixes
N/A

## Describe testing done for PR
N/A

## Special notes for your reviewer
This will increase amount of time the check-build action takes since we will be building everything (and not just our plugins)

## Does this PR introduce a user-facing change?
N/A
