### PR TITLE
Enable the ability to create a release from a release branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ _test
 _output
 /addons/repos/generated/
 /build
-/offline
 hack/NEW_BUILD_VERSION
 cayman_trigger.txt
 artifacts

--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,6 @@ build-plugin: version clean-plugin install-cli-plugins ## build only CLI plugins
 	@printf "\n[COMPLETE] installed TCE-specific plugins at $${XDG_DATA_HOME}/tanzu-cli/. "
 	@printf "These plugins will be automatically detected by your tanzu CLI.\n"
 
-rebuild-all: version install-cli install-cli-plugins
-rebuild-plugin: version install-cli-plugins
-
 release: build-all package-release ### builds and produces the release packaging/tarball for TCE in your local Go environment
 
 release-docker: release-env-check ### builds and produces the release packaging/tarball for TCE in a containerized environment
@@ -183,10 +180,6 @@ package-release:
 # IMPORTANT: This should only ever be called CI/github-action
 .PHONY: tag-release
 tag-release: version
-# reset here to avoid conflicts, checkout main, and then make sure it's pristine
-	git reset --hard
-	git checkout main
-	git reset --hard
 ifeq ($(shell expr $(BUILD_VERSION)), $(shell expr $(CONFIG_VERSION)))
 	go run ./hack/tags/tags.go -tag $(BUILD_VERSION) -release
 	BUILD_VERSION=${NEW_BUILD_VERSION} hack/update-tag.sh
@@ -203,8 +196,6 @@ upload-signed-assets: release-env-check
 
 clean-release:
 	rm -rf ./build
-	rm -rf ./metadata
-	rm -rf ./offline
 # RELEASE MANAGEMENT
 
 # TANZU CLI
@@ -216,12 +207,9 @@ install-cli:
 	TANZU_CORE_REPO_BRANCH="tce-v1.3.0" TKG_CLI_REPO_BRANCH="tce-v1.3.0-saui" CLUSTER_API_REPO_BRANCH="tce-v0.3.14" TKG_PROVIDERS_REPO_BRANCH="tce-v1.3.0" TANZU_TKG_CLI_PLUGINS_REPO_BRANCH="tce-v1.3.0" BUILD_VERSION=${CORE_BUILD_VERSION} hack/build-tanzu.sh
 
 .PHONY: clean-core
-clean-core: clean-cli-metadata
+clean-core:
 	rm -rf /tmp/tce-release
-
-.PHONY: clean-cli-metadata
-clean-cli-metadata:
-	- rm -rf ${XDG_DATA_HOME}/tanzu-cli/*
+	rm -rf ${XDG_DATA_HOME}/tanzu-cli/*
 # TANZU CLI
 
 # PLUGINS
@@ -244,12 +232,8 @@ test-plugins: ## run tests on TCE plugins
 	@echo "No tests to run."
 
 .PHONY: clean-plugin
-clean-plugin: clean-plugin-metadata
+clean-plugin:
 	rm -rf ${ARTIFACTS_DIR}
-
-.PHONY: clean-plugin-metadata
-clean-plugin-metadata:
-	- rm -rf ${XDG_DATA_HOME}/tanzu-repository/*
 # PLUGINS
 
 # MISC


### PR DESCRIPTION
## What this PR does / why we need it
There were improvements made in the `v0.5.0` release for the release process and this PR should enable handling doing builds from a release branch which I would prefer naming `release-0.5` (for example) if we need to do bug fixes, patches, etc on a non-main release. This actually happens to match the branch format for the `core` repo (`v1.3.X` -> `release-1.3`).

Additionally:
- removes some dead targets `rebuild-plugin` and `rebuild-all`... just call `build` and `build-all`
- removes dead code relating to metadata and the old repo on local disk

## Which issue(s) this PR fixes
Fixes: https://github.com/vmware-tanzu/tce/issues/555

## Describe testing done for PR
I simulated the effects of the script on a different personal repo: https://github.com/dvonthenen/branchtest

After this gets merged, I'm going to push a "fake" tag for testing end to end.

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
No
