### PR TITLE
Need to record correct hash for previous release [trivial]

### DIFF
--- a/hack/cut-release.sh
+++ b/hack/cut-release.sh
@@ -110,7 +110,7 @@ echo "NEW_DEV_BUILD_VERSION: ${NEW_DEV_BUILD_VERSION}"
 # commit dev file
 git add hack/DEV_BUILD_VERSION.yaml
 if [[ "${BUILD_VERSION}" != *"-"* ]]; then
-    echo "${WHICH_HASH}" | tee ./hack/PREVIOUS_RELEASE_HASH
+    echo "${ACTUAL_COMMIT_SHA}" | tee ./hack/PREVIOUS_RELEASE_HASH
     git add hack/PREVIOUS_RELEASE_HASH
 fi
 git commit -s -m "auto-generated - update dev version"


### PR DESCRIPTION
## What this PR does / why we need it
In updating a previous PR https://github.com/vmware-tanzu/tce/pull/1337 to use the "actual" commit hash for the tag, I forgot to update the hash that get recorded for when we cut the GA release to be the new start sha when doing release notes.

## Details for the Release Notes
```release-note
Record the correct sha when cutting the GA release to be used for the next `--start-sha`.
```

## Which issue(s) this PR fixes
NA

## Describe testing done for PR
NA

## Special notes for your reviewer
NA