### PR TITLE
Add RelEng Team Ownership to Test Directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,9 @@
 ## Ownership of the entire TCE repository
 *                          @vmware-tanzu/tce-owners
 
+## Ownership of release engineering efforts
+test                       @vmware-tanzu/tce-releng
+
 # Package Ownership
 
 ## Ownership of the ako-operator package


### PR DESCRIPTION
## What this PR does / why we need it
This adds the releng team to have code ownership over the `test` folder which deals with e2e testing.

## Which issue(s) this PR fixes
Fixes: https://github.com/vmware-tanzu/tce/issues/1087