### PR TITLE
remove updateStrategy config value from fluent-bit package

### DIFF
--- a/addons/packages/fluent-bit/1.7.5/bundle/config/overlays/overlay-daemonset.yaml
+++ b/addons/packages/fluent-bit/1.7.5/bundle/config/overlays/overlay-daemonset.yaml
@@ -4,7 +4,6 @@
 #@overlay/match by=overlay.subset({"kind":"DaemonSet", "metadata": {"name": "fluent-bit"}}), expects=1
 ---
 spec:
-  updateStrategy: #@ data.values.fluent_bit.daemonset.updateStrategy
   template:
     metadata:
       labels: #@ data.values.fluent_bit.daemonset.podLabels


### PR DESCRIPTION
## What this PR does / why we need it

This is a small fix to the fluent-bit addon to remove an invalid configuration value

## Which issue(s) this PR fixes

No separately-tracked issue

## Describe testing done for PR

Previously, `ytt -f addons/packages/fluent-bit/1.7.5/bundle` would fail with the error:

```
ytt: Error:
- struct has no .updateStrategy field or method
    in <toplevel>
      bundle/config/overlays/overlay-daemonset.yaml:7 |   updateStrategy: #@ data.values.fluent_bit.daemonset.updateStrategy
```

The command no longer fails and now produces the expected yaml output

