### PR TITLE
clear plugin cache during un/install

### DIFF
--- a/hack/install.bat
+++ b/hack/install.bat
@@ -16,8 +16,11 @@ set PATH=%PATH%;%TANZU_CLI_DIR%
 :: start copy plugins
 SET PLUGIN_DIR=%LocalAppData%\tanzu-cli
 SET TCE_DIR=%LocalAppData%\tce
+SET TANZU_CACHE_DIR=%LocalAppData%\.cache\tanzu
 mkdir %PLUGIN_DIR%
 mkdir %TCE_DIR%
+:: delete the plugin cache if it exists, before installing new plugins
+rmdir /Q /S %TANZU_CACHE_DIR%
 
 :: core
 copy /B /Y bin\tanzu-plugin-cluster.exe %PLUGIN_DIR%

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -60,6 +60,13 @@ done
 mkdir -p "${XDG_DATA_HOME}/tce"
 install "${MY_DIR}/uninstall.sh" "${XDG_DATA_HOME}/tce"
 
+# if plugin cache pre-exists, remove it so new plugins are detected
+TANZU_PLUGIN_CACHE="${HOME}/.cache/tanzu/catalog.yaml"
+if [[ -n "${TANZU_PLUGIN_CACHE}" ]]; then
+  echo "Removing old plugin cache from ${TANZU_PLUGIN_CACHE}"
+  rm -f "${TANZU_PLUGIN_CACHE}" > /dev/null
+fi
+
 # explicit init of tanzu cli and add tce repo
 TANZU_CLI_NO_INIT=true tanzu init
 TCE_REPO="$(tanzu plugin repo list | grep tce)"

--- a/hack/uninstall.bat
+++ b/hack/uninstall.bat
@@ -11,6 +11,14 @@ rmdir /Q /S "%TANZU_CLI_DIR%"
 SET PLUGIN_DIR=%LocalAppData%\tanzu-cli
 rmdir /Q /S %PLUGIN_DIR%
 
+:: start delete tanzu configuration
+SET TANZU_CONFIG_DIR=%LocalAppData%\.config\tanzu
+rmdir /Q /S %TANZU_CONFIG_DIR%
+
+:: start delete tanzu cache
+SET TANZU_CACHE_DIR=%LocalAppData%\.cache\tanzu
+rmdir /Q /S %TANZU_CACHE_DIR%
+
 :: start delete tce
 SET TCE_DIR=%LocalAppData%\tce
 rmdir /Q /S %TCE_DIR%

--- a/hack/uninstall.sh
+++ b/hack/uninstall.sh
@@ -33,6 +33,7 @@ fi
 
 rm -rf "${HOME}/.tanzu"
 rm -rf "${HOME}/.config/tanzu"
+rm -rf "${HOME}/.cache/tanzu"
 rm -rf "${XDG_DATA_HOME}/tanzu-cli"
 rm -rf "${XDG_DATA_HOME}/tce"
 


### PR DESCRIPTION
## What this PR does / why we need it

This commit adds a check for the plugin cache file on a users system.
When our users install or uninstall, this file should be cleared,
otherwise changes (new or otherwise) to plugins will not show up. This
is true for users who previously had TCE (tanzu) installed.

## Details for the Release Notes

```release-note
Install and uninstall scripts now clear the plugin cache to ensure tanzu CLI reports the most up-to-date plugins
```

## Which issue(s) this PR fixes

Fixes: https://github.com/vmware-tanzu/tce/issues/1290

## Describe testing done for PR

Ran install/uninstall, verified it does clear the cache.

## Special notes for your reviewer

None
