### PR TITLE
fix code snipped in capd managed guide

### DIFF
--- a/docs/site/content/docs/assets/capd-clusters.md
+++ b/docs/site/content/docs/assets/capd-clusters.md
@@ -58,9 +58,11 @@ This behavior will eventually be addressed in
     -  ``<MGMT-CLUSTER-NAME>`` must end with a letter, not a numeric character, and must be compliant with DNS hostname requirements described here: [RFC 1123](https://tools.ietf.org/html/rfc1123).
 
 2. Validate the management cluster started:
-    ```
+
+    ```sh
     tanzu management-cluster get
     ```
+
     The output should look similar to the following:
 
     ```sh


### PR DESCRIPTION

## What this PR does / why we need it

Correct the formatting for hugo's markdown rendering to ensure the code
snippet is not white text on a white background.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1527

## Describe testing done for PR

Run `hugo serve` and view the output.

![image](https://user-images.githubusercontent.com/6200057/131704670-108cd1e0-7baa-454b-85ca-9bd72333cb4d.png)

## Special notes for your reviewer

None
