### PR TITLE
Update README for current package, retire xip.io

### DIFF
--- a/addons/packages/knative-serving/0.22.0/README.md
+++ b/addons/packages/knative-serving/0.22.0/README.md
@@ -4,7 +4,7 @@ This package provides serverless functionality using [Knative](https://knative.d
 
 ## Components
 
-* Knative Serving
+* Knative Serving version: 0.22.0
 
 ## Configuration
 
@@ -13,7 +13,7 @@ You can configure the following:
 | Config | Values | Description |
 |--------|--------|-------------|
 |namespace| `any namespace` **(default: knative-serving)**|Namespace where you want to install knative|
-|domain.type | real, xip.io, nip.io **(default: xip.io)**|Type of DNS resolution to use for your knative services. We can use real dns, in which case, you need to provide a domain.name or else use xip.io or nip.io|
+|domain.type | real, sslip.io, nip.io **(default: nip.io)**|Type of DNS resolution to use for your knative services. We can use real dns, in which case, you need to provide a domain.name or else use sslip.io or nip.io|
 |domain.name | `any domain name` **(default: empty)**|If you have a valid domain, make sure that it's properly configure to your ingress controller|
 |ingress.external.namespace|`any namespace` **(default: projectcontour)**|Namespace of the ingress controller for external services|
 |ingress.internal.namespace|`any namespace` **(default: projectcontour)**|Namespace of the ingress controller for internal services. If you don't want to have internal services separated from external, use the same namespace for both.|
@@ -24,16 +24,14 @@ You can configure the following:
 The knative-serving package requires use of Contour for ingress. To successfully install and use the knative-serving package, you must first install Contour.
 
 ```shell
-tanzu package install contour.tce.vmware.com
+tanzu package install contour --package-name contour.community.tanzu.vmware.com --namespace contour-external --version 1.17.1
 ```
 
 After the Contour package has been installed, you can install knative-serving.
 
 ```shell
-tanzu package install knative-serving.tce.vmware.com
+tanzu package install knative-serving --package-name knative-serving.community.tanzu.vmware.com --namespace knative-serving --version 0.22.0
 ```
-
-__NOTE__: You can provide your own configuration file. Check the help for how to do this.
 
 ## Usage Example
 
@@ -82,9 +80,9 @@ kubectl apply --filename helloworld-service.yaml
 watch kubectl get pods --namespace example
 ```
 
-1. At this point you will have a Magic DNS (xip.io) configured to provide you access to your service. If you want to use real DNS or any other Magic DNS you'll need to provide the appropriate configuration to the knative-serving package when installing it.
+1. At this point you will have a Magic DNS (nip.io) configured to provide you access to your service. If you want to use real DNS or any other Magic DNS you'll need to provide the appropriate configuration to the knative-serving package when installing it.
 
-> __NOTE__: xip only works under some conditions. You can use real DNS, check the configuration options for this package.
+> __NOTE__: nip only works if your Contour has a loadbalancer with a reachable IP address. If you don't have a loadbalancer or have a loadbalancer that only be reached by CNAME, you can use real DNS, see the configuration options for this package.
 
 1. Get the Knative services. This will show which applications are available and the URL to access them.
 
@@ -92,13 +90,13 @@ watch kubectl get pods --namespace example
 kubectl get ksvc --namespace example
 
 NAMESPACE   NAME              URL                                                   LATESTCREATED           LATESTREADY             READY   REASON
-example     helloworld-go     http://helloworld-go.default.18.204.46.247.xip.io     helloworld-go-00001     helloworld-go-00001     True
+example     helloworld-go     http://helloworld-go.default.18.204.46.247.nip.io     helloworld-go-00001     helloworld-go-00001     True
 ```
 
 1. Make a request to the application. Make a request to the application via a cURL of the URL from the previous step.
 
 ```shell
-curl http://helloworld-go.default.18.204.46.247.xip.io
+curl http://helloworld-go.default.18.204.46.247.nip.io
 
 Hello Go Sample v1!
 ```

--- a/addons/packages/knative-serving/0.22.0/bundle/config/overlays/assertions.yaml
+++ b/addons/packages/knative-serving/0.22.0/bundle/config/overlays/assertions.yaml
@@ -2,7 +2,7 @@
 #@ load("@ytt:assert", "assert")
 
 #! Assert domain type
-#@ data.values.domain.type=="real" or data.values.domain.type=="xip.io" or data.values.domain.type=="nip.io" or assert.fail("values.domain.type accepted values are: real, xip.io, nip.io")
+#@ data.values.domain.type=="real" or data.values.domain.type=="sslip.io" or data.values.domain.type=="nip.io" or assert.fail("values.domain.type accepted values are: real, sslip.io, nip.io")
 
 #@ if data.values.domain.type=="real":
 #@ data.values.domain.name or assert.fail("values.domain.name needs to be provided if domain.type is real")

--- a/addons/packages/knative-serving/0.22.0/bundle/config/values.yaml
+++ b/addons/packages/knative-serving/0.22.0/bundle/config/values.yaml
@@ -3,8 +3,8 @@
 namespace: knative-serving
 #! See https://knative.dev/docs/install/install-serving-with-yaml/#configure-dns
 domain:  
-  type: xip.io #! Values: real, xip.io, nip.io
-  name:        #! Values: Your own domain name if type real or empty if type xip.io or nip.io
+  type: nip.io #! Values: real, sslip.io, nip.io
+  name:        #! Values: Your own domain name if type real or empty if type sslip.io or nip.io
 #! Only contour is supported. See https://knative.dev/docs/install/install-serving-with-yaml/#install-a-networking-layer
 #! If you want to separate external and internal services, provide the namespace of the internal and external contour ingress controller,
 #! otherwise use the same for both, the namespace where contour has been installed.


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Fixes #1459

Also retires `xip.io`, which died in the great Basecamp exodus of 2021. Adds`sslip.io`, an equivalent service.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Changes knative-serving domain options to retire xip.io, which no longer functions.
```

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

None.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

The `values.yaml` change seem innocuous, and the README.md changes were modelled on https://github.com/vmware-tanzu/community-edition/tree/main/addons/packages/cert-manager/1.5.1#usage-examples, but not putting all components in the default namespace.