### PR TITLE
Add tanzu-addons-manager package

### DIFF
--- a/addons/packages/tanzu-addons-manager/1.4.0/README.md
+++ b/addons/packages/tanzu-addons-manager/1.4.0/README.md
@@ -1,0 +1,21 @@
+# tanzu-addons-manager
+
+This package provides addons lifecycle management capabilities on tanzu clusters.
+
+## Components
+
+* tanzu-addons-manager
+
+## Configuration
+
+The following configuration values can be set to customize the tanzu-addons-manager installation.
+
+### Global
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `tanzuAddonsManager.namespace` | Optional | the namespace in which to deploy tanzu-addons-manager. |
+| `tanzuAddonsManager.createNamespace` | Optional | boolean flag to indicate whether to create namespace or not. |
+| `tanzuAddonsManager.deployment.hostNetwork` | Optional | boolean flag to indicate whether to deploy in hostnetwork or not. |
+| `tanzuAddonsManager.deployment.priorityClassName` | Optional | priority class name for tanzu-addons-manager deployment. |
+| `tanzuAddonsManager.deployment.tolerations` | Optional | tolerations for tanzu-addons-manager deployment. |

--- a/addons/packages/tanzu-addons-manager/1.4.0/bundle/.imgpkg/images.yml
+++ b/addons/packages/tanzu-addons-manager/1.4.0/bundle/.imgpkg/images.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- annotations:
+    kbld.carvel.dev/id: projects-stg.registry.vmware.com/tkg/sandbox/tanzu_core/addons/tanzu-addons-manager:v1.4.0-pre-alpha-1-443-g8227aed3
+  image: projects-stg.registry.vmware.com/tkg/sandbox/tanzu_core/addons/tanzu-addons-manager@sha256:593029f16242549283ec28c1650872e685685109ba8c784ed581d689e003ea74
+kind: ImagesLock

--- a/addons/packages/tanzu-addons-manager/1.4.0/bundle/config/overlays/overlay-addons-manager.yaml
+++ b/addons/packages/tanzu-addons-manager/1.4.0/bundle/config/overlays/overlay-addons-manager.yaml
@@ -1,0 +1,50 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@ if data.values.tanzuAddonsManager.createNamespace:
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: #@ data.values.tanzuAddonsManager.namespace
+#@ end
+
+#@overlay/match by=overlay.subset({"kind":"ServiceAccount", "metadata": {"name": "tanzu-addons-manager-sa"}})
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: #@ data.values.tanzuAddonsManager.namespace
+
+#@overlay/match by=overlay.subset({"kind":"ClusterRoleBinding", "metadata": {"name": "tanzu-addons-manager-clusterrolebinding"}})
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+subjects:
+#@overlay/match by=overlay.subset({"kind":"ServiceAccount", "name": "tanzu-addons-manager-sa"})
+- kind: ServiceAccount
+  name: tanzu-addons-manager-sa
+  namespace: #@ data.values.tanzuAddonsManager.namespace
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata": {"name": "tanzu-addons-controller-manager"}})
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: #@ data.values.tanzuAddonsManager.namespace
+spec:
+  selector:
+    matchLabels:
+      app: tanzu-addons-manager
+  template:
+    spec:
+      #@ if/end data.values.tanzuAddonsManager.deployment.hostNetwork:
+      #@overlay/match missing_ok=True
+      hostNetwork: true
+      #@ if/end data.values.tanzuAddonsManager.deployment.priorityClassName:
+      #@overlay/match missing_ok=True
+      priorityClassName: #@ data.values.tanzuAddonsManager.deployment.priorityClassName
+      #@ if hasattr(data.values.tanzuAddonsManager.deployment, 'tolerations') and data.values.tanzuAddonsManager.deployment.tolerations:
+      #@overlay/match missing_ok=True
+      tolerations: #@ data.values.tanzuAddonsManager.deployment.tolerations
+      #@ end

--- a/addons/packages/tanzu-addons-manager/1.4.0/bundle/config/upstream/addons-manager.yaml
+++ b/addons/packages/tanzu-addons-manager/1.4.0/bundle/config/upstream/addons-manager.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tanzu-addons-manager
+  name: tanzu-addons-manager-sa
+  namespace: tanzu-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tanzu-addons-manager-clusterrole
+rules:
+- apiGroups:
+  - run.tanzu.vmware.com
+  resources:
+  - tanzukubernetesreleases
+  - tanzukubernetesreleases/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - kubeadmcontrolplanes
+  - kubeadmcontrolplanes/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kappctrl.k14s.io
+  resources:
+  - apps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tanzu-addons-manager-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tanzu-addons-manager-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: tanzu-addons-manager-sa
+  namespace: tanzu-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tanzu-addons-manager
+  name: tanzu-addons-controller-manager
+  namespace: tanzu-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tanzu-addons-manager
+  template:
+    metadata:
+      labels:
+        app: tanzu-addons-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-addr=0
+        - --enable-leader-election=false
+        image: projects-stg.registry.vmware.com/tkg/sandbox/tanzu_core/addons/tanzu-addons-manager:v1.4.0-pre-alpha-1-443-g8227aed3
+        imagePullPolicy: IfNotPresent
+        name: tanzu-addons-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 40Mi
+      serviceAccount: tanzu-addons-manager-sa
+      terminationGracePeriodSeconds: 10

--- a/addons/packages/tanzu-addons-manager/1.4.0/bundle/config/values.yaml
+++ b/addons/packages/tanzu-addons-manager/1.4.0/bundle/config/values.yaml
@@ -1,0 +1,11 @@
+#@data/values
+#@overlay/match-child-defaults missing_ok=True
+
+---
+tanzuAddonsManager:
+  namespace: tanzu-system
+  createNamespace: true
+  deployment:
+    hostNetwork: false
+    priorityClassName: null
+    tolerations: []

--- a/addons/packages/tanzu-addons-manager/1.4.0/bundle/vendir.lock.yml
+++ b/addons/packages/tanzu-addons-manager/1.4.0/bundle/vendir.lock.yml
@@ -1,0 +1,7 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - manual: {}
+    path: addons-manager.yaml
+  path: config/upstream
+kind: LockConfig

--- a/addons/packages/tanzu-addons-manager/1.4.0/bundle/vendir.yml
+++ b/addons/packages/tanzu-addons-manager/1.4.0/bundle/vendir.yml
@@ -1,0 +1,8 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.12.0
+directories:
+- path: config/upstream
+  contents:
+  - path: addons-manager.yaml 
+    manual: {}

--- a/addons/packages/tanzu-addons-manager/1.4.0/package.yaml
+++ b/addons/packages/tanzu-addons-manager/1.4.0/package.yaml
@@ -1,0 +1,26 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: tanzu-addons-manager.community.tanzu.vmware.com.1.4.0
+  namespace: tanzu-addons-manager
+spec:
+  refName: tanzu-addons-manager.community.tanzu.vmware.com
+  version: 1.4.0
+  releaseNotes: "tanzu-addons-manager 1.4.0"
+  licenses:
+    - "UNKNOWN"
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects.registry.vmware.com/tce/tanzu-addons-manager@sha256:7d7934adcb921d16acc3eb2eab3f104d2eec10b2cca86194c1f7b512b0e847d4
+      template:
+        - ytt:
+            paths:
+              - config/
+        - kbld:
+            paths:
+              - "-"
+              - .imgpkg/images.yml
+      deploy:
+        - kapp: {}

--- a/addons/packages/tanzu-addons-manager/metadata.yaml
+++ b/addons/packages/tanzu-addons-manager/metadata.yaml
@@ -1,0 +1,17 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  name: tanzu-addons-manager.community.tanzu.vmware.com
+  namespace: tanzu-addons-manager
+spec:
+  displayName: "tanzu-addons-manager"
+  longDescription: "Core addons lifecycle management using tanzu-addons-manager"
+  shortDescription: "Core addons lifecycle management using tanzu-addons-manager"
+  providerName: VMware
+  maintainers:
+  - name: Lucheng Bao 
+  - name: Daniel Guo 
+  - name: Vijay Katam
+  - name: Shyaam Nagarajan 
+  categories:
+    - "addons-lifecycle-management"


### PR DESCRIPTION
## What this PR does / why we need it
Add tanzu-addons-manager package. Tanzu-addons-manager is a controller that manages lifecycle of core addons on tanzu cluster. Source: https://github.com/vmware-tanzu/tanzu-framework/tree/main/addons/controllers


## Describe testing done for PR
ytt --ignore-unknown-comments -f .
