### PR TITLE
Removed versioned annotation for CSI

### DIFF
--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/overlays/add-secret.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/overlays/add-secret.yaml
@@ -7,8 +7,6 @@ kind: Secret
 metadata:
   name: vsphere-config-secret
   namespace: #@ values.vsphereCSI.namespace
-  annotations:
-    kapp.k14s.io/versioned: ""
 stringData:
   csi-vsphere.conf: #@ vsphere_conf(values)
 type: Opaque

--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/overlays/update-csi-driver.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/overlays/update-csi-driver.yaml
@@ -56,14 +56,6 @@ spec:
         - name: csi-resizer
         #@ end
 
-#@overlay/match by=overlay.subset({"kind":"ConfigMap"})
----
-metadata:
-  #@overlay/match missing_ok=True
-  annotations:
-    kapp.k14s.io/versioned: ""
-  namespace: #@ values.vsphereCSI.namespace
-
 #@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "vsphere-csi-node"}})
 ---
 metadata:
@@ -106,7 +98,7 @@ spec:
 #@ role_bindings = overlay.subset({"kind": "RoleBinding", "metadata": {"namespace": "vmware-system-csi"}})
 #@ services = overlay.subset({"kind": "Service", "metadata": {"namespace": "vmware-system-csi"}})
 
-#@overlay/match by=overlay.or_op(config_maps, service_accounts, roles, role_bindings, services), expects=5
+#@overlay/match by=overlay.or_op(config_maps, service_accounts, roles, role_bindings, services), expects=6
 ---
 metadata:
   namespace: #@ values.vsphereCSI.namespace

--- a/addons/packages/vsphere-csi/2.3.0/package.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:73603224de011558df3bd8878350129b67fd197cade425974c80e5fe648f115
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:a1d643897fba28f052781bbab11c25bdd4e8084c89d656e09b2f617162ab42f3
       template:
         - ytt:
             paths:


### PR DESCRIPTION
* CSI controller looks for configmap internal-feature-states.csi.vsphere.vmware.com whereas kapp creates it as internal-feature-states.csi.vsphere.vmware.com-ver-1
* Remove versioned annotation for vsphere-config-secret as it is not needed due to https://github.com/vmware-tanzu/carvel-kapp-controller/pull/127


Signed-off-by: Vijay Katam <vkatam@vmware.com>

## What this PR does / why we need it
CSI controller looks for configmap internal-feature-states.csi.vsphere.vmware.com whereas kapp creates it as internal-feature-states.csi.vsphere.vmware.com-ver-1

## Describe testing done for PR
Tested ytt render to ensure that `kapp.k14s.io/versioned` is not there


## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
