### PR TITLE
Enhance long running github actions

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -8,30 +8,56 @@ on:
       - "**.go"
       - "cli/cmd/plugin/**/go.mod"
       - "**.sh"
-      - ".github/**"
+      - ".github/workflows/build-staging.yaml"
     tags-ignore:
       - "**"
-
 jobs:
-  build:
-    name: Release Staging
+  start-runner:
+    name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
+    outputs:
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Download Dependencies
+        run: |
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
+            -o ensure-dependencies.sh
+          chmod +x ./ensure-dependencies.sh
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh \
+            -o setup.sh
+          chmod +x ./setup.sh
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+        run: |
+          ./ensure-dependencies.sh
+          GITHUB_TOKEN=${GITHUB_TOKEN} AMI_ID=ami-0e264e3eabfba9c3d ./setup.sh
+          INSTANCE_ID=$(cat ./instanceid.txt)
+          echo "INSTANCE_ID: ${INSTANCE_ID}"
+          echo ::set-output name=ec2-instance-id::${INSTANCE_ID}
+  build-release:
+    name: Build Release for Staging
+    needs: start-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
           go-version: "1.16"
         id: go
-
       - name: Config credentials
         env:
           GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         run: |
           git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
-
       - name: Check out code
         uses: actions/checkout@v1
-
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:
@@ -39,30 +65,11 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
-      - name: Get Tanzu Framework
-        run: |
-          git clone https://github.com/vmware-tanzu/tanzu-framework.git
-          pushd tanzu-framework
-          git checkout tce-main
-          make controller-gen
-          make set-unstable-versions
-          popd
-
       - name: Get dependencies
         run: |
-          for i in $(find . -type d); do
-            if [[ -f "${i}/go.mod" ]]; then
-              pushd $i
-                go mod edit --replace github.com/vmware-tanzu/tanzu-framework=$GITHUB_WORKSPACE/tanzu-framework
-                go get -v -t -d ./...
-              popd
-            fi
-          done
-
+          make get-deps
       - name: Build
         run: make build
-
       - name: Upload Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main
@@ -70,3 +77,31 @@ jobs:
           path: ./artifacts
           destination: tce-cli-plugins-staging
           credentials: ${{ secrets.GCP_BUCKET_SA }}
+  stop-runner:
+    name: Stop self-hosted EC2 runner
+    needs:
+      - start-runner # required to get output from the start-runner job
+      - build-release # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Download Dependencies
+        run: |
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
+            -o ensure-dependencies.sh
+          chmod +x ./ensure-dependencies.sh
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh \
+            -o teardown.sh
+          chmod +x ./teardown.sh
+      - name: Stop EC2 runner
+        id: stop-ec2-runner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+        run: |
+          ./ensure-dependencies.sh
+          GITHUB_TOKEN=${GITHUB_TOKEN} INSTANCE_ID=${{ needs.start-runner.outputs.ec2-instance-id }} ./teardown.sh

--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    tags-ignore:
+      - "**"
+
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
@@ -29,12 +32,12 @@ jobs:
           AWS_REGION: us-west-2
         run: |
           ./ensure-dependencies.sh
-          GITHUB_TOKEN=${GITHUB_TOKEN} AMI_ID=ami-062fb282337a81776 ./setup.sh
+          GITHUB_TOKEN=${GITHUB_TOKEN} AMI_ID=ami-0e264e3eabfba9c3d ./setup.sh
           INSTANCE_ID=$(cat ./instanceid.txt)
           echo "INSTANCE_ID: ${INSTANCE_ID}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_ID}
   build-release:
-    name: Build Release based on PR
+    name: Build Release based on Main
     needs: start-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
@@ -125,4 +128,3 @@ jobs:
         run: |
           ./ensure-dependencies.sh
           GITHUB_TOKEN=${GITHUB_TOKEN} INSTANCE_ID=${{ needs.start-runner.outputs.ec2-instance-id }} ./teardown.sh
-          

--- a/.github/workflows/check-pr-docker-management.yaml
+++ b/.github/workflows/check-pr-docker-management.yaml
@@ -1,13 +1,11 @@
-name: Check - Standalone Docker Cluster
+name: Check - Management Docker Cluster
 on:
   pull_request:
     branches:
       - main
     paths:
-      - "**.go"
-      - "cli/cmd/plugin/**/go.mod"
-      - "**.sh"
-      - ".github/**"
+      - "Makefile"
+      - ".github/workflows/check-pr-docker-management.yaml"
     types:
       - assigned
       - opened
@@ -39,7 +37,7 @@ jobs:
           AWS_REGION: us-west-2
         run: |
           ./ensure-dependencies.sh
-          GITHUB_TOKEN=${GITHUB_TOKEN} AMI_ID=ami-062fb282337a81776 ./setup.sh
+          GITHUB_TOKEN=${GITHUB_TOKEN} AMI_ID=ami-0e264e3eabfba9c3d ./setup.sh
           INSTANCE_ID=$(cat ./instanceid.txt)
           echo "INSTANCE_ID: ${INSTANCE_ID}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_ID}
@@ -90,9 +88,9 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Create Cluster
-        run: CLUSTER_PLAN=dev env time -f "%e" -o create-cluster-time.txt tanzu standalone-cluster create mytest -i docker -v 10
+        run: CLUSTER_PLAN=dev env time -f "%e" -o create-cluster-time.txt tanzu management-cluster create mytest -i docker -v 10
       - name: Check Create Cluster
-        id: check-create-cluster 
+        id: check-create-cluster
         run: |
           ./hack/runner/check-setup.sh
           CREATE_TIME=$(cat ./create-cluster-time.txt)
@@ -109,7 +107,7 @@ jobs:
         run: |
           GIT_SHA=$(git rev-parse HEAD)
           TCE_VERSION=$(git describe --tags --abbrev=0)
-          echo "tce.pr.standalone-cluster.create-time ${{ needs.create-cluster.outputs.create-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
+          echo "tce.pr.management-cluster.create-time ${{ needs.create-cluster.outputs.create-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
             --header "Authorization: Bearer ${{ secrets.VMW_WAVEFRONT_API_TOKEN }}" \
             --data @- \
             https://vmware.wavefront.com/report
@@ -123,7 +121,7 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Delete Cluster
-        run: env time -f "%e" -o delete-cluster-time.txt tanzu standalone-cluster delete mytest --yes -v 10
+        run: env time -f "%e" -o delete-cluster-time.txt tanzu management-cluster delete mytest --yes -v 10
       - name: Check Delete Cluster
         id: check-delete-cluster
         run: |
@@ -142,7 +140,7 @@ jobs:
         run: |
           GIT_SHA=$(git rev-parse HEAD)
           TCE_VERSION=$(git describe --tags --abbrev=0)
-          echo "tce.pr.standalone-cluster.delete-time ${{ needs.delete-cluster.outputs.delete-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
+          echo "tce.pr.management-cluster.delete-time ${{ needs.delete-cluster.outputs.delete-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
             --header "Authorization: Bearer ${{ secrets.VMW_WAVEFRONT_API_TOKEN }}" \
             --data @- \
             https://vmware.wavefront.com/report
@@ -175,4 +173,3 @@ jobs:
         run: |
           ./ensure-dependencies.sh
           GITHUB_TOKEN=${GITHUB_TOKEN} INSTANCE_ID=${{ needs.start-runner.outputs.ec2-instance-id }} ./teardown.sh
-          

--- a/.github/workflows/check-pr-docker-standalone.yaml
+++ b/.github/workflows/check-pr-docker-standalone.yaml
@@ -1,11 +1,13 @@
-name: Check - Management Docker Cluster
+name: Check - Standalone Docker Cluster
 on:
   pull_request:
     branches:
       - main
     paths:
-      - "Makefile"
-      - ".github/workflows/check-management-pr.yaml"
+      - "**.go"
+      - "cli/cmd/plugin/**/go.mod"
+      - "**.sh"
+      - ".github/workflows/check-pr-docker-standalone.yaml"
     types:
       - assigned
       - opened
@@ -37,7 +39,7 @@ jobs:
           AWS_REGION: us-west-2
         run: |
           ./ensure-dependencies.sh
-          GITHUB_TOKEN=${GITHUB_TOKEN} AMI_ID=ami-062fb282337a81776 ./setup.sh
+          GITHUB_TOKEN=${GITHUB_TOKEN} AMI_ID=ami-0e264e3eabfba9c3d ./setup.sh
           INSTANCE_ID=$(cat ./instanceid.txt)
           echo "INSTANCE_ID: ${INSTANCE_ID}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_ID}
@@ -88,7 +90,7 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Create Cluster
-        run: CLUSTER_PLAN=dev env time -f "%e" -o create-cluster-time.txt tanzu management-cluster create mytest -i docker -v 10
+        run: CLUSTER_PLAN=dev env time -f "%e" -o create-cluster-time.txt tanzu standalone-cluster create mytest -i docker -v 10
       - name: Check Create Cluster
         id: check-create-cluster
         run: |
@@ -107,7 +109,7 @@ jobs:
         run: |
           GIT_SHA=$(git rev-parse HEAD)
           TCE_VERSION=$(git describe --tags --abbrev=0)
-          echo "tce.pr.management-cluster.create-time ${{ needs.create-cluster.outputs.create-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
+          echo "tce.pr.standalone-cluster.create-time ${{ needs.create-cluster.outputs.create-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
             --header "Authorization: Bearer ${{ secrets.VMW_WAVEFRONT_API_TOKEN }}" \
             --data @- \
             https://vmware.wavefront.com/report
@@ -121,7 +123,7 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Delete Cluster
-        run: env time -f "%e" -o delete-cluster-time.txt tanzu management-cluster delete mytest --yes -v 10
+        run: env time -f "%e" -o delete-cluster-time.txt tanzu standalone-cluster delete mytest --yes -v 10
       - name: Check Delete Cluster
         id: check-delete-cluster
         run: |
@@ -140,7 +142,7 @@ jobs:
         run: |
           GIT_SHA=$(git rev-parse HEAD)
           TCE_VERSION=$(git describe --tags --abbrev=0)
-          echo "tce.pr.management-cluster.delete-time ${{ needs.delete-cluster.outputs.delete-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
+          echo "tce.pr.standalone-cluster.delete-time ${{ needs.delete-cluster.outputs.delete-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
             --header "Authorization: Bearer ${{ secrets.VMW_WAVEFRONT_API_TOKEN }}" \
             --data @- \
             https://vmware.wavefront.com/report
@@ -173,4 +175,3 @@ jobs:
         run: |
           ./ensure-dependencies.sh
           GITHUB_TOKEN=${GITHUB_TOKEN} INSTANCE_ID=${{ needs.start-runner.outputs.ec2-instance-id }} ./teardown.sh
-          

--- a/.github/workflows/e2e-aws-management-cluster.yaml
+++ b/.github/workflows/e2e-aws-management-cluster.yaml
@@ -8,7 +8,7 @@ on:
       - "**.go"
       - "cli/cmd/plugin/**/go.mod"
       - "**.sh"
-      - ".github/**"
+      - ".github/workflows/e2e-aws-management-cluster.yaml"
     tags-ignore:
       - "**"
 

--- a/.github/workflows/e2e-aws-standalone-cluster.yaml
+++ b/.github/workflows/e2e-aws-standalone-cluster.yaml
@@ -8,7 +8,7 @@ on:
       - "**.go"
       - "cli/cmd/plugin/**/go.mod"
       - "**.sh"
-      - ".github/**"
+      - ".github/workflows/e2e-aws-standalone-cluster.yaml"
     tags-ignore:
       - "**"
 

--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -8,26 +8,53 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-fake.[0-9]+"
 
 jobs:
-  build:
-    name: Fake Release (Testing)
+  start-runner:
+    name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
+    outputs:
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Download Dependencies
+        run: |
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
+            -o ensure-dependencies.sh
+          chmod +x ./ensure-dependencies.sh
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh \
+            -o setup.sh
+          chmod +x ./setup.sh
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+        run: |
+          ./ensure-dependencies.sh
+          GITHUB_TOKEN=${GITHUB_TOKEN} AMI_ID=ami-0e264e3eabfba9c3d ./setup.sh
+          INSTANCE_ID=$(cat ./instanceid.txt)
+          echo "INSTANCE_ID: ${INSTANCE_ID}"
+          echo ::set-output name=ec2-instance-id::${INSTANCE_ID}
+  build-release:
+    name: Fake Release (Testing)
+    needs: start-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
           go-version: "1.16"
         id: go
-
       - name: Config credentials
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         run: |
           git config --global pull.rebase true
           git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
-
       - name: Check out code
         uses: actions/checkout@v1
-
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:
@@ -35,22 +62,18 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
       - name: Get the Tag
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
       - name: Get dependencies
         run: |
           make get-deps
-
-      - name: Generate release
+      - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         run: |
           make ensure-deps
           make release
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -65,7 +88,6 @@ jobs:
             - THIS IS JUST A PLACE HOLDER
           draft: true
           prerelease: true
-
       - name: Upload Linux AMD64 Asset
         id: upload-linux-amd64-asset
         uses: actions/upload-release-asset@v1
@@ -76,7 +98,6 @@ jobs:
           asset_path: ./build/tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
-
       - name: Upload Darwin AMD64 Asset
         id: upload-darwin-amd64-asset
         uses: actions/upload-release-asset@v1
@@ -87,7 +108,6 @@ jobs:
           asset_path: ./build/tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
-
       - name: Upload Darwin ARM64 Asset
         id: upload-darwin-arm64-asset
         uses: actions/upload-release-asset@v1
@@ -98,7 +118,6 @@ jobs:
           asset_path: ./build/tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
-
       - name: Upload Windows AMD64 Asset
         id: upload-windows-amd64-asset
         uses: actions/upload-release-asset@v1
@@ -109,16 +128,13 @@ jobs:
           asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
-
       - name: Checkout for Update
         uses: actions/checkout@v1
-
       - name: Commit Next Dev Version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           ACTUAL_COMMIT_SHA: ${{ github.sha }}
         run: make cut-release
-
       - name: Upload Cayman Trigger Asset
         id: upload-cayman-trigger-asset
         uses: actions/upload-release-asset@v1
@@ -129,3 +145,31 @@ jobs:
           asset_path: ./cayman_trigger.txt
           asset_name: cayman_trigger.txt
           asset_content_type: text/plain
+  stop-runner:
+    name: Stop self-hosted EC2 runner
+    needs:
+      - start-runner # required to get output from the start-runner job
+      - build-release # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Download Dependencies
+        run: |
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
+            -o ensure-dependencies.sh
+          chmod +x ./ensure-dependencies.sh
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh \
+            -o teardown.sh
+          chmod +x ./teardown.sh
+      - name: Stop EC2 runner
+        id: stop-ec2-runner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+        run: |
+          ./ensure-dependencies.sh
+          GITHUB_TOKEN=${GITHUB_TOKEN} INSTANCE_ID=${{ needs.start-runner.outputs.ec2-instance-id }} ./teardown.sh

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -9,26 +9,53 @@ on:
       - "!*-*"
 
 jobs:
-  build:
-    name: Release
+  start-runner:
+    name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
+    outputs:
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Download Dependencies
+        run: |
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
+            -o ensure-dependencies.sh
+          chmod +x ./ensure-dependencies.sh
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh \
+            -o setup.sh
+          chmod +x ./setup.sh
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+        run: |
+          ./ensure-dependencies.sh
+          GITHUB_TOKEN=${GITHUB_TOKEN} AMI_ID=ami-0e264e3eabfba9c3d ./setup.sh
+          INSTANCE_ID=$(cat ./instanceid.txt)
+          echo "INSTANCE_ID: ${INSTANCE_ID}"
+          echo ::set-output name=ec2-instance-id::${INSTANCE_ID}
+  build-release:
+    name: GA Release
+    needs: start-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
           go-version: "1.16"
         id: go
-
       - name: Config credentials
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         run: |
           git config --global pull.rebase true
           git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
-
       - name: Check out code
         uses: actions/checkout@v1
-
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:
@@ -36,22 +63,18 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
       - name: Get the Tag
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
       - name: Get dependencies
         run: |
           make get-deps
-
-      - name: Generate release
+      - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         run: |
           make ensure-deps
           make release
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -66,7 +89,6 @@ jobs:
             - THIS IS JUST A PLACE HOLDER
           draft: true
           prerelease: false
-
       - name: Upload Linux AMD64 Asset
         id: upload-linux-amd64-asset
         uses: actions/upload-release-asset@v1
@@ -77,7 +99,6 @@ jobs:
           asset_path: ./build/tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
-
       - name: Upload Darwin AMD64 Asset
         id: upload-darwin-amd64-asset
         uses: actions/upload-release-asset@v1
@@ -88,7 +109,6 @@ jobs:
           asset_path: ./build/tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
-
       - name: Upload Darwin ARM64 Asset
         id: upload-darwin-arm64-asset
         uses: actions/upload-release-asset@v1
@@ -99,7 +119,6 @@ jobs:
           asset_path: ./build/tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
-
       - name: Upload Windows AMD64 Asset
         id: upload-windows-amd64-asset
         uses: actions/upload-release-asset@v1
@@ -110,7 +129,6 @@ jobs:
           asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
-
       - name: Upload Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main
@@ -118,7 +136,6 @@ jobs:
           path: ./artifacts
           destination: tce-cli-plugins-staging
           credentials: ${{ secrets.GCP_BUCKET_SA }}
-
       - name: Upload Artifacts to Release Bucket
         id: upload-artifacts-release
         uses: google-github-actions/upload-cloud-storage@main
@@ -126,16 +143,13 @@ jobs:
           path: ./artifacts
           destination: tce-cli-plugins
           credentials: ${{ secrets.GCP_BUCKET_SA }}
-
       - name: Checkout for Update
         uses: actions/checkout@v1
-
       - name: Commit Next Dev Version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           ACTUAL_COMMIT_SHA: ${{ github.sha }}
         run: make cut-release
-
       - name: Upload Cayman Trigger Asset
         id: upload-cayman-trigger-asset
         uses: actions/upload-release-asset@v1
@@ -146,3 +160,31 @@ jobs:
           asset_path: ./cayman_trigger.txt
           asset_name: cayman_trigger.txt
           asset_content_type: text/plain
+  stop-runner:
+    name: Stop self-hosted EC2 runner
+    needs:
+      - start-runner # required to get output from the start-runner job
+      - build-release # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Download Dependencies
+        run: |
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
+            -o ensure-dependencies.sh
+          chmod +x ./ensure-dependencies.sh
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh \
+            -o teardown.sh
+          chmod +x ./teardown.sh
+      - name: Stop EC2 runner
+        id: stop-ec2-runner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+        run: |
+          ./ensure-dependencies.sh
+          GITHUB_TOKEN=${GITHUB_TOKEN} INSTANCE_ID=${{ needs.start-runner.outputs.ec2-instance-id }} ./teardown.sh

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -10,26 +10,53 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"
 
 jobs:
-  build:
-    name: Pre-Release
+  start-runner:
+    name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
+    outputs:
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Download Dependencies
+        run: |
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
+            -o ensure-dependencies.sh
+          chmod +x ./ensure-dependencies.sh
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh \
+            -o setup.sh
+          chmod +x ./setup.sh
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+        run: |
+          ./ensure-dependencies.sh
+          GITHUB_TOKEN=${GITHUB_TOKEN} AMI_ID=ami-0e264e3eabfba9c3d ./setup.sh
+          INSTANCE_ID=$(cat ./instanceid.txt)
+          echo "INSTANCE_ID: ${INSTANCE_ID}"
+          echo ::set-output name=ec2-instance-id::${INSTANCE_ID}
+  build-release:
+    name: Alpha, Beta, or RC Release
+    needs: start-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.start-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
           go-version: "1.16"
         id: go
-
       - name: Config credentials
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         run: |
           git config --global pull.rebase true
           git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
-
       - name: Check out code
         uses: actions/checkout@v1
-
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:
@@ -37,22 +64,18 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
       - name: Get the Tag
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
       - name: Get dependencies
         run: |
           make get-deps
-
-      - name: Generate release
+      - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         run: |
           make ensure-deps
           make release
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -67,7 +90,6 @@ jobs:
             - THIS IS JUST A PLACE HOLDER
           draft: true
           prerelease: true
-
       - name: Upload Linux AMD64 Asset
         id: upload-linux-amd64-asset
         uses: actions/upload-release-asset@v1
@@ -78,7 +100,6 @@ jobs:
           asset_path: ./build/tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
-
       - name: Upload Darwin AMD64 Asset
         id: upload-darwin-amd64-asset
         uses: actions/upload-release-asset@v1
@@ -89,7 +110,6 @@ jobs:
           asset_path: ./build/tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
-
       - name: Upload Darwin ARM64 Asset
         id: upload-darwin-arm64-asset
         uses: actions/upload-release-asset@v1
@@ -100,7 +120,6 @@ jobs:
           asset_path: ./build/tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
-
       - name: Upload Windows AMD64 Asset
         id: upload-windows-amd64-asset
         uses: actions/upload-release-asset@v1
@@ -111,7 +130,6 @@ jobs:
           asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
-
       - name: Upload Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main
@@ -119,7 +137,6 @@ jobs:
           path: ./artifacts
           destination: tce-cli-plugins-staging
           credentials: ${{ secrets.GCP_BUCKET_SA }}
-
       - name: Upload Artifacts to Release Bucket
         id: upload-artifacts-release
         uses: google-github-actions/upload-cloud-storage@main
@@ -127,16 +144,13 @@ jobs:
           path: ./artifacts
           destination: tce-cli-plugins
           credentials: ${{ secrets.GCP_BUCKET_SA }}
-
       - name: Checkout for Update
         uses: actions/checkout@v1
-
       - name: Commit Next Dev Version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           ACTUAL_COMMIT_SHA: ${{ github.sha }}
         run: make cut-release
-
       - name: Upload Cayman Trigger Asset
         id: upload-cayman-trigger-asset
         uses: actions/upload-release-asset@v1
@@ -147,3 +161,31 @@ jobs:
           asset_path: ./cayman_trigger.txt
           asset_name: cayman_trigger.txt
           asset_content_type: text/plain
+  stop-runner:
+    name: Stop self-hosted EC2 runner
+    needs:
+      - start-runner # required to get output from the start-runner job
+      - build-release # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Download Dependencies
+        run: |
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
+            -o ensure-dependencies.sh
+          chmod +x ./ensure-dependencies.sh
+          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh \
+            -o teardown.sh
+          chmod +x ./teardown.sh
+      - name: Stop EC2 runner
+        id: stop-ec2-runner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+        run: |
+          ./ensure-dependencies.sh
+          GITHUB_TOKEN=${GITHUB_TOKEN} INSTANCE_ID=${{ needs.start-runner.outputs.ec2-instance-id }} ./teardown.sh

--- a/hack/runner/setup.sh
+++ b/hack/runner/setup.sh
@@ -20,10 +20,12 @@ fi
 RUNNER_TOKEN=$(curl -X POST -H "Accept: application/vnd.github.v3+json" -H "authorization: Bearer ${GITHUB_TOKEN}" https://api.github.com/repos/vmware-tanzu/community-edition/actions/runners/registration-token | jq .token -r)
 INSTANCE_ID=$(aws ec2 run-instances --image-id "${AMI_ID}" --count 1 --instance-type t2.2xlarge --key-name default --security-group-ids sg-03315c6a6ce53b6b7 --region us-west-2 --subnet-id subnet-f0837888 --tag-specifications "ResourceType=instance,Tags=[{Key=token,Value=${RUNNER_TOKEN}}]" | jq .Instances[].InstanceId -r)
 aws ec2 wait instance-running --instance-ids "${INSTANCE_ID}" --region us-west-2
+echo "${INSTANCE_ID}" | tee instanceid.txt
 
 sleep 30
 
-while true
+i=0
+while [ $i -ne 30 ]
 do
     RUNNER_STATUS=$(curl -H "Accept: application/vnd.github.v3+json" -H "authorization: Bearer ${GITHUB_TOKEN}" https://api.github.com/repos/vmware-tanzu/community-edition/actions/runners | jq -r ".runners[] | select(.name==\"${INSTANCE_ID}\") | .status")
 
@@ -31,7 +33,14 @@ do
         break
     fi
 
-    sleep 3
+    i=$((i+1))
+    echo "Attempt $i... sleeping"
+    sleep 10
 done
 
-echo "${INSTANCE_ID}" | tee instanceid.txt
+if [ $i == 30 ]; then
+    echo "Timed out trying to initialize runner"
+    exit 1
+fi
+
+echo "setup completed successfully"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR updates all GitHub action that takes some time to run to use the new runner method.

Some significant changes:
- The AMI was also updated to allow starting/stopping the instance I'm using to build the AMI without triggering an attempt to register to GitHub.
- A runner timeout is at 5mins. If we can't setup the AWS runner in 5 minutes, we error out. The job (and only that job) can always be restarted should there be a networking or etc issue.

Other small changes:
- spacing and line endings to support formatting
- text changes for jobs in actions to be user friendly
- Remove doing a "check-main" when tagging for a release
- update certain actions to trigger only when the action itself is updated vs any action is updated

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Enhance long running github actions by enabling jobs to complete faster
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA