### PR TITLE
add note that capd doesn't support restart

### DIFF
--- a/docs/site/content/docs/assets/capd-clusters.md
+++ b/docs/site/content/docs/assets/capd-clusters.md
@@ -194,3 +194,7 @@ guest-md-0-f68799ffd-lpqsh   Ready    <none>                 67m   v1.20.4+vmwar
 ```
 
 > In the above `4ae` is a control plane node.
+
+⚠️: If the Docker host machine is rebooted, the cluster will need to be
+re-created. Support for clusters surviving a host reboot is track in issue
+[#832](https://github.com/vmware-tanzu/community-edition/issues/832).

--- a/docs/site/content/docs/assets/capd-standalone-clusters.md
+++ b/docs/site/content/docs/assets/capd-standalone-clusters.md
@@ -69,3 +69,7 @@ This behavior will eventually be addressed in
     kube-system       kube-scheduler-tkg-mgmt-docker-20210429071830-control-plane-vd8nl            1/1     Running   0          4m12s
     tkr-system        tkr-controller-manager-96445c85d-8qh44                                       1/1     Running   0          3m52s
     ```
+
+⚠️: If the Docker host machine is rebooted, the cluster will need to be
+re-created. Support for clusters surviving a host reboot is track in issue
+[#832](https://github.com/vmware-tanzu/community-edition/issues/832).


### PR DESCRIPTION
## What this PR does / why we need it

This commit adds a note to the getting started documentation that we
cannot (currently) survive a host restart when using CAPD.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Documentation updated to note that docker-based deployments cannot (currently survive a restart)
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1464

## Describe testing done for PR

Run `hugo server` and validate the change.

![image](https://user-images.githubusercontent.com/6200057/131707406-5a8dbde8-32df-4bf4-8e6c-1f6f3be2a5bf.png)

## Special notes for your reviewer

None 
