### PR TITLE
Report cluster creation & deletion times to VMware Wavefront for internal reporting

### DIFF
--- a/.github/workflows/check-management-pr.yaml
+++ b/.github/workflows/check-management-pr.yaml
@@ -5,7 +5,7 @@ on:
       - main
     paths:
       - "Makefile"
-      - ".github/workflow/check-management-pr.yaml"
+      - ".github/workflows/check-management-pr.yaml"
     types:
       - assigned
       - opened
@@ -80,32 +80,75 @@ jobs:
           ./install.sh
   create-cluster:
     name: Create Cluster
+    outputs:
+      create-cluster-time: ${{ steps.check-create-cluster.outputs.create-cluster-time }}
     needs:
       - start-runner # required to start the main job when the runner is ready
       - build-release
     runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Create Cluster
-        run: CLUSTER_PLAN=dev tanzu management-cluster create mytest -i docker -v 10
+        run: CLUSTER_PLAN=dev env time -f "%e" -o create-cluster-time.txt tanzu management-cluster create mytest -i docker -v 10
       - name: Check Create Cluster
+        id: check-create-cluster
         run: |
           ./hack/runner/check-setup.sh
+          CREATE_TIME=$(cat ./create-cluster-time.txt)
+          echo "CREATE_TIME: ${CREATE_TIME}"
+          echo ::set-output name=create-cluster-time::${CREATE_TIME}
+  report-cluster-create-time:
+    name: Report Cluster Creation Time
+    needs:
+      - start-runner # required to start the main job when the runner is ready
+      - create-cluster
+    runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
+    steps:
+      - name: Report cluster create time
+        run: |
+          GIT_SHA=$(git rev-parse HEAD)
+          TCE_VERSION=$(git describe --tags --abbrev=0)
+          echo "tce.pr.management-cluster.create-time ${{ needs.create-cluster.outputs.create-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
+            --header "Authorization: Bearer ${{ secrets.VMW_WAVEFRONT_API_TOKEN }}" \
+            --data @- \
+            https://vmware.wavefront.com/report
   delete-cluster:
     name: Delete Cluster
+    outputs:
+      delete-cluster-time: ${{ steps.check-delete-cluster.outputs.delete-cluster-time }}
     needs:
       - start-runner # required to start the main job when the runner is ready
       - create-cluster
     runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Delete Cluster
-        run: tanzu management-cluster delete mytest --yes -v 10
+        run: env time -f "%e" -o delete-cluster-time.txt tanzu management-cluster delete mytest --yes -v 10
       - name: Check Delete Cluster
+        id: check-delete-cluster
         run: |
           ./hack/runner/check-teardown.sh
+          DELETE_TIME=$(cat ./delete-cluster-time.txt)
+          echo "DELETE_TIME: ${DELETE_TIME}"
+          echo ::set-output name=delete-cluster-time::${DELETE_TIME}
+  report-cluster-delete-time:
+    name: Report Cluster Delete Time
+    needs:
+      - start-runner # required to start the main job when the runner is ready
+      - delete-cluster
+    runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
+    steps:
+      - name: Report cluster deletion time
+        run: |
+          GIT_SHA=$(git rev-parse HEAD)
+          TCE_VERSION=$(git describe --tags --abbrev=0)
+          echo "tce.pr.management-cluster.delete-time ${{ needs.delete-cluster.outputs.delete-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
+            --header "Authorization: Bearer ${{ secrets.VMW_WAVEFRONT_API_TOKEN }}" \
+            --data @- \
+            https://vmware.wavefront.com/report
   stop-runner:
     name: Stop self-hosted EC2 runner
     needs:
       - start-runner # required to get output from the start-runner job
+      - report-cluster-delete-time # also wait on cluster deletion being reported
       - delete-cluster # required to wait when the main job is done
     runs-on: ubuntu-latest
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs

--- a/.github/workflows/check-standalone-pr.yaml
+++ b/.github/workflows/check-standalone-pr.yaml
@@ -82,32 +82,75 @@ jobs:
           ./install.sh
   create-cluster:
     name: Create Cluster
+    outputs:
+      create-cluster-time: ${{ steps.check-create-cluster.outputs.create-cluster-time }}
     needs:
       - start-runner # required to start the main job when the runner is ready
       - build-release
     runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Create Cluster
-        run: CLUSTER_PLAN=dev tanzu standalone-cluster create mytest -i docker -v 10
+        run: CLUSTER_PLAN=dev env time -f "%e" -o create-cluster-time.txt tanzu standalone-cluster create mytest -i docker -v 10
       - name: Check Create Cluster
+        id: check-create-cluster 
         run: |
           ./hack/runner/check-setup.sh
+          CREATE_TIME=$(cat ./create-cluster-time.txt)
+          echo "CREATE_TIME: ${CREATE_TIME}"
+          echo ::set-output name=create-cluster-time::${CREATE_TIME}
+  report-cluster-create-time:
+    name: Report Cluster Creation Time
+    needs:
+      - start-runner # required to start the main job when the runner is ready
+      - create-cluster
+    runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
+    steps:
+      - name: Report cluster create time
+        run: |
+          GIT_SHA=$(git rev-parse HEAD)
+          TCE_VERSION=$(git describe --tags --abbrev=0)
+          echo "tce.pr.standalone-cluster.create-time ${{ needs.create-cluster.outputs.create-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
+            --header "Authorization: Bearer ${{ secrets.VMW_WAVEFRONT_API_TOKEN }}" \
+            --data @- \
+            https://vmware.wavefront.com/report
   delete-cluster:
     name: Delete Cluster
+    outputs:
+      delete-cluster-time: ${{ steps.check-delete-cluster.outputs.delete-cluster-time }}
     needs:
       - start-runner # required to start the main job when the runner is ready
       - create-cluster
     runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Delete Cluster
-        run: tanzu standalone-cluster delete mytest --yes -v 10
+        run: env time -f "%e" -o delete-cluster-time.txt tanzu standalone-cluster delete mytest --yes -v 10
       - name: Check Delete Cluster
+        id: check-delete-cluster
         run: |
           ./hack/runner/check-teardown.sh
+          DELETE_TIME=$(cat ./delete-cluster-time.txt)
+          echo "DELETE_TIME: ${DELETE_TIME}"
+          echo ::set-output name=delete-cluster-time::${DELETE_TIME}
+  report-cluster-delete-time:
+    name: Report Cluster Delete Time
+    needs:
+      - start-runner # required to start the main job when the runner is ready
+      - delete-cluster
+    runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
+    steps:
+      - name: Report cluster deletion time
+        run: |
+          GIT_SHA=$(git rev-parse HEAD)
+          TCE_VERSION=$(git describe --tags --abbrev=0)
+          echo "tce.pr.standalone-cluster.delete-time ${{ needs.delete-cluster.outputs.delete-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
+            --header "Authorization: Bearer ${{ secrets.VMW_WAVEFRONT_API_TOKEN }}" \
+            --data @- \
+            https://vmware.wavefront.com/report
   stop-runner:
     name: Stop self-hosted EC2 runner
     needs:
       - start-runner # required to get output from the start-runner job
+      - report-cluster-delete-time # also wait on cluster deletion being reported
       - delete-cluster # required to wait when the main job is done
     runs-on: ubuntu-latest
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs

--- a/METRICS.md
+++ b/METRICS.md
@@ -1,0 +1,29 @@
+# Metrics
+
+The TCE project automatically reports metrics
+regarding cluster creation, builds, and more.
+
+_*Note*_: At the time of this writing, metrics can only be visualized via the internal VMware WaveFront instance.
+In the future, it is intended that the WaveFront dashboard used to monitor TCE performance
+will be made public and viewable by the community.
+
+Metrics are _only_ reported on GitHub Action runs and are injested directly by WaveFront.
+This gives the maintainers and community reproducable data points for potential performance regressions.
+
+## Reports on Pull Request runs
+
+### PR Sources
+
+- `tce.github.<PR-number>`: The GitHub PR number that the metric data-point originated from
+
+### PR Metrics
+
+- `tce.pr.standalone-cluster.create-time`: The time it takes to create a standalone cluster reported in seconds
+- `tce.pr.standalone-cluster.delete-time`: The time it takes to delete a standalone cluster reported in seconds
+- `tce.pr.management-cluster.create-time`: The time it takes to create a management cluster reported in seconds
+- `tce.pr.management-cluster.delete-time`: The time it takes to delete a management cluster reported in seconds
+
+### PR Metadata
+
+- `sha`: The git sha the data point originated from
+- `version`: The git tag version the data point originated from


### PR DESCRIPTION
## What this PR does / why we need it
This PR implements sending cluster creation and deletion times to our internal Wavefront. This is purely for internal reporting and helps the maintainers determine if there's been a performance regression.

In the future, we hope to make these metrics publicly available via a WaveFront dashboard

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
- Added internal cluster creation times to wavefront
```

## Which issue(s) this PR fixes
Fixes: #1549

## Describe testing done for PR
`tce.pr.standalone-cluster.create-time`:

![Screen Shot 2021-09-02 at 4 05 16 PM](https://user-images.githubusercontent.com/23109390/131922649-4ddb2bef-dd09-4723-b3c5-e2d95e65809f.png)

`tce.pr.standalone-cluster.delete-time`:

![Screen Shot 2021-09-02 at 4 05 33 PM](https://user-images.githubusercontent.com/23109390/131922666-aba1aae1-debc-49a7-a22b-55aa2758ec60.png)

`tce.pr.management-cluster.create-time`:

![Screen Shot 2021-09-02 at 4 04 25 PM](https://user-images.githubusercontent.com/23109390/131922588-745797d5-89dd-4a44-811a-7090ab28ec14.png)

`tce.pr.management-cluster.delete-time`:

![Screen Shot 2021-09-02 at 4 04 52 PM](https://user-images.githubusercontent.com/23109390/131922622-e85812da-b076-4967-97b9-e24d50156c4c.png)


## Special notes for your reviewer
N/a
