### PR TITLE
Move cert-manager to core packages yaml

### DIFF
--- a/addons/repos/core.yaml
+++ b/addons/repos/core.yaml
@@ -32,6 +32,12 @@ package_repository:
       image: projects.registry.vmware.com/tce/calico@sha256:a380a4888c8692eff6361dbe54185df2456dc4c877077d142de7348c613b46bf
       description: This package provides networking and network security solution for containers.
 
+    - name: cert-manager
+      domain: tce.vmware.com
+      version: 1.3.1-vmware.1
+      image: projects.registry.vmware.com/tce/cert-manager@sha256:c7bfcd2b5475377ce7f7d62c5b2a89f9a8e0b543ad792d2ed979b13dc46c8afc
+      description: This package provides certificate management functionality.
+
     - name: kapp-controller
       domain: tce.vmware.com
       version: 0.20.0-vmware0

--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -14,12 +14,6 @@ package_repository:
       kappWaitTimeout: 5m
 
   packages:
-    - name: cert-manager
-      domain: tce.vmware.com
-      version: 1.3.1-vmware.1
-      image: projects.registry.vmware.com/tce/cert-manager@sha256:c7bfcd2b5475377ce7f7d62c5b2a89f9a8e0b543ad792d2ed979b13dc46c8afc
-      description: This package provides certificate management functionality.
-
     - name: contour
       domain: tce.vmware.com
       version: 1.15.1-vmware.1


### PR DESCRIPTION
## What this PR does / why we need it

The Pinniped package is a core package that depends on `cert-manager` to do its job.  Therefore, it seems that the `cert-manager` package should be in the core packages as well. 

## Describe testing done for PR

This is a suggested change before #731 is merged which is the PR to migrate the Pinniped package.
While manually testing through #731, we have found that we need to manually install `cert-manager` via `kubectl create -f /path/to/upstream/cert-manager.yaml` ([file](https://github.com/vmware-tanzu/tce/blob/main/addons/packages/cert-manager/bundle/config/upstream/cert-manager.yaml)) in order to get Pinniped in a functioning state.

## Does this PR introduce a user-facing change?

```release-note
cert-manager package is moved to core packages.
```
