### PR TITLE
add docs on waiting for pkg repo reconcile

### DIFF
--- a/docs/site/content/docs/assets/package-installation.md
+++ b/docs/site/content/docs/assets/package-installation.md
@@ -31,6 +31,24 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
 
    > By installing the Tanzu Community Edition package repository, [kapp-controller](https://carvel.dev/kapp-controller/) will make multiple packages available in the cluster.
 
+1. [Optional] Verify the package repository has reconciled.
+
+    ```sh
+    tanzu package repository list
+    ```
+
+    The output will look similar to the following:
+
+    ```sh
+    / Retrieving repositories...
+      NAME      REPOSITORY                                    STATUS
+    DETAILS
+      tce-repo  projects.registry.vmware.com/tce/main:stable  Reconcile succeeded
+    ```
+
+    > It may take some time to see `Reconcile succeeded`. Until then, packages
+    > won't show up in the available list described in the next step.
+
 1. List the available packages.
 
     ```sh


### PR DESCRIPTION
## What this PR does / why we need it

This commits instructs the user to check to see if the package
repository has successfully reconciled before listing available packages.
Without this change, users may go right to listing packages and come up
with an empty list.

## Details for the Release Notes

```release-note
Documentation added to check for package repository reconciliation status before listing packages
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1428

## Describe testing done for PR

Validate the change using `hugo serve`

![image](https://user-images.githubusercontent.com/6200057/131566414-349a9a9f-b2cb-4d87-8c79-aab4e4783328.png)

## Special notes for your reviewer

None