### PR TITLE
Fix build staging

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -45,8 +45,18 @@ jobs:
             fi
           done
 
+      - name: Get Tanzu Framework
+        run: |
+          git clone https://github.com/vmware-tanzu/tanzu-framework.git
+          pushd tanzu-framework
+          git checkout tce-main
+          make set-unstable-versions
+          popd
+
       - name: Build
-        run: make build
+        run: |
+          go mod edit --replace github.com/vmware-tanzu/tanzu-framework=./tanzu-framework
+          make build
 
       - name: Upload Artifacts to Staging Bucket
         id: upload-artifacts-staging


### PR DESCRIPTION
## What this PR does / why we need it
The dev/staging builds have been broken since switching to `tanzu-framework` because the default is not to allow dev tag versions on plugins. you can see past failures here:
https://github.com/vmware-tanzu/tce/actions/workflows/build-staging.yaml

The error:
```
Error: version cannot be empty for plugin "standalone-cluster"
```

This should get around that issue and hopefully fix this GH action.

## Which issue(s) this PR fixes
Fixes: https://github.com/vmware-tanzu/tce/issues/1099

## Describe testing done for PR
NA

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
No