### PR TITLE
Bump tanzu-framework standalone cluster branch

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/go.mod
+++ b/cli/cmd/plugin/standalone-cluster/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6 // indirect
 	github.com/spf13/cobra v1.2.0
-	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210722164745-bc90d1f66712
+	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210810220208-f82021aac362
 	k8s.io/klog/v2 v2.8.0
 )
 

--- a/cli/cmd/plugin/standalone-cluster/go.sum
+++ b/cli/cmd/plugin/standalone-cluster/go.sum
@@ -1240,8 +1240,8 @@ github.com/vmware-tanzu/carvel-vendir v0.19.0 h1:4FTeDcxwEuZWdFlFqh+11NqnJciCkkO
 github.com/vmware-tanzu/carvel-vendir v0.19.0/go.mod h1:HF7iLB0NyEFHuCvM0EJ42fERk20l2ImpktJzhSEdqOU=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159 h1:c7sM3NrAQGmTvq57Aw96BBzBO67apYZpZs/51PfjddA=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159/go.mod h1:1DBZEj6GmcWxe77d8YOeac1JIa8ttP21uTHUlAyji2g=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210722164745-bc90d1f66712 h1:PvBodHD3Gft/A5N9L9iuiGIQtm5JnoAuN8wc/i9I/Hk=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210722164745-bc90d1f66712/go.mod h1:YlKYq37/Nl5Msi5U7Wf+YSBibarPfAFu9DOSq4DLBrg=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210810220208-f82021aac362 h1:pINqXpPWhaa/pVhjM+jY3EHnhjt8SYvqVdyWGiUr44s=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210810220208-f82021aac362/go.mod h1:YlKYq37/Nl5Msi5U7Wf+YSBibarPfAFu9DOSq4DLBrg=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
 github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=


### PR DESCRIPTION
## What this PR does / why we need it
Bumps our dependency on tanzu-framework @ `tce-main` to use the `~/.config/tanzu` directory and not the deprecated `~/.tanzu` directory.

## Which issue(s) this PR fixes
Fixes: https://github.com/vmware-tanzu/tanzu-framework/issues/348

This was noticed and originally thought to be some kind of Github API error or networking hiccup. But it was pulling configurations from the old ~/.tanzu folder. This was reproducible by first deleting the ~/.config/tanzu directory and then attempting to deploy a standalone cluster. This would fail with the error noted in the issue above. Then deleting the ~/.tanzu directory and re-running standalone cluster creation would be successful. 

## Describe testing done for PR
Built, deployed capd standalone cluster, deleted the cluster.

## Special notes for your reviewer
See https://github.com/vmware-tanzu/tanzu-framework/pull/361 for further details

## Does this PR introduce a user-facing change?
```release-note
- Standalone cluster now stores the boostrap cluster objects under the ~/.config/tanzu config directory
```
