### PR TITLE
Fix CODEOWNER for @vmware-tanzu/tce-releng to `test/` not `test`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@
 *                          @vmware-tanzu/tce-owners
 
 ## Ownership of release engineering efforts
-test                       @vmware-tanzu/tce-releng
+test/                       @vmware-tanzu/tce-releng
 
 # Package Ownership
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
The CODEOWNER permissions that was there gave ownership to @vmware-tanzu/tce-releng group/team to anything that had `test` in the path. This fixes is so it's just the `test/` folder off root.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix CODEOWNER for @vmware-tanzu/tce-releng group/team
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA