### PR TITLE
Add kapp-controller rebase rules for Antrea APIService resource

### DIFF
--- a/addons/packages/antrea/0.11.3/bundle/config/kapp-config.yaml
+++ b/addons/packages/antrea/0.11.3/bundle/config/kapp-config.yaml
@@ -6,3 +6,15 @@ rebaseRules:
   sources: [existing, new]
   resourceMatchers:
   - kindNamespaceNameMatcher: {kind: ConfigMap, namespace: kube-system, name: antrea-ca}
+
+- path: [spec, caBundle]
+  type: copy
+  sources: [existing, new]
+  resourceMatchers:
+  - anyMatcher:
+      matchers:
+      - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1alpha1.stats.antrea.tanzu.vmware.com}
+      - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1beta1.controlplane.antrea.tanzu.vmware.com}
+      - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1beta1.networking.antrea.tanzu.vmware.com}
+      - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1beta1.system.antrea.tanzu.vmware.com}
+      - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1beta2.controlplane.antrea.tanzu.vmware.com}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->
Since antrea-controller updates the caBundle field of the APIService resource, there should be a rebase rule for the Antrea-managed APIService resource so that antrea-controller and kapp-controller are not sending conflicting updates to apiserver.
**Antrea-managed APIService resource:**
```
$ kubectl get apiservice | grep antrea | grep kube-system
v1alpha1.stats.antrea.tanzu.vmware.com               kube-system/antrea           True        2d16h
v1beta1.controlplane.antrea.tanzu.vmware.com         kube-system/antrea           True        2d16h
v1beta1.networking.antrea.tanzu.vmware.com           kube-system/antrea           True        2d16h
v1beta1.system.antrea.tanzu.vmware.com               kube-system/antrea           True        2d16h
v1beta2.controlplane.antrea.tanzu.vmware.com         kube-system/antrea           True        2d16h
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: <redacted internal link>

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Add kapp-controller rebase rules for Antrea APIService resource
```
