### PR TITLE
Contour fix job

### DIFF
--- a/addons/packages/contour/1.15.1/bundle/config/overlays/remove-certgen-job.yaml
+++ b/addons/packages/contour/1.15.1/bundle/config/overlays/remove-certgen-job.yaml
@@ -20,14 +20,13 @@
 
 #@ else:
 
-#@overlay/match by=regex_match,expects="0+"
+#@overlay/match by=overlay.subset({"kind":"Job"})
 ---
 metadata:
   #@overlay/match missing_ok=True
   annotations:
     #@overlay/match missing_ok=True
     kapp.k14s.io/update-strategy: "fallback-on-replace"
-#@overlay/match missing_ok=True
 spec:
   #@overlay/remove
   ttlSecondsAfterFinished: 0

--- a/addons/packages/contour/1.15.1/bundle/config/overlays/remove-certgen-job.yaml
+++ b/addons/packages/contour/1.15.1/bundle/config/overlays/remove-certgen-job.yaml
@@ -17,4 +17,19 @@
 #@overlay/match by=overlay.subset({"roleRef": {"name": "contour-certgen"}})
 #@overlay.remove
 ---
+
+#@ else:
+
+#@overlay/match by=regex_match,expects="0+"
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/update-strategy: "fallback-on-replace"
+#@overlay/match missing_ok=True
+spec:
+  #@overlay/remove
+  ttlSecondsAfterFinished: 0
+
 #@ end

--- a/addons/packages/contour/1.17.1/bundle/config/overlays/remove-certgen-job.yaml
+++ b/addons/packages/contour/1.17.1/bundle/config/overlays/remove-certgen-job.yaml
@@ -20,14 +20,13 @@
 
 #@ else:
 
-#@overlay/match by=regex_match,expects="0+"
+#@overlay/match by=overlay.subset({"kind":"Job"}),expects=1
 ---
 metadata:
   #@overlay/match missing_ok=True
   annotations:
     #@overlay/match missing_ok=True
     kapp.k14s.io/update-strategy: "fallback-on-replace"
-#@overlay/match missing_ok=True
 spec:
   #@overlay/remove
   ttlSecondsAfterFinished: 0

--- a/addons/packages/contour/1.17.1/bundle/config/overlays/remove-certgen-job.yaml
+++ b/addons/packages/contour/1.17.1/bundle/config/overlays/remove-certgen-job.yaml
@@ -17,4 +17,19 @@
 #@overlay/match by=overlay.subset({"roleRef": {"name": "contour-certgen"}})
 #@overlay.remove
 ---
+
+#@ else:
+
+#@overlay/match by=regex_match,expects="0+"
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/update-strategy: "fallback-on-replace"
+#@overlay/match missing_ok=True
+spec:
+  #@overlay/remove
+  ttlSecondsAfterFinished: 0
+
 #@ end


### PR DESCRIPTION
## What this PR does / why we need it
Contour runs a Job that has a ttl set to 0, so that it gets immediately removed and kapp-controllers fails to validate existence of the job.
This PR removes the ttl and add a kapp annotation so that Job is recreated every time as instructed by @cppforlife 

## Which issue(s) this PR fixes
No issue is opened for this.

## Describe testing done for PR
Tested with `ytt -f config` in the bundle dir and `ytt -f config -v certificates.useCertManager=true` to test both cases defined in the modified overlay file. Tested both versions of the package.
