### PR TITLE
remove antrean configmap kapp.k14s.io/versioned annotation

### DIFF
--- a/addons/packages/antrea/0.11.3/bundle/config/overlay/antrea_overlay.yaml
+++ b/addons/packages/antrea/0.11.3/bundle/config/overlay/antrea_overlay.yaml
@@ -152,23 +152,9 @@ selfSignedCert: true
 
 #@ end
 
-#@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-ca"}})
----
-kind: ConfigMap
-metadata:
-  name: antrea-ca
-  #@overlay/match missing_ok=True
-  annotations:
-    kapp.k14s.io/versioned: ""
-
 #@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-config-b59fc7d2b4"}})
 ---
 kind: ConfigMap
-metadata:
-  name: antrea-config-b59fc7d2b4
-  annotations:
-    #@overlay/match missing_ok=True
-    kapp.k14s.io/versioned: ""
 data:
   antrea-agent.conf: #@ yaml.encode(antrea_agent_conf())
   antrea-controller.conf: #@ yaml.encode(antrea_controller_conf())

--- a/addons/packages/antrea/0.11.3/package.yaml
+++ b/addons/packages/antrea/0.11.3/package.yaml
@@ -14,7 +14,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/antrea@sha256:6a301c336c30b83c4aa704b557fc83af9e6e99af1a7242e9bdb1bd13d362402c
+            image: projects.registry.vmware.com/tce/antrea@sha256:35a2848a2e6cb317f40776e16b2511b226d11930a5245747b655678e5b9a65a1
       template:
         - ytt:
             paths:

--- a/addons/packages/antrea/0.13.3/bundle/config/overlay/antrea_overlay.yaml
+++ b/addons/packages/antrea/0.13.3/bundle/config/overlay/antrea_overlay.yaml
@@ -199,23 +199,9 @@ tlsCipherSuites: #@ values.antrea.config.tlsCipherSuites
 
 #@ end
 
-#@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-ca"}})
----
-kind: ConfigMap
-metadata:
-  name: antrea-ca
-  #@overlay/match missing_ok=True
-  annotations:
-    kapp.k14s.io/versioned: ""
-
 #@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-config-ctb8mftc58"}})
 ---
 kind: ConfigMap
-metadata:
-  name: antrea-config-ctb8mftc58
-  annotations:
-    #@overlay/match missing_ok=True
-    kapp.k14s.io/versioned: ""
 data:
   antrea-agent.conf: #@ yaml.encode(antrea_agent_conf())
   antrea-controller.conf: #@ yaml.encode(antrea_controller_conf())

--- a/addons/packages/antrea/0.13.3/package.yaml
+++ b/addons/packages/antrea/0.13.3/package.yaml
@@ -14,7 +14,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/antrea@sha256:c18b16353172653e2ab03cc56679c697b7c48543a009d37ccf3803b6f261713c
+            image: projects.registry.vmware.com/tce/antrea@sha256:bf80a1114ac0dda12753ac4d7d34e1ff34052f9228636df823a5852480bf0be2
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->
`kapp.k14s.io/versioned` annotation need to be removed because it adds a `ver-x` suffix to the configmaps. As the ConfigMap names are hardcoded in antrea manifest, it will not be able to read from the new name.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
