### PR TITLE
Allow TANZU_FRAMEWORK_REPO_HASH to be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ endif
 
 FRAMEWORK_BUILD_VERSION=$$(cat "./hack/FRAMEWORK_BUILD_VERSION")
 NEW_BUILD_VERSION=$$(cat "./hack/NEW_BUILD_VERSION" 2>/dev/null)
+TANZU_FRAMEWORK_REPO_HASH ?= e5fd424c7a7e9b741cf6c1d1aeb3dc7fb06dffda
 
 LD_FLAGS = -s -w
 LD_FLAGS += -X "github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli.BuildDate=$(BUILD_DATE)"
@@ -217,7 +218,7 @@ build-cli: install-cli
 .PHONY: install-cli
 install-cli:
 	TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH="tkg-compatibility" \
-	TANZU_FRAMEWORK_REPO_HASH="e5fd424c7a7e9b741cf6c1d1aeb3dc7fb06dffda" BUILD_EDITION=tce TCE_BUILD_VERSION=$(BUILD_VERSION) \
+	TANZU_FRAMEWORK_REPO_HASH=$(TANZU_FRAMEWORK_REPO_HASH) BUILD_EDITION=tce TCE_BUILD_VERSION=$(BUILD_VERSION) \
 	FRAMEWORK_BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} hack/build-tanzu.sh
 
 .PHONY: clean-framework


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

Make it easier to override TANZU_FRAMEWORK_REPO_HASH without modifying the Makefile

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
