### PR TITLE
Use `install-cli-plugins` in place of `build-cli-plugins` in Makefile `build-all` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ $(TOOLING_BINARIES):
 ##### BUILD TARGETS #####
 build: build-plugin
 
-build-all: release-env-check version clean install-cli build-cli-plugins ## build all CLI plugins that are used in TCE
+build-all: release-env-check version clean install-cli install-cli-plugins ## build all CLI plugins that are used in TCE
 	@printf "\n[COMPLETE] installed plugins at $${XDG_DATA_HOME}/tanzu-cli/. "
 	@printf "These plugins will be automatically detected by tanzu CLI.\n"
 	@printf "\n[COMPLETE] installed tanzu CLI at $(TANZU_CLI_INSTALL_PATH). "


### PR DESCRIPTION
## What this PR does / why we need it
Uses `install-cli-plugins` instead of `build-cli-plugins` in the `build-all` Makefile target

Fixes an issue where `build-all` wouldn't actually install the plugins (like standalone-cluster or conformance). But, since `install-cli-plugins` is dependent on `build-cli-plugins`, we can simply swap out the those two targets

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
- Fix plugins not being installed with Makefile build-all target
```

## Which issue(s) this PR fixes
Fixes: #1558

## Describe testing done for PR
1. `./hack/uninstall.sh`
2. `make build-all`
3. `tanzu -h` and notice the `conformance` and `standalone-cluster` plugins are present
```
❯ tanzu -h
Tanzu CLI

Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components
    codegen                 Tanzu code generation tool
    test                    Test the CLI

  Run
    cluster                 Kubernetes cluster operations
    conformance             Run Sonobuoy conformance tests against clusters
    kubernetes-release      Kubernetes release operations
    management-cluster      Kubernetes management cluster operations
    package                 Tanzu package management
    standalone-cluster      Create clusters without a dedicated management cluster

  System
    completion              Output shell completion code
    config                  Configuration for the CLI
    init                    Initialize the CLI
    login                   Login to the platform
    plugin                  Manage CLI plugins
    update                  Update the CLI
    version                 Version information
```

## Special notes for your reviewer
If there's a better way to go about this, happy to also do that!
