### PR TITLE
Fix timeout on runner so that AWS can clean up

### DIFF
--- a/hack/runner/setup.sh
+++ b/hack/runner/setup.sh
@@ -40,7 +40,7 @@ done
 
 if [ $i == 30 ]; then
     echo "Timed out trying to initialize runner"
-    exit 1
+    echo "timedout" | tee timedout.txt
+else
+    echo "setup completed successfully"
 fi
-
-echo "setup completed successfully"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
We can't exit out of the setup script because it short circuits the rest of the workflow and the clean up never happens. Put down a marker file so that we can set the instance id, then error out.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA