### PR TITLE
Add newline check when generating package repository #1125

### DIFF
--- a/hack/packages/generate-package-repository.go
+++ b/hack/packages/generate-package-repository.go
@@ -120,7 +120,7 @@ func copyYaml(packageFilepath string, outputFile *os.File) {
 	_, err = outputFile.Write(source)
 	check(err)
 
-	slice = source[len(source)-1 : len(source)]
+	slice = source[len(source)-1:]
 	if string(slice) != "\n" {
 		if _, err := outputFile.WriteString("\n"); err != nil {
 			panic(err)


### PR DESCRIPTION
## What this PR does / why we need it

Add newline check when generating package repository

## Which issue(s) this PR fixes

Fixes: #1125 

## Describe testing done for PR
```
make generate-package-repo CHANNEL=main
```

## Special notes for your reviewer

-

## Does this PR introduce a user-facing change?
```release-note
NONE
```
