### PR TITLE
set ceip off for all standalone cluster creations

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/create.go
+++ b/cli/cmd/plugin/standalone-cluster/create.go
@@ -87,6 +87,10 @@ func create(cmd *cobra.Command, args []string) error {
 		Bind:              iso.bind,
 		Browser:           iso.browser,
 		Edition:           BuildEdition,
+		// all tce-based clusters should opt out of CEIP
+		// since standalone-clusters are specific to TCE, we'll
+		// always set this to "false"
+		CeipOptIn: "false",
 	}
 
 	if iso.infrastructureProvider != "" {


### PR DESCRIPTION
## What this PR does / why we need it

CEIP should be off for all operations involving TCE. This commit ensure
that CEIP is set to false, regardless of flags or environment variables.

## Details for the Release Notes

```release-note
CEIP (telemetry) is now disabled by default for all standalone-clusters
```

## Which issue(s) this PR fixes

Relates: https://github.com/vmware-tanzu/community-edition/issues/1273

## Describe testing done for PR

Bootstrap a cluster and verify CEIP is off (set log level to `9`)

## Special notes for your reviewer

None
