### PR TITLE
Trivial: adjust wording in readme for `addon/package` wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ If one exists, please feel free to comment and add any additional context you ma
 
 The following describes the key directories that make up this repository.
 
-* **addons/**: our packages and package repos installed in TCE clusters.
-  * **packages/**: software packages installed in TCE clusters.
+* **addons/**: our packages and package repos available to be installed in TCE clusters.
+  * **packages/**: software packages installable in TCE clusters.
   * **repos/**: bundles of packages that can be installed in TCE clusters making all packages within available.
 * **cli/**: plugins that add TCE-specific functionality to the `tanzu` CLI
   * **cmd/plugin/${PLUGIN_NAME}/**: individual go module for each plugin, implemented in [cobra](https://github.com/spf13/cobra)


### PR DESCRIPTION
## What this PR does / why we need it
Adjusts the wording in the readme to reflect the fact that packages in `addon/packages` are _not_ installed by default

## Which issue(s) this PR fixes
N/a - based on user feedback

## Describe testing done for PR
`make check`

## Special notes for your reviewer
N/a

## Does this PR introduce a user-facing change?
N/a
