### PR TITLE
[Docs] Fix code block poor contrast

### DIFF
--- a/docs/site/themes/template/assets/scss/_components.scss
+++ b/docs/site/themes/template/assets/scss/_components.scss
@@ -320,7 +320,7 @@
         }
         code {
             border: 2px solid #EFEFEF;
-            color: $darkgrey;
+            color: $white;
             padding: 2px 8px;
         }
         pre {
@@ -741,7 +741,7 @@
         }
         code {
             border: 2px solid #EFEFEF;
-            color: $grey;
+            color: $white;
             padding: 2px 8px;
         }
         pre {


### PR DESCRIPTION
## What this PR does / why we need it
Removes poor contrast for code blocks. 

Changes the contrast ratio to [16.29:1](https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=202020) which passes the AAA check

## Which issue(s) this PR fixes
Fixes #1028

## Describe testing done for PR
`hugo serve` and looks good!

## Special notes for your reviewer
cc @endocrimes if you'd like to review!

## Does this PR introduce a user-facing change?
```release-note
Docs: Code blocks have high contrast in support of WCAG standards
```
