### PR TITLE
Fix releasedAt in Package CR to be metav1.time format

### DIFF
--- a/addons/packages/cert-manager/1.3.1/package.yaml
+++ b/addons/packages/cert-manager/1.3.1/package.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refName: cert-manager.community.tanzu.vmware.com
   version: 1.3.1
-  releasedAt: "2021-04-14"
+  releasedAt: 2021-04-14T18:00:00Z
   releaseNotes: "cert-manager 1.3.1 https://github.com/jetstack/cert-manager/releases/tag/v1.3.1"
   licenses:
     - "Apache 2.0"

--- a/addons/packages/cert-manager/1.4.0/package.yaml
+++ b/addons/packages/cert-manager/1.4.0/package.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refName: cert-manager.community.tanzu.vmware.com
   version: 1.4.0
-  releasedAt: "2021-06-15"
+  releasedAt: 2021-06-15T18:00:00Z
   releaseNotes: "cert-manager 1.4.0 https://github.com/jetstack/cert-manager/releases/tag/v1.4.0"
   licenses:
     - "Apache 2.0"

--- a/addons/packages/contour/1.15.1/package.yaml
+++ b/addons/packages/contour/1.15.1/package.yaml
@@ -7,7 +7,7 @@ spec:
   refName: contour.community.tanzu.vmware.com
   version: 1.15.1
   releaseNotes: "contour 1.15.1 https://github.com/projectcontour/contour/releases/tag/v1.15.1"
-  releasedAt: "2021-06-01"
+  releasedAt: 2021-06-01T18:00:00Z
   licenses:
     - "Apache 2.0"
   template:

--- a/addons/packages/external-dns/0.8.0/package.yaml
+++ b/addons/packages/external-dns/0.8.0/package.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refName: external-dns.community.tanzu.vmware.com
   version: 0.8.0
-  releasedAt: "2021-06-11"
+  releasedAt: 2021-06-11T18:00:00Z
   releaseNotes: "external-dns 0.8.0 https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.8.0"
   valuesSchema:
     openAPIv3:

--- a/addons/packages/harbor/2.2.3/package.yaml
+++ b/addons/packages/harbor/2.2.3/package.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   refName: harbor.community.tanzu.vmware.com
   version: 2.2.3
-  releasedAt: "2021-07-07"
+  releasedAt: 2021-07-07T18:00:00Z
   releaseNotes: "harbor 2.2.3 https://github.com/goharbor/harbor/releases/tag/v2.2.3"
   licenses:
     - "Apache 2.0"

--- a/addons/packages/multus-cni/3.7.1/package.yaml
+++ b/addons/packages/multus-cni/3.7.1/package.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refName: multus-cni.community.tanzu.vmware.com
   version: 3.7.1
-  releasedAt: "2021-06-04"
+  releasedAt: 2021-06-04T18:00:00Z
   releaseNotes: "multus-cni 3.7.1 https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v3.7.1"
   licenses:
     - "Apache 2.0"


### PR DESCRIPTION
Signed-off-by: Shyaam Nagarajan <nagarajans@vmware.com>

## What this PR does / why we need it
Package CR releasedAt is a metav1.Time type and not string type.
