### PR TITLE
fix release commit with merge flag [trivial]

### DIFF
--- a/hack/update-tag.sh
+++ b/hack/update-tag.sh
@@ -91,7 +91,7 @@ git add hack/FAKE_BUILD_VERSION.yaml
 git commit -m "auto-generated - update fake version"
 git push origin "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}"
 gh pr create --title "auto-generated - update fake version" --body "auto-generated - update fake version"
-gh pr merge "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}"
+gh pr merge "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}" --merge
 
 # skip the tagging the dev release... commit the file is a good enough simulation
 
@@ -107,7 +107,7 @@ git add hack/DEV_BUILD_VERSION.yaml
 git commit -m "auto-generated - update dev version"
 git push origin "${WHICH_BRANCH}-update-${NEW_DEV_BUILD_VERSION}"
 gh pr create --title "auto-generated - update dev version" --body "auto-generated - update dev version"
-gh pr merge "${WHICH_BRANCH}-update-${NEW_DEV_BUILD_VERSION}"
+gh pr merge "${WHICH_BRANCH}-update-${NEW_DEV_BUILD_VERSION}" --merge
 
 # tag the new dev release
 git tag -m "${NEW_DEV_BUILD_VERSION}" "${NEW_DEV_BUILD_VERSION}"


### PR DESCRIPTION
## What this PR does / why we need it
This piggy backs on this merged PR:
https://github.com/vmware-tanzu/tce/pull/1207

The latest test run for the release process failed here because we were running from a script without user input:
https://github.com/vmware-tanzu/tce/runs/3196446079?check_suite_focus=true

with the following error:
```
remote: 
remote: Create a pull request for 'main-update-v0.7.0-dev.1004' on GitHub by visiting:        
remote:      https://github.com/vmware-tanzu/tce/pull/new/main-update-v0.7.0-dev.1004        
remote: 
To https://github.com/vmware-tanzu/tce
 * [new branch]      main-update-v0.7.0-dev.1004 -> main-update-v0.7.0-dev.1004
+ gh pr create --title 'auto-generated - update fake version' --body 'auto-generated - update fake version'
https://github.com/vmware-tanzu/tce/pull/1209
+ gh pr merge main-update-v0.7.0-dev.1004
--merge, --rebase, or --squash required when not running interactively
```

this adds `--merge` option to the command!