### PR TITLE
Docs: Include link in quickstart to "prepare AWS account" docs

### DIFF
--- a/docs/site/content/docs/assets/aws-clusters.md
+++ b/docs/site/content/docs/assets/aws-clusters.md
@@ -3,6 +3,9 @@
 This section describes setting up management and workload clusters for
 Amazon EC2.
 
+Ensure that you have set up your AWS account to be ready to deploy Tanzu clusters.
+Refer to the [Prepare to Deploy a Management or Standalone Cluster to Amazon EC2](../aws) docs for instructions on deploying an SSH key-pair and preparing your AWS account.
+
 1. Initialize the Tanzu Community Edition installer interface.
 
     ```sh

--- a/docs/site/content/docs/assets/aws-standalone-clusters.md
+++ b/docs/site/content/docs/assets/aws-standalone-clusters.md
@@ -2,6 +2,9 @@
 
 This section covers setting up a standalone cluster in Amazon EC2. A standalone cluster provides a workload cluster that is **not** managed by a centralized management cluster.
 
+Ensure that you have set up your AWS account to be ready to deploy Tanzu clusters.
+Refer to the [Prepare to Deploy a Management or Standalone Cluster to Amazon EC2](../aws) docs for instructions on deploying an SSH key-pair and preparing your AWS account.
+
 1. Initialize the Tanzu Community Edition Installer Interface.
 
     ```sh


### PR DESCRIPTION
## What this PR does / why we need it
Adds a link in the quickstart guides to the "prepare aws account" section of the docs. This way, users following the quickstart guides can have instructions to deploy SSH keypairs and successfully prepare their AWS account

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
- Link in docs to the "prepare aws account" docs so users can deploy an ssh key-pair
```

## Which issue(s) this PR fixes
Fixes: #1494

## Describe testing done for PR
`hugo serve` and looked good!

## Special notes for your reviewer
N/a
