### PR TITLE
Continue release even on stderr

### DIFF
--- a/hack/update-tag.sh
+++ b/hack/update-tag.sh
@@ -3,7 +3,7 @@
 # Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set -o errexit
+# set -o errexit
 set -o nounset
 set -o pipefail
 set -o xtrace


### PR DESCRIPTION
## What this PR does / why we need it
This bascially matches the follow as the signing process. We should continue on even when an error on stderr is encountered because the higher level process already does the error handling for those conditions.
