### PR TITLE
Fix release CI by downloading the release-notes utility [Trivial]

### DIFF
--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -55,7 +55,9 @@ jobs:
       - name: Generate release
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: make release
+        run: |
+          make ensure-deps
+          make release
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -56,7 +56,9 @@ jobs:
       - name: Generate release
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: make release
+        run: |
+          make ensure-deps
+          make release
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -57,7 +57,9 @@ jobs:
       - name: Generate release
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: make release
+        run: |
+          make ensure-deps
+          make release
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
Signed-off-by: dvonthenen <vonthenend@vmware.com>

## What this PR does / why we need it
In order to use the utility in CI, I kinda need to download it. 😀

## Details for the Release Notes
```release-note
NONE
```

## Which issue(s) this PR fixes
Fixes: #

## Describe testing done for PR
NA

## Special notes for your reviewer
NA