### PR TITLE
Save PR and Merge Builds and Make Them Available

### DIFF
--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -38,6 +38,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Get Pull Request ID
+        id: get_pullrequest
+        run: echo ::set-output name=PULL_NUMBER::$(echo "$GITHUB_REF" | awk -F / '{print $3}')
+
       - name: Get dependencies
         run: |
           for i in $(find . -type d); do
@@ -51,4 +55,24 @@ jobs:
       - name: Build
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: make build-all
+        run: make release
+
+      - name: Upload Artifacts to PR Bucket
+        id: upload-artifacts-staging
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: ./artifacts
+          destination: tce-cli-plugins-staging/build-pullrequest/${{ steps.get_pullrequest.outputs.PULL_NUMBER }}
+          credentials: ${{ secrets.GCP_BUCKET_SA }}
+
+      - name: Comment with Artifact Download Location
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'You can download your pull request artifacts by deleting your existing TCE bucket by running: `tanzu plugin repo delete tce`, then updating the TCE bucket pointer to the staging bucket by running: `tanzu plugin repo add --name tce --gcp-bucket-name tce-cli-plugins-staging --gcp-root-path build-pullrequest/${{ steps.get_pullrequest.outputs.PULL_NUMBER }}/artifacts` and then doing a `tanzu plugin upgrade YOUR_PLUGIN_NAME`'
+            })

--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -33,6 +33,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Get Pull Request ID
+        id: get_pullrequest
+        run: echo ::set-output name=PULL_NUMBER::$(echo "$GITHUB_REF" | awk -F / '{print $3}')
+
       - name: Run all checks
         run: |
           make check
@@ -50,4 +54,24 @@ jobs:
       - name: Build
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: make build-all
+        run: make release
+
+      - name: Upload Artifacts to Merge Bucket
+        id: upload-artifacts-staging
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: ./artifacts
+          destination: tce-cli-plugins-staging/build-mergemain/${{ steps.get_pullrequest.outputs.PULL_NUMBER }}
+          credentials: ${{ secrets.GCP_BUCKET_SA }}
+
+      - name: Comment with Artifact Download Location
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'You can download your integrated build artifacts by updating your TCE bucket pointer, to: `tanzu plugin repo add --name tce --gcp-bucket-name tce-cli-plugins-staging --gcp-root-path build-mergemain/${{ steps.get_pullrequest.outputs.PULL_NUMBER }}/artifacts` and then doing a `tanzu plugin upgrade YOUR_PLUGIN_NAME`'
+            })


### PR DESCRIPTION
## What this PR does / why we need it
When a PR is created or updated, the build checker will upload the artifacts to a known location so that a developer can point to them, update the plugin, and then use.

After the PR is merged, the original PR will generate a similar build but one that is integrated with `main` branch and have the latest bits and functionality.