### PR TITLE
Explicit --merge when using the gh cli

### DIFF
--- a/hack/cut-release.sh
+++ b/hack/cut-release.sh
@@ -109,7 +109,7 @@ git add hack/FAKE_BUILD_VERSION.yaml
 git commit -s -m "auto-generated - update fake version"
 git push origin "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}"
 gh pr create --title "auto-generated - update fake version" --body "auto-generated - update fake version"
-gh pr merge "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}" --admin
+gh pr merge "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}" --merge --admin
 
 # skip the tagging the dev release... commit the file is a good enough simulation
 
@@ -140,7 +140,7 @@ fi
 git commit -s -m "auto-generated - update dev version"
 git push origin "${WHICH_BRANCH}-update-${NEW_DEV_BUILD_VERSION}"
 gh pr create --title "auto-generated - update dev version" --body "auto-generated - update dev version"
-gh pr merge "${WHICH_BRANCH}-update-${NEW_DEV_BUILD_VERSION}" --admin
+gh pr merge "${WHICH_BRANCH}-update-${NEW_DEV_BUILD_VERSION}" --merge --admin
 
 # tag the new dev release
 git tag -m "${NEW_DEV_BUILD_VERSION}" "${NEW_DEV_BUILD_VERSION}"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->
You need to use `--merge` on the gh cli when performing a merge on the cli non-interactively. Please see:
https://github.com/vmware-tanzu/community-edition/runs/3415008898?check_suite_focus=true

Error:
```
 * [new branch]      main-update-v0.8.0-dev.113 -> main-update-v0.8.0-dev.113
+ gh pr create --title 'auto-generated - update fake version' --body 'auto-generated - update fake version'
https://github.com/vmware-tanzu/community-edition/pull/1433
+ gh pr merge main-update-v0.8.0-dev.113 --admin
--merge, --rebase, or --squash required when not running interactively
```

## Details for the Release Notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA