### PR TITLE
[E2E][AWS] Delete local kind bootstrap cluster responsible for standalone cluster creation, before standalone cluster deletion

### DIFF
--- a/test/aws/deploy-tce.sh
+++ b/test/aws/deploy-tce.sh
@@ -24,6 +24,8 @@ echo "Setting CLUSTER_NAME to ${CLUSTER_NAME}..."
 # Cleanup function
 function deletecluster {
     echo "$@"
+    echo "Deleting local kind bootstrap cluster(s) running in Docker container(s)"
+    docker ps --all --format "{{ .Names }}" | grep tkg-kind | xargs docker rm --force
     tanzu standalone-cluster delete ${CLUSTER_NAME} -y || { aws-nuke-tear-down "STANDALONE CLUSTER DELETION FAILED! Deleting the cluster using AWS-NUKE..."; }
 }
 


### PR DESCRIPTION
## What this PR does / why we need it

TLDR; Fixes AWS E2E test cleanup

Longer version -

During the TCE standalone cluster deletion process, the local kind bootstrap
cluster that created the standalone cluster could be up and running for some
reason, for example due of some issue. This local kind bootstrap cluster with
all the cluster API providers could be repeatedly reconciling to keep the
standalone cluster resources up and running to keep the standalone cluster up
and running. This can hinder the standalone cluster deletion process. To avoid
this situation, we would have to delete the local kind bootstrap responsible
for standalone cluster creation

## Which issue(s) this PR fixes

Fixes #1265 

## Describe testing done for PR

Test run - https://github.com/karuppiah7890/tce/runs/3300502726?check_suite_focus=true . The failure is not due to aws-nuke and aws-nuke has removed all the resources pertaining to the cluster that was created, leaving out other resources which were already created in a different pipeline and not deleted

## Special notes for your reviewer

Note that we delete all Docker containers which have `tkg-kind` in their name. When running in CI pipeline there's no problem with this. In fact in CI there's no problem with even doing `docker ps --all --quiet | xargs docker rm -f` but if someone runs it in local they could lose their other Docker containers. And even now they could lose their other Docker containers which can be any cluster with a name having `tkg-kind` in it, bootstrap clusters, management / workload / standalone clusters etc. I tried to see if we can just delete the bootstrap cluster responsible for creating the particular standalone cluster, but it wasn't easy. Given a standalone cluster name, there is one place that I noticed that gives the information about the corresponding bootstrap cluster, which is - `~/.config/tanzu/tkg/config.yaml`, for example from my machine, the `tkg` field has this -

```yaml
tkg:
    regions:
        - name: guest-cluster-14979
          context: guest-cluster-14979-admin@guest-cluster-14979
          file: /Users/karuppiahn/.kube-tkg/config
          status: Success
          isCurrentContext: false
        - name: guest-cluster-30941
          context: kind-tkg-kind-c49mq6l94811tinpfd0g
          file: /Users/karuppiahn/.kube-tkg/tmp/config_t8YsLICV
          status: Failed
          isCurrentContext: false
        - name: guest-cluster-30426
          context: kind-tkg-kind-c49ojvt94817cjom1eb0
          file: /Users/karuppiahn/.kube-tkg/tmp/config_NaWXUsw3
          status: Failed
          isCurrentContext: false
    current-region-context: !!seq kind-tkg-kind-c49ojvt94817cjom1eb0
```

Note that `guest-cluster-30426` is the standalone cluster name and the context name `kind-tkg-kind-c49ojvt94817cjom1eb0` has the name of the bootstrap cluster responsible for creating the standalone cluster which is `tkg-kind-c49ojvt94817cjom1eb0`. Even inside the kube config file `/Users/karuppiahn/.kube-tkg/tmp/config_NaWXUsw3` the reference to `kind-tkg-kind-c49ojvt94817cjom1eb0` can be found. I wasn't sure if I should go to this config yaml file and get this name and trim out the initial `kind` to delete the particular local kind bootstrap cluster. Let me know if that's necessary to support running locally with the least friction as in that case it will delete exactly one appropriate local kind bootstrap cluster

## Does this PR introduce a user-facing change?

```release-note
NONE
```
