### PR TITLE
Improve CI response time by detecting non-responsive runners

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -21,13 +21,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh \
-            -o setup.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -96,13 +96,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh \
-            -o teardown.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -16,13 +16,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh \
-            -o setup.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -124,13 +124,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh \
-            -o teardown.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/.github/workflows/check-pr-docker-management.yaml
+++ b/.github/workflows/check-pr-docker-management.yaml
@@ -21,13 +21,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh \
-            -o setup.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -171,13 +171,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh \
-            -o teardown.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/.github/workflows/check-pr-docker-standalone.yaml
+++ b/.github/workflows/check-pr-docker-standalone.yaml
@@ -23,13 +23,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh \
-            -o setup.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -173,13 +173,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh \
-            -o teardown.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -17,13 +17,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh \
-            -o setup.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -166,13 +166,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh \
-            -o teardown.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -18,13 +18,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh \
-            -o setup.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -181,13 +181,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh \
-            -o teardown.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -19,13 +19,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh \
-            -o setup.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -182,13 +182,13 @@ jobs:
       - name: Download Dependencies
         shell: bash
         run: |
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh \
-            -o ensure-dependencies.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh \
-            -o teardown.sh
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' -O \
+            -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/hack/runner/setup.sh
+++ b/hack/runner/setup.sh
@@ -17,30 +17,60 @@ if [[ -z "${AMI_ID}" ]]; then
     exit 1
 fi
 
-RUNNER_TOKEN=$(curl -X POST -H "Accept: application/vnd.github.v3+json" -H "authorization: Bearer ${GITHUB_TOKEN}" https://api.github.com/repos/vmware-tanzu/community-edition/actions/runners/registration-token | jq .token -r)
-INSTANCE_ID=$(aws ec2 run-instances --image-id "${AMI_ID}" --count 1 --instance-type t2.2xlarge --key-name default --security-group-ids sg-03315c6a6ce53b6b7 --region us-west-2 --subnet-id subnet-f0837888 --tag-specifications "ResourceType=instance,Tags=[{Key=token,Value=${RUNNER_TOKEN}}]" | jq .Instances[].InstanceId -r)
-aws ec2 wait instance-running --instance-ids "${INSTANCE_ID}" --region us-west-2
-echo "${INSTANCE_ID}" | tee instanceid.txt
-
-sleep 30
+succeeded=false
+numOfTimesToRetry=3
+numOfTimesToPoll=30
+mustHaveStatusBefore=10
 
 i=0
-while [ $i -ne 30 ]
+while [ $i -ne $numOfTimesToRetry ]
 do
-    RUNNER_STATUS=$(curl -H "Accept: application/vnd.github.v3+json" -H "authorization: Bearer ${GITHUB_TOKEN}" https://api.github.com/repos/vmware-tanzu/community-edition/actions/runners | jq -r ".runners[] | select(.name==\"${INSTANCE_ID}\") | .status")
+    set +x
+    RUNNER_TOKEN=$(curl -X POST -H "Accept: application/vnd.github.v3+json" -H "authorization: Bearer ${GITHUB_TOKEN}" https://api.github.com/repos/vmware-tanzu/community-edition/actions/runners/registration-token | jq .token -r)
+    INSTANCE_ID=$(aws ec2 run-instances --image-id "${AMI_ID}" --count 1 --instance-type t2.2xlarge --key-name default --security-group-ids sg-03315c6a6ce53b6b7 --region us-west-2 --subnet-id subnet-f0837888 --tag-specifications "ResourceType=instance,Tags=[{Key=token,Value=${RUNNER_TOKEN}}]" | jq .Instances[].InstanceId -r)
+    set -x
+    aws ec2 wait instance-running --instance-ids "${INSTANCE_ID}" --region us-west-2
+    echo "${INSTANCE_ID}" | tee instanceid.txt
 
-    if [[ "${RUNNER_STATUS}" == "online" ]]; then
+    # dont poll yet... give a small head start
+    echo "Sleeping for 30s"
+    sleep 30
+
+    # retry loop and get signal on what to do...
+    j=0
+    while [ $j -ne $numOfTimesToPoll ]
+    do
+        RUNNER_STATUS=$(curl -H "Accept: application/vnd.github.v3+json" -H "authorization: Bearer ${GITHUB_TOKEN}" https://api.github.com/repos/vmware-tanzu/community-edition/actions/runners | jq -r ".runners[] | select(.name==\"${INSTANCE_ID}\") | .status")
+
+        if [[ "${RUNNER_STATUS}" == "" && $j -gt $mustHaveStatusBefore ]]; then
+            echo "The node should have already returned some status... retry"
+            break
+        fi
+        if [[ "${RUNNER_STATUS}" == "online" ]]; then
+            echo "Succeeded!"
+            succeeded=true
+            break
+        fi
+
+        j=$((j+1))
+        echo "Attempt poll $j... sleeping"
+        sleep 10
+    done
+
+    if [[ $succeeded == "true" ]]; then
+        echo "Succeeded! breaking the retry loop!"
         break
     fi
 
+    # delete instance and retry
     i=$((i+1))
-    echo "Attempt $i... sleeping"
-    sleep 10
+    echo "Retrying setup $i..."
+    aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" --region us-west-2 > /dev/null 2>&1
 done
 
-if [ $i == 30 ]; then
+if [ $succeeded == "true" ]; then
+    echo "setup completed successfully"
+else
     echo "Timed out trying to initialize runner"
     echo "timedout" | tee timedout.txt
-else
-    echo "setup completed successfully"
 fi


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Once in a blue moon when you deploy a self-hosted runner, the runner fails to initialize... this is easily detectable because the node for some reason doesn't report any kind of status for a good amount of time. This usually burns the entire 5min timeout for initialization which leads to failure (usually when the agent is registered, the status is "offline" until it's not). This allows to detect for early non-responsive or agents that failed to register which is detected in 1/3 of the total timeout time and then retries up to a maximum of 3 times by creating a new ec2 instance and starting the process over again automatically.

This happens roughly about 1-3 times a day based on the large number of jobs that get kicked off.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA