### PR TITLE
Revert pull_request_target to pull_request

### DIFF
--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -1,7 +1,7 @@
 name: Check build
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - assigned
       - opened

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -1,7 +1,7 @@
 name: Check lint
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - assigned
       - opened

--- a/.github/workflows/check-mdlint.yaml
+++ b/.github/workflows/check-mdlint.yaml
@@ -1,7 +1,7 @@
 name: Check mdlint
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - assigned
       - opened

--- a/.github/workflows/check-shell.yaml
+++ b/.github/workflows/check-shell.yaml
@@ -1,7 +1,7 @@
 name: Check shell
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - assigned
       - opened


### PR DESCRIPTION
## What this PR does / why we need it
Use `pull_request` instead of `pull_request_target`

Since we can't checkout the merge commit when using `pull_request_target` (https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target), then we should use `pull_request`

This will also [enable the "Approve workflow"](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks) so we can still have workflows run from forks.

## Which issue(s) this PR fixes
n/a - iterating on workflows

## Describe testing done for PR
n/a - will see how this runs after it's merged. Will try against a branch and a fork

## Special notes for your reviewer
n/a

## Does this PR introduce a user-facing change?
n/a

