### PR TITLE
[E2E] Wait for TCE package repository installation to succeed

### DIFF
--- a/test/add-tce-package-repo.sh
+++ b/test/add-tce-package-repo.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -x
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+"${MY_DIR}"/install-jq.sh
+
+echo "Adding TCE package repository..."
+
+REPO_NAME="tce-main-latest"
+REPO_URL="projects.registry.vmware.com/tce/main:latest"
+REPO_NAMESPACE="default"
+
+# TODO: Use stable version of the tce/main repo once https://github.com/vmware-tanzu/tce/issues/1250 is fixed
+tanzu package repository add ${REPO_NAME} --namespace ${REPO_NAMESPACE} --url ${REPO_URL}
+
+# Wait for reconcilation to happen within ~ 80 x 5 = 400 seconds . 80 iterations, 5 seconds sleep time.
+# Check status every ~5 seconds interval
+for (( i = 1 ; i <= 80 ; i++))
+do
+    repo_status=$(tanzu package repository get ${REPO_NAME} -o json | jq -r '.[0].status | select (. != null)')
+    if [[ ${repo_status} == "Reconcile succeeded" ]]; then
+        echo "TCE package repository added!"
+        exit 0
+    fi
+    sleep 5
+done
+
+echo "Error: Timed out while TCE package repository was reconciling!"
+exit 1

--- a/test/aws/deploy-tce.sh
+++ b/test/aws/deploy-tce.sh
@@ -90,8 +90,7 @@ kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s || 
 
 echo "Installing packages on TCE..."
 
-# TODO: Use stable version of the tce/main repo once https://github.com/vmware-tanzu/tce/issues/1250 is fixed
-tanzu package repository add tce-main-latest --namespace default --url projects.registry.vmware.com/tce/main:latest || { error "PACKAGE REPOSITORY INSTALLATION FAILED!"; deletecluster "Deleting standalone cluster"; exit 1; }
+"${MY_DIR}"/../add-tce-package-repo.sh || { error "PACKAGE REPOSITORY INSTALLATION FAILED!"; deletecluster "Deleting standalone cluster"; exit 1; }
 
 # Added this as the above command takes time to install packages
 sleep 60s

--- a/test/docker/run-tce-docker-managed-cluster.sh
+++ b/test/docker/run-tce-docker-managed-cluster.sh
@@ -35,8 +35,7 @@ tanzu cluster kubeconfig get ${GUEST_CLUSTER_NAME} --admin
 
 "${MY_DIR}"/check-tce-cluster-creation.sh ${GUEST_CLUSTER_NAME}-admin@${GUEST_CLUSTER_NAME}
 
-# TODO: Use stable version of the tce/main repo once https://github.com/vmware-tanzu/tce/issues/1250 is fixed
-tanzu package repository add tce-main-latest --namespace default --url projects.registry.vmware.com/tce/main:latest
+"${MY_DIR}"/../add-tce-package-repo.sh
 
 # wait for packages to be available
 sleep 10


### PR DESCRIPTION
## What this PR does / why we need it

We need to wait for the package repository status to be
"Reconcile succeeded" before proceeding to other steps
like listing and installing packages which are part of
the package repository. If we do not wait, we will get
package not found error while trying to install the
package

## Which issue(s) this PR fixes

Fixes: #1303 

## Describe testing done for PR

Tested locally by using `./test/add-tce-package-repo.sh` on a running local Docker standalone cluster . Also tested it by running `./test/aws/deploy-tce.sh` but excluding cluster creation, to see if `"${MY_DIR}"/../add-tce-package-repo.sh` worked

## Special notes for your reviewer

None

## Does this PR introduce a user-facing change?
```release-note
NONE
```
