### PR TITLE
Use images, not imgpkgBundles #827

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,11 +317,13 @@ generate-package-metadata: check-carvel # Usage: make generate-package-metadata 
 	@printf "\n===> Generating package metadata for $${CHANNEL}\n";\
     stat addons/repos/$${CHANNEL}.yaml &&\
 	CHANNEL_DIR=addons/repos/generated/$${CHANNEL} &&\
+    rm -rf $${CHANNEL_DIR} &&\
 	mkdir -p $${CHANNEL_DIR} 2> /dev/null &&\
 	mkdir $${CHANNEL_DIR}/packages $${CHANNEL_DIR}/.imgpkg 2> /dev/null &&\
 	ytt -f addons/repos/overlays/package.yaml -f addons/repos/$${CHANNEL}.yaml > $${CHANNEL_DIR}/packages/packages.yaml &&\
 	kbld --file $${CHANNEL_DIR}/packages --imgpkg-lock-output $${CHANNEL_DIR}/.imgpkg/images.yml >> /dev/null &&\
-	echo "\nRun the following command to push this imgpkgBundle to your OCI registry:\n\timgpkg push -b ${OCI_REGISTRY}/${CHANNEL}:$${REPO_TAG} -f $${CHANNEL_DIR}\n" &&\
+	rm -rf $${CHANNEL_DIR}/.imgpkg &&\
+	echo "\nRun the following command to push this imgpkgBundle to your OCI registry:\n\timgpkg push -i ${OCI_REGISTRY}/${CHANNEL}:$${REPO_TAG} -f $${CHANNEL_DIR}\n" &&\
 	echo "Use the URL returned from \`imgpkg push\` in the values file (\`package_repository.imgpkgBundle\`) for this channel.";\
 
 generate-package-repository-metadata: check-carvel # Usage: make generate-package-repository-metadata CHANNEL=alpha

--- a/addons/repos/overlays/package-repository.yaml
+++ b/addons/repos/overlays/package-repository.yaml
@@ -7,5 +7,5 @@ metadata:
   name: #@ data.values.package_repository.name
 spec:
   fetch:
-    imgpkgBundle:
-      image: #@ data.values.package_repository.imgpkgBundle
+    image:
+      url: #@ data.values.package_repository.imgpkgBundle


### PR DESCRIPTION
    Until we update to a new version of kapp-controller (>alpha.4), we are unable to use imgpkgBundle format.
    Unfortunately, the makefile tasks create imgpkgBundles. This causes confusion, just make the tasks do the right thing.
    The changes in this commit should be reverted when we migrate to a new kapp-controller

Signed-off-by: Nicholas Seemiller <nseemiller@vmware.com>

## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->
Until we update to a new version of kapp-controller (>alpha.4), we are unable to use imgpkgBundle format.
Unfortunately, the makefile tasks create imgpkgBundles. This causes confusion, just make the tasks do the right thing.
The changes in this commit should be reverted when we migrate to a new kapp-controller


## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #827

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
