### PR TITLE
Add e2e tests for velero

### DIFF
--- a/addons/packages/velero/1.5.2/test/Makefile
+++ b/addons/packages/velero/1.5.2/test/Makefile
@@ -1,0 +1,24 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ROOT_DIR := $(shell git rev-parse --show-toplevel)
+PLATFORM := $(shell uname | tr '[:upper:]' '[:lower:]')
+ifndef GOPATH
+GOPATH := "~/go"
+endif
+ifndef PROVIDER
+CLOUD_PROVIDER := "minio"
+endif
+
+e2e-test:
+	sh -c "rm -rf /tmp/velero-e2e-test &&\
+	mktemp -d /tmp/velero-e2e-test &&\
+	git clone https://github.com/vmware-tanzu/velero /tmp/velero-e2e-test/velero &&\
+	cd /tmp/velero-e2e-test &&\
+	$(ROOT_DIR)/addons/packages/velero/1.5.2/test/install-velero-cli.sh v1.5.2 $(PLATFORM) &&\
+	GOPATH=$(GOPATH) CLOUD_PROVIDER=$(CLOUD_PROVIDER) \
+	OBJECT_STORE_PROVIDER=minio \
+	CREDS_FILE=/tmp/credential BSL_BUCKET=velero \
+	GINKGO_FOCUS=Basic INSTALL_VELERO=false VELERO_CLI=/tmp/velero-e2e-test/velero-v1.5.2-$(PLATFORM)-amd64/velero  \
+	make -C /tmp/velero-e2e-test/velero/test/e2e run"
+

--- a/addons/packages/velero/1.5.2/test/README.md
+++ b/addons/packages/velero/1.5.2/test/README.md
@@ -1,0 +1,29 @@
+# Velero tests
+
+## End-to-End tests
+
+End-to-End tests for Velero are located in [vmware-tanzu/velero](https://github.com/vmware-tanzu/velero/tree/main/test/e2e).
+The `make e2e-test` target defined in this directory runs the `Basic` end-to-end test from velero test suite.
+
+### Prerequisites
+
+To run the velero end-to-end tests you need:
+
+* A TCE cluster and the cluster needs to be the current-context.
+
+* `velero.community.tanzu.vmware.com` package must be installed on the cluster.
+
+### Test Configuration
+
+Set the `GITHUB_TOKEN` environment variable which is needed to install velero cli while running the tests.
+Set the `GOPATH` environment variable if it is different from `~/go`.
+Set the `PROVIDER` environment variable if the cloud provider is not minio.
+
+### Run Tests
+
+Run the tests from the test directory:
+
+```bash
+cd addons/packages/velero/1.5.2/test/
+make e2e-test
+```

--- a/addons/packages/velero/1.5.2/test/install-velero-cli.sh
+++ b/addons/packages/velero/1.5.2/test/install-velero-cli.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# set -o errexit
+set -o nounset
+set -o pipefail
+set -e
+
+# Script to download asset file from tag release using GitHub API v3.
+# Inspired by: https://github.com/vmware-tanzu/community-edition/blob/main/hack/get-tce-release.sh
+
+# Validate GitHub access token
+if [ -z "$GITHUB_TOKEN" ]; then
+	echo "Error: Please define GITHUB_TOKEN variable!"
+	exit 1
+fi
+
+# Should have two arguments, release-tag and file name
+if [ $# -ne 2 ]; then
+	echo "Usage: $0 [tag] [name]"
+	echo "Example: ./install-velero-cli.sh v1.5.2 linux"
+	exit 1
+fi
+
+# Check dependencies exist
+echo "Validating dependencies ..."
+type curl grep sed tr jq
+
+# Define variables
+tag=$1
+name=$2
+
+GH_API="https://api.github.com"
+GH_REPO="$GH_API/repos/vmware-tanzu/velero"
+GH_TAGS="$GH_REPO/releases/tags/$tag"
+AUTH="Authorization: token $GITHUB_TOKEN"
+CURL_ARGS="-LJO#"
+
+# Validate GH token.
+curl -o /dev/null -sH "$AUTH" $GH_REPO || { echo "Error: Unauthenticated token or network issue!";  exit 1; }
+
+# Read asset tags
+assets=$(curl -sH "$AUTH" "$GH_TAGS")
+
+if [[ $(echo "$assets" | jq ".message") = "\"Not Found\"" ]]; then
+	echo "Error: release tag $tag not found! Please enter a valid release tag version. Ex: v0.5.0"
+	echo "Available release tags include:"
+	curl -sH "$AUTH" "${GH_REPO}/releases" | jq "[ .[] | { html_url }]"
+	exit 1
+fi
+
+# Get ID of the asset based on given name.
+id=$(echo "$assets" | jq ".assets[] | select( .browser_download_url | contains(\"${name}\"))" | jq '.id')
+if [ -z "$id" ]; then
+	echo "Error: Failed to get asset id for release containing substring $name"
+	echo "Please provide a substring for the name of an assetfile. Ex: darwin, linux"
+	echo "Available asset files include:"
+	echo "$assets" | jq "[ .assets[] | { browser_download_url }]"
+	exit 1
+fi
+
+GH_ASSET="$GH_REPO/releases/assets/$id"
+
+# Download asset file
+echo "Downloading asset ..."
+curl $CURL_ARGS -H "Authorization: token $GH_ACCESS_TOKEN" -H 'Accept: application/octet-stream' "$GH_ASSET"
+tar xvzf velero-"$tag"-"$name"-amd64.tar.gz


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR leverages the e2e tests defined in https://github.com/vmware-tanzu/velero/tree/main/test/e2e and adds a Makefile target to run them on TCE cluster.

Inspired by: https://github.com/vmware-tanzu/velero/blob/main/.github/workflows/e2e-test-kind.yaml#L106
## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add e2e tests for Velero
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
Ran this on TCE clusters on CAPD and AWS.
```
➜ make e2e-test
sh -c "rm -rf /tmp/velero /tmp/velero-v1.5.2-darwin-amd64* &&\
        git clone https://github.com/vmware-tanzu/velero /tmp/velero &&\
        cd /tmp &&\
        /Users/rkakodkar/git/repos/rajaskakodkar/community-edition/addons/packages/velero/1.5.2/test/install-velero-cli.sh v1.5.2 darwin &&\
        tar xvzf velero-v1.5.2-darwin-amd64.tar.gz &&\
        GOPATH="~/go" CLOUD_PROVIDER=minio \
        OBJECT_STORE_PROVIDER=minio \
        CREDS_FILE=/tmp/credential BSL_BUCKET=velero \
        GINKGO_FOCUS=Basic INSTALL_VELERO=false VELERO_CLI=/tmp/velero-v1.5.2-darwin-amd64/velero  \
        make -C /tmp/velero/test/e2e run"
Cloning into '/tmp/velero'...
remote: Enumerating objects: 36670, done.
remote: Counting objects: 100% (1642/1642), done.
remote: Compressing objects: 100% (684/684), done.
remote: Total 36670 (delta 1024), reused 1335 (delta 876), pack-reused 35028
Receiving objects: 100% (36670/36670), 33.57 MiB | 8.18 MiB/s, done.
Resolving deltas: 100% (24052/24052), done.
Validating dependencies ...
curl is /usr/bin/curl
grep is /usr/bin/grep
sed is /usr/bin/sed
tr is /usr/bin/tr
jq is /usr/local/bin/jq
Downloading asset ...
################################################################################################################################ 100.0%curl: Saved to filename 'velero-v1.5.2-darwin-amd64.tar.gz'

x velero-v1.5.2-darwin-amd64/LICENSE
x velero-v1.5.2-darwin-amd64/examples/README.md
x velero-v1.5.2-darwin-amd64/examples/minio
x velero-v1.5.2-darwin-amd64/examples/minio/00-minio-deployment.yaml
x velero-v1.5.2-darwin-amd64/examples/nginx-app
x velero-v1.5.2-darwin-amd64/examples/nginx-app/README.md
x velero-v1.5.2-darwin-amd64/examples/nginx-app/base.yaml
x velero-v1.5.2-darwin-amd64/examples/nginx-app/with-pv.yaml
x velero-v1.5.2-darwin-amd64/velero
go get github.com/onsi/ginkgo/ginkgo
Using credentials from /tmp/credential
Using bucket velero to store backups from E2E tests
Using cloud provider minio
Running Suite: E2e Suite
========================
Random Seed: 1631044543
Will run 1 of 7 specs

SSSSS
------------------------------
[Basic] Backup/restore of 2 namespaces When I create 2 namespaces
  should be successfully backed up and restored
  /private/tmp/velero/test/e2e/multiple_namespaces_test.go:44
Creating namespaces ...
backup cmd =/tmp/velero-v1.5.2-darwin-amd64/velero --namespace velero create backup backup-318a0a2d-85fc-4bbc-a910-09b723d9f37e --exclude-namespaces default,kube-node-lease,kube-public,kube-system,tanzu-package-repo-global,tkg-system,tkg-system-public,tkr-system,velero --default-volumes-to-restic --wait
Backup request "backup-318a0a2d-85fc-4bbc-a910-09b723d9f37e" submitted successfully.
Waiting for backup to complete. You may safely press ctrl-c to stop waiting - your backup will continue in the background.
....
Backup completed with status: Completed. You may check for more information using the commands `velero backup describe backup-318a0a2d-85fc-4bbc-a910-09b723d9f37e` and `velero backup logs backup-318a0a2d-85fc-4bbc-a910-09b723d9f37e`.
get backup cmd =/tmp/velero-v1.5.2-darwin-amd64/velero --namespace velero backup get -o json backup-318a0a2d-85fc-4bbc-a910-09b723d9f37e
Cleaning up namespaces ...
restore cmd =/tmp/velero-v1.5.2-darwin-amd64/velero --namespace velero create restore restore-318a0a2d-85fc-4bbc-a910-09b723d9f37e --from-backup backup-318a0a2d-85fc-4bbc-a910-09b723d9f37e --wait
Restore request "restore-318a0a2d-85fc-4bbc-a910-09b723d9f37e" submitted successfully.
Waiting for restore to complete. You may safely press ctrl-c to stop waiting - your restore will continue in the background.
.....
Restore completed with status: Completed. You may check for more information using the commands `velero restore describe restore-318a0a2d-85fc-4bbc-a910-09b723d9f37e` and `velero restore logs restore-318a0a2d-85fc-4bbc-a910-09b723d9f37e`.
get restore cmd =/tmp/velero-v1.5.2-darwin-amd64/velero --namespace velero restore get -o json restore-318a0a2d-85fc-4bbc-a910-09b723d9f37e
Cleaning up namespaces ...

• [SLOW TEST:18.904 seconds]
[Basic] Backup/restore of 2 namespaces
/private/tmp/velero/test/e2e/multiple_namespaces_test.go:19
  When I create 2 namespaces
  /private/tmp/velero/test/e2e/multiple_namespaces_test.go:43
    should be successfully backed up and restored
    /private/tmp/velero/test/e2e/multiple_namespaces_test.go:44
------------------------------
S
JUnit report was created: /private/tmp/velero/test/e2e/report.xml

Ran 1 of 7 Specs in 18.904 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 6 Skipped
PASS
You're using deprecated Ginkgo functionality:
=============================================
Ginkgo 2.0 is under active development and will introduce (a small number of) breaking changes.
To learn more, view the migration guide at https://github.com/onsi/ginkgo/blob/v2/docs/MIGRATING_TO_V2.md
To comment, chime in at https://github.com/onsi/ginkgo/issues/711

  You are using a custom reporter.  Support for custom reporters will likely be removed in V2.  Most users were using them to generate junit or teamcity reports and this functionality will be merged into the core reporter.  In addition, Ginkgo 2.0 will support emitting a JSON-formatted report that users can then manipulate to generate custom reports.

  If this change will be impactful to you please leave a comment on https://github.com/onsi/ginkgo/issues/711
  Learn more at: https://github.com/onsi/ginkgo/blob/v2/docs/MIGRATING_TO_V2.md#removed-custom-reporters

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=1.16.4


Ginkgo ran 1 suite in 29.713192274s
Test Suite Passed

```
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA