### PR TITLE
Use `getTKGConfigDir` in standalone clusterconfig create / delete

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/create.go
+++ b/cli/cmd/plugin/standalone-cluster/create.go
@@ -127,21 +127,20 @@ func saveStandaloneClusterConfig(clusterName, clusterConfigPath string) error {
 		return fmt.Errorf("cannot read cluster config file: %v", err)
 	}
 
-	// get the user homedir
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
 	// Save the cluster configuration for future restore cycle
-	configDir := filepath.Join(homeDir, ".config", "tanzu", "tkg", "configs")
-	err = os.MkdirAll(configDir, 0755)
+	configDir, err := getTKGConfigDir()
 	if err != nil {
 		return err
 	}
 
-	clusterConfigFile := clusterName + "_ClusterConfig"
-	writeConfigPath := filepath.Join(configDir, clusterConfigFile)
+	clusterConfigDir := filepath.Join(configDir, "clusterconfigs")
+	err = os.MkdirAll(clusterConfigDir, 0755)
+	if err != nil {
+		return err
+	}
+
+	clusterConfigFile := clusterName + ".yaml"
+	writeConfigPath := filepath.Join(clusterConfigDir, clusterConfigFile)
 
 	log.Infof("Saving bootstrap cluster config for standalone cluster at '%v'", writeConfigPath)
 	err = os.WriteFile(writeConfigPath, clusterConfigBytes, constants.ConfigFilePermissions)

--- a/cli/cmd/plugin/standalone-cluster/delete.go
+++ b/cli/cmd/plugin/standalone-cluster/delete.go
@@ -101,34 +101,22 @@ func teardown(cmd *cobra.Command, args []string) error {
 }
 
 func getStandaloneClusterConfig(clusterName string) (string, error) {
-	homeDir, err := os.UserHomeDir()
+	configDir, err := getTKGConfigDir()
 	if err != nil {
 		return "", err
 	}
 
 	// fetch the expected cluster configuration for the restore cycle
-	configDir := filepath.Join(homeDir, ".config", "tanzu", "tkg", "configs")
-	clusterConfigFile := clusterName + "_ClusterConfig"
-	readConfigPath := filepath.Join(configDir, clusterConfigFile)
+	clusterConfigDir := filepath.Join(configDir, "clusterconfigs")
+	clusterConfigFile := clusterName + ".yaml"
+	readConfigPath := filepath.Join(clusterConfigDir, clusterConfigFile)
 
 	log.Infof("Loading bootstrap cluster config for standalone cluster at '%v'", readConfigPath)
 
 	_, err = os.Stat(readConfigPath)
 	if os.IsNotExist(err) {
-		log.Infof("no bootstrap cluster config found - looking for UI bootstrap config file")
-
-		configDir := filepath.Join(homeDir, ".config", "tanzu", "clusterconfigs")
-		clusterConfigFile := clusterName + ".yaml"
-		UIConfigPath := filepath.Join(configDir, clusterConfigFile)
-
-		log.Infof("Loading UI bootstrap cluster config for standalone cluster at '%v'", UIConfigPath)
-
-		_, err = os.Stat(UIConfigPath)
-		if os.IsNotExist(err) {
-			log.Infof("no bootstrap cluster config found - using default config")
-			return "", nil
-		}
-		return UIConfigPath, nil
+		log.Infof("no bootstrap cluster config found - using default config")
+		return "", nil
 	}
 
 	return readConfigPath, nil


### PR DESCRIPTION
## What this PR does / why we need it
This fixes some improper paths that were missing loading the cluster configs for creating / deleting standalone clusters. Now, clusterconfig files will always be created at `<tkg-config-dir>/tkg/clusterconfigs/<my-cluster>.yaml`

## Which issue(s) this PR fixes
Fixes: #1200 

## Describe testing done for PR
- Ran standalone create / delete via docker :heavy_check_mark: 
- Ran standalone create / delete for AWS. Got most of the way, but _I think_ I'm running into something similar here: https://github.com/vmware-tanzu/tanzu-framework/issues/262

## Special notes for your reviewer
@stmcginnis would love if you could try this for azure since I'm a bit blocked on trying this on AWS. Thanks much!

## Does this PR introduce a user-facing change?
```release-note
Standalone clusterconfigs are loaded from the default tkg config dir: `~/.config/tanzu/tkg/clusterconfigs`
```
