### PR TITLE
Fix release process after separate go.mods

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -49,8 +49,8 @@ jobs:
           for i in $(find . -type d); do
             if [[ -f "${i}/go.mod" ]]; then
               pushd $i
-                go get -v -t -d ./...
                 go mod edit --replace github.com/vmware-tanzu/tanzu-framework=$GITHUB_WORKSPACE/tanzu-framework
+                go get -v -t -d ./...
               popd
             fi
           done

--- a/Makefile
+++ b/Makefile
@@ -192,18 +192,18 @@ package-release:
 tag-release: version
 ifeq ($(shell expr $(BUILD_VERSION)), $(shell expr $(CONFIG_VERSION)))
 	BUILD_VERSION=$(BUILD_VERSION) hack/pre-update-tag.sh
-	go run ./hack/tags/tags.go -tag $(BUILD_VERSION) -release
+	cd ./hack/tags && go run ./tags.go -tag $(BUILD_VERSION) -release && cd ../..
 	OLD_BUILD_VERSION=$(BUILD_VERSION) NEW_BUILD_VERSION=${NEW_BUILD_VERSION} hack/update-tag.sh
 else
 	BUILD_VERSION=$(BUILD_VERSION) hack/pre-update-tag.sh
-	go run ./hack/tags/tags.go -tag $(BUILD_VERSION)
+	cd ./hack/tags && go run ./tags.go -tag $(BUILD_VERSION) && cd ../..
 	BUILD_VERSION=$(BUILD_VERSION) FAKE_RELEASE=$(shell expr $(BUILD_VERSION) | grep fake) hack/update-tag.sh
 endif
 	echo "$(BUILD_VERSION)" | tee -a ./cayman_trigger.txt
 
 .PHONY: upload-signed-assets
 upload-signed-assets: release-env-check
-	go run ./hack/asset/asset.go -tag $(BUILD_VERSION)
+	cd ./hack/asset && go run ./asset.go -tag $(BUILD_VERSION) && cd ../..
 # IMPORTANT: This should only ever be called CI/github-action
 
 clean-release:

--- a/hack/asset/asset.go
+++ b/hack/asset/asset.go
@@ -110,12 +110,6 @@ func main() {
 		return
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		fmt.Printf("Getwd failed: %v\n", err)
-		return
-	}
-
 	draftRelease, err := getDraftRelease(tag)
 	if err != nil {
 		fmt.Printf("getDraftRelease failed: %v\n", err)
@@ -123,7 +117,7 @@ func main() {
 	}
 
 	darwinAssetFilename := fmt.Sprintf("tce-darwin-amd64-%s.tar.gz", tag)
-	darwinAsset := filepath.Join(cwd, "build", darwinAssetFilename)
+	darwinAsset := filepath.Join("..", "..", "build", darwinAssetFilename)
 	err = uploadToDraftRelease(draftRelease, darwinAsset)
 	if err != nil {
 		fmt.Printf("uploadToDraftRelease(darwin) failed: %v\n", err)
@@ -131,7 +125,7 @@ func main() {
 	}
 
 	linuxAssetFilename := fmt.Sprintf("tce-linux-amd64-%s.tar.gz", tag)
-	linuxAsset := filepath.Join(cwd, "build", linuxAssetFilename)
+	linuxAsset := filepath.Join("..", "..", "build", linuxAssetFilename)
 	err = uploadToDraftRelease(draftRelease, linuxAsset)
 	if err != nil {
 		fmt.Printf("uploadToDraftRelease(linux) failed: %v\n", err)
@@ -139,14 +133,14 @@ func main() {
 	}
 
 	windowsAssetFilename := fmt.Sprintf("tce-windows-amd64-%s.tar.gz", tag)
-	windowsAsset := filepath.Join(cwd, "build", windowsAssetFilename)
+	windowsAsset := filepath.Join("..", "..", "build", windowsAssetFilename)
 	err = uploadToDraftRelease(draftRelease, windowsAsset)
 	if err != nil {
 		fmt.Printf("uploadToDraftRelease(windows) failed: %v\n", err)
 		return
 	}
 
-	checksumAsset := filepath.Join(cwd, "build", DefaultCheckSumFilename)
+	checksumAsset := filepath.Join("..", "..", "build", DefaultCheckSumFilename)
 	err = uploadToDraftRelease(draftRelease, checksumAsset)
 	if err != nil {
 		fmt.Printf("uploadToDraftRelease(checksum) failed: %v\n", err)

--- a/hack/tags/tags.go
+++ b/hack/tags/tags.go
@@ -21,12 +21,12 @@ const (
 	DefaultTagVersion string = "dev.1"
 
 	// DevFullPathFilename filename
-	DevFullPathFilename string = "hack/DEV_BUILD_VERSION.yaml"
+	DevFullPathFilename string = "DEV_BUILD_VERSION.yaml"
 	// FakeFullPathFilename filename
-	FakeFullPathFilename string = "hack/FAKE_BUILD_VERSION.yaml"
+	FakeFullPathFilename string = "FAKE_BUILD_VERSION.yaml"
 
 	// NewVersionFullPathFilename filename
-	NewVersionFullPathFilename string = "hack/NEW_BUILD_VERSION"
+	NewVersionFullPathFilename string = "NEW_BUILD_VERSION"
 
 	// NumberOfSemVerSeparators is 3
 	NumberOfSemVerSeparators int = 3


### PR DESCRIPTION
## What this PR does / why we need it
Similar fix to https://github.com/vmware-tanzu/tce/pull/1114. Updated after switching to separate go mods. This is required in order for the release process to function correctly.

Also, there was a small issue (which hasn't surfaced yet) on the build staging workflow after merging https://github.com/vmware-tanzu/tce/pull/1112. Need to reverse the order... edit replace first, THEN download the dependencies. This makes it so that if newer dependencies are introduced based on doing this edit replace, we will download them as well.

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
NA

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
No
