### PR TITLE
Building using correct repo name (`tce` -> `community-edition`) relating to code/scripts/etc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Commands meant to be used directly by developers feature help text. You can see 
 ### Fetch the source
 
 ```shell
-git clone https://github.com/vmware-tanzu/tce
+git clone https://github.com/vmware-tanzu/community-edition
 ```
 
 ### Building the CLI and all plugins from source
@@ -68,7 +68,7 @@ This section describes the process for contributing a bug fix or new feature.
 This project operates according to the _talk, then code_ rule.
 If you plan to submit a pull request for anything more than a typo or obvious bug fix, first you _should_ [raise an issue][new-issue] to discuss your proposal, before submitting any code.
 
-Depending on the size of the feature you may be expected to first write a design proposal. Follow the [Proposal Process](https://github.com/vmware-tanzu/tce/blob/master/GOVERNANCE.md#proposal-process) documented in TCE's Governance.
+Depending on the size of the feature you may be expected to first write a design proposal. Follow the [Proposal Process](https://github.com/vmware-tanzu/community-edition/blob/master/GOVERNANCE.md#proposal-process) documented in TCE's Governance.
 
 ### Commit message and PR guidelines
 
@@ -180,7 +180,7 @@ By making a contribution to this project, I certify that:
     this project or the open source license(s) involved.
 ```
 
-[new-issue]: https://github.com/vmware-tanzu/tce/issues/new/choose
+[new-issue]: https://github.com/vmware-tanzu/community-edition/issues/new/choose
 
 ### Multiple Go Modules
 

--- a/Makefile
+++ b/Makefile
@@ -151,11 +151,11 @@ release-docker: release-env-check ### builds and produces the release packaging/
 		-e HOME=/go \
 		-e GH_ACCESS_TOKEN=${GH_ACCESS_TOKEN} \
 		-e GITLAB_CI_BUILD=true \
-		-w /go/src/tce \
-		-v ${PWD}:/go/src/tce \
+		-w /go/src/community-edition \
+		-v ${PWD}:/go/src/community-edition \
 		-v /tmp:/tmp \
 		golang:1.16.2 \
-		sh -c "cd /go/src/tce &&\
+		sh -c "cd /go/src/community-edition &&\
 			./hack/fix-for-ci-build.sh &&\
 			make release"
 
@@ -276,7 +276,7 @@ get-package-config: # Extracts the package values.yaml file. Usage: make get-pac
 	&& rm -rf $${TEMP_DIR}
 
 test-packages-unit: check-carvel
-	$(GO) test -coverprofile cover.out -v `go list ./... | grep github.com/vmware-tanzu/tce/addons/packages | grep -v e2e`
+	$(GO) test -coverprofile cover.out -v `go list ./... | grep github.com/vmware-tanzu/community-edition/addons/packages | grep -v e2e`
 
 create-repo: # Usage: make create-repo NAME=my-repo
 	cp hack/packages/templates/repo.yaml addons/repos/${NAME}.yaml

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ requirements without having to start from scratch.
 ## Architectures / Designs
 
 To support our [_talk, then
-code_](https://github.com/vmware-tanzu/tce/blob/main/CONTRIBUTING.md#before-you-submit-a-pull-request)
+code_](https://github.com/vmware-tanzu/community-edition/blob/main/CONTRIBUTING.md#before-you-submit-a-pull-request)
 approach, all implementation (both completed and intended) is captured in the
 following.
 

--- a/cli/cmd/plugin/conformance/go.mod
+++ b/cli/cmd/plugin/conformance/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmware-tanzu/tce/cli/cmd/plugin/conformance
+module github.com/vmware-tanzu/community-edition/cli/cmd/plugin/conformance
 
 go 1.16
 

--- a/cli/cmd/plugin/conformance/main.go
+++ b/cli/cmd/plugin/conformance/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"os"
 
-	conformance "github.com/vmware-tanzu/tce/cli/cmd/plugin/conformance/pkg"
+	conformance "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/conformance/pkg"
 
 	klog "k8s.io/klog/v2"
 

--- a/cli/cmd/plugin/standalone-cluster/go.mod
+++ b/cli/cmd/plugin/standalone-cluster/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmware-tanzu/tce
+module github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster
 
 go 1.16
 

--- a/cli/cmd/plugin/standalone-cluster/go.sum
+++ b/cli/cmd/plugin/standalone-cluster/go.sum
@@ -1327,8 +1327,6 @@ github.com/vmware-tanzu/carvel-vendir v0.19.0 h1:4FTeDcxwEuZWdFlFqh+11NqnJciCkkO
 github.com/vmware-tanzu/carvel-vendir v0.19.0/go.mod h1:HF7iLB0NyEFHuCvM0EJ42fERk20l2ImpktJzhSEdqOU=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159 h1:c7sM3NrAQGmTvq57Aw96BBzBO67apYZpZs/51PfjddA=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159/go.mod h1:1DBZEj6GmcWxe77d8YOeac1JIa8ttP21uTHUlAyji2g=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819135111-fc80ab1ae92e h1:ED20wrKr+6/n1b0ZS9eTDdIAayMq/QtmV8xo/65iUx0=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819135111-fc80ab1ae92e/go.mod h1:2ph3SY8wu6ZX0Z350YJe0f/1DdHkIE320jIHKH/WQC4=
 github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819152703-b3f599310640 h1:zp8tXeEwxvl0UrsvKlxeAX63O09Az/KQH6+LyuziY1E=
 github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210819152703-b3f599310640/go.mod h1:2ph3SY8wu6ZX0Z350YJe0f/1DdHkIE320jIHKH/WQC4=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/docs/site/config.yaml
+++ b/docs/site/config.yaml
@@ -37,9 +37,9 @@ menu:
     url: /docs/contributing/
 params:
   twitter_url: "https://twitter.com/"
-  github_url: "https://github.com/vmware-tanzu/tce"
+  github_url: "https://github.com/vmware-tanzu/community-edition"
   slack_url: "https://slack.com/"
-  github_base_url: "https://github.com/vmware-tanzu/tce"
+  github_base_url: "https://github.com/vmware-tanzu/community-edition"
   use_advanced_docs: true
   docs_right_sidebar: true
   docs_search: false

--- a/docs/site/content/community/_index.html
+++ b/docs/site/content/community/_index.html
@@ -16,7 +16,7 @@ layout: section
                 <img src="/img/github-image.svg" />
             </div>
             <div class="content">
-                <h3><a href="https://github.com/vmware-tanzu/tce">Dig into the Code on GitHub</a></h3>
+                <h3><a href="https://github.com/vmware-tanzu/community-edition">Dig into the Code on GitHub</a></h3>
                 <p>Get familiar with our code. File and help us resolve issues. Participate in the discussions.</p>
             </div>
         </div>

--- a/docs/site/content/docs/assets/cli-install-linux.md
+++ b/docs/site/content/docs/assets/cli-install-linux.md
@@ -1,11 +1,11 @@
-1. Download the release for [Linux](https://github.com/vmware-tanzu/tce/releases/download/v0.7.0/tce-linux-amd64-v0.7.0.tar.gz) via web browser.
+1. Download the release for [Linux](https://github.com/vmware-tanzu/community-edition/releases/download/v0.7.0/tce-linux-amd64-v0.7.0.tar.gz) via web browser.
 
 1. _[Alternative]_ Download the release using CLI
 
     ```sh
     curl -H "Authorization: token ${GH_ACCESS_TOKEN}" \
         -H "Accept: application/vnd.github.v3.raw" \
-        -L https://api.github.com/repos/vmware-tanzu/tce/contents/hack/get-tce-release.sh | \
+        -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/get-tce-release.sh | \
         bash -s RELEASE_VERSION DISTRIBUTION
     ```
 

--- a/docs/site/content/docs/assets/cli-install-mac.md
+++ b/docs/site/content/docs/assets/cli-install-mac.md
@@ -1,4 +1,4 @@
-1. Download the release for [macOS](https://github.com/vmware-tanzu/tce/releases/download/v0.7.0/tce-darwin-amd64-v0.7.0.tar.gz).
+1. Download the release for [macOS](https://github.com/vmware-tanzu/community-edition/releases/download/v0.7.0/tce-darwin-amd64-v0.7.0.tar.gz).
 
 1. Unpack the release.
 

--- a/docs/site/content/docs/assets/cli-install-windows.md
+++ b/docs/site/content/docs/assets/cli-install-windows.md
@@ -1,4 +1,4 @@
-1. Download the release for [Windows](https://github.com/vmware-tanzu/tce/releases/download/v0.7.0/tce-windows-amd64-v0.7.0.tar.gz).
+1. Download the release for [Windows](https://github.com/vmware-tanzu/community-edition/releases/download/v0.7.0/tce-windows-amd64-v0.7.0.tar.gz).
 
 1. Open a Command Prompt as an administrator, change to the download directory and unpack the release, for example,
 

--- a/docs/site/content/docs/assets/package-installation.md
+++ b/docs/site/content/docs/assets/package-installation.md
@@ -76,7 +76,7 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
     ```
 
 1. [Optional]: Download the configuration for a package. For the moment, you will need to refer to the
-   [TCE GitHub repository](https://github.com/vmware-tanzu/tce/tree/main/addons/packages). Select the package/version
+   [TCE GitHub repository](https://github.com/vmware-tanzu/community-edition/tree/main/addons/packages). Select the package/version
    and navigate into the `bundle/config` directory. Download or copy/paste the `values.yaml` file.
 
 1. [Optional]: Alter the values.yaml file.

--- a/docs/site/content/docs/assets/tce-feedback.md
+++ b/docs/site/content/docs/assets/tce-feedback.md
@@ -1,5 +1,5 @@
 ## 📋 Feedback
 
 Thank you for trying Tanzu Community Edition! Please be sure to [fill out our survey](https://tb3xduryx4x.typeform.com/to/RVmhMHwR) and [leave feedback
-here](https://github.com/vmware-tanzu/tce/issues/new?assignees=&labels=feedback&template=feedback-on-tanzu-community-edition-template.md&title=)
+here](https://github.com/vmware-tanzu/community-edition/issues/new?assignees=&labels=feedback&template=feedback-on-tanzu-community-edition-template.md&title=)
 after trying this guide!

--- a/docs/site/themes/template/layouts/partials/contributors.html
+++ b/docs/site/themes/template/layouts/partials/contributors.html
@@ -2,10 +2,10 @@
   <div class="wrapper">
       <h2>Meet the Tanzu Community Edition Team</h2>
       <p>
-        Tanzu Community Edition is the result of lots of work by our <a href="https://github.com/vmware-tanzu/tce/blob/main/MAINTAINERS.md">dedicated team</a> of maintainers, core contributors, and stakeholders. We are very happy to release it as an open source software project, and we welcome you to join us as a user or as a contributor yourself.
+        Tanzu Community Edition is the result of lots of work by our <a href="https://github.com/vmware-tanzu/community-edition/blob/main/MAINTAINERS.md">dedicated team</a> of maintainers, core contributors, and stakeholders. We are very happy to release it as an open source software project, and we welcome you to join us as a user or as a contributor yourself.
       </p>
       <p>
-        You can get support through our GitHub project page.  If you encounter an issue or have a question, feel free to reach out on the GitHub <a href="https://github.com/vmware-tanzu/tce/issues">issues page</a> for Tanzu Community Edition.  Please see our <a href="https://github.com/vmware-tanzu/tce/blob/main/CONTRIBUTING.md">contributing</a> document for more information about contributing to the project.
+        You can get support through our GitHub project page.  If you encounter an issue or have a question, feel free to reach out on the GitHub <a href="https://github.com/vmware-tanzu/community-edition/issues">issues page</a> for Tanzu Community Edition.  Please see our <a href="https://github.com/vmware-tanzu/community-edition/blob/main/CONTRIBUTING.md">contributing</a> document for more information about contributing to the project.
       </p>
       <div class="grid three">
         {{ $contributors := .Site.GetPage "/contributors" }}

--- a/hack/asset/asset.go
+++ b/hack/asset/asset.go
@@ -48,7 +48,7 @@ func getDraftRelease(tag string) (*github.RepositoryRelease, error) {
 	}
 
 	opt := &github.ListOptions{}
-	releasesGH, _, err := client.Repositories.ListReleases(context.Background(), "vmware-tanzu", "tce", opt)
+	releasesGH, _, err := client.Repositories.ListReleases(context.Background(), "vmware-tanzu", "community-edition", opt)
 	if err != nil {
 		fmt.Printf("Repositories.ListReleases returned error: %v\n", err)
 		return nil, err
@@ -90,7 +90,7 @@ func uploadToDraftRelease(release *github.RepositoryRelease, fullPathFilename st
 	opt := &github.UploadOptions{
 		Name: filename,
 	}
-	_, _, err = client.Repositories.UploadReleaseAsset(context.Background(), "vmware-tanzu", "tce", *release.ID, opt, fileAsset)
+	_, _, err = client.Repositories.UploadReleaseAsset(context.Background(), "vmware-tanzu", "community-edition", *release.ID, opt, fileAsset)
 	if err != nil {
 		fmt.Printf("Repositories.UploadReleaseAsset returned error: %v\n", err)
 		return err

--- a/hack/asset/go.mod
+++ b/hack/asset/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmware-tanzu/tce/hack/asset
+module github.com/vmware-tanzu/community-edition/hack/asset
 
 go 1.16
 

--- a/hack/get-tce-release.sh
+++ b/hack/get-tce-release.sh
@@ -33,7 +33,7 @@ tag=$1
 name=$2
 
 GH_API="https://api.github.com"
-GH_REPO="$GH_API/repos/vmware-tanzu/tce"
+GH_REPO="$GH_API/repos/vmware-tanzu/community-edition"
 GH_TAGS="$GH_REPO/releases/tags/$tag"
 AUTH="Authorization: token $GH_ACCESS_TOKEN"
 CURL_ARGS="-LJO#"

--- a/hack/package-release.sh
+++ b/hack/package-release.sh
@@ -108,9 +108,9 @@ cp -f "${ROOT_REPO_DIR}/hack/install.sh" "${PACKAGE_DARWIN_AMD64_DIR}"
 cp -f "${ROOT_REPO_DIR}/hack/uninstall.sh" "${PACKAGE_DARWIN_AMD64_DIR}"
 cp -f "${ROOT_REPO_DIR}/hack/install.bat" "${PACKAGE_WINDOWS_AMD64_DIR}"
 cp -f "${ROOT_REPO_DIR}/hack/uninstall.bat" "${PACKAGE_WINDOWS_AMD64_DIR}"
-chown -R "$USER":"$(id -g -n "$USER")" "${PACKAGE_LINUX_AMD64_DIR}"
-chown -R "$USER":"$(id -g -n "$USER")" "${PACKAGE_DARWIN_AMD64_DIR}"
-chown -R "$USER":"$(id -g -n "$USER")" "${PACKAGE_WINDOWS_AMD64_DIR}"
+chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_LINUX_AMD64_DIR}"
+chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_DARWIN_AMD64_DIR}"
+chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_WINDOWS_AMD64_DIR}"
 
 # packaging
 rm -f tce-linux-amd64-*.tar.gz

--- a/hack/packages/go.mod
+++ b/hack/packages/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmware-tanzu/tce/hack/packages
+module github.com/vmware-tanzu/community-edition/hack/packages
 
 go 1.16
 

--- a/hack/release/go.mod
+++ b/hack/release/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmware-tanzu/tce/hack/release
+module github.com/vmware-tanzu/community-edition/hack/release
 
 go 1.16
 

--- a/hack/release/release.go
+++ b/hack/release/release.go
@@ -79,7 +79,7 @@ func getDraftRelease(tag string) (*github.RepositoryRelease, error) {
 	}
 
 	opt := &github.ListOptions{}
-	releasesGH, _, err := client.Repositories.ListReleases(context.Background(), "vmware-tanzu", "tce", opt)
+	releasesGH, _, err := client.Repositories.ListReleases(context.Background(), "vmware-tanzu", "community-edition", opt)
 	if err != nil {
 		fmt.Printf("Repositories.ListReleases returned error: %v\n", err)
 		return nil, err
@@ -119,7 +119,7 @@ func updateReleaseNotesOnDraft(release *github.RepositoryRelease, fullPathFilena
 
 	strNotes := string(notes)
 	release.Body = &strNotes
-	_, _, err = client.Repositories.EditRelease(context.Background(), "vmware-tanzu", "tce", *release.ID, release)
+	_, _, err = client.Repositories.EditRelease(context.Background(), "vmware-tanzu", "community-edition", *release.ID, release)
 	if err != nil {
 		fmt.Printf("Repositories.EditRelease returned error: %v\n", err)
 		return err

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmware-tanzu/tce/hack/tools
+module github.com/vmware-tanzu/community-edition/hack/tools
 
 go 1.16
 

--- a/test/add-tce-package-repo.sh
+++ b/test/add-tce-package-repo.sh
@@ -16,7 +16,7 @@ REPO_NAME="tce-main-latest"
 REPO_URL="projects.registry.vmware.com/tce/main:latest"
 REPO_NAMESPACE="default"
 
-# TODO: Use stable version of the tce/main repo once https://github.com/vmware-tanzu/tce/issues/1250 is fixed
+# TODO: Use stable version of the tce/main repo once https://github.com/vmware-tanzu/community-edition/issues/1250 is fixed
 tanzu package repository add ${REPO_NAME} --namespace ${REPO_NAMESPACE} --url ${REPO_URL}
 
 # Wait for reconcilation to happen within ~ 80 x 5 = 400 seconds . 80 iterations, 5 seconds sleep time.


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->
This changes all the repo names from `tce` to `community-edition` for all code and some of the immediately obvious documentation needs. *The addons/packages has not been addressed.* The rename of the repo is actually transparent to the end-user this is just to conform to github best practices defined here:
https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/renaming-a-repository

## Details for the Release Notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
This changes all build/code references from `tce` to `community-edition` to hande the rename of the repo.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/1122

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
I performed a `make release` and it built successfully.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
The rename of the repo is actually transparent to the end-user this is just to conform to github best practices defined here:
https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/renaming-a-repository