### PR TITLE
enable opt-in K8s logging exclusion for fluent-bit

### DIFF
--- a/addons/packages/fluent-bit/1.7.5/bundle/config/values.yaml
+++ b/addons/packages/fluent-bit/1.7.5/bundle/config/values.yaml
@@ -44,7 +44,7 @@ fluent_bit:
         Merge_Log           On
         Merge_Log_Key       log_processed
         K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        K8S-Logging.Exclude On
 
       [FILTER]
         Name                modify


### PR DESCRIPTION
## What this PR does / why we need it

The fluent-bit Kubernetes filter provides an option for excluding pods from fluent-bit's log collection. This PR enables this option by default, allowing the fluent-bit pods themselves to be excluded from log collection.

https://docs.fluentbit.io/manual/pipeline/filters/kubernetes

This is important for the OOTB install experience for the fluent-bit package. By default, all logs are written to STDOUT on the `fluent-bit` pod, unless the user customizes the fluent-bit install to point to another service, such as ElasticSearch, Loki, or Syslog. By excluding the logs from the fluent-bit pods themselves from log collection, we avoid an infinite logging loop where the fluent-bit pods would ingest their own log output and output it back again.

The pods in the DaemonSet are already annotated appropriately for exclusion from log ingestion, but we missed the required `K8S-Logging.Exclude` flag when we investigated this previously.
