### PR TITLE
add workaround for standard repo

### DIFF
--- a/docs/site/content/docs/assets/package-installation.md
+++ b/docs/site/content/docs/assets/package-installation.md
@@ -12,6 +12,17 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
     kubectl config use-context ${WORKLOAD_CLUSTER_NAME}-admin@${WORKLOAD_CLUSTER_NAME}
     ```
 
+1. Delete the standard package repository
+
+
+    ```sh
+    tanzu package repository delete -n tanzu-package-repo-global tanzu-standard
+    ```
+
+    > This is a temporary workaround for a small regression introduced in
+    > tanzu-framework. This step will not be required in future releases.
+
+
 1. Install the TCE package repository.
 
     ```sh


### PR DESCRIPTION
## What this PR does / why we need it

This commit documents a workaround for users to remove the standard
package repository. This is a temporary workaround until the repo
becomes pluggable in TCE.

## Details for the Release Notes

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: https://github.com/vmware-tanzu/tce/issues/1350

