### PR TITLE
Added os specific installation prerequisites

### DIFF
--- a/docs/site/content/docs/assets/cli-install-linux.md
+++ b/docs/site/content/docs/assets/cli-install-linux.md
@@ -1,3 +1,4 @@
+## Installation Procedure
 1. Download the release for [Linux](https://github.com/vmware-tanzu/community-edition/releases/download/v0.7.0/tce-linux-amd64-v0.7.0.tar.gz) via web browser.
 
 1. _[Alternative]_ Download the release using CLI. Alternatively, you may download a release using the provided remote script.

--- a/docs/site/content/docs/assets/cli-install-mac.md
+++ b/docs/site/content/docs/assets/cli-install-mac.md
@@ -1,3 +1,4 @@
+## Installation Procedure
 1. Download the release for [macOS](https://github.com/vmware-tanzu/community-edition/releases/download/v0.7.0/tce-darwin-amd64-v0.7.0.tar.gz).
 
 1. Unpack the release.

--- a/docs/site/content/docs/assets/cli-install-windows.md
+++ b/docs/site/content/docs/assets/cli-install-windows.md
@@ -1,3 +1,5 @@
+## Installation Procedure
+
 1. Download the release for [Windows](https://github.com/vmware-tanzu/community-edition/releases/download/v0.7.0/tce-windows-amd64-v0.7.0.tar.gz).
 
 1. Open a Command Prompt **as an administrator**, change to the download directory and unpack the release, for example,

--- a/docs/site/content/docs/latest/getting-started-standalone.md
+++ b/docs/site/content/docs/latest/getting-started-standalone.md
@@ -6,24 +6,30 @@ CLI.
 {{% include "/docs/assets/standalone-desc.md" %}}
 {{% include "/docs/assets/standalone-warning.md" %}}
 {{% include "/docs/assets/tce-feedback.md" %}}
-{{% include "/docs/assets/pre-reqs.md" %}}
 
 
-## CLI Installation
+
+## Tanzu Community Edition Installation
+
+Tanzu Community Edition consists of the Tanzu CLI and a select set of plugins. You will install Tanzu Community Edition on your local machine and then use the Tanzu CLI on your local machine to deploy a cluster to your chosen target platform.
 
 {{< tabs tabTotal="3" tabID="1" tabName1="Linux" tabName2="Mac" tabName3="Windows">}}
 {{< tab tabNum="1" >}}
 
+{{% include "/docs/assets/prereq-linux.md" %}}
 {{% include "/docs/assets/cli-install-linux.md" %}}
 
 {{< /tab >}}
 {{< tab tabNum="2" >}}
 
+{{% include "/docs/assets/prereq-mac.md" %}}
 {{% include "/docs/assets/cli-install-mac.md" %}}
 
 {{< /tab >}}
 {{< tab tabNum="3" >}}
 
+
+{{% include "/docs/assets/prereq-windows.md" %}}
 {{% include "/docs/assets/cli-install-windows.md" %}}
 
 {{< /tab >}}

--- a/docs/site/content/docs/latest/getting-started.md
+++ b/docs/site/content/docs/latest/getting-started.md
@@ -5,24 +5,29 @@ Tanzu CLI.
 
 {{% include "/docs/assets/mgmt-desc.md" %}}
 {{% include "/docs/assets/tce-feedback.md" %}}
-{{% include "/docs/assets/pre-reqs.md" %}}
 
 
-## CLI Installation
+
+## Tanzu Community Edition Installation
+
+Tanzu Community Edition consists of the Tanzu CLI and a select set of plugins. You will install Tanzu Community Edition on your local machine and then use the Tanzu CLI on your local machine to deploy a cluster to your chosen target platform.
 
 {{< tabs tabTotal="3" tabID="1" tabName1="Linux" tabName2="Mac" tabName3="Windows">}}
 {{< tab tabNum="1" >}}
 
+{{% include "/docs/assets/prereq-linux.md" %}}
 {{% include "/docs/assets/cli-install-linux.md" %}}
 
 {{< /tab >}}
 {{< tab tabNum="2" >}}
 
+{{% include "/docs/assets/prereq-mac.md" %}}
 {{% include "/docs/assets/cli-install-mac.md" %}}
 
 {{< /tab >}}
 {{< tab tabNum="3" >}}
 
+{{% include "/docs/assets/prereq-windows.md" %}}
 {{% include "/docs/assets/cli-install-windows.md" %}}
 
 {{< /tab >}}

--- a/docs/site/content/docs/latest/installation-planning.md
+++ b/docs/site/content/docs/latest/installation-planning.md
@@ -1,24 +1,16 @@
 # Planning Your Installation
 There are four main steps involved in deploying Tanzu Community Edition. The following section describes the main steps and how they are invoked:
 
-1. Install the Tanzu CLI.
-   You will download this from GitHub and install it on your desktop machine.
+1. Install Tanzu Community Edition.
+   You will download this from GitHub and install it on your desktop machine. This installs the Tanzu CLI.
    For more information, see [Installing the Tanzu CLI](cli-installation).
 2. Prepare to deploy a cluster. For more information, see [Preparing to Deploy a Cluster](prepare-deployment).
-2. Create a cluster on your infrastructure provider. There are two ways to approach this:
-   * Create a management cluster and then create a workload cluster. First, create the management cluster using the Tanzu Kubernetes Grid Installer. This installer is initiated from the Tanzu CLI. Then, create a workload cluster using the Tanzu CLI. For more information, see [Management cluster description](installation-planning/#management-cluster-description), [Workload cluster description](installation-planning/#workload-cluster-description).<br>
-   or  <br>
+3. Create a cluster on your [target platform](installation-planning/#target-platform). There are two ways to approach this:
+   * Use the Tanzu CLI to open the Tanzu Community Edition installer interface, create a [management cluster](installation-planning/#management-cluster-description), and then create a [workload cluster](installation-planning/#workload-cluster). <br>
+   **or**  <br>
 
-   * Create a standalone cluster using Tanzu Kubernetes Grid Installer. For more information,see
-    [Standalone cluster description](installation-planning/#standalone-cluster-description).
+   * Use the Tanzu CLI to open the installer interface and create a [standalone cluster](installation-planning/#standalone-cluster).
 
-   There are four infrastructure providers:
-
-
-    * Amazon EC2
-    * Microsoft Azure
-    * Docker
-    * vSphere
    For more information, see [Deploying Clusters](clusters-deploy.md).
 4. Install and configure packages using the Tanzu CLI. For more information, see [Packages Overview](packages-intro).
 
@@ -28,21 +20,29 @@ The following section provides descriptions of the main components involved in a
 
 {{% include "/docs/assets/mgmt-desc.md" %}}
 
-### Workload cluster description
+### Workload cluster
 After you deploy the management cluster, you can deploy a workload cluster. The workload cluster is deployed by the management cluster. The workload cluster is used to run your application workloads. The workload clusters is deployed using the Tanzu CLI.
 
 {{% include "/docs/assets/standalone-desc.md" %}}
 
-### Bootstrap Machine
-The bootstrap machine is the laptop, host, or server on which you download and run the Tanzu CLI. This is where the initial bootstrapping of a management or standalone cluster occurs before it is pushed to the platform where it will run. You run tanzu, kubectl and other commands on the bootstrap machine. The bootstrap machine can be a local physical machine or a VM that you access via a console window or client shell.
+### Bootstrap
+The bootstrap (noun) machine is the laptop, host, or server on which you download and run the Tanzu CLI. This is where the initial bootstrapping (verb) of a management or standalone cluster occurs before it is pushed to the platform where it will run. You run tanzu, kubectl and other commands on the bootstrap machine.
+Using the Tanzu CLI to deploy a cluster to a target platform is often referred to as bootstrapping (verb).
 
 
-### Tanzu Kubernetes Grid Installer
-The Tanzu Kubernetes Grid installer is a graphical wizard that you start up by running the ``tanzu management-cluster create --ui`` command. The installer wizard runs locally in a browser on the bootstrap machine and provides a user interface to guide you through the process of deploying a management or standalone cluster.
+### Tanzu Community Edition installer interface
+The installer interface is a graphical wizard that you start up by running the ``tanzu management-cluster create --ui`` command. The installer interface runs locally in a browser on the bootstrap machine and provides a user interface to guide you through the process of deploying a management or standalone cluster.
 
 The installer interface launches in a browser and takes you through steps to configure the management or standalone cluster.
 
+### Target Platform
+The target platform is the cloud provider or local Docker where you will deploy your cluster.
+There are four available target platforms:
 
+- Amazon EC2
+- Microsoft Azure
+- Docker
+- vSphere
 ### Package
 {{% include "/docs/assets/package-description.md" %}}
 


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it

- Changed to OS-specific prereqs using include - fixes: #1548 (relates to: #1482)
- Adds the following note to windows cli install fixes: #1543
>You cannot bootstrap a cluster to Docker from a Windows bootstrap machine, only Linux and Mac are supported at this time for Docker cluster deployments.

### Minor
- Minor- replace some cases of Tanzu cli with Tanzu Community Edition, reason is some locations in the doc, the tanzu cli was being referred to as the product
- Minor -corrected naming for the installer interface as per style guide
- Minor- some changes to glossary terms in planning your installation - (relates to: #1075)
- Minor -Changed some occurrences 'infrastructure provider' to 'target platform'  -  relates to Doc feedback from Steve Wong #1482

## Details for the Release Notes (PLEASE PROVIDE)

```
Adds operating system specific prerequisites to improve linear flow of doc
```

## Which issue(s) this PR fixes

Fixes: #1543
Fixes: #1548

## Describe testing done for PR


## Special notes for your reviewer

