### PR TITLE
Fix CODEOWNER for `@vmware-tanzu/tce-releng` to `/test/` not `test/`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@
 *                          @vmware-tanzu/tce-owners
 
 ## Ownership of release engineering efforts
-test/                       @vmware-tanzu/tce-releng
+/test/                       @vmware-tanzu/tce-releng
 
 # Package Ownership
 


### PR DESCRIPTION
## What this PR does / why we need it

The CODEOWNER permissions that was there gave ownership to @vmware-tanzu/tce-releng group/team to anything that had `test/` in the path. This fixes it so it's just the `/test/` folder off root.

Noticed the issue in #1566 PR

Related - #1544
Docs - https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#codeowners-syntax

Docs example - 

```
# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/*  docs@example.com

# In this example, @doctocat owns any file in the `/docs`
# directory in the root of your repository and any of its
# subdirectories.
/docs/ @doctocat
```

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Fix CODEOWNER for @vmware-tanzu/tce-releng group/team
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

NA
