### PR TITLE
More CI fixes for Release Notes [trivial]

### DIFF
--- a/hack/cut-release.sh
+++ b/hack/cut-release.sh
@@ -56,9 +56,13 @@ git pull origin "${WHICH_BRANCH}"
 pushd "./hack/release" || exit 1
 PREVIOUS_RELEASE_HASH=$(cat ../PREVIOUS_RELEASE_HASH)
 
-release-notes --org vmware-tanzu --repo tce --branch "${WHICH_BRANCH}" \
+echo "Generating release notes..."
+set +x
+GITHUB_TOKEN="${GITHUB_TOKEN}" release-notes \
+  --org vmware-tanzu --repo tce --branch "${WHICH_BRANCH}" \
   --start-sha "${PREVIOUS_RELEASE_HASH}" --end-sha "${WHICH_HASH}" \
   --required-author "" --go-template go-template:../release.template --output release-notes.txt
+set -x
 
 sed -i.bak -e "s/{<VERSION>}/${BUILD_VERSION}/g" ./release-notes.txt && rm ./release-notes.txt.bak
 


### PR DESCRIPTION
## What this PR does / why we need it
It looks like we need an explicit passing of the token to the release-notes utility. Turned on `set +/-x` to obscure the token from being displayed.

## Details for the Release Notes
```release-note
NONE
```

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
NA

## Special notes for your reviewer
NA
