### PR TITLE
Add license check github workflow

### DIFF
--- a/.github/workflows/check-license.yaml
+++ b/.github/workflows/check-license.yaml
@@ -1,4 +1,5 @@
-name: Check - misspell
+---
+name: Check - license
 
 on:
   pull_request:
@@ -7,21 +8,24 @@ on:
       - opened
       - synchronize
       - reopened
+    paths:
+      - "**.go"
+      - "**.sh"
 
 jobs:
-  checkmisspell:
-    name: Check - misspell
+  checklicense:
+    name: Check - license
     runs-on: ubuntu-latest
     steps:
       - name: Config credentials
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
 
       - name: Check out code
         uses: actions/checkout@v1
 
-      - name: Run misspell
+      - name: Run license check
         run: |
-          make misspell
+          make licensecheck

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ OCI_REGISTRY := projects.registry.vmware.com/tce
 
 ##### LINTING TARGETS #####
 .PHONY: lint mdlint shellcheck check yamllint misspell
-check: ensure-deps lint mdlint shellcheck yamllint misspell
+check: ensure-deps lint mdlint shellcheck yamllint misspell licensecheck
 
 .PHONY: ensure-deps
 ensure-deps:
@@ -128,8 +128,12 @@ shellcheck:
 
 yamllint:
 	hack/check-yaml.sh
+
 misspell:
 	hack/check-misspell.sh
+
+licensecheck:
+	hack/check-license.sh
 
 ##### LINTING TARGETS #####
 

--- a/hack/addon-dev/dev-deploy-addon.sh
+++ b/hack/addon-dev/dev-deploy-addon.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # This script bundles an addons configuration / manifests and uploads a Package CR to the cluster.
 # Lastly it applies the InstalledPackage, ClusterRoleBinding, and ServiceAccount YAMLs to validate the
 # addon works as expected.

--- a/hack/builder/builder.go
+++ b/hack/builder/builder.go
@@ -1,6 +1,6 @@
 // +build tools
 
-// Copyright 2021 VMware, Inc. All Rights Reserved.
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package builder imports dependencies needed for building and forces `go mod` to see them as dependencies

--- a/hack/check-license.sh
+++ b/hack/check-license.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HACK_DIR="$(dirname "${BASH_SOURCE[0]}")"
+REPO_ROOT_DIR="$(dirname "${HACK_DIR}"/)"
+
+echo "Checking License in files ..."
+required_keywords=("VMware Tanzu Community Edition contributors" "SPDX-License-Identifier" "Apache-2.0")
+extensions_to_check=("sh" "go")
+
+check_output=$(mktemp /tmp/tce-licence-check.XXXXXX)
+for ext in "${extensions_to_check[@]}"; do
+  find "$REPO_ROOT_DIR" -name "*.$ext" -a \! -path "*vendor/*" -a \! -path "./.*" -a \! -path "./addons/*" -print0 |
+    while IFS= read -r -d '' path; do
+      for rword in "${required_keywords[@]}"; do
+        if ! grep -q "$rword" "$path"; then
+          echo "   $path" >> "$check_output"
+        fi
+      done
+    done
+done
+
+if [ -s "$check_output" ]; then
+  echo "No license header found in:"
+  sort < "$check_output" | uniq
+  echo "License check failed!"
+  echo "Please add the license in each listed file and verify using 'make checklicense'"
+  rm "$check_output"
+  exit 1
+else
+  echo "License check passed!"
+fi
+rm "$check_output"

--- a/hack/check-mdlint.sh
+++ b/hack/check-mdlint.sh
@@ -1,18 +1,7 @@
 #!/bin/bash
 
-# Copyright 2019 The Kubernetes Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 set -o errexit
 set -o nounset

--- a/hack/check-shell.sh
+++ b/hack/check-shell.sh
@@ -1,18 +1,7 @@
 #!/bin/bash
 
-# Copyright 2019 The Kubernetes Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 set -o errexit
 set -o nounset

--- a/hack/copy-images-to-tce.sh
+++ b/hack/copy-images-to-tce.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-# This script is responsible for copying all images referenced in a BOM from the 
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is responsible for copying all images referenced in a BOM from the
 # https://projects.registry.vmware.com/tkr repository into
 # https://projects.registry.vmware.com/tce.
 
@@ -11,7 +14,7 @@ TKG_REPO=projects.registry.vmware.com/tkg
 TCE_REPO=projects.registry.vmware.com/tce
 images=( "$(grep -E 'imagePath: .*$' -A1 ~/.tanzu/tkg/bom/tkg-bom-v1.3.0.yaml | sed -n "s/^.*imagePath: \s*\(\S*\).*$/\1/p")" )
 tags=( "$(grep -E 'imagePath: .*$' -A1 ~/.tanzu/tkg/bom/tkg-bom-v1.3.0.yaml | sed -n "s/^.*tag: \s*\(\S*\).*$/\1/p")" )
-for i in "${!tags[@]}"; do 
+for i in "${!tags[@]}"; do
   src=$(printf "%s/%s:%s\n" "${TKG_REPO}" "${images[$i]}" "${tags[$i]}")
   dst=$(printf "%s/%s:%s\n" "${TCE_REPO}" "${images[$i]}" "${tags[$i]}")
   printf "\n\n====== copying %s:%s ======\n\n" "${images[$i]}" "${tags[$i]}"

--- a/hack/packages/create-package.sh
+++ b/hack/packages/create-package.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # this shell script creates the prescribed directory structure for a Tanzu package.
 
 # set this value to your package name

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -1,6 +1,6 @@
 // +build tools
 
-// Copyright 2021 VMware, Inc. All Rights Reserved.
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package tools imports things required by build scripts, to force `go mod` to see them as dependencies

--- a/hack/workflows/packages/copy-package-readmes-to-docs.go
+++ b/hack/workflows/packages/copy-package-readmes-to-docs.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (
@@ -33,9 +36,9 @@ type SubItem struct {
 }
 
 type SubFolderItem struct {
-	Page    string    `yaml:"page,omitempty"`
-	URL     string    `yaml:"url,omitempty"`
-	Package MyPackage `yaml:"package,omitempty"`
+	Page     string    `yaml:"page,omitempty"`
+	URL      string    `yaml:"url,omitempty"`
+	Package  MyPackage `yaml:"package,omitempty"`
 	SubItems []SubItem `yaml:"subitems,omitempty"`
 }
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
 - Add script hack/check-licese.sh and target 'make licensecheck'
 - This check looks for license in go files and shell scripts
   Following keywords are required:
    - "VMware Tanzu Community Edition contributors"
    - "SPDX-License-Identifier"
    - "Apache-2.0"
 - Fix/update licenses in files in repo

Signed-off-by: Navid Shaikh <navids@vmware.com>

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add license check presubmit github workflow.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #725

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
- Run `make licensecheck` and `make shellcheck` and verify no erors.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
- Please verify the required keywords.
- This check is only running for go files and shell scripts.
- This check excludes `*vendor/*` and `./addons/*` dir.