### PR TITLE
Remove unnecessary checks for github actions

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "**.go"
+      - "**.sh"
+      - ".github/**"
     tags-ignore:
       - "**"
 

--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "**.go"
+      - "**.sh"
+      - ".github/**"
     types:
       - assigned
       - opened
@@ -51,4 +55,4 @@ jobs:
       - name: Build
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: make build-all
+        run: make release

--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -50,4 +50,4 @@ jobs:
       - name: Build
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: make build-all
+        run: make release


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->
We shouldn't run certain long-running actions on certain GitHub actions depending on what is submitted. This helps with minimizing the number of GH API calls we make on these tokens! What has changed:
- We should only build staging binaries when a `go`, `sh`, or `GitHub action` file is modified
- We should perform a full `tarball` build on a PR request only when a `go`, `sh`, or `GitHub action` file is modified
- We should always build the entire `tarball` when merging to main


## Details for the Release Notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
No
