### PR TITLE
Fix path used for version/tag automation

### DIFF
--- a/hack/tags/tags.go
+++ b/hack/tags/tags.go
@@ -21,9 +21,9 @@ const (
 	DefaultTagVersion string = "dev.1"
 
 	// DevFullPathFilename filename
-	DevFullPathFilename string = "DEV_BUILD_VERSION.yaml"
+	DevFullPathFilename string = "../DEV_BUILD_VERSION.yaml"
 	// FakeFullPathFilename filename
-	FakeFullPathFilename string = "FAKE_BUILD_VERSION.yaml"
+	FakeFullPathFilename string = "../FAKE_BUILD_VERSION.yaml"
 
 	// NewVersionFullPathFilename filename
 	NewVersionFullPathFilename string = "NEW_BUILD_VERSION"


### PR DESCRIPTION
## What this PR does / why we need it
This run failed when attempting to push a `fake` test tag to exercise the release automation. I incorrectly updated the path after the separate go.mod PR. You can find details here (https://github.com/vmware-tanzu/tce/pull/1121)...  basically, we `cd` into the go run dir but the file exists one level up. 

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
NA

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
NA