### PR TITLE
shellcheck: Add License check for shell scripts and Makefiles

### DIFF
--- a/addons/packages/calico/test/Makefile
+++ b/addons/packages/calico/test/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message

--- a/addons/packages/external-dns/test/Makefile
+++ b/addons/packages/external-dns/test/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message

--- a/addons/packages/harbor/2.2.3/bundle/config/scripts/generate-passwords.sh
+++ b/addons/packages/harbor/2.2.3/bundle/config/scripts/generate-passwords.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -o errexit
 
 function random_string() {

--- a/addons/packages/pinniped/hack/Makefile
+++ b/addons/packages/pinniped/hack/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message

--- a/addons/packages/pinniped/hack/regen-readme.sh
+++ b/addons/packages/pinniped/hack/regen-readme.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/addons/packages/test/pkg/Makefile
+++ b/addons/packages/test/pkg/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message

--- a/cli/cmd/plugin/conformance/Makefile
+++ b/cli/cmd/plugin/conformance/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message

--- a/cli/cmd/plugin/diagnostics/Makefile
+++ b/cli/cmd/plugin/diagnostics/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message

--- a/cli/cmd/plugin/standalone-cluster/Makefile
+++ b/cli/cmd/plugin/standalone-cluster/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message

--- a/hack/addon-dev/dev-deploy-addon.sh
+++ b/hack/addon-dev/dev-deploy-addon.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # This script bundles an addons configuration / manifests and uploads a Package CR to the cluster.
 # Lastly it applies the InstalledPackage, ClusterRoleBinding, and ServiceAccount YAMLs to validate the
 # addon works as expected.

--- a/hack/asset/Makefile
+++ b/hack/asset/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message

--- a/hack/builder/Makefile
+++ b/hack/builder/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 BUILD_DATE ?= $$(date -u +"%Y-%m-%d")

--- a/hack/check-mdlint.sh
+++ b/hack/check-mdlint.sh
@@ -1,18 +1,7 @@
 #!/bin/bash
 
-# Copyright 2019 The Kubernetes Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 set -o errexit
 set -o nounset

--- a/hack/check-shell.sh
+++ b/hack/check-shell.sh
@@ -1,18 +1,7 @@
 #!/bin/bash
 
-# Copyright 2019 The Kubernetes Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 set -o errexit
 set -o nounset
@@ -30,13 +19,49 @@ usage: ${0} [FLAGS]
 FLAGS
   -l    use your local shellcheck (warning - errors may differ from docker!)
   -h    prints this help screen
+  -x    verify license header
 EOF
 }
 
-while getopts ':lh' opt; do
+verify_license() {
+  printf "\nChecking License in shell scripts and Makefiles ...\n"
+  local required_keywords=("VMware Tanzu Community Edition contributors" "SPDX-License-Identifier: Apache-2.0")
+  local file_patterns_to_check=("*.sh" "Makefile")
+
+  local result
+  result=$(mktemp /tmp/tce-licence-check.XXXXXX)
+  for ext in "${file_patterns_to_check[@]}"; do
+    find . -path ./vendor -prune -o -name "$ext" -type f -print0 |
+      while IFS= read -r -d '' path; do
+        for rword in "${required_keywords[@]}"; do
+          if ! grep -q "$rword" "$path"; then
+            echo "   $path" >> "$result"
+          fi
+        done
+      done
+  done
+
+  if [ -s "$result" ]; then
+    echo "No required license header found in:"
+    sort < "$result" | uniq
+    echo "License check failed!"
+    echo "Please add the license in each listed file and verify using 'make shellcheck'"
+    rm "$result"
+    return 1
+  else
+    echo "License check passed!"
+    rm "$result"
+    return 0
+  fi
+}
+
+while getopts ':lhx' opt; do
   case "${opt}" in
   l)
     DO_DOCKER=0
+    ;;
+  x)
+    verify_license || exit 1; exit 0
     ;;
   h)
     usage 1>&2; exit 1
@@ -58,3 +83,5 @@ else
   docker run --rm -t -v "$(pwd)":/build:ro gcr.io/cluster-api-provider-vsphere/extra/shellcheck --version
   docker run --rm -t -v "$(pwd)":/build:ro gcr.io/cluster-api-provider-vsphere/extra/shellcheck
 fi
+
+verify_license

--- a/hack/copy-images-to-tce.sh
+++ b/hack/copy-images-to-tce.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-# This script is responsible for copying all images referenced in a BOM from the 
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is responsible for copying all images referenced in a BOM from the
 # https://projects.registry.vmware.com/tkr repository into
 # https://projects.registry.vmware.com/tce.
 

--- a/hack/packages/Makefile
+++ b/hack/packages/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message

--- a/hack/packages/create-package.sh
+++ b/hack/packages/create-package.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # this shell script creates the prescribed directory structure for a Tanzu package.
 
 # set this value to your package name

--- a/hack/release/Makefile
+++ b/hack/release/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message

--- a/hack/workflows/packages/Makefile
+++ b/hack/workflows/packages/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
- 'make shelcheck' now checks license header for shell scrips and
  Makefiles
- Add 'hack/check-shell.sh -x' option to run only license check
- Update license in shell scripts and Makefiles
- Followup of #1567 

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add license check for shell scripts and Makefiles. Run 'make shellcheck' to verify license headers.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #725 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
- Run `make shellcheck` and verify no errors
- Run `./hack/check-license.sh -x` and verify no errors

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
- Scans all dirs except `./vendor`
