### PR TITLE
Check for TKG proxy env vars. Set to empty if non present

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/delete.go
+++ b/cli/cmd/plugin/standalone-cluster/delete.go
@@ -49,6 +49,23 @@ func teardown(cmd *cobra.Command, args []string) error {
 	}
 	clusterName := args[0]
 
+	// Check for TKG_HTTPS_PROXY, TKG_HTTP_PROXY, TKG_NO_PROXY env variables
+	// Set to empty if not present
+	_, ok := os.LookupEnv("TKG_NO_PROXY")
+	if !ok {
+		os.Setenv("TKG_NO_PROXY", "")
+	}
+
+	_, ok = os.LookupEnv("TKG_HTTP_PROXY")
+	if !ok {
+		os.Setenv("TKG_HTTP_PROXY", "")
+	}
+
+	_, ok = os.LookupEnv("TKG_HTTPS_PROXY")
+	if !ok {
+		os.Setenv("TKG_HTTPS_PROXY", "")
+	}
+
 	configDir, err := getTKGConfigDir()
 	if err != nil {
 		return NonUsageError(cmd, err, "unable to determine Tanzu configuration directory.")


### PR DESCRIPTION
## What this PR does / why we need it
In standalone cluster delete, check for the presence of `TKG_NO_PROXY`, `TKG_HTTP_PROXY`, and `TKG_HTTPS_PROXY` env vars. If none found, set them to empty.

## Which issue(s) this PR fixes
Fixes: #1218

## Describe testing done for PR
Successfully can run
```
$ tanzu standalone-cluster create --ui
```
and deploy to AWS and then delete the cluster with
```
$ tanzu standalone-cluster delete my-cluster
```
without error

## Special notes for your reviewer
N/a - Might be nice if someone also verified this on Azure / vSphere

## Does this PR introduce a user-facing change?
N/a
