### PR TITLE
TKG-6021: Dex deployment errors out on Kube 1.21

### DIFF
--- a/addons/packages/pinniped/0.4.3/bundle/config/overlay/dex-deployment.yaml
+++ b/addons/packages/pinniped/0.4.3/bundle/config/overlay/dex-deployment.yaml
@@ -47,7 +47,12 @@ spec:
         - mountPath: /etc/dex/cfg
           name: config
         - name: tls
-          mountPath: /etc/dex/tls          
+          mountPath: /etc/dex/tls
+        env:
+          - name: KUBERNETES_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
       dnsPolicy: ClusterFirst
       serviceAccountName: dex
       restartPolicy: Always
@@ -67,7 +72,6 @@ spec:
           secretName: dex-cert-tls          
       - name: theme
         emptyDir: {}
-
 
 #@overlay/match by=overlay.subset({"kind": "Deployment", "metadata": {"name": "dex"}})
 ---


### PR DESCRIPTION
WIP until we verify the fix on a running cluster 
- dex bug: https://github.com/dexidp/dex/issues/2082

## What this PR does / why we need it
<redacted internal link>

In summary:

- Pinniped package has been migrated to tce and vendored into tkg-packages
- Kubernetes underlying the management cluster has been updated to version 1.21.x
- The packaging team has been smoke testing the new packages
- The pinniped package with an ldap config is hung as dex cannot deploy, thus the post-deploy job does not run


