### PR TITLE
Use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -1,7 +1,7 @@
 name: Check build
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - assigned
       - opened

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -1,7 +1,7 @@
 name: Check lint
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - assigned
       - opened

--- a/.github/workflows/check-mdlint.yaml
+++ b/.github/workflows/check-mdlint.yaml
@@ -1,7 +1,7 @@
 name: Check mdlint
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - assigned
       - opened

--- a/.github/workflows/check-shell.yaml
+++ b/.github/workflows/check-shell.yaml
@@ -1,7 +1,7 @@
 name: Check shell
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - assigned
       - opened


### PR DESCRIPTION
This enables workflows to run from forks now that we have enterprise GitHub

## What this PR does / why we need it
This will allow people who've forked TCE to run our GitHub workflows from their fork (thus, enabling CI / CD tests like building, md lint, and shellcheck)

## Which issue(s) this PR fixes
Fixes: #552

## Describe testing done for PR
n/a

## Special notes for your reviewer
n/a

## Does this PR introduce a user-facing change?
n/a
