### PR TITLE
assert required configuration present for external-dns

### DIFF
--- a/addons/packages/external-dns/bundle/config/overlays/assertions.yaml
+++ b/addons/packages/external-dns/bundle/config/overlays/assertions.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:assert", "assert")
+
+#! Check to see that deployment args is not empty
+#@ if data.values.deployment.args == None:
+#@ assert.fail("Missing required values:\nconfiguration is required for external-dns")
+#@ end
+
+#! Search deployment args for provider and source flags
+#@ providerFound = False
+#@ sourceFound = False
+#@ for entry in data.values.deployment.args:
+#@ if entry.startswith("--provider"):
+#@ providerFound = True
+#@ end
+#@ if entry.startswith("--source"):
+#@ sourceFound = True
+#@ end
+#@ end
+
+#! Fail to render if provider or source flag are not present
+#@ failMessage = ""
+#@ if not providerFound:
+#@ failMessage += "\n--provider is required in deployment.args to define a DNS provider where records will be created"
+#@ end
+#@ if not sourceFound:
+#@ failMessage += "\n--source is required in deployment.args to query for endpoints"
+#@ end
+#@ if failMessage != "":
+#@ assert.fail("Missing required values:{}".format(failMessage))
+#@ end


### PR DESCRIPTION
Signed-off-by: Aidan Obley <aobley@vmware.com>
Co-authored-by: Guangyuan Wang <wguangyuan@vmware.com>

## What this PR does / why we need it
During ytt rendering, a helpful error will be returned when using the default configuration to guide the user.
Additionally, if the user misses the required arguments of `--provider` or `--source` an error will be raised.

## Which issue(s) this PR fixes
This doesn't fully address https://github.com/vmware-tanzu/tce/issues/636 but adds the assertions for the external-dns package. The full fix will come when the `package` plugin is able to return the ytt rendering errors to users.

## Describe testing done for PR
We have verified that the ytt templates render and error as expected. ~We were unable to test the response from the `package install` command as it is not yet available on a dailybuild from core.~

We were able to build and run against the latest `package` plugin from `core`. See https://github.com/vmware-tanzu/tce/pull/833#issuecomment-868851431 for the output.


## Does this PR introduce a user-facing change?
```release-note
- external-dns package will now error on missing required configuration
```
