### PR TITLE
Error on install as root

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -8,6 +8,11 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+if [[ "$EUID" -eq 0 ]]; then
+  echo "Do not run this script as root"
+  exit
+fi
+
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 BUILD_OS=$(uname 2>/dev/null || echo Unknown)


### PR DESCRIPTION
## What this PR does / why we need it
Do not allow the use to run the Linux `install.sh` script as root.

## Which issue(s) this PR fixes
https://github.com/vmware-tanzu/tce/issues/1171

## Describe testing done for PR
Tested `./install.sh` works
Tested `sudo ./install.sh` errors out as expected

## Special notes for your reviewer
No

## Does this PR introduce a user-facing change?
No
