### PR TITLE
external-dns: update maintainers

### DIFF
--- a/addons/packages/external-dns/metadata.yaml
+++ b/addons/packages/external-dns/metadata.yaml
@@ -11,7 +11,6 @@ spec:
   maintainers:
     - name: Edwin Xie
     - name: Christian Ang
-    - name: Gabriel Rosenhouse
     - name: Tyler Schultz
     - name: David McClure
     - name: Aidan Obley


### PR DESCRIPTION
I'm moving to another team for 3 months, so removing myself from external-dns maintainers for the time being.