### PR TITLE
[build] Download golang modules before hand while building Tanzu Framework

### DIFF
--- a/hack/build-tanzu.sh
+++ b/hack/build-tanzu.sh
@@ -53,6 +53,9 @@ BUILD_SHA="$(git describe --match="$(git rev-parse --short HEAD)" --always)"
 sed -i.bak -e "s/ --dirty//g" ./Makefile && rm ./Makefile.bak
 sed -i.bak -e "s/\$(shell git describe --tags --abbrev=0 2>\$(NUL))/${FRAMEWORK_BUILD_VERSION}/g" ./Makefile && rm ./Makefile.bak
 
+go mod download
+go mod tidy
+
 # allow unstable (non-GA) version plugins
 if [[ "${TCE_BUILD_VERSION}" == *"-"* ]]; then
 make controller-gen


### PR DESCRIPTION
## What this PR does / why we need it

Detailed description can be found in #1190 

This is a workaround for the issue that happens when running
`make build-install-cli-all` in Tanzu Framework repo in
pristine or brand new machines like CI/CD execution
environments where it silently fails half way as explained
in #1190 and hence causes Tanzu Framework to Not be built
completely along with the Tanzu CLI the core binary. The
failure is noticed only in the package stage of
`make release` where it fails with an error saying core
binary is not found in the artifacts but the root cause
is a silent failure which occurs way before the package
stage


## Which issue(s) this PR fixes

Fixes #1190

## Describe testing done for PR

Notice how this Action shows that the make release works
https://github.com/karuppiah7890/tce/runs/3179571547?check_suite_focus=true#step:5:719

Ignore the error at the end of the workflow which is related to sshuttle but the make release works

Also, ignore that the Actions uses my fork of Tanzu Framework https://github.com/karuppiah7890/tce/blob/e2e-vsphere-standalone-cluster-ga-config-trial/hack/build-tanzu.sh#L43 which I used to add some extra debug logs to debug the issue to find the root cause and get the details mentioned in #1190 , the `go mod` commands are here - https://github.com/karuppiah7890/tce/blob/e2e-vsphere-standalone-cluster-ga-config-trial/hack/build-tanzu.sh#L56-L57

## Special notes for your reviewer

I added `go mod tidy` but I added after the download following this - https://github.com/vmware-tanzu/tanzu-framework/blob/main/Makefile#L202-L204 . I was wondering if I should put `go mod tidy` or not, as it could change `go.mod` and `go.sum`, though it ideally shouldn't - developers would have usually committed the updated `go.mod` and `go.sum`. And if it does change the `go.mod` or `go.sum` then the download should be done again for the local cache, so, maybe change the order of the commands? Like, first `go mod tidy` then `go mod download`?

## Does this PR introduce a user-facing change?

```release-note
NONE
```
