### PR TITLE
Revert "Make kapp-controller api port configurable (#958)"

### DIFF
--- a/addons/packages/kapp-controller/0.20.0/bundle/config/overlays/update-deployment.yaml
+++ b/addons/packages/kapp-controller/0.20.0/bundle/config/overlays/update-deployment.yaml
@@ -19,10 +19,6 @@ spec:
         - #@ "-packaging-global-namespace={}".format(values.kappController.globalNamespace)
         #@overlay/append
         - #@ "-concurrency={}".format(values.kappController.deployment.concurrency)
-        ports:
-          #@overlay/match by="name"
-          - name: api
-            containerPort: #@ values.kappController.deployment.apiPort
       #@ if/end values.kappController.deployment.hostNetwork:
       hostNetwork: #@ values.kappController.deployment.hostNetwork
       #@ if/end values.kappController.deployment.priorityClassName:

--- a/addons/packages/kapp-controller/0.20.0/bundle/config/values.yaml
+++ b/addons/packages/kapp-controller/0.20.0/bundle/config/values.yaml
@@ -11,7 +11,6 @@ kappController:
     priorityClassName: null
     concurrency: 2
     tolerations: []
-    apiPort: 10350
   config:
     caCerts: ""
     httpProxy: ""

--- a/addons/packages/kapp-controller/metadata.yaml
+++ b/addons/packages/kapp-controller/metadata.yaml
@@ -9,7 +9,6 @@ spec:
   shortDescription: "app/package lifecycle management"
   providerName: VMware
   maintainers:
-    - name: Eli Wrenn
     - name: Lucheng Bao
   categories:
     - "lifecycle management"


### PR DESCRIPTION
This reverts commit 9c1e7023e12d5e5512b859400bc74305767f7098.

## What this PR does / why we need it

Configurable api port requires change in kapp-controller https://github.com/vmware-tanzu/carvel-kapp-controller/pull/287 to be merged first.