### PR TITLE
Adds missing Windows cli steps to install doc

### DIFF
--- a/docs/site/content/docs/latest/cli-installation.md
+++ b/docs/site/content/docs/latest/cli-installation.md
@@ -5,15 +5,20 @@ To use Tanzu Community Edition, you must download and run the Tanzu CLI on a loc
 
 ## Procedure
 
-{{< tabs tabTotal="2" tabID="1" tabName1="Mac" tabName2="Linux" >}}
+{{< tabs tabTotal="3" tabID="1" tabName1="Linux" tabName2="Mac" tabName3="Windows">}}
 {{< tab tabNum="1" >}}
 
-{{% include "/docs/assets/cli-install-mac.md" %}}
+{{% include "/docs/assets/cli-install-linux.md" %}}
 
 {{< /tab >}}
 {{< tab tabNum="2" >}}
 
-{{% include "/docs/assets/cli-install-linux.md" %}}
+{{% include "/docs/assets/cli-install-mac.md" %}}
+
+{{< /tab >}}
+{{< tab tabNum="3" >}}
+
+{{% include "/docs/assets/cli-install-windows.md" %}}
 
 {{< /tab >}}
 {{< /tabs >}}


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
Adds missing Windows cli steps to install doc

## Details for the Release Notes
n/a - relates to missing content
```
none
```

## Which issue(s) this PR fixes

Fixes: #1374 

## Describe testing done for PR
Previewed here: https://deploy-preview-1386--quirky-franklin-8969be.netlify.app/docs/latest/cli-installation/



