### PR TITLE
git workflow needs more conditions #1516

### DIFF
--- a/.github/workflows/copy-package-readmes-to-docs.yml
+++ b/.github/workflows/copy-package-readmes-to-docs.yml
@@ -1,6 +1,10 @@
 name: copy-to-docs
 on:
   push:
+    branches:
+      - main
+    tags-ignore:
+      - "**"
     paths:
       - addons/packages/**/*/[rR][eE][aA][dD][mM][eE].md
       - addons/repos/main.yaml


### PR DESCRIPTION
## What this PR does / why we need it

The git workflow to automatically copy package documentation
to the docs folder is triggering off pushes to any branch.

This will restrict the workflow to run only on pushes to main.

## Details for the Release Notes
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1516

## Describe testing done for PR

-

## Special notes for your reviewer

-