### PR TITLE
Add instructions for using capd on windows for docker

### DIFF
--- a/docs/site/content/docs/assets/capd-clusters-windows.md
+++ b/docs/site/content/docs/assets/capd-clusters-windows.md
@@ -1,0 +1,225 @@
+## Create Local Docker Clusters
+
+This section describes setting up a management cluster on your local workstation
+using Docker.
+
+⚠️: Tanzu Community Edition support for Docker is **experimental** and may require troubleshooting on your system.
+
+### ⚠️  Warning on DockerHub Rate Limiting
+
+When using the Docker (CAPD) provider, the load balancer image (HA Proxy) is
+pulled from DockerHub. DockerHub limits pulls per user and this can especially
+impact users who share a common IP, in the case of NAT or VPN. If DockerHub
+rate-limiting is an issue in your environment, you can pre-pull the load
+balancer image to your machine by running the following command.
+
+```sh
+docker pull kindest/haproxy:v20210715-a6da3463
+```
+
+This behavior will eventually be addressed in
+[https://github.com/vmware-tanzu/community-edition/issues/897](https://github.com/vmware-tanzu/community-edition/issues/897).
+
+### Local Docker Bootstrapping
+
+1. Ensure your Docker engine has adequate resources. The  minimum requirements with no other containers running are: 6 GB of RAM and 4 CPUs.
+    * **Linux**: Run ``docker system info``
+    * **Mac**: Select Preferences > Resources > Advanced
+
+1. Create the management cluster.
+
+    ```sh
+    CLUSTER_PLAN=dev tanzu management-cluster create -i docker <STANDALONE-CLUSTER-NAME>
+    ```
+    > For increased logs, you can append `-v 10`.
+
+    > ⚠️ Capture the name of your cluster, it will be referenced as
+    > ${CLUSTER_NAME} going forward.
+
+    > ⚠️ The deployment will fail due to the CLI client being unable
+    > to reach the API server running in the WSL VM. This is expected.
+
+1. Let the deployment report failure.
+
+1. Retrieve the address of the WSL VM.
+
+    > ⚠️ Capture the VM IP of your cluster, it will be referenced as
+    > ${WSL_VM_IP} going forward.
+
+1. Query the docker daemon to get the forwarded port for HA Proxy. In the
+   following example, the port is `44393`
+
+    ```sh
+    $ docker ps | grep -i ha
+    44c0a71735ef   kindest/haproxy:v20210715-a6da3463
+
+    "haproxy -sf 7 -W -d…"   2 days ago     Up 2 days     35093/tcp,
+    0.0.0.0:44393->6443/tcp     muuhmuh-lb
+    ```
+
+    > ⚠️ Capture the port mentioned above, it will be referenced as
+    > ${HA_PROXY_PORT} going forward.
+
+1. Edit your `~/.kube/config` file.
+
+1. Locate the YAML entry for your `${CLUSTER_NAME}`
+
+1. In that YAML entry, replace `certificate-authority-data: < BASE64 DATA >`
+   with `insecure-skip-tls-verify: true`.
+
+1. In the YAML entry, replace `server: < api server value >` with
+   `${WSL_VM_IP}:${HA_PROXY_PORT}`. Assuming the `${CLUSTER_NAME}` was
+test, the entry would now look as follows.
+
+    ```yaml
+    - cluster:
+        insecure-skip-tls-verify: true
+        server: https://192.0.1.1:44393
+      name: test
+    ```
+
+1. Save the file and exit.
+
+    > `kubectl` and `tanzu` CLI should now be able to interact with your
+    > cluster.
+
+
+2. Validate the management cluster started:
+
+    ```sh
+    tanzu management-cluster get
+    ```
+
+    The output should look similar to the following:
+
+    ```sh
+
+    NAME                                               READY  SEVERITY  REASON  SINCE  MESSAGE
+    /tkg-mgmt-docker-20210601125056                                                                 True                     28s
+    ├─ClusterInfrastructure - DockerCluster/tkg-mgmt-docker-20210601125056                          True                     32s
+    ├─ControlPlane - KubeadmControlPlane/tkg-mgmt-docker-20210601125056-control-plane               True                     28s
+    │ └─Machine/tkg-mgmt-docker-20210601125056-control-plane-5pkcp                                  True                     24s
+    │   └─MachineInfrastructure - DockerMachine/tkg-mgmt-docker-20210601125056-control-plane-9wlf2
+      └─MachineDeployment/tkg-mgmt-docker-20210601125056-md-0
+        └─Machine/tkg-mgmt-docker-20210601125056-md-0-5d895cbfd9-khj4s                              True                     24s
+          └─MachineInfrastructure - DockerMachine/tkg-mgmt-docker-20210601125056-md-0-d544k
+
+
+    Providers:
+
+      NAMESPACE                          NAME                   TYPE                    PROVIDERNAME  VERSION  WATCHNAMESPACE
+      capd-system                        infrastructure-docker  InfrastructureProvider  docker        v0.3.10
+      capi-kubeadm-bootstrap-system      bootstrap-kubeadm      BootstrapProvider       kubeadm       v0.3.14
+      capi-kubeadm-control-plane-system  control-plane-kubeadm  ControlPlaneProvider    kubeadm       v0.3.14
+      capi-system                        cluster-api            CoreProvider            cluster-api   v0.3.14
+    ```
+
+3. Capture the management cluster's kubeconfig and take note of the command for accessing the cluster in the message, as you will use this for setting the context in the next step.
+
+    ```sh
+    tanzu management-cluster kubeconfig get <MGMT-CLUSTER-NAME> --admin
+    ```
+    - Where <``MGMT-CLUSTER-NAME>`` should be set to the name returned by `tanzu management-cluster get`.
+    - For example, if your management cluster is called 'mtce', you will see a message similar to:
+    ```sh
+    Credentials of workload cluster 'mtce' have been saved.
+    You can now access the cluster by running 'kubectl config use-context mtce-admin@mtce'
+    ```
+
+4. Set your kubectl context to the management cluster.
+
+    ```sh
+    kubectl config use-context <MGMT-CLUSTER-NAME>-admin@<MGMT-CLUSTER-NAME>
+    ```
+
+5. Validate you can access the management cluster's API server.
+
+    ```sh
+    kubectl get nodes
+    ```
+    You will see output similar to:
+    ```sh
+    NAME                         STATUS   ROLES                  AGE   VERSION
+    guest-control-plane-tcjk2    Ready    control-plane,master   59m   v1.20.4+vmware.1
+    guest-md-0-f68799ffd-lpqsh   Ready    <none>                 59m   v1.20.4+vmware.1
+    ```
+
+6. Create your workload cluster.
+
+   ```shell
+   tanzu cluster create <WORKLOAD-CLUSTER-NAME> --plan dev
+   ```
+
+7.  Validate the cluster starts successfully.
+
+    ```sh
+    tanzu cluster list
+    ```
+
+8.  Capture the workload cluster's kubeconfig.
+
+    ```sh
+    tanzu cluster kubeconfig get <WORKLOAD-CLUSTER-NAME> --admin
+    ```
+
+9.  Set your `kubectl` context accordingly.
+
+    ```sh
+    kubectl config use-context <WORKLOAD-CLUSTER-NAME>-admin@<WORKLOAD-CLUSTER-NAME>
+    ```
+
+10. Verify you can see pods in the cluster.
+
+    ```sh
+    kubectl get pods --all-namespaces
+    ```
+    The output will look similar to the following:
+    ```sh
+    NAMESPACE     NAME                                                    READY   STATUS    RESTARTS   AGE
+    kube-system   antrea-agent-9d4db                                      2/2     Running   0          3m42s
+    kube-system   antrea-agent-vkgt4                                      2/2     Running   1          5m48s
+    kube-system   antrea-controller-5d594c5cc7-vn5gt                      1/1     Running   0          5m49s
+    kube-system   coredns-5d6f7c958-hs6vr                                 1/1     Running   0          5m49s
+    kube-system   coredns-5d6f7c958-xf6cl                                 1/1     Running   0          5m49s
+    kube-system   etcd-tce-guest-control-plane-b2wsf                      1/1     Running   0          5m56s
+    kube-system   kube-apiserver-tce-guest-control-plane-b2wsf            1/1     Running   0          5m56s
+    kube-system   kube-controller-manager-tce-guest-control-plane-b2wsf   1/1     Running   0          5m56s
+    kube-system   kube-proxy-9825q                                        1/1     Running   0          5m48s
+    kube-system   kube-proxy-wfktm                                        1/1     Running   0          3m42s
+    kube-system   kube-scheduler-tce-guest-control-plane-b2wsf            1/1     Running   0          5m56s
+    ```
+
+You now have local clusters running on Docker. The nodes can be seen by running the  following command:
+
+```shell
+$ docker ps
+```
+The output will be similar to the following:
+```sh
+CONTAINER ID   IMAGE                                                         COMMAND                  CREATED             STATUS             PORTS                                  NAMES
+33e4e422e102   projects.registry.vmware.com/tkg/kind/node:v1.20.4_vmware.1   "/usr/local/bin/entr…"   About an hour ago   Up About an hour                                          guest-md-0-f68799ffd-lpqsh
+4ae2829ab6e1   projects.registry.vmware.com/tkg/kind/node:v1.20.4_vmware.1   "/usr/local/bin/entr…"   About an hour ago   Up About an hour   41637/tcp, 127.0.0.1:41637->6443/tcp   guest-control-plane-tcjk2
+c0947823840b   kindest/haproxy:2.1.1-alpine                                  "/docker-entrypoint.…"   About an hour ago   Up About an hour   42385/tcp, 0.0.0.0:42385->6443/tcp     guest-lb
+a2f156fe933d   projects.registry.vmware.com/tkg/kind/node:v1.20.4_vmware.1   "/usr/local/bin/entr…"   About an hour ago   Up About an hour                                          mgmt-md-0-b8689788f-tlv68
+128bf25b9ae9   projects.registry.vmware.com/tkg/kind/node:v1.20.4_vmware.1   "/usr/local/bin/entr…"   About an hour ago   Up About an hour   40753/tcp, 127.0.0.1:40753->6443/tcp   mgmt-control-plane-9rdcq
+e59ca95c14d7   kindest/haproxy:2.1.1-alpine                                  "/docker-entrypoint.…"   About an hour ago   Up About an hour   35621/tcp, 0.0.0.0:35621->6443/tcp     mgmt-lb
+```
+
+The above reflects 1 management cluster and 1 workload cluster, both featuring 1 control plane node and 1 worker node.
+Each cluster gets an `haproxy` container fronting the control plane node(s). This enables scaling the control plane into
+an HA configuration.
+
+🛠️: For troubleshooting failed bootstraps, you can exec into a container and use the kubeconfig at `/etc/kubernetes/admin.conf` to access
+the API server directly. For example:
+
+```shell
+$ docker exec -it 4ae /bin/bash
+
+root@guest-control-plane-tcjk2:/# kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes
+
+NAME                         STATUS   ROLES                  AGE   VERSION
+guest-control-plane-tcjk2    Ready    control-plane,master   67m   v1.20.4+vmware.1
+guest-md-0-f68799ffd-lpqsh   Ready    <none>                 67m   v1.20.4+vmware.1
+```
+
+> In the above `4ae` is a control plane node.

--- a/docs/site/content/docs/assets/capd-standalone-clusters-windows.md
+++ b/docs/site/content/docs/assets/capd-standalone-clusters-windows.md
@@ -1,0 +1,115 @@
+## Create Standalone Docker Clusters
+
+This section describes setting up a standalone cluster on your local workstation
+using Docker. This provides you a workload cluster that is **not** managed by a centralized management cluster.
+
+⚠️: Tanzu Community Edition support for Docker is **experimental** and may require troubleshooting on your system.
+
+### ⚠️  Warning on DockerHub Rate Limiting
+
+When using the Docker (CAPD) provider, the load balancer image (HA Proxy) is
+pulled from DockerHub. DockerHub limits pulls per user and this can especially
+impact users who share a common IP, in the case of NAT or VPN. If DockerHub
+rate-limiting is an issue in your environment, you can pre-pull the load
+balancer image to your machine by running the following command.
+
+```sh
+docker pull kindest/haproxy:v20210715-a6da3463
+```
+
+This behavior will eventually be addressed in
+[https://github.com/vmware-tanzu/community-edition/issues/897](https://github.com/vmware-tanzu/community-edition/issues/897).
+
+### Local Docker Bootstrapping
+
+1. Ensure your Docker engine has adequate resources. The  minimum requirements with no other containers running are: 6 GB of RAM and 4 CPUs.
+    * **Linux**: Run ``docker system info``
+    * **Mac**: Select Preferences > Resources > Advanced
+
+1. Create the standalone cluster.
+
+    ```sh
+    tanzu standalone-cluster create -i docker <STANDALONE-CLUSTER-NAME>
+    ```
+    >``<STANDALONE-CLUSTER-NAME>`` must end with a letter, not a numeric character, and must be compliant with DNS hostname requirements [RFC 952](https://tools.ietf.org/html/rfc952) and [RFC 1123](https://tools.ietf.org/html/rfc1123).
+    > For increased logs, you can append `-v 10`.
+
+    > ⚠️ Capture the name of your cluster, it will be referenced as
+    > ${CLUSTER_NAME} going forward.
+
+    > ⚠️ The deployment will fail due to the CLI client being unable
+    > to reach the API server running in the WSL VM. This is expected.
+
+1. Let the deployment report failure.
+
+1. Retrieve the address of the WSL VM.
+
+    > ⚠️ Capture the VM IP of your cluster, it will be referenced as
+    > ${WSL_VM_IP} going forward.
+
+1. Query the docker daemon to get the forwarded port for HA Proxy. In the
+   following example, the port is `44393`
+
+    ```sh
+    $ docker ps | grep -i ha
+    44c0a71735ef   kindest/haproxy:v20210715-a6da3463
+
+    "haproxy -sf 7 -W -d…"   2 days ago     Up 2 days     35093/tcp,
+    0.0.0.0:44393->6443/tcp     muuhmuh-lb
+    ```
+
+    > ⚠️ Capture the port mentioned above, it will be referenced as
+    > ${HA_PROXY_PORT} going forward.
+
+1. Edit your `~/.kube/config` file.
+
+1. Locate the YAML entry for your `${CLUSTER_NAME}`
+
+1. In that YAML entry, replace `certificate-authority-data: < BASE64 DATA >`
+   with `insecure-skip-tls-verify: true`.
+
+1. In the YAML entry, replace `server: < api server value >` with
+   `${WSL_VM_IP}:${HA_PROXY_PORT}`. Assuming the `${CLUSTER_NAME}` was
+test, the entry would now look as follows.
+
+    ```yaml
+    - cluster:
+        insecure-skip-tls-verify: true
+        server: https://192.0.1.1:44393
+      name: test
+    ```
+
+1. Save the file and exit.
+
+    > `kubectl` and `tanzu` CLI should now be able to interact with your
+    > cluster.
+
+1. Set your kubectl context to the cluster.
+
+    ```sh
+    kubectl config use-context <STANDALONE-CLUSTER-NAME>-admin@<STANDALONE-CLUSTER-NAME>
+    ```
+
+1. Validate you can access the cluster's API server.
+
+    ```sh
+    kubectl get pod -A
+    ```
+    The output should look similar to the following:
+
+    ```sh
+    NAMESPACE         NAME                                                                         READY   STATUS    RESTARTS   AGE
+    kapp-controller   kapp-controller-5c66dcc7cf-62jl2                                             1/1     Running   0          3m52s
+    kube-system       antrea-agent-7vs9l                                                           2/2     Running   0          3m52s
+    kube-system       antrea-agent-zkgv7                                                           2/2     Running   0          3m28s
+    kube-system       antrea-controller-785dbc59b8-6vj86                                           1/1     Running   0          3m52s
+    kube-system       coredns-68d49685bd-sjp7t                                                     1/1     Running   0          3m52s
+    kube-system       coredns-68d49685bd-xr5b2                                                     1/1     Running   0          3m52s
+    kube-system       etcd-tkg-mgmt-docker-20210429071830-control-plane-vd8nl                      1/1     Running   0          4m12s
+    kube-system       kube-apiserver-tkg-mgmt-docker-20210429071830-control-plane-vd8nl            1/1     Running   0          4m12s
+    kube-system       kube-controller-manager-tkg-mgmt-docker-20210429071830-control-plane-vd8nl   1/1     Running   0          4m12s
+    kube-system       kube-proxy-7r54w                                                             1/1     Running   0          3m28s
+    kube-system       kube-proxy-m6l64                                                             1/1     Running   0          3m52s
+    kube-system       kube-scheduler-tkg-mgmt-docker-20210429071830-control-plane-vd8nl            1/1     Running   0          4m12s
+    tkr-system        tkr-controller-manager-96445c85d-8qh44                                       1/1     Running   0          3m52s
+    ```

--- a/docs/site/content/docs/latest/getting-started-standalone.md
+++ b/docs/site/content/docs/latest/getting-started-standalone.md
@@ -50,6 +50,8 @@ Tanzu Community Edition consists of the Tanzu CLI and a select set of plugins. Y
 {{< /tab >}}
 {{< tab tabNum="3" >}}
 
+### ⚠️ If bootstrapping docker-based clusers on Windows, [see our Windows guide](../ref-windows-capd).
+
 {{% include "/docs/assets/capd-standalone-clusters.md" %}}
 
 {{< /tab >}}

--- a/docs/site/content/docs/latest/getting-started.md
+++ b/docs/site/content/docs/latest/getting-started.md
@@ -48,6 +48,8 @@ Tanzu Community Edition consists of the Tanzu CLI and a select set of plugins. Y
 {{< /tab >}}
 {{< tab tabNum="3" >}}
 
+### ⚠️ If bootstrapping docker-based clusers on Windows, [see our Windows guide](../ref-windows-capd). 
+
 {{% include "/docs/assets/capd-clusters.md" %}}
 
 {{< /tab >}}

--- a/docs/site/content/docs/latest/ref-windows-capd.md
+++ b/docs/site/content/docs/latest/ref-windows-capd.md
@@ -1,0 +1,121 @@
+# Docker-based Clusters on Windows
+
+In order to run Docker-based clusters on Windows, multiple additional steps are
+required. At this time, we don't recommend deploying TCE clusters onto Docker
+for Windows unless you're willing to tinker with lower level details around
+Windows Subsystem for Linux. If you wish to continue, the following steps will
+take you through deploying Docker-based clusters on Windows.
+
+## Compile the WSL Kernel
+
+⚠️ : These steps will have you use a custom-built kernel that will be used for
+**all** your WSL-based VMs.
+
+The CNI used by TCE (antrea) requires specific configuration in the kernel that
+is not enabled in the default WSL kernel. In future versions of antrea, this
+kernel configuration will not be required (tracked in
+[antrea#2635](https://github.com/antrea-io/antrea/issues/2635)). This section
+covers compiling a kernel that will work with Antrea.
+
+  > Thanks to [the kind
+  > project](https://kind.sigs.k8s.io/docs/user/using-wsl2/) for hosting this
+  > instructions, which we were able to build atop.
+
+1. Run and enter an Ubuntu container to build the kernel
+
+    ```txt
+    docker run --name wsl-kernel-builder --rm -it ubuntu@sha256:9d6a8699fb5c9c39cf08a0871bd6219f0400981c570894cd8cbea30d3424a31f bash
+    ```
+
+1. From inside the container, run the following
+
+
+    ```sh
+    WSL_COMMIT_REF=linux-msft-5.4.72 # change this line to the version you want to build
+    apt update
+    apt install -y git build-essential flex bison libssl-dev libelf-dev bc
+
+    mkdir src
+    cd src
+    git init
+    git remote add origin https://github.com/microsoft/WSL2-Linux-Kernel.git
+    git config --local gc.auto 0
+    git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +${WSL_COMMIT_REF}:refs/remotes/origin/build/linux-msft-wsl-5.4.y 
+    git checkout --progress --force -B build/linux-msft-wsl-5.4.y refs/remotes/origin/build/linux-msft-wsl-5.4.y
+
+    # adds support for clientIP-based session affinity
+    sed -i 's/# CONFIG_NETFILTER_XT_MATCH_RECENT is not set/CONFIG_NETFILTER_XT_MATCH_RECENT=y/' Microsoft/config-wsl
+
+    # required module for antrea
+    sed -i 's/# CONFIG_NETFILTER_XT_TARGET_CT is not set/CONFIG_NETFILTER_XT_TARGET_CT=y/' Microsoft/config-wsl
+
+    # build the kernel
+    make -j2 KCONFIG_CONFIG=Microsoft/config-wsl
+    ```
+
+1. Once the above completes, in a **new** powershell session, run the following
+
+    ```sh
+    docker cp wsl-kernel-builder:/src/arch/x86/boot/bzImage .
+    ```
+
+1. Set the `.wslconfig` file to point at the new kernel (`bzImage`).
+
+    ```txt
+    [wsl2]
+    kernel=C:\\Users\\<your_user>\\bzImage
+    ```
+
+    > As seen above, you should escape the `\` by writing `\\`.
+
+    > The above path may differ for you depending on where you compiled/saved
+    > the
+    > kernel.
+
+1. Shutdown WSL.
+
+    ```sh
+    wsl --shutdown
+    ```
+
+1. Restart WSL VMs.
+
+    > This can be done via Docker desktop or using `wsl`.
+
+    > You may need to restart Docker desktop even after restarting wsl.
+
+1. Verify the kernel version run by WSL is consistent with what you compiled
+   above.
+
+    ```sh
+    wsl uname -a
+    Linux DESKTOP-4T1VL4L 5.4.72-microsoft-standard-WSL2+ #1 SMP Sat Sep 11 16:50:20 UTC 2021 x86_64 Linux
+    ```
+
+1. In a WSL VM with appropriate tools (e.g. Ubuntu) verify the kernel
+   configuration required by antrea is present.
+
+    ```sh
+    wsl zgrep CONFIG_NETFILTER_XT_TARGET_CT /proc/config.gz
+
+    CONFIG_NETFILTER_XT_TARGET_CT=y
+    ```
+
+## Create a Managed or Standalone CAPD Cluster
+
+{{< tabs tabTotal="2" tabID="1" tabName1="Managed" tabName2="Standalone" >}}
+{{< tab tabNum="1" >}}
+
+{{% include "/docs/assets/capd-clusters-windows.md" %}}
+
+{{< /tab >}}
+{{< tab tabNum="2" >}}
+
+{{% include "/docs/assets/capd-standalone-clusters-windows.md" %}}
+
+{{< /tab >}}
+{{< /tabs >}}
+
+{{% include "/docs/assets/package-installation.md" %}}
+{{% include "/docs/assets/octant-install.md" %}}
+{{% include "/docs/assets/clean-up-standalone.md" %}}

--- a/docs/site/data/docs/latest-toc.yml
+++ b/docs/site/data/docs/latest-toc.yml
@@ -93,6 +93,8 @@ toc:
           url: /error_messages
         - page: Troubleshoot bootstrap cluster
           url: /tsg-bootstrap
+        - page: Docker-based Clusters on Windows
+          url: /ref-windows-capd
     - title: Packages
       subfolderitems:
         - page: Packages Introduction


### PR DESCRIPTION
## What this PR does / why we need it

This commit adds the build steps for creating a custom kernel to allows
for local (CAPD-based) installations to work on Windows. This custom
kernel is required to support antrea's usage of the
CONFIG_NETFILTER_XT_TARGET_CT configuration in the kernel.

This custom kernel will not be required in the long term. The relevant
antrea issue is https://github.com/antrea-io/antrea/issues/2635.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Added build configuration for create a custom kernel that enables TCE CAPD-based clusters to run on Windows.
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1431

## Describe testing done for PR

Render site with `hugo server`.

Go through steps at http://localhost:1313/docs/latest/ref-windows-capd/

## Special notes for your reviewer

Validate the above on Windows
