### PR TITLE
Refactors makefile to use more explicit build and install targets

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -77,7 +77,7 @@ jobs:
           make get-deps
       - name: Build
         shell: bash
-        run: make build
+        run: make build-tce-cli-plugins
       - name: Upload Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,15 +21,15 @@ The CLI and some of its plugins live in different repositories. To build the CLI
 hosted in the TCE repository, run the following.
 
 ```shell
-make build-all
+make install-all-tanzu-cli-plugins
 ```
 
 After build and install, you'll see an output similar to the following.
 
 ```text
-[COMPLETE] installed plugins at /home/josh/.local/share/tanzu-cli/. These plugins will be automatically detected by tanzu CLI.
+[COMPLETE] built and installed plugins at /home/josh/.local/share/tanzu-cli/. These plugins will be automatically detected by tanzu CLI.
 
-[COMPLETE] installed tanzu CLI at /home/josh/bin/tanzu. Move this binary to a location in your path!
+[COMPLETE] built and installed tanzu CLI at /home/josh/bin/tanzu. Move this binary to a location in your path!
 ```
 
 As seen in the message above, you can now move `tanzu` from the location it was installed into a location in your path (such as `/usr/local/bin`).
@@ -40,13 +40,13 @@ Plugins are automatically installed in the correctly location, so when calling `
 If you already have `tanzu` CLI installed and wish to only compile and install TCE-specific plugins, run the following.
 
 ```shell
-make build-plugin
+make install-tce-cli-plugins
 ```
 
 After build and install, you'll see an output similar to the following.
 
 ```text
-[COMPLETE] installed TCE-specific plugins at /home/josh/.local/share/tanzu-cli/. These plugins will be automatically detected by your tanzu CLI.
+[COMPLETE] built and installed TCE-specific plugins at /home/josh/.local/share/tanzu-cli/. These plugins will be automatically detected by your tanzu CLI.
 ```
 
 Now that the TCE-specifc plugins are installed on your system, you will see their command when running `tanzu`.

--- a/hack/install-tanzu.sh
+++ b/hack/install-tanzu.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+if [[ -z "${TCE_RELEASE_DIR}" ]]; then
+    echo "TCE_RELEASE_DIR is not set"
+    exit 1
+fi
+
+# Check and change directories to the pre-built tanzu binaries
+ROOT_REPO_DIR="${TCE_RELEASE_DIR}"
+
+if [ ! -d "${ROOT_REPO_DIR}" ] || [ ! -d "${ROOT_REPO_DIR}/tanzu-framework" ]; then
+    echo "Error! No Tanzu Framework build directory found"
+    echo "Please run \`make build-cli\` first to clone the repository"
+fi
+
+cd "${ROOT_REPO_DIR}/tanzu-framework" || exit 1
+
+BUILD_SHA="$(git describe --match="$(git rev-parse --short HEAD)" --always)"
+
+
+ #Only do an install if the environments to build contain the current host OS.
+ #The tanzu-framework `build-install-cli-all` target always uses the current host OS, and if that's not being built it will fail.
+GOHOSTOS=$(go env GOHOSTOS)
+if [[ "$ENVS" == *"${GOHOSTOS}"* ]]; then
+    BUILD_SHA=${BUILD_SHA} BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} make ENVS="${ENVS}" install-cli-plugins install-cli
+fi

--- a/hack/package-release.sh
+++ b/hack/package-release.sh
@@ -21,13 +21,17 @@ if [[ -z "${FRAMEWORK_BUILD_VERSION}" ]]; then
     echo "FRAMEWORK_BUILD_VERSION is not set"
     exit 1
 fi
+if [[ -z "${TCE_RELEASE_DIR}" ]]; then
+    echo "TCE_RELEASE_DIR is not set"
+    exit 1
+fi
 
 # Required directories
 BUILD_ROOT_DIR="${ROOT_REPO_DIR}/build"
 FRAMEWORK_BUILD_VERSION="${FRAMEWORK_BUILD_VERSION:-latest}"
 TCE_BUILD_VERSION="${BUILD_VERSION:-latest}"
 
-DEP_BUILD_DIR="/tmp/tce-release"
+DEP_BUILD_DIR="${TCE_RELEASE_DIR}"
 ROOT_FRAMEWORK_DIR="${DEP_BUILD_DIR}/tanzu-framework"
 
 PACKAGE_LINUX_AMD64_DIR="${BUILD_ROOT_DIR}/tce-linux-amd64-${BUILD_VERSION}"


### PR DESCRIPTION
## What this PR does / why we need it
Updates the make targets to be more explicit and based on feedback

- `make build-tce-cli-plugins` builds local plugins into the artifacts directory
- `make install-tce-cli-plugins` builds and installs local plugins from the artifacts directory
- `make build-all-tanzu-cli-plugins` builds the `tanzu` CLI and it's plugins. Also builds local TCE plugins
- `make install-all-tanzu-cli-plugins` builds installs the `tanzu` CLI and it's plugins. Also builds and installs local TCE plugins from the artifacts directory

This PR also ...
- Updates contributing docs to reflect the more explicit targets
- Adds `TCE_RELEASE_DIR` to makefile (and subsequent scripts) which is where tanzu framework is built locally. Should make updating this directory in the future (if need be) much easier
- Breaks out installing the tanzu CLI into it's own script so it can have it's own make target

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
- TCE build and install make targets are more explicit
```

## Which issue(s) this PR fixes
Fixes: #1558

## Describe testing done for PR
Ran all commands including `make release`. Everything looks good! Also updated GitHub actions where I found `make build`

## Special notes for your reviewer
Open to any and all feedback. Also, if there's chunks missing that also need to be updated, please advise!
