### PR TITLE
Fixes two erroneous directory aliases in Windows uninstall script #1475

### DIFF
--- a/hack/uninstall.bat
+++ b/hack/uninstall.bat
@@ -3,24 +3,82 @@
 
 @echo off
 
+set STARTTIME=%TIME%
+SET /A errno=0
+
 :: start delete tanzu cli
 SET TANZU_CLI_DIR=%ProgramFiles%\tanzu
-rmdir /Q /S "%TANZU_CLI_DIR%"
+if exist "%TANZU_CLI_DIR%" (
+  rmdir /Q /S "%TANZU_CLI_DIR%"
+)
+if exist "%TANZU_CLI_DIR%" (
+  SET /A errno=1
+)
 
 :: start delete plugins
 SET PLUGIN_DIR=%LocalAppData%\tanzu-cli
-rmdir /Q /S %PLUGIN_DIR%
+if exist "%PLUGIN_DIR%" (
+  rmdir /Q /S %PLUGIN_DIR%
+)
+if exist "%PLUGIN_DIR%" (
+  SET /A errno=1
+)
 
 :: start delete tanzu configuration
-SET TANZU_CONFIG_DIR=%LocalAppData%\.config\tanzu
-rmdir /Q /S %TANZU_CONFIG_DIR%
+SET TANZU_CONFIG_DIR=%USERPROFILE%\.config\tanzu
+if exist "%TANZU_CONFIG_DIR%" (
+  rmdir /Q /S %TANZU_CONFIG_DIR%
+)
+if exist "%TANZU_CONFIG_DIR%" (
+  SET /A errno=1
+)
 
 :: start delete tanzu cache
-SET TANZU_CACHE_DIR=%LocalAppData%\.cache\tanzu
-rmdir /Q /S %TANZU_CACHE_DIR%
+SET TANZU_CACHE_DIR=%USERPROFILE%\.cache\tanzu
+if exist "%TANZU_CACHE_DIR%" (
+  rmdir /Q /S %TANZU_CACHE_DIR%
+)
+if exist "%TANZU_CACHE_DIR%" (
+  SET /A errno=1
+)
 
 :: start delete tce
 SET TCE_DIR=%LocalAppData%\tce
-rmdir /Q /S %TCE_DIR%
+if exist "%TCE_DIR%" (
+  rmdir /Q /S %TCE_DIR%
+)
+if exist "%TCE_DIR%" (
+  SET /A errno=1
+)
 
-echo "Uninstall complete!"
+:: Get elapsed time:
+set ENDTIME=%TIME%
+
+:: Change formatting for the start and end times, adjusting for midnight crossover
+    for /F "tokens=1-4 delims=:.," %%a in ("%STARTTIME%") do (
+       set /A "start=(((%%a*60)+1%%b %% 100)*60+1%%c %% 100)*100+1%%d %% 100"
+    )
+
+    for /F "tokens=1-4 delims=:.," %%a in ("%ENDTIME%") do ( 
+       IF %ENDTIME% GTR %STARTTIME% set /A "end=(((%%a*60)+1%%b %% 100)*60+1%%c %% 100)*100+1%%d %% 100" 
+       IF %ENDTIME% LSS %STARTTIME% set /A "end=((((%%a+24)*60)+1%%b %% 100)*60+1%%c %% 100)*100+1%%d %% 100" 
+    )
+
+:: Calculate the elapsed time by subtracting values
+    set /A elapsed=end-start
+
+:: Format the results for output
+    set /A hh=elapsed/(60*60*100), rest=elapsed%%(60*60*100), mm=rest/(60*100), rest%%=60*100, ss=rest/100, cc=rest%%100
+    if %hh% lss 10 set hh=0%hh%
+    if %mm% lss 10 set mm=0%mm%
+    if %ss% lss 10 set ss=0%ss%
+    if %cc% lss 10 set cc=0%cc%
+
+    set DURATION=%hh%:%mm%:%ss%,%cc%
+
+echo Start    : %STARTTIME%
+echo Finish   : %ENDTIME%
+echo          ---------------
+echo Duration : %DURATION% 
+IF %errno%==0 (echo "Uninstall complete!") ELSE (echo "Uninstall incomplete!")
+EXIT /B %errno%


### PR DESCRIPTION
Windows uninstall left behind the .cache and .config directories because an incorrect LocalAppData directory alias was used - changed to use correct USERPROFILE alias. Also no longer output a nuisance "The system cannot find the file specified." when a directory is already missing when the script is run which can occur after a failed deployment.
Also prevented outputing "Uninstall complete" if an error occurs and now return an exit code to allow the script to be potentially be used in test automation. Also now output an elapsed time of script execution.

Fixes #1475

Signed-off-by: Steve Wong <wongsteven@vmware.com>

## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->

## Details for the Release Notes
```release-note
Fix Issue #1475 Uninstall script for Windows does not remove all community edition associated directories.
```

## Which issue(s) this PR fixes
Fixes: # 1475

## Describe testing done for PR
Tested an uninstall.bat on Windows using the 0.7.0 release, verifying that the .config and .cache directories are removed. Also placed a file with elevated access permission in a directory to cause an intentional drectory delete failure and verified that "Uninstall incomplete" is output instead of "Uninstall complete". Also verified that a nuisance "The system cannot find the file specified." is no longer output when a directory is already missing when the script is run. Also verfied  visually that an elapsed script execution time is outputed and appears to be correct. 

## Special notes for your reviewer
NONE
