### PR TITLE
Allow install script as root with override for self-hosted runner

### DIFF
--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -85,7 +85,7 @@ jobs:
         shell: bash
         run: |
           cd `find ./build -type d -name "tce-linux-amd64-*" | xargs -n1 echo -n`
-          ./install.sh
+          ALLOW_INSTALL_AS_ROOT=true ./install.sh
   create-cluster:
     name: Create Cluster
     needs:

--- a/.github/workflows/check-pr-docker-management.yaml
+++ b/.github/workflows/check-pr-docker-management.yaml
@@ -86,7 +86,7 @@ jobs:
         shell: bash
         run: |
           cd `find ./build -type d -name "tce-linux-amd64-*" | xargs -n1 echo -n`
-          ./install.sh
+          ALLOW_INSTALL_AS_ROOT=true ./install.sh
   create-cluster:
     name: Create Cluster
     outputs:

--- a/.github/workflows/check-pr-docker-standalone.yaml
+++ b/.github/workflows/check-pr-docker-standalone.yaml
@@ -88,7 +88,7 @@ jobs:
         shell: bash
         run: |
           cd `find ./build -type d -name "tce-linux-amd64-*" | xargs -n1 echo -n`
-          ./install.sh
+          ALLOW_INSTALL_AS_ROOT=true ./install.sh
   create-cluster:
     name: Create Cluster
     outputs:

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -8,9 +8,10 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-if [[ "$EUID" -eq 0 ]]; then
+ALLOW_INSTALL_AS_ROOT="${ALLOW_INSTALL_AS_ROOT:-""}"
+if [[ "$EUID" -eq 0 && "${ALLOW_INSTALL_AS_ROOT}" != "true" ]]; then
   echo "Do not run this script as root"
-  exit
+  exit 1
 fi
 
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This fixes an issue with the GitHub self-hosted runner where it was being executed by the default AMI user, but now for some reason has changed to root.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
Verified non-root user produces error. Verified that providing the override allows as root allows install.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA