### PR TITLE
[Docs] Document using the remote download script

### DIFF
--- a/docs/site/content/docs/assets/cli-install-linux.md
+++ b/docs/site/content/docs/assets/cli-install-linux.md
@@ -1,4 +1,4 @@
-1. Download the release for [Linux](https://github.com/vmware-tanzu/tce/releases/download/v0.5.0/tce-linux-amd64-v0.5.0.tar.gz) via web browser.
+1. Download the release for [Linux](https://github.com/vmware-tanzu/tce/releases/download/v0.6.0/tce-linux-amd64-v0.6.0.tar.gz) via web browser.
 
 1. _[Alternative]_ Download the release using CLI
 
@@ -10,7 +10,7 @@
     ```
 
     > Alternatively, you may download a release using the provided remote script.
-    > - The TCE release version and release distribution _must_ be passed as arguments to `bash` in order to download a releases. So, for example, to download v0.6.0 for Linux, simple provide `bash -s v0.6.0 linux` as arguments.
+    > - The TCE release version and release distribution _must_ be passed as arguments to `bash` in order to download a releases. So, for example, to download v0.6.0 for Linux, simply provide `bash -s v0.6.0 linux` as arguments.
     > - This script requires `curl`, `grep`, `sed`, `tr`, and `jq` in order to work
     > - The release will be downloaded to the local directory as `tce-linux-amd64-v0.6.0.tar.gz`
     > - *_Note:_* This _currently_ requires the use of a GitHub personal access token.
@@ -19,13 +19,13 @@
 1. Unpack the release.
 
     ```sh
-    tar xzvf ~/Downloads/tce-linux-amd64-v0.5.0.tar.gz
+    tar xzvf ~/Downloads/tce-linux-amd64-v0.6.0.tar.gz
     ```
 
 1. Run the install script (make sure to use the appropriate directory for your platform).
 
     ```sh
-    cd tce-linux-amd64-v0.5.0
+    cd tce-linux-amd64-v0.6.0
     ./install.sh
     ```
 

--- a/docs/site/content/docs/assets/cli-install-mac.md
+++ b/docs/site/content/docs/assets/cli-install-mac.md
@@ -1,15 +1,15 @@
-1. Download the release for [macOS](https://github.com/vmware-tanzu/tce/releases/download/v0.5.0/tce-darwin-amd64-v0.5.0.tar.gz).
+1. Download the release for [macOS](https://github.com/vmware-tanzu/tce/releases/download/v0.6.0/tce-darwin-amd64-v0.6.0.tar.gz).
 
 1. Unpack the release.
 
     ```sh
-    tar xzvf ~/Downloads/tce-darwin-amd64-v0.5.0.tar.gz
+    tar xzvf ~/Downloads/tce-darwin-amd64-v0.6.0.tar.gz
     ```
 
 1. Run the install script.
 
     ```sh
-    cd tce-darwin-amd64-v0.5.0
+    cd tce-darwin-amd64-v0.6.0
     ./install.sh
     ```
 


### PR DESCRIPTION
## What this PR does / why we need it
This documents downloading a TCE release using the remote `get-tce-release.sh` script. 

## Which issue(s) this PR fixes
Related to feedback received around downloading TCE releases in abnormal filesystems or distributions where the browser download folder may not be accessible. This allows for users to download a release using the remote script piped into bash.

## Describe testing done for PR
Ran the following locally to verify:
```
    curl -H "Authorization: token ${GH_ACCESS_TOKEN}" \
        -H "Accept: application/vnd.github.v3.raw" \
        -L https://api.github.com/repos/vmware-tanzu/tce/contents/hack/get-tce-release.sh | \
        bash -s RELEASE_VERSION DISTRIBUTION
```