### PR TITLE
Make kapp-controller api port configurable

### DIFF
--- a/addons/packages/kapp-controller/0.20.0/bundle/config/overlays/update-deployment.yaml
+++ b/addons/packages/kapp-controller/0.20.0/bundle/config/overlays/update-deployment.yaml
@@ -19,6 +19,10 @@ spec:
         - #@ "-packaging-global-namespace={}".format(values.kappController.globalNamespace)
         #@overlay/append
         - #@ "-concurrency={}".format(values.kappController.deployment.concurrency)
+        ports:
+          #@overlay/match by="name"
+          - name: api
+            containerPort: #@ values.kappController.deployment.apiPort
       #@ if/end values.kappController.deployment.hostNetwork:
       hostNetwork: #@ values.kappController.deployment.hostNetwork
       #@ if/end values.kappController.deployment.priorityClassName:

--- a/addons/packages/kapp-controller/0.20.0/bundle/config/values.yaml
+++ b/addons/packages/kapp-controller/0.20.0/bundle/config/values.yaml
@@ -11,6 +11,7 @@ kappController:
     priorityClassName: null
     concurrency: 2
     tolerations: []
+    apiPort: 10350
   config:
     caCerts: ""
     httpProxy: ""

--- a/addons/packages/kapp-controller/metadata.yaml
+++ b/addons/packages/kapp-controller/metadata.yaml
@@ -9,6 +9,7 @@ spec:
   shortDescription: "app/package lifecycle management"
   providerName: VMware
   maintainers:
+    - name: Eli Wrenn
     - name: Lucheng Bao
   categories:
     - "lifecycle management"


### PR DESCRIPTION
kapp-controller api port is configurable and defaulted to 10350 so that it does not conflict with antrea port in 0.13

Signed-off-by: Vijay Katam <vkatam@vmware.com>

## What this PR does / why we need it
kapp-controller api port conflicts with antrea-controller

## Describe testing done for PR
ytt render kapp-controller config with values

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
