### PR TITLE
Fix linting coverage and issues

### DIFF
--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -25,31 +25,5 @@ jobs:
         run: |
           git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
-      - name: Run golangci-lint - standalone
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.38.0
-          args: --timeout=10m -v
-          working-directory: cli/cmd/plugin/standalone-cluster
-
-      - name: Run golangci-lint - hack/asset
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.38.0
-          args: --timeout=10m -v
-          working-directory: hack/asset
-
-      - name: Run golangci-lint - hack/packages
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.38.0
-          args: --timeout=10m -v
-          working-directory: hack/packages
-
-      - name: Run golangci-lint - hack/release
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.38.0
-          args: --timeout=10m -v
-          working-directory: hack/release
-
+      - name: Run golangci-lint
+        run: make lint

--- a/addons/packages/external-dns/test/e2e/externaldns_suite_test.go
+++ b/addons/packages/external-dns/test/e2e/externaldns_suite_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/addons/packages/external-dns/test/e2e/externaldns_test.go
+++ b/addons/packages/external-dns/test/e2e/externaldns_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/addons/packages/external-dns/test/go.mod
+++ b/addons/packages/external-dns/test/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/onsi/ginkgo v1.16.4
-	github.com/onsi/gomega v1.13.0
+	github.com/onsi/gomega v1.16.0
 	github.com/vmware-tanzu/tce/addons/packages/test/pkg v0.0.0-00010101000000-000000000000
 )
 

--- a/addons/packages/test/pkg/go.mod
+++ b/addons/packages/test/pkg/go.mod
@@ -1,3 +1,9 @@
 module github.com/vmware-tanzu/tce/addons/packages/test/pkg
 
 go 1.16
+
+require (
+	github.com/onsi/ginkgo v1.16.4
+	github.com/onsi/gomega v1.16.0
+	k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e
+)

--- a/addons/packages/test/pkg/go.sum
+++ b/addons/packages/test/pkg/go.sum
@@ -95,4 +95,5 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
+k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e h1:ldQh+neBabomh7+89dTpiFAB8tGdfVmuIzAHbvtl+9I=
 k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/addons/packages/test/pkg/repo/repo.go
+++ b/addons/packages/test/pkg/repo/repo.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package repo
 
 import (

--- a/addons/packages/test/pkg/utils/cli.go
+++ b/addons/packages/test/pkg/utils/cli.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/addons/packages/test/pkg/utils/file.go
+++ b/addons/packages/test/pkg/utils/file.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/addons/packages/test/pkg/utils/validation.go
+++ b/addons/packages/test/pkg/utils/validation.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/addons/packages/test/pkg/ytt/ytt.go
+++ b/addons/packages/test/pkg/ytt/ytt.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package ytt
 
 import (
@@ -38,7 +41,7 @@ func (ytt *Command) RenderTemplate(filePaths []string, input io.Reader) (string,
 
 	args := ytt.buildArgs(filePaths, input)
 
-	cmd := exec.Command(ytt.path, args...)
+	cmd := exec.Command(ytt.path, args...) //nolint
 	cmd.Stdin = input
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -76,13 +79,11 @@ func (ytt *Command) buildArgs(filePaths []string, input io.Reader) []string {
 	}
 
 	for _, filePath := range filePaths {
-		args = append(args, "-f")
-		args = append(args, filePath)
+		args = append(args, "-f", filePath)
 	}
 
 	if input != nil {
-		args = append(args, "-f")
-		args = append(args, "-")
+		args = append(args, "-f", "-")
 	}
 
 	return args

--- a/cli/cmd/plugin/conformance/pkg/version.go
+++ b/cli/cmd/plugin/conformance/pkg/version.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/vmware-tanzu/sonobuoy/pkg/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
 )
 
-// Implement a custom version command because we cannot expose both
+// VersionCmd implements a custom version command because we cannot expose both
 // TCE and Sonobuoy via a PluginDescriptor's `Version` field, which
 // needs a strict semantic version-compatible string.
 var VersionCmd = NewCmdVersion()

--- a/cli/cmd/plugin/conformance/test/test.go
+++ b/cli/cmd/plugin/conformance/test/test.go
@@ -1,1 +1,4 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package test


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

The linting job runs within the scope of a module, so for each module
added to the repo, the linting target would need to be updated to cover
each one. Modules have been added, but linting wasn't covering them
because this was missed.

This updates the linting target to pick up all submodules in the repo.
It also fixes uncovered by this additional coverage.

## Details for the Release Notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #1414

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

`make lint`
