### PR TITLE
Implements PR Blocking e2e for Management Cluster

### DIFF
--- a/.github/workflows/check-management-pr.yaml
+++ b/.github/workflows/check-management-pr.yaml
@@ -1,13 +1,11 @@
-name: Check - Standalone Docker Cluster
+name: Check - Management Docker Cluster
 on:
   pull_request:
     branches:
       - main
     paths:
-      - "**.go"
-      - "cli/cmd/plugin/**/go.mod"
-      - "**.sh"
-      - ".github/**"
+      - "Makefile"
+      - ".github/workflow/check-management-pr.yaml"
     types:
       - assigned
       - opened
@@ -88,7 +86,7 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Create Cluster
-        run: CLUSTER_PLAN=dev tanzu standalone-cluster create mytest -i docker -v 10
+        run: CLUSTER_PLAN=dev tanzu management-cluster create mytest -i docker -v 10
       - name: Check Create Cluster
         run: |
           ./hack/runner/check-setup.sh
@@ -100,7 +98,7 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Delete Cluster
-        run: tanzu standalone-cluster delete mytest --yes -v 10
+        run: tanzu management-cluster delete mytest --yes -v 10
       - name: Check Delete Cluster
         run: |
           ./hack/runner/check-teardown.sh


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Similar to the Standalone Cluster PR Blocking test, this does the same for a management cluster. The only time this test should get executed is when the hash in the `Makefile` is updated OR when this workflow changes.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Implements PR Blocking e2e for Management Cluster similar to that of Standalone Cluster
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA