### PR TITLE
Allow building single platforms via Makefile and speed up build-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ REQUIRED_BINARIES := imgpkg kbld ytt
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
+GOHOSTOS ?= $(shell go env GOHOSTOS)
+GOHOSTARCH ?= $(shell go env GOHOSTARCH)
+# Add supported OS-ARCHITECTURE combinations here
+ENVS := linux-amd64 windows-amd64 darwin-amd64
 
 TOOLS_DIR := $(ROOT_DIR)/hack/tools
 TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
@@ -130,7 +134,7 @@ $(TOOLING_BINARIES):
 ##### BUILD TARGETS #####
 build: build-plugin
 
-build-all: release-env-check version clean install-cli install-cli-plugins ## build all CLI plugins that are used in TCE
+build-all: release-env-check version clean install-cli build-cli-plugins ## build all CLI plugins that are used in TCE
 	@printf "\n[COMPLETE] installed plugins at $${XDG_DATA_HOME}/tanzu-cli/. "
 	@printf "These plugins will be automatically detected by tanzu CLI.\n"
 	@printf "\n[COMPLETE] installed tanzu CLI at $(TANZU_CLI_INSTALL_PATH). "
@@ -191,13 +195,13 @@ clean-release:
 
 # TANZU CLI
 .PHONY: build-cli
-build-cli: install-cli
-
-.PHONY: install-cli
-install-cli:
+build-cli:
 	TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH="tkg-compatibility" \
 	TANZU_FRAMEWORK_REPO_HASH=$(TANZU_FRAMEWORK_REPO_HASH) BUILD_EDITION=tce TCE_BUILD_VERSION=$(BUILD_VERSION) \
-	FRAMEWORK_BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} hack/build-tanzu.sh
+	FRAMEWORK_BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} ENVS="${ENVS}" hack/build-tanzu.sh
+
+.PHONY: install-cli
+install-cli: build-cli
 
 .PHONY: clean-framework
 clean-framework:
@@ -207,9 +211,12 @@ clean-framework:
 # TANZU CLI
 
 # PLUGINS
+# Dynamically generate OS-ARCH targets to allow for parallel execution
+PLUGIN_JOBS := $(addprefix build-cli-plugins-,${ENVS})
+
 .PHONY: prep-build-cli
 prep-build-cli:
-	@cd ./cli/cmd/plugin/ && for plugin in *; do\
+	@cd ./cli/cmd/plugin/ && for plugin in */; do\
 		printf "===> Preparing $${plugin}\n";\
 		working_dir=`pwd`;\
 		cd $${plugin};\
@@ -218,12 +225,28 @@ prep-build-cli:
 	done
 
 .PHONY: build-cli-plugins
-build-cli-plugins: prep-build-cli
-	@cd ./hack/builder/ && $(MAKE) compile
+build-cli-plugins: prep-build-cli ${PLUGIN_JOBS}
+
+# Entries for PLUGIN_JOBS are generated from this template
+.PHONY: build-cli-plugins-%
+build-cli-plugins-%: prep-build-cli
+	$(eval ARCH = $(word 2,$(subst -, ,$*)))
+	$(eval OS = $(word 1,$(subst -, ,$*)))
+
+	@printf "===> Building with ${OS}-${ARCH}\n";
+
+	@cd ./hack/builder/ && $(MAKE) compile OS=${OS} ARCH=${ARCH}
+
+.PHONY: build-cli-plugins-local
+build-cli-plugins-local: build-cli-plugins-${GOHOSTOS}-${GOHOSTARCH}
 
 .PHONY: install-cli-plugins
-install-cli-plugins: build-cli-plugins
+install-cli-plugins:
 	@cd ./hack/builder/ && $(MAKE) install-plugins
+
+.PHONY: build-install-plugins
+build-install-plugins: build-cli-plugins-local install-cli-plugins
+	@printf "CLI plugins built and installed\n"
 
 test-plugins: ## run tests on TCE plugins
 	# TODO(joshrosso): update once we get our testing strategy in place

--- a/hack/build-tanzu.sh
+++ b/hack/build-tanzu.sh
@@ -10,6 +10,9 @@ set -o xtrace
 
 # defaults
 TANZU_FRAMEWORK_REPO_HASH="${TANZU_FRAMEWORK_REPO_HASH:-""}"
+# by default, this value is passed in from the TCE makefile, but leaving it empty also works for builindg
+# all of tanzu-framework's environments
+ENVS="${ENVS:-""}"
 
 # Change directories to a clean build space
 ROOT_REPO_DIR="/tmp/tce-release"
@@ -52,7 +55,16 @@ fi
 # make configure-bom
 # build and install all "tanzu-framework" CLI plugins
 # (e.g. management-cluster, cluster, etc)
-BUILD_SHA=${BUILD_SHA} BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} make build-install-cli-all
+BUILD_SHA=${BUILD_SHA} BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} make ENVS="${ENVS}" clean-catalog-cache clean-cli-plugins build-cli
+
+# Only do an install if the environments to build contain the current host OS.
+# The tanzu-framework `build-install-cli-all` target always uses the current host OS, and if that's not being built it will fail.
+GOHOSTOS=$(go env GOHOSTOS)
+if [[ "$ENVS" == *"${GOHOSTOS}"* ]]; then
+BUILD_SHA=${BUILD_SHA} BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} make ENVS="${ENVS}" install-cli-plugins install-cli
+fi
+
+
 # by default, tanzu-framework only builds admins plugins for the current platform. we need darwin also.
 BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} GOHOSTOS=linux GOHOSTARCH=amd64 make build-plugin-admin
 BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} GOHOSTOS=darwin GOHOSTARCH=amd64 make build-plugin-admin

--- a/hack/builder/Makefile
+++ b/hack/builder/Makefile
@@ -3,6 +3,8 @@
 BUILD_DATE ?= $$(date -u +"%Y-%m-%d")
 BUILD_SHA ?= $$(git rev-parse --short HEAD)
 BUILD_EDITION=tce-standalone
+OS ?= $(shell go env GOOS)
+ARCH ?= $(shell go env GOARCH)
 
 ifndef IS_OFFICIAL_BUILD
 IS_OFFICIAL_BUILD = ""
@@ -66,7 +68,7 @@ check: check-go check-build-version check-ld-flags check-artifacts
 
 compile: check ## Compiles the TCE plugins using the Tanzu Framework builder
 	$(GO) run github.com/vmware-tanzu/tanzu-framework/cmd/cli/plugin-admin/builder cli compile --version $(BUILD_VERSION) \
-		--ldflags "$(LD_FLAGS)" --path ../../cli/cmd/plugin --artifacts ../../${ARTIFACTS_DIR}
+		--ldflags "$(LD_FLAGS)" --path ../../cli/cmd/plugin --artifacts ../../${ARTIFACTS_DIR} --target ${OS}_${ARCH}
 
 install-plugins: check ## Installs the compiled TCE plugins
 	TANZU_CLI_NO_INIT=true $(GO) run -ldflags "$(LD_FLAGS)" github.com/vmware-tanzu/tanzu-framework/cmd/cli/tanzu \


### PR DESCRIPTION
## What this PR does / why we need it
This PR introduces the `ENVS` (combination of OS and processor architecture) make variable within our own Makefile and seeds it down through to the tanzu-framework Makefile invocation.

Additionally, this PR now only installs binaries when building for the host OS. `make build-all` will still work as before since all platforms are being built. For building and installing locally now, please use the `install-cli-plugins` target.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1140

## Describe testing done for PR
Building just TCE plugins:

```
make build-all ENVS=linux-amd64
make build-all ENVS=windows-amd64
make build-all ENVS=darwin-amd64
make clean
make build-all
make build-all ENVS=linux-i386 -> should fail due to tanzu-framework error that checks platform info
make install-cli-plugins
```

Building everything, including the tanzu CLI from our `Makefile`.

```
make clean
make build-all
```

## Special notes for your reviewer

Using `time` on my local macOS machine, here's the difference in build times for `make build-all` after a `make clean`

| Change SHA | Time |
| --- | --- |
| this PR | 281.14s |
|  96e76e6d7c21950266b3ecaad3d8f45047e0b80 (head of main) | 545.88s |

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Add support for an `ENVS` makefile variable, in order to build for a single platform at a time.
When specifying an `ENVS` value that does not include the current host OS, neither the `tanzu` CLI nor plugins will be installed.

`make build-all` and `make release` both still build all platforms, but do *not* install the plugins anymore.
`make install-cli-plugins` will install plugins, but not build them.
`make build-install-plugins` will build, then install TCE-specific plugins, but not the `tanzu` CLI or tanzu-framework plugins.
```
