### PR TITLE
Add newline check when generating package repository #1125

### DIFF
--- a/hack/packages/generate-package-repository.go
+++ b/hack/packages/generate-package-repository.go
@@ -11,8 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"gopkg.in/yaml.v3"
 )
 
 type Package struct {
@@ -55,7 +53,7 @@ func main() {
 	err = os.MkdirAll(packagesDir, 0755)
 	check(err)
 
-	targetChannelFilename := filepath.Join(RepoDirectoryPath, channel + ".yaml")
+	targetChannelFilename := filepath.Join(RepoDirectoryPath, channel+".yaml")
 	source, err := ioutil.ReadFile(targetChannelFilename)
 	check(err)
 
@@ -119,7 +117,7 @@ func copyYaml(packageFilepath string, outputFile *os.File) {
 	_, err = outputFile.Write(source)
 	check(err)
 
-	slice = source[len(source)-1:len(source)]
+	slice = source[len(source)-1 : len(source)]
 	if string(slice) != "\n" {
 		if _, err := outputFile.WriteString("\n"); err != nil {
 			panic(err)


### PR DESCRIPTION
## What this PR does / why we need it

When generating the package repository, a check for a newline \n character at the end of package yaml files is needed. If a package.yaml file does not end with a newline, the next package.yaml file to be added will start on the same line as the previous file. This will result in malformed yaml.

The current `package.yaml` file for the Prometheus package does not end with a newline, causing this problem.

## Which issue(s) this PR fixes

Fixes: #1125 

## Describe testing done for PR
Run `make generate-package-repo CHANNEL=main`

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
