### PR TITLE
Run GitHub actions in PRs with plugin go mod changes

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "**.go"
+      - "cli/cmd/plugin/**/go.mod"
       - "**.sh"
       - ".github/**"
     tags-ignore:

--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "**.go"
+      - "cli/cmd/plugin/**/go.mod"
       - "**.sh"
       - ".github/**"
     types:

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -9,6 +9,7 @@ on:
       - reopened
     paths:
       - "**.go"
+      - "**/go.mod"
       - "hack/check-lint.sh"
 
 jobs:


### PR DESCRIPTION
## What this PR does / why we need it
Changes github actions to run a build when any of our plugin `go.mod` files change. Then, we can capture any build breaks that may happen due to dependency changes

Also runs linting on any go module changes (since the linter will catch any improper formatting, etc)

## Details for the Release Notes
```release-note
NONE
```

## Which issue(s) this PR fixes
Fixes: #1450

## Describe testing done for PR
N/a

## Special notes for your reviewer
N/a
