### PR TITLE
Add ReleasedAt field to package yaml in grafana, fluent-bit and prome…

### DIFF
--- a/addons/packages/fluent-bit/1.7.5/package.yaml
+++ b/addons/packages/fluent-bit/1.7.5/package.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   refName: fluent-bit.community.tanzu.vmware.com
   version: 1.7.5
+  releasedAt: 2021-05-13T18:00:00Z
   releaseNotes: "fluent-bit 1.7.5 https://github.com/fluent/fluent-bit/releases/tag/v1.7.5"
   capacityRequirementsDescription: "Varies significantly based on cluster size. This should be tuned based on observed usage."
   valuesSchema:

--- a/addons/packages/grafana/7.5.7/package.yaml
+++ b/addons/packages/grafana/7.5.7/package.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   refName: grafana.community.tanzu.vmware.com
   version: 7.5.7
+  releasedAt: 2021-05-19T18:00:00Z
   releaseNotes: "grafana 7.5.7 https://github.com/grafana/grafana/releases/tag/v7.5.7"
   capacityRequirementsDescription: "Varies significantly based on cluster size. A starting point is 6GB RAM and 1 CPU, but this should be tuned based on observed usage."
   valuesSchema:

--- a/addons/packages/prometheus/2.27.0/package.yaml
+++ b/addons/packages/prometheus/2.27.0/package.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   refName: prometheus.community.tanzu.vmware.com
   version: 2.27.0
+  releasedAt: 2021-05-12T18:00:00Z
   releaseNotes: "prometheus 2.27.0 https://github.com/prometheus/prometheus/releases/tag/v2.27.0"
   capacityRequirementsDescription: "Varies significantly based on cluster size. A starting point is 16GB RAM and 4 CPU, but this should be tuned based on observed usage."
   valuesSchema:


### PR DESCRIPTION
…theus.

## What this PR does / why we need it
This PR contains changes to adds "ReleasedAt" info to the package yaml's for Grafana, Prometheus and Fluent-bit

As Luke is out this week, appreciate if @seemiller  or @jpmcb could help merge this in today. I did make sure to sign the commits :) 

Cc: @hillrw3 

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
Ran make check successfuly.

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
This PR adds the "releasedAt" field to Package resources and hence the Users will be able to find corresponding release info for packages in TMC. 
For TCE I don't think this is an user-facing change.
