### PR TITLE
Remove unnecessary GitHub Token from checkout step in GitHub Actions workflows

### DIFF
--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -26,8 +26,6 @@ jobs:
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
       - name: Check out code
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         uses: actions/checkout@v1
 
       - name: Restore Go Cache
@@ -108,8 +106,6 @@ jobs:
           asset_content_type: application/gzip
 
       - name: Checkout for Update
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         uses: actions/checkout@v1
 
       - name: Commit Next Dev Version

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -27,8 +27,6 @@ jobs:
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
       - name: Check out code
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         uses: actions/checkout@v1
 
       - name: Restore Go Cache
@@ -125,8 +123,6 @@ jobs:
           credentials: ${{ secrets.GCP_BUCKET_SA }}
 
       - name: Checkout for Update
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         uses: actions/checkout@v1
 
       - name: Commit Next Dev Version

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -28,8 +28,6 @@ jobs:
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
       - name: Check out code
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         uses: actions/checkout@v1
 
       - name: Restore Go Cache
@@ -126,8 +124,6 @@ jobs:
           credentials: ${{ secrets.GCP_BUCKET_SA }}
 
       - name: Checkout for Update
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         uses: actions/checkout@v1
 
       - name: Commit Next Dev Version


### PR DESCRIPTION
## What this PR does / why we need it

The token isn't really necessary and isn't used, so it's better to remove
them as it's kind of like unused code / dead code

Fixes #1390

## Details for the Release Notes

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #1390 

## Describe testing done for PR

None

## Special notes for your reviewer

None