### PR TITLE
Fix release CI using PR mathod (part 4) - remove logout

### DIFF
--- a/hack/cut-release.sh
+++ b/hack/cut-release.sh
@@ -109,7 +109,7 @@ git add hack/FAKE_BUILD_VERSION.yaml
 git commit -s -m "auto-generated - update fake version"
 git push origin "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}"
 gh pr create --title "auto-generated - update fake version" --body "auto-generated - update fake version"
-gh pr merge "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}" --merge --admin
+gh pr merge "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}" --rebase --admin
 
 # skip the tagging the dev release... commit the file is a good enough simulation
 
@@ -147,6 +147,3 @@ git tag -m "${NEW_DEV_BUILD_VERSION}" "${NEW_DEV_BUILD_VERSION}"
 git push origin "${NEW_DEV_BUILD_VERSION}"
 
 fi
-
-# logout
-echo "Y" | gh auth logout --hostname github.com


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->
Removes the explicit logout because yields error if you do not clear out the GITHUB_TOKEN

## Details for the Release Notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
