### PR TITLE
Remove workaround for set-unstable-versions

### DIFF
--- a/hack/build-tanzu.sh
+++ b/hack/build-tanzu.sh
@@ -23,9 +23,6 @@ if [[ -z "${TCE_BUILD_VERSION}" ]]; then
 fi
 
 rm -rf "${ROOT_REPO_DIR}/tanzu-framework"
-# TODO remove after this issue has been fixed
-# https://github.com/vmware-tanzu/tanzu-framework/issues/144
-mv -f "${HOME}/.config/tanzu" "${HOME}/.config/tanzu-$(date +"%Y-%m-%d_%H:%M")"
 set +x
 if [[ -n "${TANZU_FRAMEWORK_REPO_HASH}" ]]; then
     TANZU_FRAMEWORK_REPO_BRANCH="main"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

https://github.com/vmware-tanzu/tanzu-framework/issues/144
caused issues with loading config, so we were renaming the config
directory during full release builds. This issues is now closed. This
would not impact the end user, but it's nice for development workflows
to not manipulate that config directory.

## Details for the Release Notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```