### PR TITLE
Script to easily download a TCE release from Github

### DIFF
--- a/hack/get-tce-release.sh
+++ b/hack/get-tce-release.sh
@@ -11,7 +11,7 @@ set -e
 # Script to download asset file from tag release using GitHub API v3.
 # Inspired by: http://stackoverflow.com/a/35688093/55075
 
-# Validate Github access token
+# Validate GitHub access token
 if [ -z "$GH_ACCESS_TOKEN" ]; then
     echo "Error: Please define GH_ACCESS_TOKEN variable!"
     exit 1
@@ -36,14 +36,13 @@ GH_API="https://api.github.com"
 GH_REPO="$GH_API/repos/vmware-tanzu/tce"
 GH_TAGS="$GH_REPO/releases/tags/$tag"
 AUTH="Authorization: token $GH_ACCESS_TOKEN"
-WGET_ARGS="--content-disposition --auth-no-challenge --no-cookie"
 CURL_ARGS="-LJO#"
 
 # Validate GH token.
 curl -o /dev/null -sH "$AUTH" $GH_REPO || { echo "Error: Unauthenticated token or network issue!";  exit 1; }
 
 # Read asset tags
-assets=$(curl -sH "$AUTH" $GH_TAGS)
+assets=$(curl -sH "$AUTH" "$GH_TAGS")
 
 if [[ $(echo "$assets" | jq ".message") = "\"Not Found\"" ]]; then
     echo "Error: release tag $tag not found! Please enter a valid release tag version. Ex: v0.5.0"
@@ -58,7 +57,7 @@ if [ -z "$id" ]; then
     echo "Error: Failed to get asset id for release containing substring $name"
     echo "Please provide a substring for the name of an assetfile. Ex: darwin, linux"
     echo "Available asset files include:"
-    echo $assets | jq "[ .assets[] | { browser_download_url }]"
+    echo "$assets" | jq "[ .assets[] | { browser_download_url }]"
     exit 1
 fi
 


### PR DESCRIPTION
## What this PR does / why we need it
When using Windows Subsystem Linux (WSL), users don't always have easy access to the disk mount that a browser may download release tarballs to. We can almost think of these as semi-airgapped environments. Therefore, this script enables users to easily download a TCE release from Github releases

## Which issue(s) this PR fixes
Related to #849 and is a first step in better WSL support / speed of testing

## Describe testing done for PR
A user can run:
```
./hack/get-tce-release.sh v0.5.0 linux
```
and the folder they are in will be populated with the linux release tar. This script also has some nice features to display the available release tags and available asset files for users for a given release tag:

Ex of printing available releases:
```
❯ ./hack/get-tce-release.sh v0.999.0 linux
...
Error: release tag v0.999.0 not found! Please enter a valid release tag version. Ex: v0.5.0
Available release tags include:
[
  {
    "html_url": "https://github.com/vmware-tanzu/tce/releases/tag/v0.6.0-rc.1"
  },
  {
    "html_url": "https://github.com/vmware-tanzu/tce/releases/tag/v0.5.0"
  },
...
```

Ex of printing available asset files:
```
❯ ../hack/get-tce-release.sh v0.5.0 not-an-os
...
Error: Failed to get asset id for release containing substring not-an-os
Please provide a substring for the name of an assetfile. Ex: darwin, linux
Available asset files include:
[
  {
    "browser_download_url": "https://github.com/vmware-tanzu/tce/releases/download/v0.5.0/tce-checksums.txt"
  },
  {
    "browser_download_url": "https://github.com/vmware-tanzu/tce/releases/download/v0.5.0/tce-darwin-amd64-v0.5.0.tar.gz"
  },
  {
    "browser_download_url": "https://github.com/vmware-tanzu/tce/releases/download/v0.5.0/tce-linux-amd64-v0.5.0.tar.gz"
  }
]
```

Let me know if this needs anything else!!

## Special notes for your reviewer
This will have a follow up docs PR to document how users can get a github access token and how they can run this from a semi-airgapped environment (like in WSL)
