### PR TITLE
Update package license to Apache 2.0 for contour, external-dns, harbo…

### DIFF
--- a/addons/packages/contour/1.15.1/package.yaml
+++ b/addons/packages/contour/1.15.1/package.yaml
@@ -9,7 +9,7 @@ spec:
   releaseNotes: "contour 1.15.1 https://github.com/projectcontour/contour/releases/tag/v1.15.1"
   releasedAt: 2021-06-01T18:00:00Z
   licenses:
-    - "VMware's End User License Agreement (Underlying OSS license: Apache License 2.0)"
+    - "Apache 2.0"
   template:
     spec:
       fetch:

--- a/addons/packages/contour/1.17.1/package.yaml
+++ b/addons/packages/contour/1.17.1/package.yaml
@@ -9,7 +9,7 @@ spec:
   releaseNotes: "contour 1.17.1 https://github.com/projectcontour/contour/releases/tag/v1.17.1"
   releasedAt: 2021-07-23T18:00:00Z
   licenses:
-    - "VMware's End User License Agreement (Underlying OSS license: Apache License 2.0)"
+    - "Apache 2.0"
   template:
     spec:
       fetch:

--- a/addons/packages/external-dns/0.8.0/package.yaml
+++ b/addons/packages/external-dns/0.8.0/package.yaml
@@ -71,7 +71,7 @@ spec:
                 $ref: "#/definitions/io.k8s.api.core.v1.Volume"
   capacityRequirementsDescription: "No specific capacity requirements."
   licenses:
-    - "VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)"
+    - "Apache 2.0"
   template:
     spec:
       fetch:

--- a/addons/packages/harbor/2.2.3/package.yaml
+++ b/addons/packages/harbor/2.2.3/package.yaml
@@ -8,7 +8,7 @@ spec:
   releasedAt: 2021-07-07T18:00:00Z
   releaseNotes: "harbor 2.2.3 https://github.com/goharbor/harbor/releases/tag/v2.2.3"
   licenses:
-    - "VMware's End User License Agreement (Underlying OSS license: Apache License 2.0)"
+    - "Apache 2.0"
   valuesSchema:
     openAPIv3:
       title: harbor.community.tanzu.vmware.com.2.2.3 values schema

--- a/addons/packages/multus-cni/3.7.1/package.yaml
+++ b/addons/packages/multus-cni/3.7.1/package.yaml
@@ -9,7 +9,7 @@ spec:
   releasedAt: 2021-06-04T18:00:00Z
   releaseNotes: "multus-cni 3.7.1 https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v3.7.1"
   licenses:
-    - "VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)"
+    - "Apache 2.0"
   capacityRequirementsDescription: "No specific requirements."
   valuesSchema:
     openAPIv3:


### PR DESCRIPTION
…r and multus-cni

## What this PR does / why we need it
Based on this comment from @stmcginnis , https://github.com/vmware-tanzu/tce/pull/1259#discussion_r686239894 
looks like we did want all the packages to reflect license as "Apache 2.0" instead of an VMware license for TCE repo.

Once the corresponding owners vendor these changes into TKG, they will need to provide downstream overlays to reflect the correct VMware license.

## Details for the Release Notes

```
Package licenses for contour, external-dns, harbor, and multus-cni have been updated to reflect Apache 2.0 licensing.
```

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
NA

## Special notes for your reviewer
NA

## Does this PR introduce a user-facing change?
NA