### PR TITLE
Bumps tanzu-framework/tce-main shas after rebase to get latest commit…

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/go.mod
+++ b/cli/cmd/plugin/standalone-cluster/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6 // indirect
 	github.com/spf13/cobra v1.2.0
-	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819135111-fc80ab1ae92e
+	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819152703-b3f599310640
 	k8s.io/klog/v2 v2.8.0
 )
 

--- a/cli/cmd/plugin/standalone-cluster/go.sum
+++ b/cli/cmd/plugin/standalone-cluster/go.sum
@@ -1329,6 +1329,8 @@ github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159 h1:c7s
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159/go.mod h1:1DBZEj6GmcWxe77d8YOeac1JIa8ttP21uTHUlAyji2g=
 github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819135111-fc80ab1ae92e h1:ED20wrKr+6/n1b0ZS9eTDdIAayMq/QtmV8xo/65iUx0=
 github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819135111-fc80ab1ae92e/go.mod h1:2ph3SY8wu6ZX0Z350YJe0f/1DdHkIE320jIHKH/WQC4=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819152703-b3f599310640 h1:zp8tXeEwxvl0UrsvKlxeAX63O09Az/KQH6+LyuziY1E=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819152703-b3f599310640/go.mod h1:2ph3SY8wu6ZX0Z350YJe0f/1DdHkIE320jIHKH/WQC4=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
 github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=

--- a/hack/builder/go.mod
+++ b/hack/builder/go.mod
@@ -8,5 +8,6 @@ go 1.16
 require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/spf13/cobra v1.2.1
-	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819135111-fc80ab1ae92e
+	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819000359-75cfa0e3ada3
+	sigs.k8s.io/controller-runtime v0.9.0 // indirect
 )

--- a/hack/builder/go.sum
+++ b/hack/builder/go.sum
@@ -1583,6 +1583,8 @@ github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210818143825-5dfd
 github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210818143825-5dfd45a960b9/go.mod h1:2ph3SY8wu6ZX0Z350YJe0f/1DdHkIE320jIHKH/WQC4=
 github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210818150133-ab306729ecd3 h1:3RGgH/IFrIhHgppCFvzAqqHkX5VDKGOTsQTG5Xa7h7w=
 github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210818150133-ab306729ecd3/go.mod h1:2ph3SY8wu6ZX0Z350YJe0f/1DdHkIE320jIHKH/WQC4=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819000359-75cfa0e3ada3 h1:8esDJrq5PylEykbu2DQ2LrpXMDzgbEw6KpuSXO7C6ic=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819000359-75cfa0e3ada3/go.mod h1:oha3eMWZ3UyaSOqL2/aLaNPZOUBeoqT0zm68l9fmyYA=
 github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819135111-fc80ab1ae92e h1:ED20wrKr+6/n1b0ZS9eTDdIAayMq/QtmV8xo/65iUx0=
 github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819135111-fc80ab1ae92e/go.mod h1:2ph3SY8wu6ZX0Z350YJe0f/1DdHkIE320jIHKH/WQC4=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=


### PR DESCRIPTION
## What this PR does / why we need it
Captures latest tanzu framework commits on `tce-main`

Also uses `main` from tanzu framework to build in the `hack/builder` so we aren't using a TCE branch to build

## Details for the Release Notes
```release-note
NONE
```

## Which issue(s) this PR fixes
Fixes: #1354

## Describe testing done for PR
`make build-all` and deployed standalone cluster correctly

## Special notes for your reviewer
Please confirm the shas are correct
