### PR TITLE
doc note: can't bootstrap to Docker from Windows

### DIFF
--- a/docs/site/content/docs/assets/capd-clusters.md
+++ b/docs/site/content/docs/assets/capd-clusters.md
@@ -5,6 +5,15 @@ using Docker.
 
 ⚠️: Tanzu Community Edition support for Docker is **experimental** and may require troubleshooting on your system.
 
+**Note: You cannot bootstrap a cluster to Docker from a Windows bootstrap machine, only Linux and Mac are supported at this time for Docker cluster deployments.**
+
+## Prerequisites
+The following additional configuration is needed for the Docker engine on your local client machine (with no other containers running):
+| |
+|:------------------------|
+|6 GB of RAM |
+|15 GB of local machine disk storage for images |
+|4 CPUs|
 ### ⚠️  Warning on DockerHub Rate Limiting
 
 When using the Docker (CAPD) provider, the load balancer image (HA Proxy) is
@@ -20,12 +29,8 @@ docker pull kindest/haproxy:v20210715-a6da3463
 This behavior will eventually be addressed in
 [https://github.com/vmware-tanzu/community-edition/issues/897](https://github.com/vmware-tanzu/community-edition/issues/897).
 
-### Local Docker Bootstrapping
-
-1. Ensure your Docker engine has adequate resources. The  minimum requirements with no other containers running are: 6 GB of RAM and 4 CPUs.
-    * **Linux**: Run ``docker system info``
-    * **Mac**: Select Preferences > Resources > Advanced
-    Note: To optimise your Docker system and ensure a successful deployment, you may wish to complete the next two optional steps.
+### Before You Begin
+ To optimise your Docker system and ensure a successful deployment, you may wish to complete the next two optional steps.
 
 1. (Optional): Stop all existing containers.
 
@@ -39,6 +44,8 @@ This behavior will eventually be addressed in
    ```sh
     docker system prune -a --volumes
    ```
+### Local Docker Bootstrapping
+
 1. Initialize the Tanzu Community Edition installer interface.
 
    ```sh

--- a/docs/site/content/docs/assets/capd-standalone-clusters.md
+++ b/docs/site/content/docs/assets/capd-standalone-clusters.md
@@ -5,6 +5,16 @@ using Docker. This provides you a workload cluster that is **not** managed by a 
 
 ⚠️: Tanzu Community Edition support for Docker is **experimental** and may require troubleshooting on your system.
 
+**Note: You cannot bootstrap a cluster to Docker from a Windows bootstrap machine, only Linux and Mac are supported at this time for Docker cluster deployments.**
+
+## Prerequisites
+The following additional configuration is needed for the Docker engine on your local client machine (with no other containers running):
+| |
+|:------------------------|
+|6 GB of RAM |
+|15 GB of local machine disk storage for images |
+|4 CPUs|
+
 ### ⚠️  Warning on DockerHub Rate Limiting
 
 When using the Docker (CAPD) provider, the load balancer image (HA Proxy) is
@@ -21,10 +31,6 @@ This behavior will eventually be addressed in
 [https://github.com/vmware-tanzu/community-edition/issues/897](https://github.com/vmware-tanzu/community-edition/issues/897).
 
 ### Local Docker Bootstrapping
-
-1. Ensure your Docker engine has adequate resources. The  minimum requirements with no other containers running are: 6 GB of RAM and 4 CPUs.
-    * **Linux**: Run ``docker system info``
-    * **Mac**: Select Preferences > Resources > Advanced
 
 1. Create the standalone cluster.
 


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

- Adds note that windows client can't bootstrap to Docker: fixes: #1543

- Adds the disk storage space for Docker - fixes:  #921
(relates to: #1520)

- minor - improve layout of Docker topics 

## Details for the Release Notes (PLEASE PROVIDE)

```
Adds doc for Docker disk space requirement. Adds doc note that Windows client can't bootstrap a cluster to Docker. 
```

## Which issue(s) this PR fixes
Fixes: #1543
Fixes: #921
-->


## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
