### PR TITLE
Fix regression in automated package doc update #1502

### DIFF
--- a/docs/site/data/docs/latest-toc.yml
+++ b/docs/site/data/docs/latest-toc.yml
@@ -19,8 +19,44 @@ toc:
           url: /cli-installation
         - page: Preparing to Deploy a Cluster
           url: /prepare-deployment
+          subitems:
+            - subpage: Prepare to Deploy a Cluster to Amazon EC2
+              suburl: /aws
+            - subpage: Prepare to Deploy a Cluster to vSphere
+              suburl: /vsphere
+            - subpage: Prepare to Deploy a Cluster to Azure
+              suburl: /azure-mgmt
         - page: Deploying Clusters
           url: /clusters-deploy
+          subitems:
+            - subpage: Deploy a Management Cluster to Amazon EC2
+              suburl: /aws-install-mgmt
+            - subpage: Deploy a Management Cluster to Azure
+              suburl: /azure-install-mgmt
+            - subpage: Deploy a Management Cluster to Docker
+              suburl: /docker-install-mgmt
+            - subpage: Deploy a Management Cluster to vSphere
+              suburl: /vsphere-install-mgmt
+            - subpage: Deploy a Standalone Cluster to Amazon EC2
+              suburl: /aws-install-standalone
+            - subpage: Deploy a Standalone Cluster to Azure
+              suburl: /azure-install-standalone
+            - subpage: Deploy a Standalone Cluster to Docker
+              suburl: /docker-install-standalone
+            - subpage: Deploy a Standalone Cluster to vSphere
+              suburl: /vsphere-install-standalone
+            - subpage: Deploying a Workload Cluster
+              suburl: /workload-clusters
+            - subpage: Examine the cluster
+              suburl: /verify-deployment
+            - subpage: Scale Management Cluster
+              suburl: /scale-mgmt
+            - subpage: Delete Management Cluster
+              suburl: /delete-mgmt
+            - subpage: Delete Workload Cluster
+              suburl: /delete-cluster
+            - subpage: Uninstall the Tanzu CLI
+              suburl: /cli-uninstall
     - title: Reference
       subfolderitems:
         - page: AWS Account Reference

--- a/hack/workflows/packages/copy-package-readmes-to-docs.go
+++ b/hack/workflows/packages/copy-package-readmes-to-docs.go
@@ -26,10 +26,16 @@ type MyPackage struct {
 	Versions    []string `yaml:"versions"`
 }
 
+type SubItem struct {
+	Subpage string `yaml:"subpage"`
+	SubUrl  string `yaml:"suburl"`
+}
+
 type SubFolderItem struct {
 	Page    string    `yaml:"page,omitempty"`
 	URL     string    `yaml:"url,omitempty"`
 	Package MyPackage `yaml:"package,omitempty"`
+	SubItems []SubItem `yaml:"subitems,omitempty"`
 }
 
 type TocItem struct {


### PR DESCRIPTION
## What this PR does / why we need it

The code that automatically copies package readme files
and regenerates the documentation table of contents was
omitting part of the yaml structure. This commit restores
the missing contents and updates the yaml parsing to
include the missing sections.


## Details for the Release Notes
```release-note
Restores missing content for the documentation table of contents
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1502

## Describe testing done for PR

1. Modified `main.yaml` - removed a package version
1. ran `cd hack/workflows/packages && go run copy-package-readmes-to-docs.go`
1. ran `git status` - noticed that `latest-toc.yaml` was modified
1. inspected `latest-toc.yaml`, verified that the newly restored content was still in place
1. reverted change to `main.yaml`
1. re-ran `go run copy-package-readmes-to-docs.go`
1. re-ran `git status`, verified no changes.
1. started the Hugo server and verified missing content had been restored

## Special notes for your reviewer

- none
