### PR TITLE
fix default adc will be written back by add-on manager issue

### DIFF
--- a/addons/packages/ako-operator/1.4.0/bundle/config/kapp-config.yaml
+++ b/addons/packages/ako-operator/1.4.0/bundle/config/kapp-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ako-operator-kapp-config
+  labels:
+    kapp.k14s.io/config: ""
+data:
+  config.yml: |
+    apiVersion: kapp.k14s.io/v1alpha1
+    kind: Config
+    rebaseRules:
+    - paths:
+      - [spec, extraConfigs]
+      - [spec, dataNetwork]
+      - [spec, serviceEngineGroup] 
+      type: copy
+      sources: [existing, new]
+      resourceMatchers:
+      - apiVersionKindMatcher: {apiVersion: networking.tkg.tanzu.vmware.com/v1alpha1, kind: AKODeploymentConfig}

--- a/addons/packages/ako-operator/1.4.0/bundle/config/upstream/akooperator/static.yaml
+++ b/addons/packages/ako-operator/1.4.0/bundle/config/upstream/akooperator/static.yaml
@@ -182,6 +182,7 @@ spec:
                         enum:
                         - NodePort
                         - ClusterIP
+                        - NodePortLocal          
                         type: string
                       shardVSSize:
                         description: ShardVSSize string describes ingress shared virtual service size Valid value should be SMALL, MEDIUM or LARGE, default value is SMALL


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

Currently, we deploy default AKODeploymentConfig using add-on manager, which makes it uneditable.

To allow users to enable L7 or modify other AKO configurations in the management cluster or default select-all AKODeploymentConfig, we need to add rebase rule for kapp-controller

## Details for the Release Notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
