### PR TITLE
Only list directories for prep-build-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ clean-framework:
 # PLUGINS
 .PHONY: prep-build-cli
 prep-build-cli:
-	@cd ./cli/cmd/plugin/ && for plugin in *; do\
+	@cd ./cli/cmd/plugin/ && for plugin in $$(ls -d */); do\
 		printf "===> Preparing $${plugin}\n";\
 		working_dir=`pwd`;\
 		cd $${plugin};\


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

In our prep-build-cli make target we iterate through all CLI plugins to
run `go mod download` ahead of actually building to make sure all
dependencies have been fetched. This had been iterating through
everything in that directory, but a README file was added that would
cause error output when the script tried to cd into it as a directory.

```
===> Preparing README.md
/bin/sh: 4: cd: can't cd to README.md
go mod download: no modules specified (see 'go help mod download')
```

This makes a minor update to the command to only iterate through the
directories in the plugin directory instead of all list results.

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

Ran local `make prep-build-cli` and `make build-all`.

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
