### PR TITLE
Rename checkout step in gh actions workflows

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
 
       - name: Restore Go Cache

--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
 
       - name: Restore Go Cache

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -16,7 +16,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - name: Check out code
+        uses: actions/checkout@v1
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2

--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -22,7 +22,7 @@ jobs:
         run: |
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
 
       - name: Restore Go Cache

--- a/.github/workflows/check-mdlint.yaml
+++ b/.github/workflows/check-mdlint.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
 
       - name: Run mdlint

--- a/.github/workflows/check-shell.yaml
+++ b/.github/workflows/check-shell.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
 
       - name: Run shellcheck

--- a/.github/workflows/e2e-all-tests.yaml
+++ b/.github/workflows/e2e-all-tests.yaml
@@ -24,7 +24,7 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           df -h
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
 
       - name: Run E2E Tests

--- a/.github/workflows/e2e-tce-docker-managed-cluster.yaml
+++ b/.github/workflows/e2e-tce-docker-managed-cluster.yaml
@@ -24,7 +24,7 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           df -h
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
 
       - name: Run TCE Docker Managed Cluster E2E Test

--- a/.github/workflows/e2e-tce-docker-standalone-cluster.yaml
+++ b/.github/workflows/e2e-tce-docker-standalone-cluster.yaml
@@ -24,7 +24,7 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           df -h
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
 
       - name: Run TCE Docker Standalone Cluster E2E Test

--- a/.github/workflows/e2e-tce-vsphere-standalone-cluster.yaml
+++ b/.github/workflows/e2e-tce-vsphere-standalone-cluster.yaml
@@ -23,7 +23,7 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           df -h
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
 
       - name: Run TCE vSphere Standalone Cluster E2E Test

--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -25,7 +25,7 @@ jobs:
           git config --global pull.rebase true
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         uses: actions/checkout@v1

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -26,7 +26,7 @@ jobs:
           git config --global pull.rebase true
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         uses: actions/checkout@v1

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -27,7 +27,7 @@ jobs:
           git config --global pull.rebase true
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         uses: actions/checkout@v1

--- a/.github/workflows/update-packages.yaml
+++ b/.github/workflows/update-packages.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
 
       - name: Push


### PR DESCRIPTION
## What this PR does / why we need it

This isn't necessarily true and may confuse people further down the road. The GitHub actions/checkout workflow simply checks out the code into the workflows "workspace". Then, the repository is available for the workflow. It isn't doing anything with go modules or restoring the modcache for use in this workflow. Ref: https://github.com/actions/checkout

## Details for the Release Notes
```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #1387

## Describe testing done for PR

I didn't do any testing. I don't think changing the step name will affect the workflow in any way

## Special notes for your reviewer

As part of this PR I also added the step name for a step in one of the workflows https://github.com/vmware-tanzu/tce/pull/1388/files#diff-8a025d062b2b1ed8d6f6bf798e774c9f10ab9c085506caee01748ee3feab1d21R19
