### PR TITLE
Quickfix for building CLI plugins before attempting to install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ build-cli-plugins-%: prep-build-cli
 build-cli-plugins-local: build-cli-plugins-${GOHOSTOS}-${GOHOSTARCH}
 
 .PHONY: install-cli-plugins
-install-cli-plugins:
+install-cli-plugins: build-cli-plugins
 	@cd ./hack/builder/ && $(MAKE) install-plugins
 
 .PHONY: build-install-plugins


### PR DESCRIPTION
## What this PR does / why we need it
Fixes a dropped build dependency on `make build`

Without `build-cli-plugins` as a dependency on `install-cli-plugins`, we won't ever build the plugins before attempting to install them.

## Details for the Release Notes
```release-note
NONE
```

## Which issue(s) this PR fixes
Fixes: #1511

## Describe testing done for PR
- `make build` now works
- `make build-all` still works
- `make release` still works

## Special notes for your reviewer
N/a
