### PR TITLE
Trivial: Fix Markdown linting failures. No trailing spaces

### DIFF
--- a/cli/cmd/README.md
+++ b/cli/cmd/README.md
@@ -24,7 +24,7 @@ my-plugin
   | go.sum
   | Makefile             # It is expected that each go module has it's own Makefile
   |                      # with common, expected targets for building, testing, and running
-  | 
+  |
   |-- test/              # Test files for your CLI plugin. A valid Go package is required.
   |   test.go
 ```


### PR DESCRIPTION
## What this PR does / why we need it
Quick followup to one of my `cli/cmd/README.md` edit. Had a trailing whitespace in there causing failures

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
Related to: https://github.com/vmware-tanzu/community-edition/pull/1547

## Describe testing done for PR
`make mdlint` now passes

## Special notes for your reviewer
N/a cc @nrb 
