### PR TITLE
Fix alertmanager config as secret instead of ConfigMap. Modify defaults for Grafana

### DIFF
--- a/addons/packages/grafana/bundle/config/overlays/overlay-grafana-pvc.yaml
+++ b/addons/packages/grafana/bundle/config/overlays/overlay-grafana-pvc.yaml
@@ -10,9 +10,9 @@ spec:
   #@overlay/replace
   accessModes:
     - #@ data.values.grafana.pvc.accessMode
-  #@ if/end data.values.grafana.pvc.storage_class:
+  #@ if/end data.values.grafana.pvc.storageClassName:
   #@overlay/match missing_ok=True
-  storageClassName: #@ data.values.grafana.pvc.storage_class
+  storageClassName: #@ data.values.grafana.pvc.storageClassName
   resources:
     requests:
       storage: #@ data.values.grafana.pvc.storage

--- a/addons/packages/grafana/bundle/config/values.yaml
+++ b/addons/packages/grafana/bundle/config/values.yaml
@@ -9,34 +9,19 @@ grafana:
   deployment:
     replicas: 1
     containers:
-      resources:
-        limits:
-          cpu: 100m
-          memory: 128Mi
-        requests:
-          cpu: 100m
-          memory: 128Mi
-    podAnnotations:
-      annotation: grafana
-      env: prod
-    podLabels:
-      app: grafana
-      env: prod
+      resources: {}
+    podAnnotations: {}
+    podLabels: {}
     k8sSidecar:
       containers:
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
+        resources: {}
   #! Grafana service configuration
   service:
     type: LoadBalancer
     port: 9090
     targetPort: 3000
-    labels:
-      lable: grafana
-    annotations:
-      annotation: grafana
+    labels: {}
+    annotations: {}
   #! The grafana configuration.
   config:
     grafana_ini: |
@@ -78,7 +63,7 @@ grafana:
   #! Grafana pvc configuration
   pvc:
     annotations: {}
-    storage_class: null
+    storageClassName: null
     accessMode: ReadWriteOnce
     storage: "2Gi"
   secret:

--- a/addons/packages/prometheus/bundle/config/overlays/overlay-alertmanager.yaml
+++ b/addons/packages/prometheus/bundle/config/overlays/overlay-alertmanager.yaml
@@ -1,9 +1,9 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 
-#@overlay/match by=overlay.subset({"kind":"ConfigMap", "metadata":{"name":"alertmanager"}})
+#@overlay/match by=overlay.subset({"kind":"Secret", "metadata":{"name":"alertmanager"}})
 ---
-data:
+stringData:
   #@overlay/match missing_ok=True
   alertmanager.yml: #@ data.values.alertmanager.config.alertmanager_yml
 

--- a/addons/packages/prometheus/bundle/config/upstream/alertmanager/deployment.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/alertmanager/deployment.yaml
@@ -51,8 +51,8 @@ spec:
         runAsUser: 65534
       volumes:
         - name: config-volume
-          configMap:
-            name: alertmanager
+          secret:
+            secretName: alertmanager
         - name: storage-volume
           persistentVolumeClaim:
             claimName: alertmanager

--- a/addons/packages/prometheus/bundle/config/upstream/alertmanager/secret.yaml
+++ b/addons/packages/prometheus/bundle/config/upstream/alertmanager/secret.yaml
@@ -1,12 +1,12 @@
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   labels:
     component: "alertmanager"
     app: prometheus
   name: alertmanager
   namespace: default
-data:
+stringData:
   alertmanager.yml: |
     {}

--- a/addons/packages/prometheus/bundle/config/values.yaml
+++ b/addons/packages/prometheus/bundle/config/values.yaml
@@ -24,7 +24,7 @@ prometheus:
     configmapReload:
       containers:
         args:
-          - --volume-dir=/etc/config/new
+          - --volume-dir=/etc/config
           - --webhook-url=http://127.0.0.1:9090/-/reload
         resources: {}
   #! Prometheus service configuration
@@ -177,7 +177,7 @@ alertmanager:
     accessMode: ReadWriteOnce
     storage: "2Gi"
 
-  #! The alertmanager configuration
+  #! The alertmanager configuration. Note that alertmanager config is a kubernetes secret.
   config:
     alertmanager_yml: |
       global: {}


### PR DESCRIPTION
## What this PR does / why we need it
Alertmanager:
Fix for alertmanager not sending any notifications. This is because alertmanager config is a kubernetes secret and not a configMap.

Grafana:
Modified grafana default values. Fixed values files per tobs naming conventions.

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
Deployed prometheus/alertmanger and grafana on kind and verified all pods are running. 

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
Na