### PR TITLE
Use GITHUB_TOKEN instead of GH_ACCESS_TOKEN for pull req workflows

### DIFF
--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -21,9 +21,9 @@ jobs:
 
       - name: Config credentials
         env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
@@ -34,5 +34,5 @@ jobs:
 
       - name: Build
         env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GH_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make build-all

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -26,9 +26,9 @@ jobs:
 
       - name: Config credentials
         env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/check-mdlint.yaml
+++ b/.github/workflows/check-mdlint.yaml
@@ -24,9 +24,9 @@ jobs:
 
       - name: Config credentials
         env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/.github/workflows/check-shell.yaml
+++ b/.github/workflows/check-shell.yaml
@@ -24,9 +24,9 @@ jobs:
 
       - name: Config credentials
         env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1


### PR DESCRIPTION
## What this PR does / why we need it
This will attempt to use the `GITHUB_TOKEN` (which should be a read only access token [documented here](https://docs.github.com/en/actions/reference/authentication-in-a-workflow)) for any `pull_request` target on GitHub actions. This is in place of `GH_ACCESS_TOKEN`

## Which issue(s) this PR fixes
n/a should enable builds to pass from forks. Ex: #1021 
