### PR TITLE
Fix clone/checkout on specific commit

### DIFF
--- a/hack/build-tanzu.sh
+++ b/hack/build-tanzu.sh
@@ -46,6 +46,7 @@ pushd "${ROOT_REPO_DIR}/tanzu-framework" || exit 1
 git reset --hard
 if [[ -n "${TANZU_FRAMEWORK_REPO_HASH}" ]]; then
     echo "checking out specific hash: ${TANZU_FRAMEWORK_REPO_HASH}"
+    git fetch --depth 1 origin "${TANZU_FRAMEWORK_REPO_HASH}"
     git checkout "${TANZU_FRAMEWORK_REPO_HASH}"
 fi
 BUILD_SHA="$(git describe --match="$(git rev-parse --short HEAD)" --always)"


### PR DESCRIPTION
## What this PR does / why we need it
This fixes checking out a specific commit on tanzu framework when providing a hash.

## Which issue(s) this PR fixes
https://github.com/vmware-tanzu/tce/issues/1176

## Describe testing done for PR
Works locally

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
NA