### PR TITLE
add darwin arm64 build target, improve m1 devx

### DIFF
--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -88,6 +88,17 @@ jobs:
           asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
 
+      - name: Upload Darwin ARM64 Asset
+        id: upload-darwin-arm64-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build/tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_name: tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
+          asset_content_type: application/gzip
+
       - name: Upload Windows AMD64 Asset
         id: upload-windows-amd64-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -89,6 +89,17 @@ jobs:
           asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
 
+      - name: Upload Darwin ARM64 Asset
+        id: upload-darwin-arm64-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build/tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_name: tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
+          asset_content_type: application/gzip
+
       - name: Upload Windows AMD64 Asset
         id: upload-windows-amd64-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -90,6 +90,17 @@ jobs:
           asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
 
+      - name: Upload Darwin ARM64 Asset
+        id: upload-darwin-arm64-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build/tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_name: tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
+          asset_content_type: application/gzip
+
       - name: Upload Windows AMD64 Asset
         id: upload-windows-amd64-asset
         uses: actions/upload-release-asset@v1

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ docs/site/resources
 
 # package configuration values files
 *-values.yaml
+.envrc

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GOARCH ?= $(shell go env GOARCH)
 GOHOSTOS ?= $(shell go env GOHOSTOS)
 GOHOSTARCH ?= $(shell go env GOHOSTARCH)
 # Add supported OS-ARCHITECTURE combinations here
-ENVS := linux-amd64 windows-amd64 darwin-amd64
+ENVS := linux-amd64 windows-amd64 darwin-amd64 darwin-arm64
 
 TOOLS_DIR := $(ROOT_DIR)/hack/tools
 TOOLS_BIN_DIR := $(TOOLS_DIR)/bin

--- a/hack/asset/asset.go
+++ b/hack/asset/asset.go
@@ -116,13 +116,24 @@ func main() {
 		return
 	}
 
-	darwinAssetFilename := fmt.Sprintf("tce-darwin-amd64-%s.tar.gz", tag)
-	darwinAsset := filepath.Join("..", "..", "build", darwinAssetFilename)
-	err = uploadToDraftRelease(draftRelease, darwinAsset)
+	darwinAMD64AssetFilename := fmt.Sprintf("tce-darwin-amd64-%s.tar.gz", tag)
+	darwinAMD64Asset := filepath.Join("..", "..", "build", darwinAMD64AssetFilename)
+	err = uploadToDraftRelease(draftRelease, darwinAMD64Asset)
 	if err != nil {
-		fmt.Printf("uploadToDraftRelease(darwin) failed: %v\n", err)
+		fmt.Printf("uploadToDraftRelease(darwin-amd64) failed: %v\n", err)
 		return
 	}
+
+	// TODO: Uncomment this when cluster creation is supported on Darwin/ARM64
+	/*
+		darwinARM64AssetFilename := fmt.Sprintf("tce-darwin-arm64-%s.tar.gz", tag)
+		darwinARM64Asset := filepath.Join("..", "..", "build", darwinARM64AssetFilename)
+		err = uploadToDraftRelease(draftRelease, darwinARM64Asset)
+		if err != nil {
+			fmt.Printf("uploadToDraftRelease(darwin-arm64) failed: %v\n", err)
+			return
+		}
+	*/
 
 	linuxAssetFilename := fmt.Sprintf("tce-linux-amd64-%s.tar.gz", tag)
 	linuxAsset := filepath.Join("..", "..", "build", linuxAssetFilename)

--- a/hack/build-tanzu.sh
+++ b/hack/build-tanzu.sh
@@ -66,7 +66,8 @@ fi
 
 
 # by default, tanzu-framework only builds admins plugins for the current platform. we need darwin also.
-BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} GOHOSTOS=linux GOHOSTARCH=amd64 make build-plugin-admin
-BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} GOHOSTOS=darwin GOHOSTARCH=amd64 make build-plugin-admin
-BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} GOHOSTOS=windows GOHOSTARCH=amd64 make build-plugin-admin
+BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} GOHOSTOS=linux GOHOSTARCH=amd64 make ENVS="${ENVS}" build-plugin-admin
+BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} GOHOSTOS=darwin GOHOSTARCH=amd64 make ENVS="${ENVS}" build-plugin-admin
+BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} GOHOSTOS=darwin GOHOSTARCH=arm64 make ENVS="${ENVS}" build-plugin-admin
+BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} GOHOSTOS=windows GOHOSTARCH=amd64 make ENVS="${ENVS}" build-plugin-admin
 popd || exit 1

--- a/hack/package-release.sh
+++ b/hack/package-release.sh
@@ -32,16 +32,19 @@ ROOT_FRAMEWORK_DIR="${DEP_BUILD_DIR}/tanzu-framework"
 
 PACKAGE_LINUX_AMD64_DIR="${BUILD_ROOT_DIR}/tce-linux-amd64-${BUILD_VERSION}"
 PACKAGE_DARWIN_AMD64_DIR="${BUILD_ROOT_DIR}/tce-darwin-amd64-${BUILD_VERSION}"
+PACKAGE_DARWIN_ARM64_DIR="${BUILD_ROOT_DIR}/tce-darwin-arm64-${BUILD_VERSION}"
 PACKAGE_WINDOWS_AMD64_DIR="${BUILD_ROOT_DIR}/tce-windows-amd64-${BUILD_VERSION}"
 
 # delete and create everything
 rm -rf "${BUILD_ROOT_DIR}"
 rm -rf "${PACKAGE_LINUX_AMD64_DIR}"
 rm -rf "${PACKAGE_DARWIN_AMD64_DIR}"
+rm -rf "${PACKAGE_DARWIN_ARM64_DIR}"
 rm -rf "${PACKAGE_WINDOWS_AMD64_DIR}"
 mkdir -p "${BUILD_ROOT_DIR}"
 mkdir -p "${PACKAGE_LINUX_AMD64_DIR}/bin"
 mkdir -p "${PACKAGE_DARWIN_AMD64_DIR}/bin"
+mkdir -p "${PACKAGE_DARWIN_ARM64_DIR}/bin"
 mkdir -p "${PACKAGE_WINDOWS_AMD64_DIR}/bin"
 
 # Common directories
@@ -83,6 +86,23 @@ cp -f "${ROOT_FRAMEWORK_ARTFACTS_ADMIN_DIR}/darwin/amd64/cli/builder/${FRAMEWORK
 cp -f "${ROOT_TCE_ARTIFACTS_DIR}/standalone-cluster/${TCE_BUILD_VERSION}/tanzu-standalone-cluster-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-standalone-cluster"
 cp -f "${ROOT_TCE_ARTIFACTS_DIR}/conformance/${TCE_BUILD_VERSION}/tanzu-conformance-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-conformance"
 
+# copy tanzu cli bits Darwin ARM64
+# Tanzu bits
+cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/darwin/arm64/cli/core/${FRAMEWORK_BUILD_VERSION}/tanzu-core-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu"
+# cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/darwin/arm64/cli/alpha/${FRAMEWORK_BUILD_VERSION}/tanzu-alpha-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-alpha"
+cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/darwin/arm64/cli/cluster/${FRAMEWORK_BUILD_VERSION}/tanzu-cluster-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-cluster"
+cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/darwin/arm64/cli/kubernetes-release/${FRAMEWORK_BUILD_VERSION}/tanzu-kubernetes-release-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-kubernetes-release"
+cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/darwin/arm64/cli/login/${FRAMEWORK_BUILD_VERSION}/tanzu-login-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-login"
+cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/darwin/arm64/cli/package/${FRAMEWORK_BUILD_VERSION}/tanzu-package-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-package"
+cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/darwin/arm64/cli/pinniped-auth/${FRAMEWORK_BUILD_VERSION}/tanzu-pinniped-auth-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-pinniped-auth"
+cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/darwin/arm64/cli/management-cluster/${FRAMEWORK_BUILD_VERSION}/tanzu-management-cluster-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-management-cluster"
+
+cp -f "${ROOT_FRAMEWORK_ARTFACTS_ADMIN_DIR}/darwin/arm64/cli/builder/${FRAMEWORK_BUILD_VERSION}/tanzu-builder-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-builder"
+
+# TCE bits (New folder structure using tanzu-framwork main)
+cp -f "${ROOT_TCE_ARTIFACTS_DIR}/standalone-cluster/${TCE_BUILD_VERSION}/tanzu-standalone-cluster-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-standalone-cluster"
+cp -f "${ROOT_TCE_ARTIFACTS_DIR}/conformance/${TCE_BUILD_VERSION}/tanzu-conformance-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-conformance"
+
 # copy tanzu cli bits Windows AMD64
 # Tanzu bits
 cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/windows/amd64/cli/core/${FRAMEWORK_BUILD_VERSION}/tanzu-core-windows_amd64.exe" "${PACKAGE_WINDOWS_AMD64_DIR}/bin/tanzu.exe"
@@ -106,18 +126,23 @@ cp -f "${ROOT_REPO_DIR}/hack/install.sh" "${PACKAGE_LINUX_AMD64_DIR}"
 cp -f "${ROOT_REPO_DIR}/hack/uninstall.sh" "${PACKAGE_LINUX_AMD64_DIR}"
 cp -f "${ROOT_REPO_DIR}/hack/install.sh" "${PACKAGE_DARWIN_AMD64_DIR}"
 cp -f "${ROOT_REPO_DIR}/hack/uninstall.sh" "${PACKAGE_DARWIN_AMD64_DIR}"
+cp -f "${ROOT_REPO_DIR}/hack/install.sh" "${PACKAGE_DARWIN_ARM64_DIR}"
+cp -f "${ROOT_REPO_DIR}/hack/uninstall.sh" "${PACKAGE_DARWIN_ARM64_DIR}"
 cp -f "${ROOT_REPO_DIR}/hack/install.bat" "${PACKAGE_WINDOWS_AMD64_DIR}"
 cp -f "${ROOT_REPO_DIR}/hack/uninstall.bat" "${PACKAGE_WINDOWS_AMD64_DIR}"
 chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_LINUX_AMD64_DIR}"
 chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_DARWIN_AMD64_DIR}"
+chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_DARWIN_ARM64_DIR}"
 chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_WINDOWS_AMD64_DIR}"
 
 # packaging
 rm -f tce-linux-amd64-*.tar.gz
 rm -f tce-darwin-amd64-*.tar.gz
+rm -f tce-darwin-arm64-*.tar.gz
 rm -f tce-windows-amd64-*.tar.gz
 pushd "${BUILD_ROOT_DIR}" || exit 1
 tar -czvf "tce-linux-amd64-${TCE_BUILD_VERSION}.tar.gz" "tce-linux-amd64-${BUILD_VERSION}"
 tar -czvf "tce-darwin-amd64-${TCE_BUILD_VERSION}.tar.gz" "tce-darwin-amd64-${BUILD_VERSION}"
+tar -czvf "tce-darwin-arm64-${TCE_BUILD_VERSION}.tar.gz" "tce-darwin-arm64-${BUILD_VERSION}"
 tar -czvf "tce-windows-amd64-${TCE_BUILD_VERSION}.tar.gz" "tce-windows-amd64-${BUILD_VERSION}"
 popd || exit 1

--- a/hack/workflows/packages/copy-package-readmes-to-docs.go
+++ b/hack/workflows/packages/copy-package-readmes-to-docs.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 type PackageRepositoryPackage struct {

--- a/test/build-tce.sh
+++ b/test/build-tce.sh
@@ -32,7 +32,12 @@ echo "Installing TCE release"
 if [[ $BUILD_OS == "Linux" ]]; then
     pushd build/tce-linux-amd64*/ || exit 1
 elif [[ $BUILD_OS == "Darwin" ]]; then
-    pushd build/tce-darwin-amd64*/ || exit 1
+    if [[ "$BUILD_ARCH" == "x86_64" ]]; then
+        pushd build/tce-darwin-amd64*/ || exit 1
+    else
+        pushd build/tce-darwin-arm64*/ || exit 1
+    fi
+    
 fi
 ./install.sh || { error "TCE INSTALLATION FAILED!"; exit 1; }
 popd || exit 1

--- a/test/install-dependencies.sh
+++ b/test/install-dependencies.sh
@@ -6,6 +6,7 @@
 # This script installs dependencies needed for running build-tce.sh and deploy-tce.sh
 
 BUILD_OS=$(uname -s)
+BUILD_ARCH=$(uname -m 2>/dev/null || echo Unknown)
 export BUILD_OS
 
 # Make sure docker is installed
@@ -56,7 +57,13 @@ if [[ -z "$(command -v kubectl)" ]]; then
     if [[ "$BUILD_OS" == "Linux" ]]; then
         curl -LO https://dl.k8s.io/release/v1.20.1/bin/linux/amd64/kubectl
     elif [[ "$BUILD_OS" == "Darwin" ]]; then
-        curl -LO https://dl.k8s.io/release/v1.20.1/bin/darwin/amd64/kubectl
+        if [[ "$BUILD_ARCH" == "x86_64" ]]; then
+            curl -LO https://dl.k8s.io/release/v1.20.1/bin/darwin/amd64/kubectl
+        elif [[ "$BUILD_ARCH" == "arm64" ]]; then
+            curl -LO https://dl.k8s.io/release/v1.20.1/bin/darwin/arm64/kubectl
+        else
+            error "$BUILD_OS-$BUILD_ARCH NOT SUPPORTED!!!"
+        fi
     else
         error "$BUILD_OS NOT SUPPORTED!!!"
         exit 1


### PR DESCRIPTION
Signed-off-by: Joe Fitzgerald <jfitzgerald@vmware.com>

## What this PR does / why we need it
<!--
Add detailed explanation of what this PR does and why it is
needed.
-->
This PR causes darwin / arm64 binaries to be generated by `make release`. It also makes improvements to scripts that support building a release locally on an arm64 Mac.

## Details for the Release Notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
generate arm64 binaries for darwin
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
* ran `make release` locally and validated it succeeds

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
* This PR will be accompanied with a `cayman_vmware-tanzu_tce` MR to ensure the new binaries are notarized correctly.