### PR TITLE
Fixes environment variable name in standalone doc

### DIFF
--- a/docs/site/content/docs/assets/aws-standalone-clusters.md
+++ b/docs/site/content/docs/assets/aws-standalone-clusters.md
@@ -21,16 +21,16 @@ This section covers setting up a standalone cluster in Amazon EC2. A standalone 
 1. At the end of the UI, deploy the cluster.
 
 1. Store the name of your cluster (set during configuration or automatically generated) to a
-   `WORKLOAD_CLUSTER_NAME` environment variable.
+   `STANDALONE_CLUSTER_NAME` environment variable.
 
     ```sh
-    export WORKLOAD_CLUSTER_NAME="<INSERT_WORKLOAD_CLUSTER_NAME_HERE>"
+    export STANDALONE_CLUSTER_NAME="<INSERT_STANDALONE_CLUSTER_NAME_HERE>"
     ```
 
 1. Set your kubectl context to the cluster.
 
     ```sh
-    kubectl config use-context ${WORKLOAD_CLUSTER_NAME}-admin@${WORKLOAD_CLUSTER_NAME}
+    kubectl config use-context ${STANDALONE_CLUSTER_NAME}-admin@${STANDALONE_CLUSTER_NAME}
     ```
 
 1. Validate you can access the cluster's API server.

--- a/docs/site/content/docs/assets/azure-standalone-clusters.md
+++ b/docs/site/content/docs/assets/azure-standalone-clusters.md
@@ -18,16 +18,16 @@ This section covers setting up a standalone cluster in Azure. A standalone clust
 1. At the end of the UI, deploy the cluster.
 
 1. Store the name of your cluster (set during configuration or automatically generated) to a
-   `WORKLOAD_CLUSTER_NAME` environment variable.
+   `STANDALONE_CLUSTER_NAME` environment variable.
 
     ```sh
-    export WORKLOAD_CLUSTER_NAME="<INSERT_WORKLOAD_CLUSTER_NAME_HERE>"
+    export STANDALONE_CLUSTER_NAME="<INSERT_STANDALONE_CLUSTER_NAME_HERE>"
     ```
 
 1. Set your kubectl context to the cluster.
 
     ```sh
-    kubectl config use-context ${WORKLOAD_CLUSTER_NAME}-admin@${WORKLOAD_CLUSTER_NAME}
+    kubectl config use-context ${STANDALONE_CLUSTER_NAME}-admin@${STANDALONE_CLUSTER_NAME}
     ```
 
 1. Validate you can access the cluster's API server.

--- a/docs/site/content/docs/assets/clean-up-standalone.md
+++ b/docs/site/content/docs/assets/clean-up-standalone.md
@@ -3,7 +3,7 @@
 1. Run the `delete` command.
 
     ```sh
-    tanzu standalone-cluster delete ${WORKLOAD_CLUSTER_NAME}
+    tanzu standalone-cluster delete ${STANDALONE_CLUSTER_NAME}
     ```
 
     > This may take several minutes to complete!
@@ -11,6 +11,6 @@
 1. _Note:_ If you configured a proxy, you may need to provide the following environment variables `TKG_NO_PROXY`, `TKG_HTTP_PROXY`, `TKG_HTTPS_PROXY`
 
     ```sh
-    TKG_HTTP_PROXY="127.0.0.1" tanzu standalone-cluster delete ${GUEST_CLUSTER_NAME}
+    TKG_HTTP_PROXY="127.0.0.1" tanzu standalone-cluster delete ${STANDALONE_CLUSTER_NAME}
     ```
 

--- a/docs/site/content/docs/assets/vsphere-standalone-clusters.md
+++ b/docs/site/content/docs/assets/vsphere-standalone-clusters.md
@@ -42,15 +42,15 @@ vSphere. These clusters are not managed by a management cluster.
 1. At the end of the UI, create the standalone cluster.
 
 1. Store the name of your cluster (set during configuration or generated) to a
-   `WORKLOAD_CLUSTER_NAME` environment variable.
+   `STANDALONE_CLUSTER_NAME` environment variable.
 
     ```sh
-    export WORKLOAD_CLUSTER_NAME="<INSERT_WORKLOAD_CLUSTER_NAME_HERE>"
+    export STANDALONE_CLUSTER_NAME="<INSERT_STANDALONE_CLUSTER_NAME_HERE>"
     ```
 1. Set your kubectl context to the cluster.
 
     ```sh
-    kubectl config use-context ${WORKLOAD_CLUSTER_NAME}-admin@${WORKLOAD_CLUSTER_NAME}
+    kubectl config use-context ${STANDALONE_CLUSTER_NAME}-admin@${STANDALONE_CLUSTER_NAME}
     ```
 
 1. Validate you can access the cluster's API server.


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
closes: #1236 
Changes environment variable from WORKLOAD_CLUSTER_NAME to STANDALONE_CLUSTER_NAME in the doc


## Details for the Release Notes
trivial

## Which issue(s) this PR fixes

Fixes: #1236 

## Describe testing done for PR
Previewed here:
https://deploy-preview-1358--quirky-franklin-8969be.netlify.app/docs/latest/getting-started-standalone/

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
