### PR TITLE
Update local path storage docs to be more generic & not just about Docker

### DIFF
--- a/addons/packages/local-path-storage/0.0.19/README.md
+++ b/addons/packages/local-path-storage/0.0.19/README.md
@@ -1,8 +1,14 @@
 # Local Path Storage
 
 This package provides local path node storage and primarily supports RWO AccessMode.
-It utilizes the kubernetes [Local Persistent Volume feature](https://kubernetes.io/blog/2018/04/13/local-persistent-volumes-beta/)
-and in TCE, is primarily intended for use with CAPD.
+It utilizes the Kubernetes [Local Persistent Volume feature](https://kubernetes.io/blog/2018/04/13/local-persistent-volumes-beta/)
+and in Tanzu Community Edition, it is primarily intended for use with Docker, although it will work with any infrastructure provider
+or package where persistent storage is needed.
+
+This package also provides a `StorageClass`.
+If there is no `StorageClass` already installed on the cluster,
+then the `StorageClass` provided in this package will automatically be made the default.
+Otherwise, the [`storageclass.kubernetes.io/is-default-class` may need to be modified.](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/)
 
 ## Limitations
 
@@ -10,7 +16,7 @@ The local-path-storage binds to a single host node
 and is not intended to dynamically change hosts.
 Therefore, a PVC can _only_ be used by the node that creates it.
 This can lead to unintended data loss when scaling or when pods roll from one node to another.
-Further, it can make scheduling difficult since applications are "tied" to the node that creates it's PV.
+Further, it can make scheduling difficult since applications are "tied" to the node that created it's PV.
 
 Further, local-path-storage does _not_ enforce capacity limitations
 and may possibly overwhelem the local node's disc capacity.
@@ -32,8 +38,8 @@ The local-path-storage pods will dynamically reload the config map upon configur
 ## Usage Examples
 
 A StorageClass is required in order to use PVCs and store data (which is necessary for services
-like Prometheus). The local-path-storage provider enables local CAPD clusters to store data locally.
-Using a local PVC with Docker lets a developer work quickly on their own workstation with CAPD.
+like Prometheus). The local-path-storage provider enables local Docker clusters to store data locally.
+Using a local PVC with Docker lets a developer work quickly on their own workstation with Docker.
 
 A local storage provider may also be used in special cases for caching, sharding data in distributed datastores,
 and other node failure tollerant storage models.

--- a/docs/site/content/docs/assets/package-installation.md
+++ b/docs/site/content/docs/assets/package-installation.md
@@ -180,7 +180,11 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
 For more information about how this package model works from a server-side and client-side perspective, see the
 [Package Management design doc](./designs/package-management.md).
 
-_Note:_ For installation of packages on a Docker deployment that require storage
-(like Prometheus or Grafana), please install the `local-path-storage` package.
-This installs a default storage class.
-More information can be found in the [`local-path-storage` package documentation.](../latest/local-path-storage-config.md)
+_Note:_ For installation of packages that require persistent storage
+(like Prometheus or Grafana), you must _first_ have a [`StorageClass`](https://kubernetes.io/docs/concepts/storage/storage-classes/) installed.
+TCE provides the [`local-path-storage`](../package-readme-local-path-storage-0.0.19) package for quick and easy local node storage.
+It is primarily intended to be used with Docker, but will work on any infrastructure.
+This installs a default storage class if none is available
+and enables persistent storage to the local node's filesystem.
+But it has limitations in multi-node deployments and is not intended to dynamically change hosts.
+More information can be found in the [`local-path-storage` package documentation.](../package-readme-local-path-storage-0.0.19)


### PR DESCRIPTION
## What this PR does / why we need it
- Updates the `local-path-storage` docs to be more generic and not just focus on Docker deployments
- Fixes a broken link to the local-path-storage readme doc
- Wordsmithing some of the docs

## Details for the Release Notes
```release-note
- Updated docs on local-path-storage to be more generic
```

## Which issue(s) this PR fixes
Fixes: #1397

## Describe testing done for PR
`hugo serve`

## Special notes for your reviewer
N/a
