### PR TITLE
[Docs] Fix code block color regression

### DIFF
--- a/docs/site/themes/template/assets/scss/_components.scss
+++ b/docs/site/themes/template/assets/scss/_components.scss
@@ -320,11 +320,12 @@
         }
         code {
             border: 2px solid #EFEFEF;
-            color: $white;
+            color: $darkgrey;
             padding: 2px 8px;
         }
         pre {
             code {
+                color: $white;
                 display: block;
                 border: 15px solid #EFEFEF;
                 padding: 15px;
@@ -741,12 +742,13 @@
         }
         code {
             border: 2px solid #EFEFEF;
-            color: $white;
+            color: $darkgrey;
             padding: 2px 8px;
         }
         pre {
             white-space: pre-wrap;
             code {
+                color: $white;
                 display: block;
                 border: 15px solid #EFEFEF;
                 padding: 15px;


### PR DESCRIPTION
## What this PR does / why we need it
Fixes a docs site regression where the inline code blocks do not display since they got `color: $white` in all instances from #1041. This fixes that so only blocks that have the `.pre.code` attributes are selected for the dark background

## Which issue(s) this PR fixes
Fixes: #1050

## Describe testing done for PR
`hugo serve` and inline code blocks display and the larger code blocks still have good contrast
