### PR TITLE
[E2E] Use TCE main stable package repository instead of latest

### DIFF
--- a/test/add-tce-package-repo.sh
+++ b/test/add-tce-package-repo.sh
@@ -13,7 +13,7 @@ MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo "Adding TCE package repository..."
 
 REPO_NAME="tce-main-latest"
-REPO_URL="projects.registry.vmware.com/tce/main:latest"
+REPO_URL="projects.registry.vmware.com/tce/main:stable"
 REPO_NAMESPACE="default"
 
 # TODO: Use stable version of the tce/main repo once https://github.com/vmware-tanzu/community-edition/issues/1250 is fixed


### PR DESCRIPTION
## What this PR does / why we need it

Use TCE main stable package repository instead of latest

This PR can be merged ONLY after #1250 is fixed

## Which issue(s) this PR fixes

None

## Describe testing done for PR

Tested locally with Docker standalone cluster, the syntax of the repo URL is valid, but it doesn't work yet due to #1250 . Once it works I'll do another round of testing locally

## Special notes for your reviewer

This is a second step to the PR #1269 to fix the TODO it introduces

## Does this PR introduce a user-facing change?

```release-note
NONE
```
