### PR TITLE
Delegate Add-on to deploy AVI Secret

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.4.3/README.md
+++ b/addons/packages/load-balancer-and-ingress-service/1.4.3/README.md
@@ -53,6 +53,9 @@ The following configuration values can be set to customize the load-balancer-and
 | `persistent_volume_claim` | Optional | describes which PVC using for AKO. |
 | `mount_path` | Optional | describes AKO logs mount path. |
 | `log_file` | Optional | describes where to store AKO logs. |
+| `avi_credentials_username` | Required | describes username that addon manager will use to deploy avi secret. |
+| `avi_credentials_password` | Required | describes password that addon manager will use to deploy avi secret. |
+| `avi_credentials_certificate_authority_data` | Required | describes certificate_authority_data that addon manager will use to deploy avi secret. |
 
 ## Usage Example
 

--- a/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/overlays/overlay-statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/overlays/overlay-statefulset.yaml
@@ -1,5 +1,6 @@
 #@ load("/values.star", "values")
 #@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:base64", "base64")
 
 #@overlay/match by=overlay.subset({"kind": "Namespace"})
 ---
@@ -224,4 +225,18 @@ spec:
 
 #@ if not values.loadBalancerAndIngressService.config.l7_settings.disable_ingress_class:
 --- #@ ingress_class()
-#@ end 
+#@ end
+
+#@overlay/match by=overlay.subset({"kind": "Secret", "metadata": {"name": "avi-secret"}})
+---
+#@overlay/replace
+apiVersion: v1
+kind: Secret
+metadata:
+  name: avi-secret
+  namespace: #@ values.loadBalancerAndIngressService.namespace
+type: Opaque
+data:
+  username: #@ base64.encode(values.loadBalancerAndIngressService.config.avi_credentials.username)
+  password: #@ base64.encode(values.loadBalancerAndIngressService.config.avi_credentials.password)
+  certificate_authority_data: #@ base64.encode(values.loadBalancerAndIngressService.config.avi_credentials.certificate_authority_data)

--- a/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
@@ -203,3 +203,14 @@ spec:
               port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: avi-secret
+  namespace: avi-system
+type: Opaque
+data:
+  username: ""
+  password: ""
+  certificate_authority_data: ""

--- a/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/values.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/values.yaml
@@ -51,4 +51,8 @@ loadBalancerAndIngressService:
       psp_policy_api_version: 
     persistent_volume_claim: 
     mount_path: 
-    log_file: 
+    log_file:
+    avi_credentials:
+      username:
+      password:
+      certificate_authority_data:


### PR DESCRIPTION
## What this PR does / why we need it

Now we still use AKO Operator to deploy avi secret in workload cluster, which is separate from other AKO deployment components. 

Change to use Add-on to deploy avi secret to unify the way to deploy AKO components.



## Which issue(s) this PR fixes


## Describe testing done for PR

Manually test ytt render to make sure new fields are added correctly.

## Does this PR introduce a user-facing change?
None
