### PR TITLE
Add hash of values as an annotation to force rollout

### DIFF
--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/overlays/update-csi-driver.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/overlays/update-csi-driver.yaml
@@ -1,6 +1,8 @@
 #@ load("/values.star", "values")
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:sha256", "sha256")
 
 #@overlay/match by=overlay.subset({"kind": "Deployment", "metadata": {"name": "vsphere-csi-controller"}})
 ---
@@ -8,6 +10,8 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
+    kapp.k14s.io/update-strategy: fallback-on-replace
+    vsphere-csi/data-values-hash: #@ sha256.sum(yaml.encode(values))
   namespace: #@ values.vsphereCSI.namespace
 
 spec:
@@ -62,9 +66,15 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
+    kapp.k14s.io/update-strategy: fallback-on-replace
+    vsphere-csi/data-values-hash: #@ sha256.sum(yaml.encode(values))
   namespace: #@ values.vsphereCSI.namespace
 spec:
   template:
+    metadata:
+      labels:
+        #@overlay/match missing_ok=True
+        vsphere-csi/data-values-hash: #@ sha256.sum(yaml.encode(values))[:7]
     spec:
       containers:
         #@overlay/match by=overlay.subset({"name": "vsphere-csi-node"})

--- a/addons/packages/vsphere-csi/2.3.0/package.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:a1d643897fba28f052781bbab11c25bdd4e8084c89d656e09b2f617162ab42f3
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:187f0599d16ff12a0190c75158096b1a56a6fe23684b7cbdd27a338fbace9132
       template:
         - ytt:
             paths:


### PR DESCRIPTION
* Adds hash of values as an annotation to force rollout of deployment and daemonset
  so that pods can pick up updated secret
* Add label to daemonset spec.template.metadata.labels to force rollout of daemonset pods.
* Add update-strategy so that resources are recreated if update fails

Signed-off-by: Vijay Katam <vkatam@vmware.com>

## What this PR does / why we need it
Updates to CSI config were not resulting in rollout of new daemonset pods causing them not pick up updated secret

## Details for the Release Notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
Tested that changes to CSI config on vsphere workload cluster ensures csi-controller and daemonset pods are recreated. 
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
