### PR TITLE
Implements configurable logging verbosity in standalone cluster plugin

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/create.go
+++ b/cli/cmd/plugin/standalone-cluster/create.go
@@ -55,27 +55,10 @@ func create(cmd *cobra.Command, args []string) error {
 		clusterName = args[0]
 	}
 
-	cmd.Println(tkgctl.CreateClusterOptions{})
-
-	configDir, err := getTKGConfigDir()
-	if err != nil {
-		return NonUsageError(cmd, err, "unable to determine Tanzu configuration directory.")
-	}
-
-	// setup client options
-	opt := tkgctl.Options{
-		ConfigDir: configDir,
-		CustomizerOptions: types.CustomizerOptions{
-			RegionManagerFactory: region.NewFactory(),
-		},
-		LogOptions:                       tkgctl.LoggingOptions{Verbosity: 10},
-		ForceUpdateTKGCompatibilityImage: true,
-	}
-
 	// create new client
-	c, err := tkgctl.New(opt)
+	c, err := newTKGCtlClient(false)
 	if err != nil {
-		return NonUsageError(cmd, err, "unable to create Tanzu management config.")
+		return NonUsageError(cmd, err, "unable to create Tanzu Standalone Cluster client")
 	}
 
 	// create a new standlone cluster
@@ -104,6 +87,23 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func newTKGCtlClient(forceUpdateTKGCompatibilityImage bool) (tkgctl.TKGClient, error) {
+	configDir, err := getTKGConfigDir()
+	if err != nil {
+		return nil, Error(err, "unable to determine Tanzu configuration directory.")
+	}
+
+	return tkgctl.New(tkgctl.Options{
+		ConfigDir: configDir,
+		CustomizerOptions: types.CustomizerOptions{
+			RegionManagerFactory: region.NewFactory(),
+		},
+
+		LogOptions:                       tkgctl.LoggingOptions{Verbosity: logLevel, File: logFile},
+		ForceUpdateTKGCompatibilityImage: forceUpdateTKGCompatibilityImage,
+	})
 }
 
 func getTKGConfigDir() (string, error) {

--- a/cli/cmd/plugin/standalone-cluster/delete.go
+++ b/cli/cmd/plugin/standalone-cluster/delete.go
@@ -84,7 +84,7 @@ func teardown(cmd *cobra.Command, args []string) error {
 		KubeConfig:        "",
 		KubeContext:       "",
 		ConfigDir:         configDir,
-		LogOptions:        tkgctl.LoggingOptions{Verbosity: 10},
+		LogOptions:        tkgctl.LoggingOptions{Verbosity: logLevel, File: logFile},
 		ProviderGetter:    nil,
 		CustomizerOptions: types.CustomizerOptions{},
 		SettingsFile:      "",

--- a/cli/cmd/plugin/standalone-cluster/go.mod
+++ b/cli/cmd/plugin/standalone-cluster/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6 // indirect
 	github.com/spf13/cobra v1.2.0
-	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210825150951-f838583b4b49
+	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210825190307-0b7201772f82
 	k8s.io/klog/v2 v2.8.0
 )
 

--- a/cli/cmd/plugin/standalone-cluster/go.sum
+++ b/cli/cmd/plugin/standalone-cluster/go.sum
@@ -1327,8 +1327,8 @@ github.com/vmware-tanzu/carvel-vendir v0.19.0 h1:4FTeDcxwEuZWdFlFqh+11NqnJciCkkO
 github.com/vmware-tanzu/carvel-vendir v0.19.0/go.mod h1:HF7iLB0NyEFHuCvM0EJ42fERk20l2ImpktJzhSEdqOU=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159 h1:c7sM3NrAQGmTvq57Aw96BBzBO67apYZpZs/51PfjddA=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159/go.mod h1:1DBZEj6GmcWxe77d8YOeac1JIa8ttP21uTHUlAyji2g=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210825150951-f838583b4b49 h1:KY3aPsJm7mtZC8uoB9JTHg+NbFk2DF2JfarXPhIcTbE=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210825150951-f838583b4b49/go.mod h1:2ph3SY8wu6ZX0Z350YJe0f/1DdHkIE320jIHKH/WQC4=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210825190307-0b7201772f82 h1:KFokPD+/70y0j+4PhLwMwzcxGlwV/FfDJzqEphzrzig=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210825190307-0b7201772f82/go.mod h1:2ph3SY8wu6ZX0Z350YJe0f/1DdHkIE320jIHKH/WQC4=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
 github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=

--- a/cli/cmd/plugin/standalone-cluster/main.go
+++ b/cli/cmd/plugin/standalone-cluster/main.go
@@ -4,14 +4,11 @@
 package main
 
 import (
-	"math/rand"
 	"os"
-	"time"
-
-	klog "k8s.io/klog/v2"
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
 )
 
 var descriptor = cliv1alpha1.PluginDescriptor{
@@ -26,20 +23,20 @@ var (
 
 	// logLevel is the verbosity to print
 	logLevel int32
-)
 
-func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
-}
+	// Log file to dump logs to
+	logFile string
+)
 
 func main() {
 	// plugin!
 	p, err := plugin.NewPlugin(&descriptor)
 	if err != nil {
-		klog.Fatalf("%v", err)
+		log.Fatal(err, "unable to initilize new plugin")
 	}
 
 	p.Cmd.PersistentFlags().Int32VarP(&logLevel, "verbose", "v", 0, "Number for the log level verbosity(0-9)")
+	p.Cmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Log file path")
 
 	p.AddCommands(
 		CreateCmd,


### PR DESCRIPTION
## What this PR does / why we need it
This PR implements configurable logging in standalone clusters

This PR also bumps to the latest `tce-main` sha from Tanzu Framework which captures a number of small clean up items for standalone cluster logging. Those changes can be seen here: https://github.com/vmware-tanzu/tanzu-framework/pull/510

## Details for the Release Notes
```release-note
- Logging for standalone clusters is now configurable. Include the "-v" flag and a number 0-9 to configure logging level.
```

## Which issue(s) this PR fixes
Fixes: #1380

## Describe testing done for PR
Created and deleted Docker cluster and able to configure with
```
$ tanzu standalone-cluster create my-cluster -i docker -v 5
```
_*Note*_: the default logging is set to 0 (much like it is in the management cluster plugin

## Special notes for your reviewer
Please note that the sha we should be bumping to in `tce-main` is:
```
0b7201772f82cc9f206efd4dfb6b2605d1c007a2
```
