### PR TITLE
Fix bug in metrics server package overlay

### DIFF
--- a/addons/packages/metrics-server/0.4.0/bundle/config/overlays/overlay-deployment.yaml
+++ b/addons/packages/metrics-server/0.4.0/bundle/config/overlays/overlay-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         readinessProbe:
           failureThreshold: #@ data.values.metricsServer.config.probe.failureThreshold
           periodSeconds: #@ data.values.metricsServer.config.probe.periodSeconds
-        #@ if hasattr(data.values.metricsServer.config, 'tolerations') and data.values.metricsServer.config.tolerations:
-        #@overlay/match missing_ok=True
-        tolerations: #@ data.values.metricsServer.config.tolerations
-        #@ end
+      #@ if hasattr(data.values.metricsServer.config, 'tolerations') and data.values.metricsServer.config.tolerations:
+      #@overlay/match missing_ok=True
+      tolerations: #@ data.values.metricsServer.config.tolerations
+      #@ end

--- a/addons/packages/metrics-server/0.4.0/package.yaml
+++ b/addons/packages/metrics-server/0.4.0/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/metrics-server@sha256:c2b1f45dbc5f403917d7cabacb940e07405a5959af9f3ddf5aa5f0392bad3673
+            image: projects.registry.vmware.com/tce/metrics-server@sha256:40d467e7ee2df3b9420afc33c5fdfa0c808d513f69f576d6b9275f4e48611f11
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>
Metrics server's toleration overlay has wrong indentation.

## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
