### PR TITLE
add docs around pre-pulling ha proxy for capd

### DIFF
--- a/docs/site/content/docs/assets/capd-clusters.md
+++ b/docs/site/content/docs/assets/capd-clusters.md
@@ -5,6 +5,23 @@ using Docker.
 
 ⚠️: Tanzu Community Edition support for Docker is **experimental** and may require troubleshooting on your system.
 
+### ⚠️  Warning on DockerHub Rate Limiting
+
+When using the Docker (CAPD) provider, the load balancer image (HA Proxy) is
+pulled from DockerHub. DockerHub limits pulls per user and this can especially
+impact users who share a common IP, in the case of NAT or VPN. If DockerHub
+rate-limiting is an issue in your environment, you can pre-pull the load
+balancer image to your machine by running the following command.
+
+```sh
+docker pull kindest/haproxy:v20210715-a6da3463
+```
+
+This behavior will eventually be addressed in
+[https://github.com/vmware-tanzu/community-edition/issues/897](https://github.com/vmware-tanzu/community-edition/issues/897).
+
+### Local Docker Bootstrapping
+
 1. Ensure your Docker engine has adequate resources. The  minimum requirements with no other containers running are: 6 GB of RAM and 4 CPUs.
     * **Linux**: Run ``docker system info``
     * **Mac**: Select Preferences > Resources > Advanced

--- a/docs/site/content/docs/assets/capd-standalone-clusters.md
+++ b/docs/site/content/docs/assets/capd-standalone-clusters.md
@@ -5,6 +5,23 @@ using Docker. This provides you a workload cluster that is **not** managed by a 
 
 ⚠️: Tanzu Community Edition support for Docker is **experimental** and may require troubleshooting on your system.
 
+### ⚠️  Warning on DockerHub Rate Limiting
+
+When using the Docker (CAPD) provider, the load balancer image (HA Proxy) is
+pulled from DockerHub. DockerHub limits pulls per user and this can especially
+impact users who share a common IP, in the case of NAT or VPN. If DockerHub
+rate-limiting is an issue in your environment, you can pre-pull the load
+balancer image to your machine by running the following command.
+
+```sh
+docker pull kindest/haproxy:v20210715-a6da3463
+```
+
+This behavior will eventually be addressed in
+[https://github.com/vmware-tanzu/community-edition/issues/897](https://github.com/vmware-tanzu/community-edition/issues/897).
+
+### Local Docker Bootstrapping
+
 1. Ensure your Docker engine has adequate resources. The  minimum requirements with no other containers running are: 6 GB of RAM and 4 CPUs.
     * **Linux**: Run ``docker system info``
     * **Mac**: Select Preferences > Resources > Advanced


### PR DESCRIPTION
## What this PR does / why we need it

This commit adds docs that instructs the user on how they can pre-pull
ha proxy in case their environment is prone to DockerHub rate limiting.


## Details for the Release Notes

```release-note
NONE
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1396

## Describe testing done for PR

Run `hugo serve` and preview the site update.

![image](https://user-images.githubusercontent.com/6200057/131580552-d3dd9fde-78bc-4834-9122-e26999e1ea51.png)

## Special notes for your reviewer

This needed to be done in both the standalone and managed  getting started guides because they are already an included asset and imported via a shortcode. Shortcodes cannot parse shortcodes in our current model. (Google shortcodify Hugo for more info).
