### PR TITLE
Bump tanzu framework to capture standalone logging improvements

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/go.mod
+++ b/cli/cmd/plugin/standalone-cluster/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6 // indirect
 	github.com/spf13/cobra v1.2.0
-	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210811220910-03aa45a6760c
+	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210816150552-bd5e271afff7
 	k8s.io/klog/v2 v2.8.0
 )
 

--- a/cli/cmd/plugin/standalone-cluster/go.sum
+++ b/cli/cmd/plugin/standalone-cluster/go.sum
@@ -1240,8 +1240,8 @@ github.com/vmware-tanzu/carvel-vendir v0.19.0 h1:4FTeDcxwEuZWdFlFqh+11NqnJciCkkO
 github.com/vmware-tanzu/carvel-vendir v0.19.0/go.mod h1:HF7iLB0NyEFHuCvM0EJ42fERk20l2ImpktJzhSEdqOU=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159 h1:c7sM3NrAQGmTvq57Aw96BBzBO67apYZpZs/51PfjddA=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159/go.mod h1:1DBZEj6GmcWxe77d8YOeac1JIa8ttP21uTHUlAyji2g=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210811220910-03aa45a6760c h1:04OmC8P3gEm+3E6mgpaKQo6u0Ktlr94C70rIE2CS/Fc=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210811220910-03aa45a6760c/go.mod h1:YlKYq37/Nl5Msi5U7Wf+YSBibarPfAFu9DOSq4DLBrg=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210816150552-bd5e271afff7 h1:SOn1Anq2Bz02E0+tU5Xw4ipw7pIPfjqWLD3+vMZKACw=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210816150552-bd5e271afff7/go.mod h1:YlKYq37/Nl5Msi5U7Wf+YSBibarPfAFu9DOSq4DLBrg=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
 github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=


### PR DESCRIPTION
## What this PR does / why we need it
Captures logging changes and improvements from @stmcginnis in https://github.com/vmware-tanzu/tanzu-framework/pull/382 for standalone clusters

Related to: #845

## Describe testing done for PR
Deployed standalone cluster and see logging messages like: `Setting up standalone cluster...`

## Special notes for your reviewer
Please make sure the sha is correct from the `tce-main` branch: https://github.com/vmware-tanzu/tanzu-framework/tree/tce-main

## Does this PR introduce a user-facing change?
```release-note
- Standalone cluster logging messages now refer to standalone clusters and not management clusters
```
