### PR TITLE
Update download links for 0.7.0

### DIFF
--- a/docs/site/content/docs/assets/cli-install-linux.md
+++ b/docs/site/content/docs/assets/cli-install-linux.md
@@ -1,4 +1,4 @@
-1. Download the release for [Linux](https://github.com/vmware-tanzu/tce/releases/download/v0.6.0/tce-linux-amd64-v0.6.0.tar.gz) via web browser.
+1. Download the release for [Linux](https://github.com/vmware-tanzu/tce/releases/download/v0.7.0/tce-linux-amd64-v0.7.0.tar.gz) via web browser.
 
 1. _[Alternative]_ Download the release using CLI
 
@@ -10,22 +10,22 @@
     ```
 
     > Alternatively, you may download a release using the provided remote script.
-    > - The TCE release version and release distribution _must_ be passed as arguments to `bash` in order to download a releases. So, for example, to download v0.6.0 for Linux, simply provide `bash -s v0.6.0 linux` as arguments.
+    > - The TCE release version and release distribution _must_ be passed as arguments to `bash` in order to download a releases. So, for example, to download v0.7.0 for Linux, simply provide `bash -s v0.7.0 linux` as arguments.
     > - This script requires `curl`, `grep`, `sed`, `tr`, and `jq` in order to work
-    > - The release will be downloaded to the local directory as `tce-linux-amd64-v0.6.0.tar.gz`
+    > - The release will be downloaded to the local directory as `tce-linux-amd64-v0.7.0.tar.gz`
     > - *_Note:_* This _currently_ requires the use of a GitHub personal access token.
       Follow [the GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to aquire and use a personal access token.
 
 1. Unpack the release.
 
     ```sh
-    tar xzvf ~/<DOWNLOAD-DIR>/tce-linux-amd64-v0.6.0.tar.gz
+    tar xzvf ~/<DOWNLOAD-DIR>/tce-linux-amd64-v0.7.0.tar.gz
     ```
 
 1. Run the install script (make sure to use the appropriate directory for your platform).
 
     ```sh
-    cd tce-linux-amd64-v0.6.0
+    cd tce-linux-amd64-v0.7.0
     ./install.sh
     ```
 

--- a/docs/site/content/docs/assets/cli-install-mac.md
+++ b/docs/site/content/docs/assets/cli-install-mac.md
@@ -1,15 +1,15 @@
-1. Download the release for [macOS](https://github.com/vmware-tanzu/tce/releases/download/v0.6.0/tce-darwin-amd64-v0.6.0.tar.gz).
+1. Download the release for [macOS](https://github.com/vmware-tanzu/tce/releases/download/v0.7.0/tce-darwin-amd64-v0.7.0.tar.gz).
 
 1. Unpack the release.
 
     ```sh
-    tar xzvf ~/<DOWNLOAD-DIR>/tce-darwin-amd64-v0.6.0.tar.gz
+    tar xzvf ~/<DOWNLOAD-DIR>/tce-darwin-amd64-v0.7.0.tar.gz
     ```
 
 1. Run the install script.
 
     ```sh
-    cd tce-darwin-amd64-v0.6.0
+    cd tce-darwin-amd64-v0.7.0
     ./install.sh
     ```
 


### PR DESCRIPTION
## What this PR does / why we need it

This commit upates the documentation to point to the 0.7.0 release of
TCE.

## Details for the Release Notes

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: https://github.com/vmware-tanzu/tce/issues/1301

## Describe testing done for PR

Render Hugo site, view download links.

## Special notes for your reviewer

None
