### PR TITLE
making steps generic for all OS

### DIFF
--- a/docs/site/content/docs/assets/aws-clusters.md
+++ b/docs/site/content/docs/assets/aws-clusters.md
@@ -3,29 +3,31 @@
 This section describes setting up management and workload clusters for
 Amazon EC2.
 
-1. Initialize the Tanzu kickstart UI.
+1. Initialize the Tanzu Community Edition installer interface.
 
     ```sh
     tanzu management-cluster create --ui
     ```
 
-1. Go through the installation process for Amazon EC2. With the following
-   considerations:
+1. Complete the configuration steps in the installer interface and create the management cluster. The following configuration settings are recommended:
 
 
-   *  If you do not specify a name, the installer generates a unique name. If you do specify a name, the name must end with a letter, not a numeric character, and must be compliant with DNS hostname requirements described here: [RFC 1123](https://tools.ietf.org/html/rfc1123).
-   * Check the "Automate creation of AWS CloudFormation Stack" box if you do not have an existing TKG CloudFormation stack. This stack is used to created IAM resources that TCE clusters use in Amazon EC2.
-     You only need 1 TKG CloudFormation stack per AWS account. CloudFormation is global and not locked to a region. For more information, see [Required IAM resources](../ref-aws/#permissions).
+   *  If you do not specify a name, the installer interface for Amazon EC2 generates a unique name. If you do specify a name, the name must end with a letter, not a numeric character, and must be compliant with DNS hostname requirements described here: [RFC 1123](https://tools.ietf.org/html/rfc1123).
+   * Check the "Automate creation of AWS CloudFormation Stack" box if you do not have an existing CloudFormation stack. This stack is used to created IAM resources that Tanzu Community Edition clusters use in Amazon EC2.
+     You only need 1 CloudFormation stack per AWS account. CloudFormation is global and not locked to a region. For more information, see [Required IAM resources](../ref-aws/#permissions).
 
    * Set the instance type size to m5.xlarge or larger for both the control plane node and worker node.
 
-   * Disable **Enable Identity Management Settings**. You can disable identity management for proof-of-concept/development deployments, but it is strongly recommended to implement identity management in production deployments. For more information about enabling Identity Management, see [Identity Management ](aws-install-mgmt/#step-6-identity-management).
+   * Disable **Enable Identity Management Settings**. You can disable identity management for proof-of-concept/development deployments, but it is strongly recommended to implement identity management in production deployments. For more information about enabling Identity Management, see [Identity Management](../aws-install-mgmt/#step-6-identity-management).
 
-1. Validate the management cluster started successfully.
+2. Validate the management cluster started successfully.
 
     ```sh
     tanzu management-cluster get
+    ```
+    The output will look similar to the following:
 
+    ```sh
     NAME  NAMESPACE   STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES
     mtce  tkg-system  running  1/1           1/1      v1.20.1+vmware.2  management
 
@@ -49,61 +51,52 @@ Amazon EC2.
     capi-system                        cluster-api            CoreProvider            cluster-api   v0.3.14
     ```
 
-1. Create a cluster names that will be used throughout this Getting Started guide.  `MGMT_CLUSTER_NAME` should be set to whatever value is returned by `tanzu management-cluster get` above. Choose a name for ``WORKLOAD_CLUSTER_NAME``.  The workload cluster names must be must be 42 characters or less and must comply with DNS hostname requirements as described here: [RFC 1123](https://tools.ietf.org/html/rfc1123).
+3. Capture the management cluster's kubeconfig and take note of the command for accessing the cluster in the output message, as you will use this for setting the context in the next step.
 
     ```sh
-    export MGMT_CLUSTER_NAME="<INSERT_MGMT_CLUSTER_NAME_HERE>"
-    export WORKLOAD_CLUSTER_NAME="<INSERT_WORKLOAD_CLUSTER_NAME_HERE>"
+    tanzu management-cluster kubeconfig get <MGMT-CLUSTER-NAME> --admin
     ```
-
-1. Capture the management cluster's kubeconfig.
-
+    Where <``MGMT-CLUSTER-NAME>`` should be set to the name returned by `tanzu management-cluster get`.  <br><br>
+    For example, if your management cluster is called 'mtce', you will see a message similar to:
     ```sh
-    tanzu management-cluster kubeconfig get ${MGMT_CLUSTER_NAME} --admin
-
-    Credentials of workload cluster 'mtce' have been saved
+    Credentials of workload cluster 'mtce' have been saved.
     You can now access the cluster by running 'kubectl config use-context mtce-admin@mtce'
     ```
 
-    > Note the context name `${MGMT_CLUSTER_NAME}-admin@${MGMT_CLUSTER_NAME}`, you'll use the above command in
-    > future steps.
-
-1. Set your kubectl context to the management cluster.
+4. Set your kubectl context to the management cluster.
 
     ```sh
-    kubectl config use-context ${MGMT_CLUSTER_NAME}-admin@${MGMT_CLUSTER_NAME}
+    kubectl config use-context <MGMT-CLUSTER-NAME>-admin@<MGMT-CLUSTER-NAME>
     ```
-
-1. Validate you can access the management cluster's API server.
+    Where <``MGMT-CLUSTER-NAME>`` should be set to the name returned by `tanzu management-cluster get`.
+5. Validate you can access the management cluster's API server.
 
     ```sh
     kubectl get nodes
-
+    ```
+    The output will look similar to the following:
+    ```sh
     NAME                                       STATUS   ROLES                  AGE    VERSION
     ip-10-0-1-133.us-west-2.compute.internal   Ready    <none>                 123m   v1.20.1+vmware.2
     ip-10-0-1-76.us-west-2.compute.internal    Ready    control-plane,master   125m   v1.20.1+vmware.2
     ```
 
-1. Next you will create a workload cluster. First, setup a workload cluster config file.
+6. Next, you will create a workload cluster. First, create a workload cluster configuration file by taking a copy of the management cluster YAML configuration file that was created when you deployed your management cluster. This example names the workload cluster configuration file ``workload1.yaml``.
+
 
     ```sh
     cp  ~/.config/tanzu/tkg/clusterconfigs/<MGMT-CONFIG-FILE> ~/.config/tanzu/tkg/clusterconfigs/workload1.yaml
     ```
 
-   > ``<MGMT-CONFIG-FILE>`` is the name of the management cluster YAML config file
+   * Where ``<MGMT-CONFIG-FILE>`` is the name of the management cluster YAML configuration file. The management cluster YAML configuration file will either have the name you assigned to the management cluster, or if no name was assigned, it will be a randomly generated name.
 
-   > This step duplicates the configuration file that was created when you deployed your management cluster. The configuration file will either have the name you assigned to the management cluster, or if no name was assigned, it will be a randomly generated name.
-
-   > This duplicated file will be used as the configuration file for your workload cluster. You can edit the parameters in this new  file as required. For an example of a workload cluster template, see  [Amazon EC2 Workload Cluster Template](../aws-wl-template).
-
-   [](ignored)
-
-   > In the next two steps you will edit the parameters in this new file (`workload1`) and then use the file to deploy a workload cluster.
-
-   [](ignored)
+   * The duplicated file (``workload1.yaml``) will be used as the configuration file for your workload cluster. You can edit the parameters in this new  file as required. For an example of a workload cluster template, see  [Amazon EC2 Workload Cluster Template](../aws-wl-template).
 
 
-1. In the new workload cluster file (`~/.config/tanzu/tkg/clusterconfigs/workload1.yaml`), edit the CLUSTER_NAME parameter to assign a name to your guest cluster. For example,
+   * In the next two steps you will edit the parameters in this new file (`workload1.yaml`) and then use the file to deploy a workload cluster.
+
+
+7. In the new workload cluster file (`~/.config/tanzu/tkg/clusterconfigs/workload1.yaml`), edit the CLUSTER_NAME parameter to assign a name to your workload cluster. For example,
 
 
    ```yaml
@@ -111,42 +104,43 @@ Amazon EC2.
    CLUSTER_NAME: my-workload-cluster
    CLUSTER_PLAN: dev
    ```
-   #### Note
-   * If you did not specify a name for your management cluster, the installer generated a random unique name. In this case, you must manually add the CLUSTER_NAME parameter and assign a workload cluster name.
+
+   * If you did not specify a name for your management cluster, the installer generated a random unique name. In this case, you must manually add the CLUSTER_NAME parameter and assign a workload cluster name. The workload cluster names must be must be 42 characters or less and must comply with DNS hostname requirements as described here: [RFC 1123](https://tools.ietf.org/html/rfc1123)
    * If you specified a name for your management cluster, the CLUSTER_NAME parameter is present and needs to be changed to the new workload cluster name.
-   > The other parameters in ``workload1.yaml`` are likely fine as-is. However, you can change them as required. Reference an example configuration template here:  [Amazon EC3 Workload Cluster Template](../aws-wl-template).
+   * The other parameters in ``workload1.yaml`` are likely fine as-is. However, you can change them as required. Validation is performed on the file prior to applying it, so the `tanzu` command will return a message if something necessary is omitted. Reference an example configuration template here:  [Amazon EC2 Workload Cluster Template](../aws-wl-template).
 
-   > Validation is performed on the file prior to applying it, so the `tanzu` command will return a message if something necessary is omitted.
-
-1. Create your workload cluster.
+8. Create your workload cluster.
 
     ```sh
-    tanzu cluster create ${WORKLOAD_CLUSTER_NAME} --file ${HOME}/.tanzu/tkg/clusterconfigs/workload1.yaml
+    tanzu cluster create <WORKLOAD-CLUSTER-NAME> --file ~/.config/tanzu/tkg/clusterconfigs/workload1.yaml
     ```
 
-1. Validate the cluster starts successfully.
+9. Validate the cluster starts successfully.
 
     ```sh
     tanzu cluster list
     ```
 
-1. Capture the workload cluster's kubeconfig.
+10. Capture the workload cluster's kubeconfig.
 
     ```sh
-    tanzu cluster kubeconfig get ${WORKLOAD_CLUSTER_NAME} --admin
+    tanzu cluster kubeconfig get <WORKLOAD-CLUSTER-NAME> --admin
     ```
 
-1. Set your `kubectl` context accordingly.
+11. Set your `kubectl` context to the workload cluster.
 
     ```sh
-    kubectl config use-context ${WORKLOAD_CLUSTER_NAME}-admin@${WORKLOAD_CLUSTER_NAME}
+    kubectl config use-context <WORKLOAD-CLUSTER-NAME>-admin@<WORKLOAD-CLUSTER-NAME>
     ```
 
-1. Verify you can see pods in the cluster.
+12. Verify you can see pods in the cluster.
 
     ```sh
     kubectl get pods --all-namespaces
+    ```
+    The output will look similar to the following:
 
+    ```sh
     NAMESPACE     NAME                                                    READY   STATUS    RESTARTS   AGE
     kube-system   antrea-agent-9d4db                                      2/2     Running   0          3m42s
     kube-system   antrea-agent-vkgt4                                      2/2     Running   1          5m48s

--- a/docs/site/content/docs/assets/aws-standalone-clusters.md
+++ b/docs/site/content/docs/assets/aws-standalone-clusters.md
@@ -2,42 +2,37 @@
 
 This section covers setting up a standalone cluster in Amazon EC2. A standalone cluster provides a workload cluster that is **not** managed by a centralized management cluster.
 
-1. Initialize the Tanzu kickstart UI.
+1. Initialize the Tanzu Community Edition Installer Interface.
 
     ```sh
     tanzu standalone-cluster create --ui
     ```
 
-1. Go through the configuration steps, considering the following.
+1. Complete the configuration steps in the installer interface and create the standalone cluster. The following configuration settings are recommended:
 
 
    * Check the "Automate creation of AWS CloudFormation Stack" box if you do not have an existing TKG CloudFormation stack. This stack is used to created IAM resources that Tanzu Community Edition clusters use in Amazon EC2.
      You only need 1 TKG CloudFormation stack per AWS account. CloudFormation is global and not locked to a region.
-  
+
    * Set the instance type size to m5.xlarger or larger for the control plane node.
 
    * Disable **Enable Identity Management Settings**. You can disable identity management for proof-of-concept/development deployments, but it is strongly recommended to implement identity management in production deployments.
 
-1. At the end of the UI, deploy the cluster.
-
-1. Store the name of your cluster (set during configuration or automatically generated) to a
-   `STANDALONE_CLUSTER_NAME` environment variable.
-
-    ```sh
-    export STANDALONE_CLUSTER_NAME="<INSERT_STANDALONE_CLUSTER_NAME_HERE>"
-    ```
-
 1. Set your kubectl context to the cluster.
 
     ```sh
-    kubectl config use-context ${STANDALONE_CLUSTER_NAME}-admin@${STANDALONE_CLUSTER_NAME}
+    kubectl config use-context <STANDALONE-CLUSTER-NAME>-admin@<STANDALONE-CLUSTER-NAME>
     ```
-
+    Where `<STANDALONE-CLUSTER-NAME>` is the name of the standalone cluster that you specified or if you didn't specify a name, it's the randomly generated name.
 1. Validate you can access the cluster's API server.
 
     ```sh
     kubectl get nodes
+    ```
 
+    The output will look similar to the following:
+
+    ```sh
     NAME                                       STATUS   ROLES                  AGE    VERSION
     ip-10-0-1-133.us-west-2.compute.internal   Ready    <none>                 123m   v1.20.1+vmware.2
     ip-10-0-1-76.us-west-2.compute.internal    Ready    control-plane,master   125m   v1.20.1+vmware.2

--- a/docs/site/content/docs/assets/azure-clusters.md
+++ b/docs/site/content/docs/assets/azure-clusters.md
@@ -3,25 +3,29 @@
 This section describes setting up management and workload clusters for
 Microsoft Azure.
 
-1. Initialize the Tanzu kickstart UI.
+1. Initialize the Tanzu Community Edition installer interface.
 
     ```sh
     tanzu management-cluster create --ui
     ```
 
-1. Go through the installation process for Azure. With the following
-   considerations:
+1. Complete the configuration steps in the installer interface for Azure and create the management cluster. The following configuration settings are recommended:
 
 
+   *  If you do not specify a name, the installer interface generates a unique name. If you do specify a name, the name must end with a letter, not a numeric character, and must be compliant with DNS hostname requirements described here: [RFC 1123](https://tools.ietf.org/html/rfc1123).
    * In Management Cluster Settings, use the Instance type drop-down menu to select from different combinations of CPU, RAM, and storage for the control plane node VM or VMs. The minimum configuration is 2 CPUs and 8 GB memory
 
    * Disable **Enable Identity Management Settings**. You can disable identity management for proof-of-concept/development deployments, but it is strongly recommended to implement identity management in production deployments. For more information about enabling Identity Management, see [Identity Management](../azure-install-mgmt/#step-5-identity-management).
 
-2. Validate the management cluster started successfully.
+1. Validate the management cluster started successfully.
 
     ```sh
     tanzu management-cluster get
+    ```
 
+    The output will look similar to the following:
+
+    ```sh
     NAME            NAMESPACE   STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES
     mgmtclusterone  tkg-system  running  1/1           1/1      v1.21.2+vmware.1  management
 
@@ -45,32 +49,28 @@ Microsoft Azure.
     capi-system                        cluster-api            CoreProvider            cluster-api   v0.3.22
     capz-system                        infrastructure-azure   InfrastructureProvider  azure         v0.4.15
     ```
-3. Create a cluster name that will be used throughout this Getting Started guide. This instance of `MGMT_CLUSTER_NAME` should be set to whatever value is returned by `tanzu management-cluster get` in the previous step.
+
+1. Capture the management cluster's kubeconfig.
 
     ```sh
-    export MGMT_CLUSTER_NAME="<INSERT_MGMT_CLUSTER_NAME_HERE>"
-    export WORKLOAD_CLUSTER_NAME="<INSERT_WORKLOAD_CLUSTER_NAME_HERE>"
+    tanzu management-cluster kubeconfig get <MGMT-CLUSTER-NAME> --admin
     ```
-
-4. Capture the management cluster's kubeconfig.
+    Where <``<MGMT-CLUSTER-NAME>`` should be set to the name returned by `tanzu management-cluster get` above.  <br><br>
+    For example, if your management cluster is called 'mtce', you will see a message similar to:
 
     ```sh
-    tanzu management-cluster kubeconfig get ${MGMT_CLUSTER_NAME} --admin
-
-    Credentials of workload cluster 'mtce' have been saved
+    Credentials of workload cluster 'mtce' have been saved.
     You can now access the cluster by running 'kubectl config use-context mtce-admin@mtce'
     ```
 
-    > Note the context name `${MGMT_CLUSTER_NAME}-admin@${MGMT_CLUSTER_NAME}`, you'll use the above command in
-    > future steps.
-
-5. Set your kubectl context to the management cluster.
+1. Set your kubectl context to the management cluster.
 
     ```sh
-    kubectl config use-context ${MGMT_CLUSTER_NAME}-admin@${MGMT_CLUSTER_NAME}
+    kubectl config use-context <MGMT-CLUSTER-NAME>-admin@<MGMT-CLUSTER-NAME>
     ```
+    Where <``MGMT-CLUSTER-NAME>`` should be set to the name returned by `tanzu management-cluster get`.
 
-6. Validate you can access the management cluster's API server.
+1. Validate you can access the management cluster's API server.
 
     ```sh
     kubectl get nodes
@@ -79,63 +79,57 @@ Microsoft Azure.
     standalonedelete-control-plane-9ndzx   Ready    control-plane,master   3m36s   v1.21.2+vmware.1
     standalonedelete-md-0-7hvll            Ready    <none>                 113s    v1.21.2+vmware.1
     ```
-7. Next you will create a workload cluster. First, setup a workload cluster config file.
+1. Next you will create a workload cluster. First, setup a workload cluster configuration file.
 
     ```sh
     cp  ~/.tanzu/tkg/clusterconfigs/<MGMT-CONFIG-FILE> ~/.tanzu/tkg/clusterconfigs/workload1.yaml
     ```
 
-   > ``<MGMT-CONFIG-FILE>`` is the name of the management cluster YAML config file
+   * Where ``<MGMT-CONFIG-FILE>`` is the name of the management cluster YAML configuration file
 
-   > This step duplicates the configuration file that was created when you deployed your management cluster. The configuration file will either have the name you assigned to the management cluster, or if no name was assigned, it will be a randomly generated name.
+   * This step duplicates the configuration file that was created when you deployed your management cluster. The configuration file will either have the name you assigned to the management cluster, or if no name was assigned, it will be a randomly generated name.
 
-   > This duplicated file will be used as the configuration file for your workload cluster. You can edit the parameters in this new  file as required. For an example of a workload cluster template, see  [Azure Workload Cluster Template](../azure-wl-template).
+   * This duplicated file will be used as the configuration file for your workload cluster. You can edit the parameters in this new  file as required. For an example of a workload cluster template, see  [Azure Workload Cluster Template](../azure-wl-template).
 
-   [](ignored)
+   * In the next two steps you will edit the parameters in this new file (`workload1`) and then use the file to deploy a workload cluster.
 
-   > In the next two steps you will edit the parameters in this new file (`workload1`) and then use the file to deploy a workload cluster.
-
-   [](ignored)
-
-8. In the new workload cluster file (`~/.config/tanzu/tkg/clusterconfigs/workload1.yaml`), edit the CLUSTER_NAME parameter to assign a name to your workload cluster. For example,
+1. In the new workload cluster file (`~/.config/tanzu/tkg/clusterconfigs/workload1.yaml`), edit the CLUSTER_NAME parameter to assign a name to your workload cluster. For example,
 
    ```yaml
    CLUSTER_CIDR: 100.96.0.0/11
    CLUSTER_NAME: my-workload-cluster
    CLUSTER_PLAN: dev
    ```
-   #### Note
-   * If you did not specify a name for your management cluster, the installer generated a random unique name. In this case, you must manually add the CLUSTER_NAME parameter and assign a workload cluster name.
+   * If you did not specify a name for your management cluster, the installer generated a random unique name. In this case, you must manually add the CLUSTER_NAME parameter and assign a workload cluster name. The workload cluster names must be must be 42 characters or less and must comply with DNS hostname requirements as described here: [RFC 1123](https://tools.ietf.org/html/rfc1123)
    * If you specified a name for your management cluster, the CLUSTER_NAME parameter is present and needs to be changed to the new workload cluster name.
-   > The other parameters in ``workload1.yaml`` are likely fine as-is. However, you can change them as required. Reference an example configuration template here:  [Amazon EC3 Workload Cluster Template](../aws-wl-template).
+   * The other parameters in ``workload1.yaml`` are likely fine as-is. Validation is performed on the file prior to applying it, so the `tanzu` command will return a message if something necessary is omitted. However, you can change paramaters as required. Reference an example configuration template here:  [Azure Workload Cluster Template](../azure-wl-template).
 
-   > Validation is performed on the file prior to applying it, so the `tanzu` command will return a message if something necessary is omitted.
 
-9. Create your workload cluster.
+1. Create your workload cluster.
 
     ```sh
-    tanzu cluster create ${WORKLOAD_CLUSTER_NAME} --file ~/.tanzu/tkg/clusterconfigs/workload1.yaml
+    tanzu cluster create <WORKLOAD-CLUSTER-NAME> --file ~/.tanzu/tkg/clusterconfigs/workload1.yaml
     ```
 
-10. Validate the cluster starts successfully.
+1. Validate the cluster starts successfully.
 
     ```sh
     tanzu cluster list
     ```
 
-11. Capture the workload cluster's kubeconfig.
+1. Capture the workload cluster's kubeconfig.
 
     ```sh
-    tanzu cluster kubeconfig get ${WORKLOAD_CLUSTER_NAME} --admin
+    tanzu cluster kubeconfig get <WORKLOAD-CLUSTER-NAME> --admin
     ```
 
-12. Set your `kubectl` context accordingly.
+1. Set your `kubectl` context to the workload cluster.
 
     ```sh
-    kubectl config use-context ${WORKLOAD_CLUSTER_NAME}-admin@${WORKLOAD_CLUSTER_NAME}
+    kubectl config use-context <WORKLOAD-CLUSTER_NAME>-admin@<WORKLOAD-CLUSTER-NAME>
     ```
 
-13. Verify you can see pods in the cluster.
+1. Verify you can see pods in the cluster.
 
     ```sh
     kubectl get pods --all-namespaces

--- a/docs/site/content/docs/assets/azure-standalone-clusters.md
+++ b/docs/site/content/docs/assets/azure-standalone-clusters.md
@@ -2,39 +2,32 @@
 
 This section covers setting up a standalone cluster in Azure. A standalone cluster provides a workload cluster that is **not** managed by a centralized management cluster.
 
-1. Initialize the Tanzu kickstart UI.
+1. Initialize the Tanzu Community Edition installer interface.
 
     ```sh
     tanzu standalone-cluster create --ui
     ```
 
-1. Go through the configuration steps, considering the following.
+1. Complete the configuration steps in the installer interface and create the standalone cluster. The following configuration settings are recommended:
 
 
-   * In Management Cluster Settings, use the Instance type drop-down menu to select from different combinations of CPU, RAM, and storage for the control plane node VM or VMs. The minimum configuration is 2 CPUs and 8 GB memory
+   * Use the Instance type drop-down menu to select from different combinations of CPU, RAM, and storage for the control plane node VM or VMs. The minimum configuration is 2 CPUs and 8 GB memory.
 
    * Disable **Enable Identity Management Settings**. You can disable identity management for proof-of-concept/development deployments, but it is strongly recommended to implement identity management in production deployments. For more information about enabling Identity Management, see [Identity Management](../azure-install-mgmt/#step-5-identity-management).
-
-1. At the end of the UI, deploy the cluster.
-
-1. Store the name of your cluster (set during configuration or automatically generated) to a
-   `STANDALONE_CLUSTER_NAME` environment variable.
-
-    ```sh
-    export STANDALONE_CLUSTER_NAME="<INSERT_STANDALONE_CLUSTER_NAME_HERE>"
-    ```
 
 1. Set your kubectl context to the cluster.
 
     ```sh
-    kubectl config use-context ${STANDALONE_CLUSTER_NAME}-admin@${STANDALONE_CLUSTER_NAME}
+    kubectl config use-context <STANDALONE-CLUSTER-NAME>-admin@<STANDALONE-CLUSTER-NAME>
     ```
 
 1. Validate you can access the cluster's API server.
 
     ```sh
     kubectl get nodes
-
+    ```
+    The output will look similar to the following:
+    ```sh
     NAME                                       STATUS   ROLES                  AGE    VERSION
     ip-10-0-1-133.us-west-2.compute.internal   Ready    <none>                 123m   v1.20.1+vmware.2
     ip-10-0-1-76.us-west-2.compute.internal    Ready    control-plane,master   125m   v1.20.1+vmware.2

--- a/docs/site/content/docs/assets/capd-clusters.md
+++ b/docs/site/content/docs/assets/capd-clusters.md
@@ -5,15 +5,11 @@ using Docker.
 
 ⚠️: Tanzu Community Edition support for Docker is **experimental** and may require troubleshooting on your system.
 
-<!--In order to use Docker, you should ensure your Docker engine has plenty of resources and storage available. We do not have exact numbers at this time, but most modern laptops and desktops should be able to run this configuration. Even with a modern system, there is potential that you're using up most or all of what Docker has allocated. -->
-
 1. Ensure your Docker engine has adequate resources. The  minimum requirements with no other containers running are: 6 GB of RAM and 4 CPUs.
     * **Linux**: Run ``docker system info``
     * **Mac**: Select Preferences > Resources > Advanced
-
     Note: To optimise your Docker system and ensure a successful deployment, you may wish to complete the next two optional steps.
-    <!--Note: This is especially critical for Mac users, below you can see a screenshot from Docker Desktop's settings.-->
-    <!--  ![docker settings](/docs/img/docker-settings.png)-->
+
 1. (Optional): Stop all existing containers.
 
    ```shell
@@ -26,44 +22,38 @@ using Docker.
    ```sh
     docker system prune -a --volumes
    ```
-1. Initialize the Tanzu kickstart UI.
+1. Initialize the Tanzu Community Edition installer interface.
 
    ```sh
    tanzu management-cluster create --ui
    ```
-1. Go through the installation process for Docker. With the following considerations:
+1. Complete the configuration steps in the installer interface for Docker and create the management cluster. The following configuration settings are recommended:
 
    * The Kubernetes Network Settings are auto-filled with a default CNI Provider and Cluster Service CIDR.
    * Docker Proxy settings are experimental and are to be used at your own risk.
+   * We will have more complete `tanzu` cluster bootstrapping documentation available here in the near future.
+   * If you ran the `prune` command in the previous step, expect this to take some time, as it'll download an image that is over 1GB.
 
-    > Until we have more TCE documentation, you can find the full TKG docs
-    > [here](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.2/vmware-tanzu-kubernetes-grid-12/GUID-mgmt-clusters-deploy-management-clusters.html).
-    > We will have more complete `tanzu` cluster bootstrapping documentation available here in the near future.
-
-   > If you ran the `prune` command in the previous step, expect this to take some time, as it'll download an image that is over 1GB.
-
-    __ALTERNATIVE:__ It is also possible to use the command line to create a Docker based management cluster:
+1. (Alternative method) It is also possible to use the command line to create a Docker based management cluster:
     ```sh
-    tanzu management-cluster create -i docker --name <MY_CLUSTER_NAME> -v 10 --plan dev --ceip-participation=false
+    tanzu management-cluster create -i docker --name <MGMT-CLUSTER-NAME> -v 10 --plan dev --ceip-participation=false
     ```
-    ``<MY_CLUSTER_NAME>``  must end with a letter, not a numeric character, and must be compliant with DNS hostname requirements [RFC 952](https://tools.ietf.org/html/rfc952) and [RFC 1123](https://tools.ietf.org/html/rfc1123).
-1. Validate the management cluster started successfully
+    -  ``<MGMT-CLUSTER-NAME>`` must end with a letter, not a numeric character, and must be compliant with DNS hostname requirements described here: [RFC 1123](https://tools.ietf.org/html/rfc1123).
+
+2. Validate the management cluster started:
+    ```
+    tanzu management-cluster get
+    ```
+    The output should look similar to the following:
 
     ```sh
-    tanzu management-cluster get
 
-    NAME                            NAMESPACE   STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES
-    tkg-mgmt-docker-20210601125056  tkg-system  running  1/1           1/1      v1.20.4+vmware.1  management
-
-    Details:
-
-    NAME                                                                                            READY  SEVERITY  REASON  SINCE  MESSAGE
+    NAME                                               READY  SEVERITY  REASON  SINCE  MESSAGE
     /tkg-mgmt-docker-20210601125056                                                                 True                     28s
     ├─ClusterInfrastructure - DockerCluster/tkg-mgmt-docker-20210601125056                          True                     32s
     ├─ControlPlane - KubeadmControlPlane/tkg-mgmt-docker-20210601125056-control-plane               True                     28s
     │ └─Machine/tkg-mgmt-docker-20210601125056-control-plane-5pkcp                                  True                     24s
     │   └─MachineInfrastructure - DockerMachine/tkg-mgmt-docker-20210601125056-control-plane-9wlf2
-    └─Workers
       └─MachineDeployment/tkg-mgmt-docker-20210601125056-md-0
         └─Machine/tkg-mgmt-docker-20210601125056-md-0-5d895cbfd9-khj4s                              True                     24s
           └─MachineInfrastructure - DockerMachine/tkg-mgmt-docker-20210601125056-md-0-d544k
@@ -78,70 +68,67 @@ using Docker.
       capi-system                        cluster-api            CoreProvider            cluster-api   v0.3.14
     ```
 
-1. Create a cluster name that will be used throughout this Getting Started guide. This instance of `MGMT_CLUSTER_NAME` should be set to whatever value is returned by `tanzu management-cluster get` above.
+3. Capture the management cluster's kubeconfig and take note of the command for accessing the cluster in the message, as you will use this for setting the context in the next step.
 
     ```sh
-    export MGMT_CLUSTER_NAME="<INSERT_MGMT_CLUSTER_NAME_HERE>"
-    export WORKLOAD_CLUSTER_NAME="<INSERT_WORKLOAD_CLUSTER_NAME_HERE>"
+    tanzu management-cluster kubeconfig get <MGMT-CLUSTER-NAME> --admin
     ```
-1. Capture the management cluster's kubeconfig.
-
+    - Where <``MGMT-CLUSTER-NAME>`` should be set to the name returned by `tanzu management-cluster get`.
+    - For example, if your management cluster is called 'mtce', you will see a message similar to:
     ```sh
-    tanzu management-cluster kubeconfig get ${MGMT_CLUSTER_NAME} --admin
-
-    Credentials of workload cluster 'mtce' have been saved
+    Credentials of workload cluster 'mtce' have been saved.
     You can now access the cluster by running 'kubectl config use-context mtce-admin@mtce'
     ```
 
-   > Note the context name `${MGMT_CLUSTER_NAME}-admin@mtce`, you'll use the above command in
-   > future steps. Your management cluster name may be different than
-   > `${MGMT_CLUSTER_NAME}`.
-
-1. Set your kubectl context to the management cluster.
+4. Set your kubectl context to the management cluster.
 
     ```sh
-    kubectl config use-context ${MGMT_CLUSTER_NAME}-admin@${MGMT_CLUSTER_NAME}
+    kubectl config use-context <MGMT-CLUSTER-NAME>-admin@<MGMT-CLUSTER-NAME>
     ```
 
-1. Validate you can access the management cluster's API server.
+5. Validate you can access the management cluster's API server.
 
     ```sh
     kubectl get nodes
-
+    ```
+    You will see output similar to:
+    ```sh
     NAME                         STATUS   ROLES                  AGE   VERSION
     guest-control-plane-tcjk2    Ready    control-plane,master   59m   v1.20.4+vmware.1
     guest-md-0-f68799ffd-lpqsh   Ready    <none>                 59m   v1.20.4+vmware.1
     ```
 
-1. Create your workload cluster.
+6. Create your workload cluster.
 
    ```shell
-   tanzu cluster create ${WORKLOAD_CLUSTER_NAME} --plan dev
+   tanzu cluster create <WORKLOAD-CLUSTER-NAME> --plan dev
    ```
 
-1. Validate the cluster starts successfully.
+7.  Validate the cluster starts successfully.
 
     ```sh
     tanzu cluster list
     ```
 
-1. Capture the workload cluster's kubeconfig.
+8.  Capture the workload cluster's kubeconfig.
 
     ```sh
-    tanzu cluster kubeconfig get ${WORKLOAD_CLUSTER_NAME} --admin
+    tanzu cluster kubeconfig get <WORKLOAD-CLUSTER-NAME> --admin
     ```
 
-1. Set your `kubectl` context accordingly.
+9.  Set your `kubectl` context accordingly.
 
     ```sh
-    kubectl config use-context ${WORKLOAD_CLUSTER_NAME}-admin@${WORKLOAD_CLUSTER_NAME}
+    kubectl config use-context <WORKLOAD-CLUSTER-NAME>-admin@<WORKLOAD-CLUSTER-NAME>
     ```
 
-1. Verify you can see pods in the cluster.
+10. Verify you can see pods in the cluster.
 
     ```sh
     kubectl get pods --all-namespaces
-
+    ```
+    The output will look similar to the following:
+    ```sh
     NAMESPACE     NAME                                                    READY   STATUS    RESTARTS   AGE
     kube-system   antrea-agent-9d4db                                      2/2     Running   0          3m42s
     kube-system   antrea-agent-vkgt4                                      2/2     Running   1          5m48s
@@ -156,10 +143,13 @@ using Docker.
     kube-system   kube-scheduler-tce-guest-control-plane-b2wsf            1/1     Running   0          5m56s
     ```
 
-With the above done, you now have local clusters running atop Docker. The nodes can be seen by running a command as follows.
+You now have local clusters running on Docker. The nodes can be seen by running the  following command:
 
 ```shell
 $ docker ps
+```
+The output will be similar to the following:
+```sh
 CONTAINER ID   IMAGE                                                         COMMAND                  CREATED             STATUS             PORTS                                  NAMES
 33e4e422e102   projects.registry.vmware.com/tkg/kind/node:v1.20.4_vmware.1   "/usr/local/bin/entr…"   About an hour ago   Up About an hour                                          guest-md-0-f68799ffd-lpqsh
 4ae2829ab6e1   projects.registry.vmware.com/tkg/kind/node:v1.20.4_vmware.1   "/usr/local/bin/entr…"   About an hour ago   Up About an hour   41637/tcp, 127.0.0.1:41637->6443/tcp   guest-control-plane-tcjk2

--- a/docs/site/content/docs/assets/capd-standalone-clusters.md
+++ b/docs/site/content/docs/assets/capd-standalone-clusters.md
@@ -9,38 +9,34 @@ using Docker. This provides you a workload cluster that is **not** managed by a 
     * **Linux**: Run ``docker system info``
     * **Mac**: Select Preferences > Resources > Advanced
 
-1. Store a name for your standalone cluster.
-
-    ```sh
-    export WORKLOAD_CLUSTER_NAME="<WORKLOAD_CLUSTER_NAME>"
-    ```
-    ``<WORKLOAD_CLUSTER_NAME>`` must end with a letter, not a numeric character, and must be compliant with DNS hostname requirements [RFC 952](https://tools.ietf.org/html/rfc952) and [RFC 1123](https://tools.ietf.org/html/rfc1123).
-
 1. Create the standalone cluster.
 
     ```sh
-    tanzu standalone-cluster create -i docker ${WORKLOAD_CLUSTER_NAME}
+    tanzu standalone-cluster create -i docker <STANDALONE-CLUSTER-NAME>
     ```
-
+    >``<STANDALONE-CLUSTER-NAME>`` must end with a letter, not a numeric character, and must be compliant with DNS hostname requirements [RFC 952](https://tools.ietf.org/html/rfc952) and [RFC 1123](https://tools.ietf.org/html/rfc1123).
     > For increased logs, you can append `-v 10`.
 
-1. Validate the cluster started successfully.
+   If the deployment is successful, you should see the following output:
 
     ```txt
     Standalone cluster created!
     ```
 
-1. Set your kubectl context to the cluster.
+2. Set your kubectl context to the cluster.
 
     ```sh
-    kubectl config use-context ${WORKLOAD_CLUSTER_NAME}-admin@${WORKLOAD_CLUSTER_NAME}
+    kubectl config use-context <STANDALONE-CLUSTER-NAME>-admin@<STANDALONE-CLUSTER-NAME>
     ```
 
-1. Validate you can access the cluster's API server.
+3. Validate you can access the cluster's API server.
 
     ```sh
     kubectl get pod -A
+    ```
+    The output should look similar to the following:
 
+    ```sh
     NAMESPACE         NAME                                                                         READY   STATUS    RESTARTS   AGE
     kapp-controller   kapp-controller-5c66dcc7cf-62jl2                                             1/1     Running   0          3m52s
     kube-system       antrea-agent-7vs9l                                                           2/2     Running   0          3m52s

--- a/docs/site/content/docs/assets/clean-up-standalone.md
+++ b/docs/site/content/docs/assets/clean-up-standalone.md
@@ -3,7 +3,7 @@
 1. Run the `delete` command.
 
     ```sh
-    tanzu standalone-cluster delete ${STANDALONE_CLUSTER_NAME}
+    tanzu standalone-cluster delete <STANDALONE-CLUSTER-NAME>
     ```
 
     > This may take several minutes to complete!
@@ -11,6 +11,6 @@
 1. _Note:_ If you configured a proxy, you may need to provide the following environment variables `TKG_NO_PROXY`, `TKG_HTTP_PROXY`, `TKG_HTTPS_PROXY`
 
     ```sh
-    TKG_HTTP_PROXY="127.0.0.1" tanzu standalone-cluster delete ${STANDALONE_CLUSTER_NAME}
+    TKG_HTTP_PROXY="127.0.0.1" tanzu standalone-cluster delete <STANDALONE-CLUSTER-NAME>
     ```
 

--- a/docs/site/content/docs/assets/clean-up.md
+++ b/docs/site/content/docs/assets/clean-up.md
@@ -5,19 +5,15 @@ After going through this guide, the following enables you to clean-up resources.
 1. Delete any deployed workload clusters.
 
     ```sh
-    tanzu cluster delete ${WORKLOAD_CLUSTER_NAME}
+    tanzu cluster delete <WORKLOAD-CLUSTER-NAME>
     ```
 
 1. Once all workload clusters have been deleted, the management cluster can
-   then be removed as well.
+   then be removed as well. Run the following commands to get the name of the cluster and delete the cluster
 
     ```sh
     tanzu management-cluster get
 
-    NAME                         NAMESPACE   STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES
-    tkg-mgmt-aws-20210226062452  tkg-system  running  1/1           1/1      v1.20.1+vmware.2  management
-    ```
-
     ```sh
-    tanzu management-cluster delete ${MGMT_CLUSTER_NAME}
+    tanzu management-cluster delete <MGMT-CLUSTER-NAME>
     ```

--- a/docs/site/content/docs/assets/cli-install-linux.md
+++ b/docs/site/content/docs/assets/cli-install-linux.md
@@ -1,16 +1,15 @@
 1. Download the release for [Linux](https://github.com/vmware-tanzu/community-edition/releases/download/v0.7.0/tce-linux-amd64-v0.7.0.tar.gz) via web browser.
 
-1. _[Alternative]_ Download the release using CLI
+1. _[Alternative]_ Download the release using CLI. Alternatively, you may download a release using the provided remote script.
 
     ```sh
     curl -H "Authorization: token ${GITHUB_TOKEN}" \
         -H "Accept: application/vnd.github.v3.raw" \
         -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/get-tce-release.sh | \
-        bash -s RELEASE_VERSION DISTRIBUTION
+        bash -s <RELEASE-VERSION-DISTRIBUTION>
     ```
 
-    > Alternatively, you may download a release using the provided remote script.
-    > - The TCE release version and release distribution _must_ be passed as arguments to `bash` in order to download a releases. So, for example, to download v0.7.0 for Linux, simply provide `bash -s v0.7.0 linux` as arguments.
+    > - Where ``<RELEASE-VERSION-DISTRIBUTION>`` is the Tanzu Community Edition release version and distribution. This is a required argument for `bash` to download a releases. For example, to download v0.7.0 for Linux, provide:  <br>`bash -s v0.7.0 linux`
     > - This script requires `curl`, `grep`, `sed`, `tr`, and `jq` in order to work
     > - The release will be downloaded to the local directory as `tce-linux-amd64-v0.7.0.tar.gz`
     > - *_Note:_* This _currently_ requires the use of a GitHub personal access token.
@@ -29,7 +28,7 @@
     ./install.sh
     ```
 
-    > This installs the `Tanzu` CLI and puts all the plugins in their proper location.
+    > This installs the `Tanzu` CLI and puts all the plugins in the correct location.
     > The first time you run the `tanzu` command the installed plugins and plugin repositories are initialized. This action might take a minute.
 
 1. You must download and install the latest version of `kubectl`.

--- a/docs/site/content/docs/assets/cli-install-mac.md
+++ b/docs/site/content/docs/assets/cli-install-mac.md
@@ -13,7 +13,7 @@
     ./install.sh
     ```
 
-    > This installs the `Tanzu` CLI and puts all the plugins in their proper location.
+    > This installs the `Tanzu` CLI and puts all the plugins in the correct location.
     > The first time you run the `tanzu` command the installed plugins and plugin repositories are initialized. This action might take a minute.
 
 1. You must download and install the latest version of `kubectl`. For more information, see [Install and Set Up kubectl on macOS](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/) in the Kubernetes documentation.

--- a/docs/site/content/docs/assets/cli-install-windows.md
+++ b/docs/site/content/docs/assets/cli-install-windows.md
@@ -13,5 +13,7 @@
    cd <INSTALLATION-DIR>
    install.bat
    ```
-
+    > This installs the `Tanzu` CLI and puts all the plugins in the correct location.
+    > The first time you run the `tanzu` command the installed plugins and plugin repositories are initialized. This action might take a minute.
 1. Add `Program Files\tanzu` to your PATH.
+1. You must download and install the latest version of `kubectl`. For more information, see [Install and Set Up kubectl on Windows](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/) in the Kubernetes documentation.

--- a/docs/site/content/docs/assets/mgmt-desc.md
+++ b/docs/site/content/docs/assets/mgmt-desc.md
@@ -1,5 +1,5 @@
 ### Management cluster description
-The management cluster provides management and operations for your instance. It runs [Cluster-API](https://cluster-api.sigs.k8s.io/) which is used to create workload clusters, as well as creating shared services for all the clusters within the instance.  The management cluster is not intended to be used for application workloads. A management cluster is deployed using the Tanzu Community Edition Installer.
+The management cluster provides management and operations for your instance. It runs [Cluster-API](https://cluster-api.sigs.k8s.io/) which is used to create workload clusters, as well as creating shared services for all the clusters within the instance.  The management cluster is not intended to be used for application workloads. A management cluster is deployed using the Tanzu Community Edition installer interface.
 
 When you create a management cluster, a bootstrap cluster is created on your local machine. This is a [Kind](https://kind.sigs.k8s.io/)  based cluster -  a cluster in a container.  This bootstrap cluster then creates a cluster on your specified provider. The Cluster APIs then pivots this cluster into a management cluster.
 At this point, the local bootstrap cluster is deleted.  The management cluster can now instantiate more workload clusters.

--- a/docs/site/content/docs/assets/package-installation.md
+++ b/docs/site/content/docs/assets/package-installation.md
@@ -9,9 +9,9 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
 1. Make sure your `kubectl` context is set to either the workload cluster or standalone cluster.
 
     ```sh
-    kubectl config use-context ${WORKLOAD_CLUSTER_NAME}-admin@${WORKLOAD_CLUSTER_NAME}
+    kubectl config use-context <CLUSTER-NAME>-admin@<CLUSTER-NAME>
     ```
-
+    Where ``<CLUSTER-NAME>`` is the name of workload or standalone cluster where you want to install package.
 1. Delete the standard package repository
 
 
@@ -23,7 +23,7 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
     > tanzu-framework. This step will not be required in future releases.
 
 
-1. Install the TCE package repository.
+1. Install the Tanzu Community Edition package repository.
 
     ```sh
     tanzu package repository add tce-repo --url projects.registry.vmware.com/tce/main:stable
@@ -34,7 +34,10 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
 1. List the available packages.
 
     ```sh
-    > tanzu package available list
+    tanzu package available list
+    ```
+    The output will look similar to the following:
+    ```sh
     - Retrieving available packages...
      NAME                                           DISPLAY-NAME        SHORT-DESCRIPTION
      cert-manager.community.tanzu.vmware.com        cert-manager        Certificate management
@@ -56,6 +59,9 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
 
     ```shell
     tanzu package available get cert-manager.community.tanzu.vmware.com
+    ```
+    The output will look similar to the following:
+    ```sh
     / Retrieving package details for cert-manager.community.tanzu.vmware.com...
     NAME:               cert-manager.community.tanzu.vmware.com
     DISPLAY-NAME:       cert-manager
@@ -69,6 +75,9 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
 
     ```shell
     tanzu package available list cert-manager.community.tanzu.vmware.com
+    ```
+    The output will look similar to the following:
+    ```sh
     / Retrieving package versions for cert-manager.community.tanzu.vmware.com...
     NAME                                     VERSION  RELEASED-AT
     cert-manager.community.tanzu.vmware.com  1.3.1    2021-04-14T18:00:00Z
@@ -79,18 +88,18 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
    [TCE GitHub repository](https://github.com/vmware-tanzu/community-edition/tree/main/addons/packages). Select the package/version
    and navigate into the `bundle/config` directory. Download or copy/paste the `values.yaml` file.
 
-1. [Optional]: Alter the values.yaml file.
-
-   ```sh
-   vim values.yaml
-   ```
-
-   > You will also need to ensure that there are no lines in the file starting with `#!` or `#@` . These will cause an error when installing to the cluster.
+1. [Optional]: Alter the ``values.yaml`` file using a text editor of your choice. Ensure that there are no lines in the file starting with `#!` or `#@`, as these cause an error when installing to the cluster.
 
 1. Install the package to the cluster.
 
     ```sh
     tanzu package install cert-manager --package-name cert-manager.community.tanzu.vmware.com --version 1.4.0
+    ```
+    > If using a custom configuration values file, append `--values-file values.yaml` to the installation command. <br>
+
+    The output will look similar to the following:
+
+    ```sh
     | Installing package 'cert-manager.community.tanzu.vmware.com'
     / Getting package metadata for cert-manager.community.tanzu.vmware.com
     - Creating service account 'cert-manager-default-sa'
@@ -102,7 +111,7 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
     Added installed package 'cert-manager' in namespace 'default'
     ```
 
-   > If using a custom configuration values file, append `--values-file values.yaml` to the installation command.
+
 
 1. Verify cert-manager is installed in the cluster.
 
@@ -113,10 +122,13 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
      cert-manager  cert-manager.community.tanzu.vmware.com  1.4.0            Reconcile succeeded
      ```
 
-1. For troubleshooting, you can view `PackageInstall` and `App` objects in the cluster.
+1. For troubleshooting, you can view `PackageInstall` and `App` objects in the cluster using the following kubectl command.
 
      ```sh
      kubectl get packageInstall,apps --all-namespaces
+     ```
+     The output will look similar to the following:
+     ```sh
      NAMESPACE    NAME                                                 PACKAGE NAME                              PACKAGE VERSION                    DESCRIPTION           AGE
      default      packageinstall.packaging.carvel.dev/cert-manager     cert-manager.community.tanzu.vmware.com   1.4.0                              Reconcile succeeded   18m
      tkg-system   packageinstall.packaging.carvel.dev/antrea           antrea.tanzu.vmware.com                   0.13.3+vmware.1-tkg.1-zshippable   Reconcile succeeded   17d
@@ -128,10 +140,13 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
      tkg-system   app.kappctrl.k14s.io/metrics-server   Reconcile succeeded   28s            17d
      ```
 
-1. Remove a package from the cluster
+1. To remove a package from the cluster, run the following command:
 
      ```shell
      tanzu package installed delete cert-manager
+     ```
+     The output will look similar to the following:
+     ```sh
      | Uninstalling package 'cert-manager' from namespace 'default'
      | Getting package install for 'cert-manager'
      \ Deleting package install 'cert-manager' from namespace 'default'
@@ -143,8 +158,8 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
      / Deleting service account 'cert-manager-default-sa'
      Uninstalled package 'cert-manager' from namespace 'default'
      ```
-     
-If you're interested in how this package model works from a server-side and client-side perspective, see the
+
+For more information about how this package model works from a server-side and client-side perspective, see the
 [Package Management design doc](./designs/package-management.md).
 
 _Note:_ For installation of packages on a Docker deployment that require storage

--- a/docs/site/content/docs/assets/standalone-desc.md
+++ b/docs/site/content/docs/assets/standalone-desc.md
@@ -1,5 +1,5 @@
 ## Standalone cluster description
 
-A standalone cluster is a faster way to get a functioning cluster with minimal resources. A standalone cluster functions as a workload cluster, it can run application workloads. It does not contain any of the components related to cluster management.  It is deployed using the Tanzu Kubernetes Grid Installer. <!--will change this with global search/replace when naming settles down-->
+A standalone cluster is a faster way to get a functioning cluster with minimal resources. A standalone cluster functions as a workload cluster, it can run application workloads. It does not contain any of the components related to cluster management.  It is deployed using the Tanzu Kubernetes Grid installer interface.
 
 When you create a standalone cluster, a bootstrap cluster is created on your local machine. This is a [Kind](https://kind.sigs.k8s.io/)  based cluster - a cluster in a container.  This bootstrap cluster then creates a cluster on your specified provider, but it does not pivot into a management cluster - it functions as a workload cluster.

--- a/docs/site/content/docs/assets/vsphere-clusters.md
+++ b/docs/site/content/docs/assets/vsphere-clusters.md
@@ -3,13 +3,11 @@
 This section describes setting up management and workload clusters for
 vSphere.
 
-1. Download the machine image that matches the version of the Kubernetes you plan on deploying (1.20.1 is default).
+1. Download the machine image that matches the version of the Kubernetes you plan on deploying.
 
-    At this time, we cannot guarantee the plugin versions that will be used for cluster management.
-    While using the kickstart UI to bootstrap your cluster, you may be asked to add an `OVA` to your vSphere environment.
+    At this time, we cannot guarantee the plugin versions that will be used for cluster management.  While running the installer interface to bootstrap a cluster, you are required to add an `OVA` to your vSphere environment.
 
-    The official OVA publishing location is still to be determined. In the meantime, to get access to the necessary OVAs
-    for the current build, please ask on the `#tanzu-community-edition` Slack channel.
+    The official OVA publishing location is still to be determined. In the meantime, to get access to the necessary OVAs for the current build, please ask on the `#tanzu-community-edition` Slack channel.
 
     Please note, validation work so far has focused on the **Photon** based
     images.
@@ -18,22 +16,18 @@ vSphere.
 
 1. After importing, right-click and covert to a template.
 
-1. Initialize the Tanzu kickstart UI.
+1. Initialize the Tanzu Community Edition installer interface.
 
     ```sh
     tanzu management-cluster create --ui
     ```
 
-1. Go through the installation process for vSphere. With the following
-   considerations:
+1. Complete the configuration steps in the installer interface for vSphere and create the management cluster. The following configuration settings are recommended:
 
-   *  If you do not specify a name, the installer generates a unique name. If you do specify a name, the name must end with a letter, not a numeric character, and must be compliant with DNS hostname requirements described here: [RFC 1123](https://tools.ietf.org/html/rfc1123).
-   * Set all instance profile to large or larger.
-     * In our testing, we found resource constraints caused bootstrapping
-     issues. Choosing a large profile or more will give a better chance for
+   * If you do not specify a name, the installer generates a unique name. If you do specify a name, the name must end with a letter, not a numeric character, and must be compliant with DNS hostname requirements described here: [RFC 1123](https://tools.ietf.org/html/rfc1123).
+   * Set all instance profiles to large or larger. In our testing, we found resource constraints caused bootstrapping issues. Choosing a large profile or more will give a better chance for
      successful bootstrapping.
-   * Set your control plane IP
-     * The control plane IP is a virtual IP that fronts the Kubernetes API
+   * Set your control plane IP. The control plane IP is a virtual IP that fronts the Kubernetes API
      server. You **must** set an IP that is routable and won't be taken by
      another system (e.g. DHCP).
    * Disable **Enable Identity Management Settings**. You can disable identity management for proof-of-concept/development deployments, but it is strongly recommended to implement identity management in production deployments. For more information about enabling Identity Management, see [Identity Management ](vsphere-install-mgmt/#step-7-identity-management).
@@ -44,31 +38,23 @@ vSphere.
     tanzu management-cluster get
     ```
 
-1. Create a cluster name that will be used throughout this Getting Started guide. This instance of `MGMT_CLUSTER_NAME` should be set to whatever value is returned by `tanzu management-cluster get` above.
-
-    ```sh
-    export MGMT_CLUSTER_NAME="<INSERT_MGMT_CLUSTER_NAME_HERE>"
-    export WORKLOAD_CLUSTER_NAME="<INSERT_WORKLOAD_CLUSTER_NAME_HERE>"
-    ```
-
 1. Capture the management cluster's kubeconfig.
 
     ```sh
-    tanzu management-cluster kubeconfig get ${MGMT_CLUSTER_NAME} --admin
+    tanzu management-cluster kubeconfig get <MGMT-CLUSTER-NAME> --admin
 
-    Credentials of workload cluster 'mtce' have been saved
+    Where <``<MGMT-CLUSTER-NAME>`` should be set to the name returned by `tanzu management-cluster get` above.  <br><br>
+    For example, if your management cluster is called 'mtce', you will see a message similar to:
+    ```sh
+    Credentials of workload cluster 'mtce' have been saved.
     You can now access the cluster by running 'kubectl config use-context mtce-admin@mtce'
-    ```
-
-    > Note the context name `${MGMT_CLUSTER_NAME}-admin@${MGMT_CLUSTER_NAME}`, you'll use the above command in
-    > future steps.
 
 1. Set your kubectl context to the management cluster.
 
     ```sh
-    kubectl config use-context ${MGMT_CLUSTER_NAME}-admin@${MGMT_CLUSTER_NAME}
+    kubectl config use-context <MGMT-CLUSTER-NAME>-admin@<MGMT-CLUSTER-NAME>
     ```
-
+    Where <``MGMT-CLUSTER-NAME>`` should be set to the name returned by `tanzu management-cluster get`.
 1. Validate you can access the management cluster's API server.
 
     ```sh
@@ -79,23 +65,17 @@ vSphere.
     10-0-1-76    Ready    control-plane,master   125m   v1.20.1+vmware.2
     ```
 
-1. Next you will create a workload cluster. First, setup a workload cluster config file.
+1. Next you will create a workload cluster. First, create a workload cluster configuration file by taking a copy of the management cluster YAML configuration file that was created when you deployed your management cluster. This example names the workload cluster configuration file ``workload1.yaml``.
 
     ```sh
     cp  ~/.config/tanzu/tkg/clusterconfigs/<MGMT-CONFIG-FILE> ~/.config/tanzu/tkg/clusterconfigs/workload1.yaml
     ```
-   > ``<MGMT-CONFIG-FILE>`` is the name of the management cluster YAML config file
 
-   > This step duplicates the configuration file that was created when you deployed your management cluster. The configuration file will either have the name you assigned to the management cluster, or if no name was assigned, it will be a randomly generated name.
+    * Where ``<MGMT-CONFIG-FILE>`` is the name of the management cluster YAML config file. The management cluster YAML configuration file will either have the name you assigned to the management cluster, or if no name was assigned, it will be a randomly generated name.
 
-   > This duplicated file will be used as the configuration file for your workload cluster. You can edit the parameters in this new  file as required. For an example of a workload cluster template, see  [vSphere Workload Cluster Template](../vsphere-wl-template).
+    * The duplicated file (``workload1.yaml``) will be used as the configuration file for your workload cluster. You can edit the parameters in this new  file as required. For an example of a workload cluster template, see  [vSphere Workload Cluster Template](../vsphere-wl-template).
 
-   [](ignored)
-
-   > In the next three steps you will edit the parameters in this new file (`workload1`) and then use the file to deploy a workload cluster.
-
-   [](ignored)
-
+      * In the next two steps you will edit the parameters in this new file (`workload1.yaml`) and then use the file to deploy a workload cluster.
 
 1. In the new workload cluster file (`~/.config/tanzu/tkg/clusterconfigs/workload.yaml`), edit the CLUSTER_NAME parameter to assign a name to your workload cluster. For example,
 
@@ -105,26 +85,22 @@ vSphere.
    CLUSTER_NAME: my-workload-cluster
    CLUSTER_PLAN: dev
    ```
-   #### Note
-   * If you did not specify a name for your management cluster, the installer generated a random unique name. In this case, you must manually add the CLUSTER_NAME parameter and assign a workload cluster name.
+   * If you did not specify a name for your management cluster, the installer generated a random unique name. In this case, you must manually add the CLUSTER_NAME parameter and assign a workload cluster name. The workload cluster names must be must be 42 characters or less and must comply with DNS hostname requirements as described here: [RFC 1123](https://tools.ietf.org/html/rfc1123)
    * If you specified a name for your management cluster, the CLUSTER_NAME parameter is present and needs to be changed to the new workload cluster name.
 
 1. In the workload cluster file (`~/.config/tanzu/tkg/clusterconfigs/workload1.yaml`), edit the VSPHERE_CONTROL_PLANE_ENDPOINT parameter to apply a viable IP.
 
 
-   > This will be the API Server IP for your workload cluster. You must choose an IP that is routable and not used elsewhere in your network, e.g., out of your DHCP range.
+   * This will be the API Server IP for your workload cluster. You must choose an IP that is routable and not used elsewhere in your network, e.g., out of your DHCP range.
 
-   [](ignored)
 
-   > The other parameters in ``workload1.yaml`` are likely fine as-is. However, you can change
-   > them as required. Reference an example configuration template here:  [vSphere Workload Cluster Template](../vsphere-wl-template).
+   * The other parameters in ``workload1.yaml`` are likely fine as-is. Validation is performed on the file prior to applying it, so the `tanzu` command will return a message if something necessary is omitted. However, you can parameters as required. Reference an example configuration template here:  [vSphere Workload Cluster Template](../vsphere-wl-template).
 
-   > Validation is performed on the file prior to applying it, so the `tanzu` command will return a message if something necessary is omitted.
 
 4. Create your workload cluster.
 
     ```sh
-    tanzu cluster create ${WORKLOAD_CLUSTER_NAME} --file ~/.config/tanzu/tkg/clusterconfigs/workload1.yaml
+    tanzu cluster create <WORKLOAD-CLUSTER-NAME> --file ~/.config/tanzu/tkg/clusterconfigs/workload1.yaml
     ```
 
 5. Validate the cluster starts successfully.
@@ -136,13 +112,13 @@ vSphere.
 6. Capture the workload cluster's kubeconfig.
 
     ```sh
-    tanzu cluster kubeconfig get ${WORKLOAD_CLUSTER_NAME} --admin
+    tanzu cluster kubeconfig get <WORKLOAD-CLUSTER-NAME> --admin
     ```
 
 7. Set your `kubectl` context accordingly.
 
     ```sh
-    kubectl config use-context ${WORKLOAD_CLUSTER_NAME}-admin@${WORKLOAD_CLUSTER_NAME}
+    kubectl config use-context <WORKLOAD-CLUSTER-NAME>-admin@<WORKLOAD-CLUSTER-NAME>
     ```
 
 8. Verify you can see pods in the cluster.

--- a/docs/site/content/docs/assets/vsphere-standalone-clusters.md
+++ b/docs/site/content/docs/assets/vsphere-standalone-clusters.md
@@ -3,57 +3,41 @@
 This section describes setting up standalone clusters for
 vSphere. These clusters are not managed by a management cluster.
 
-1. Download the machine image that matches the version of the Kubernetes you plan on deploying (1.20.1 is default).
+1. Download the machine image that matches the version of the Kubernetes you plan on deploying.
 
     At this time, we cannot guarantee the plugin versions that will be
-    used for cluster management. While using the kickstart UI to bootstrap your
-    cluster, you may be asked add an `ova` to your vSphere environment. The
-    following links are points to the most recent ovas at the time of writing
-    this Getting Started guide.
+    used for cluster management. While running the installer interface to bootstrap a
+    cluster, you are required to add an `ova` to your vSphere environment.
 
-    The official OVA publishing location is still to be determined. In the meantime, to get access to the necessary OVAs
-    for the current build, please ask on the `#tanzu-community-edition` Slack channel.
+    The official OVA publishing location is still to be determined. In the meantime, to get access to the necessary OVAs for the current build, please ask on the `#tanzu-community-edition` Slack channel.
 
     Please note, validation work so far has focused on the **Photon** based
     images.
 
-1. In vCenter, right-click on your datacenter and import the OVF template.
+2. In vCenter, right-click on your datacenter and import the OVF template.
 
-1. After importing, right-click and covert to a template.
+3. After importing, right-click and covert to a template.
 
-1. Initialize the Tanzu kickstart UI.
+4. Initialize the Tanzu Community Edition installer interface.
 
     ```sh
     tanzu standalone-cluster create --ui
     ```
 
-1. Go through the configuration steps, considering the following.
+5.  Complete the configuration steps in the installer interface and create the standalone cluster. The following configuration settings are recommended:
 
-   * Set all instance profile to large or larger.
-     * In our testing, we found resource constraints caused bootstrapping
-     issues. Choosing a large profile or more will give a better chance for
-     successful bootstrapping.
-   * Set your control plane IP
-     * The control plane IP is a virtual IP that fronts the Kubernetes API
-     server. You **must** set an IP that is routable and won't be taken by
-     another system (e.g. DHCP).
-   * Disable **Enable Identity Management Settings**. You can disable identity management for proof-of-concept/development deployments, but it is strongly recommended to implement identity management in production deployments.
+      * Set all instance profile to large or larger. In our testing, we found resource constraints caused bootstrapping issues. Choosing a large profile will give a better chance for successful bootstrapping.
+      * Set your control plane IP. The control plane IP is a virtual IP that fronts the Kubernetes API server. You **must** set an IP that is routable and won't be taken by another system (e.g. DHCP).
+      * Disable **Enable Identity Management Settings**. You can disable identity management for proof-of-concept/development deployments, but it is strongly recommended to implement identity management in production deployments.
 
-1. At the end of the UI, create the standalone cluster.
-
-1. Store the name of your cluster (set during configuration or generated) to a
-   `STANDALONE_CLUSTER_NAME` environment variable.
+6. Set your kubectl context to the cluster.
 
     ```sh
-    export STANDALONE_CLUSTER_NAME="<INSERT_STANDALONE_CLUSTER_NAME_HERE>"
+    kubectl config use-context <STANDALONE-CLUSTER-NAME>-admin@<STANDALONE-CLUSTER-NAME>
     ```
-1. Set your kubectl context to the cluster.
+    Where `<STANDALONE-CLUSTER-NAME>` is the name of the standalone cluster that you specified or if you didn't specify a name, it's the randomly generated name.
 
-    ```sh
-    kubectl config use-context ${STANDALONE_CLUSTER_NAME}-admin@${STANDALONE_CLUSTER_NAME}
-    ```
-
-1. Validate you can access the cluster's API server.
+7. Validate you can access the cluster's API server.
 
     ```sh
     kubectl get nodes

--- a/docs/site/content/docs/latest/delete-mgmt.md
+++ b/docs/site/content/docs/latest/delete-mgmt.md
@@ -4,7 +4,7 @@ This topic describes how to delete management clusters from the Tanzu CLI and al
 
 To delete a management cluster, run the following command:
    ```sh
-   tanzu management-cluster delete <MGMT_CLUSTER_NAME>
+   tanzu management-cluster delete <MGMT-CLUSTER-NAME>
    ```
 
 When you run `tanzu management-cluster delete`, Tanzu Community Edition creates a temporary `kind` cleanup cluster on your bootstrap machine to manage the deletion process. The `kind` cluster is removed when the deletion process completes.

--- a/docs/site/content/docs/latest/getting-started-standalone.md
+++ b/docs/site/content/docs/latest/getting-started-standalone.md
@@ -1,6 +1,6 @@
 # Getting Started with Tanzu Community Edition
 
-This guide walks you through creating a standalone-workload cluster using Tanzu
+This guide walks you through creating a standalone cluster using Tanzu
 CLI.
 
 {{% include "/docs/assets/standalone-desc.md" %}}


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it

- [ ] The main change is fixes #https://github.com/vmware-tanzu/community-edition/issues/1384  This removes steps to create unix environment variables and changes all steps that previously used the environment variable to just use a variable in angle brackets - this is in line with what TKG do, and is the planned standard for  Tanzu Framework doc. It also means that there doesn't need to be a separate procedure to create a cluster for windows - the steps are specific to provider ( a tab for each) but generic for OS. 

- [ ] Removes reference to use vim to edit the package config file and instead makes generic reference to 'text editor of your choice'

- [ ] apply style guide convention to break up command and result

- [ ] apply style guide convention to refer to 'nzu Community Edition installer interface' on first occurrence and 'installer interface' for subsequent occurrences

- [ ] apply some missing steps to windows install topic - just to make it consistent with others, doesn't change any command

- [ ] a lot of editorial and changes to make the topics more consistent with each other and other changes to improve formatting

## Details for the Release Notes

```release-note
Make steps in the Creating Clusters topics in Getting Started generic for all OS by removing step to create unix environment variable and applying consistent way to refer to variables.
```

## Which issue(s) this PR fixes
Fixes #1384 
Fixes #1288 (partial)

## Describe testing done for PR


