### PR TITLE
Bump github prow bot to v1.1.3

### DIFF
--- a/.github/workflows/prow.yaml
+++ b/.github/workflows/prow.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       # Adds support for prow-like commands
       # Uses .github/labels.yaml to define areas and kinds
-      - uses: jpmcb/prow-github-actions@v1
+      - uses: jpmcb/prow-github-actions@v1.1.3
         with:
           prow-commands: "/approve
             /area


### PR DESCRIPTION
## What this PR does / why we need it
Bumps github-prow-bot to use `v1.1.3`, the latest release.

## Which issue(s) this PR fixes
N/a - apparently, last year, I didn't tag the first release as "v1" so we [run into this lovely error](https://github.com/vmware-tanzu/tce/runs/3068887874?check_suite_focus=true):
```
Failed to resolve action download info. Error: 
Unable to resolve action `jpmcb/prow-github-actions@v1`, unable to find version `v1`
```

So. instead, let's be explicit and get the [latest version found here](https://github.com/jpmcb/prow-github-actions/releases)

## Describe testing done for PR
N/a

## Special notes for your reviewer
N/a

## Does this PR introduce a user-facing change?
N/a
