### PR TITLE
Remove obsolete comment from package readme files #1422

### DIFF
--- a/addons/packages/cert-manager/1.3.1/README.md
+++ b/addons/packages/cert-manager/1.3.1/README.md
@@ -1,8 +1,4 @@
-# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
-
-File is available here on docs branch: ``docs\site\content\docs\latest\cert-manager-config``
-
-## cert-manager
+# cert-manager
 
 This package provides certificate management functionality using [cert-manager](https://cert-manager.io/docs/).
 

--- a/addons/packages/contour/1.15.1/README.md
+++ b/addons/packages/contour/1.15.1/README.md
@@ -1,8 +1,4 @@
-# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
-
-File is available here on docs branch: ``docs\site\content\docs\latest\contour-config``
-
-## Contour Package
+# Contour Package
 
 This package provides an ingress controller using [Contour](https://projectcontour.io/).
 

--- a/addons/packages/contour/1.17.1/README.md
+++ b/addons/packages/contour/1.17.1/README.md
@@ -1,8 +1,4 @@
-# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
-
-File is available here on docs branch: ``docs\site\content\docs\latest\contour-config``
-
-## Contour Package
+# Contour Package
 
 This package provides an ingress controller using [Contour](https://projectcontour.io/).
 

--- a/addons/packages/external-dns/0.8.0/README.md
+++ b/addons/packages/external-dns/0.8.0/README.md
@@ -1,8 +1,4 @@
-# THIS CONTENT HAS MOVED TO THE DOCS BRANCH: PLEASE MAKE ANY FURTHER UPDATES THERE**
-
-File is available here on docs branch: ``docs\site\content\docs\latest\externaldns-config``
-
-## ExternalDNS
+# ExternalDNS
 
 [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 

--- a/addons/packages/fluent-bit/1.7.5/README.md
+++ b/addons/packages/fluent-bit/1.7.5/README.md
@@ -1,8 +1,4 @@
-# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
-
-File is available here on docs branch: ``docs\site\content\docs\latest\fluentbit-config``
-
-## Fluent Bit
+# Fluent Bit
 
 > Fluent Bit is an open source Log Processor and Forwarder which allows you to collect any data like metrics and logs from different sources, enrich them with filters and send them to multiple destinations.
 

--- a/addons/packages/gatekeeper/3.2.3/README.md
+++ b/addons/packages/gatekeeper/3.2.3/README.md
@@ -1,8 +1,4 @@
-# THIS CONTENT HAS MOVED TO THE DOCS BRANCH IN:  PLEASE MAKE ANY FURTHER UPDATES THERE
-
-File is available here on docs branch: ``docs\site\content\docs\latest\gatekeeper-config``
-
-## Gatekeeper
+# Gatekeeper
 
 This package provides custom admission control using
 [gatekeeper](https://github.com/open-policy-agent/gatekeeper). Under the hood,

--- a/addons/packages/grafana/7.5.7/README.md
+++ b/addons/packages/grafana/7.5.7/README.md
@@ -1,8 +1,4 @@
-# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
-
-File is available here on docs branch: ``docs\site\content\docs\latest\grafana-config``  
-
-## Grafana
+# Grafana
 
 Grafana is open source visualization and analytics software. It allows you to query, visualize, alert on, and explore your metrics no matter where they are stored. In plain English, it provides you with tools to turn your time-series database (TSDB) data into beautiful graphs and visualizations.
 

--- a/addons/packages/knative-serving/0.22.0/README.md
+++ b/addons/packages/knative-serving/0.22.0/README.md
@@ -1,8 +1,4 @@
-# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
-
-File is available here on docs branch: ``docs\site\content\docs\latest\knative-config``  
-
-## Knative Serving
+# Knative Serving
 
 This package provides serverless functionality using [Knative](https://knative.dev/).
 

--- a/addons/packages/velero/1.5.2/README.md
+++ b/addons/packages/velero/1.5.2/README.md
@@ -1,8 +1,4 @@
-# THIS CONTENT HAS MOVED TO THE DOCS BRANCH:  PLEASE MAKE ANY FURTHER UPDATES THERE
-
-File is available here on docs branch: ``docs\site\content\docs\latest\velero-config``  
-
-## Velero
+# Velero
 
 This package provides disaster recovery capabilities using [velero](https://velero.io/). At the moment, it leverages [minio](https://github.com/minio/minio) for object storage.
 


### PR DESCRIPTION
## What this PR does / why we need it

The comment,

`# THIS CONTENT HAS MOVED TO THE DOCS BRANCH: PLEASE MAKE ANY FURTHER UPDATES THERE`,

should be removed as it is obsolete. Readme files will be copied to the docs
directory automatically per #1146

## Details for the Release Notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1422

## Describe testing done for PR

No testing is necessary for this documentation update.

## Special notes for your reviewer

none