### PR TITLE
Use the actual commit sha in the github action

### DIFF
--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -115,6 +115,7 @@ jobs:
       - name: Commit Next Dev Version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          ACTUAL_COMMIT_SHA: ${{ github.sha }}
         run: make cut-release
 
       - name: Upload Cayman Trigger Asset

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -132,6 +132,7 @@ jobs:
       - name: Commit Next Dev Version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          ACTUAL_COMMIT_SHA: ${{ github.sha }}
         run: make cut-release
 
       - name: Upload Cayman Trigger Asset

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -133,6 +133,7 @@ jobs:
       - name: Commit Next Dev Version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          ACTUAL_COMMIT_SHA: ${{ github.sha }}
         run: make cut-release
 
       - name: Upload Cayman Trigger Asset

--- a/hack/cut-release.sh
+++ b/hack/cut-release.sh
@@ -60,7 +60,7 @@ echo "Generating release notes..."
 set +x
 GITHUB_TOKEN="${GITHUB_TOKEN}" release-notes \
   --org vmware-tanzu --repo tce --branch "${WHICH_BRANCH}" \
-  --start-sha "${PREVIOUS_RELEASE_HASH}" --end-sha "${WHICH_HASH}" \
+  --start-sha "${PREVIOUS_RELEASE_HASH}" --end-sha "${ACTUAL_COMMIT_SHA}" \
   --required-author "" --go-template go-template:../release.template --output release-notes.txt
 set -x
 


### PR DESCRIPTION
## What this PR does / why we need it
It turns out, the "sha" triggering the action is actually a branch used to run the github action from which is then removed when the action is completed. If you want the actual actual sha, then you need to use this github variable. 

## Details for the Release Notes
```release-note
NONE
```

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
NA

## Special notes for your reviewer
NA