### PR TITLE
Bump tanzu-framework tce-main branch dependency

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/go.mod
+++ b/cli/cmd/plugin/standalone-cluster/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6 // indirect
 	github.com/spf13/cobra v1.2.0
-	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210823214615-88bfd6947796
+	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210825150951-f838583b4b49
 	k8s.io/klog/v2 v2.8.0
 )
 

--- a/cli/cmd/plugin/standalone-cluster/go.sum
+++ b/cli/cmd/plugin/standalone-cluster/go.sum
@@ -1327,8 +1327,8 @@ github.com/vmware-tanzu/carvel-vendir v0.19.0 h1:4FTeDcxwEuZWdFlFqh+11NqnJciCkkO
 github.com/vmware-tanzu/carvel-vendir v0.19.0/go.mod h1:HF7iLB0NyEFHuCvM0EJ42fERk20l2ImpktJzhSEdqOU=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159 h1:c7sM3NrAQGmTvq57Aw96BBzBO67apYZpZs/51PfjddA=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159/go.mod h1:1DBZEj6GmcWxe77d8YOeac1JIa8ttP21uTHUlAyji2g=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210823214615-88bfd6947796 h1:mwFxclA1HGkDk6qtjIn788Wkcopnh91o+TWzxJxQpEE=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210823214615-88bfd6947796/go.mod h1:2ph3SY8wu6ZX0Z350YJe0f/1DdHkIE320jIHKH/WQC4=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210825150951-f838583b4b49 h1:KY3aPsJm7mtZC8uoB9JTHg+NbFk2DF2JfarXPhIcTbE=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210825150951-f838583b4b49/go.mod h1:2ph3SY8wu6ZX0Z350YJe0f/1DdHkIE320jIHKH/WQC4=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
 github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=


### PR DESCRIPTION
## What this PR does / why we need it
Captures fixes for credential encoding on Azure and vSphere as part of https://github.com/vmware-tanzu/tanzu-framework/pull/508

## Details for the Release Notes
```release-note
- Bug fix for credentials not encoding correctly for vSphere or Azure preventing deletion of standalone cluster
```

## Which issue(s) this PR fixes
Fixes #1241
Fixes #1432

## Describe testing done for PR
Able to deploy and delete AWS, Azure, Docker, and vSphere standalone clusters

## Special notes for your reviewer
Please note the sha ontop of tce-main should be 
```
f838583b4b49875d94360cc83d0889e4166fbd69
```
