### PR TITLE
Package docs workflow should exit cleanly #1619

### DIFF
--- a/hack/workflows/packages/update-package-readmes.sh
+++ b/hack/workflows/packages/update-package-readmes.sh
@@ -25,14 +25,14 @@ git checkout -b "${BRANCH_NAME}"
 
 set +o errexit
 
-git stash pop
+result=$(git stash pop 2>&1)
 
 # exit cleanly if no changes detected
-exitCode=$?
-if [ $exitCode -ne 0 ]; then
+if [[ "${result}" == *"No stash entries"* ]]; then
     echo "No changes detected"
     exit 0
 fi
+
 set -o errexit
 
 git add .

--- a/hack/workflows/packages/update-package-readmes.sh
+++ b/hack/workflows/packages/update-package-readmes.sh
@@ -20,10 +20,20 @@ BRANCH_NAME=update-package-readmes-$(date +%s)
 
 git stash
 
-# create branch off main
+# create a branch off main
 git checkout -b "${BRANCH_NAME}"
 
+set +o errexit
+
 git stash pop
+
+# exit cleanly if no changes detected
+exitCode=$?
+if [ $exitCode -ne 0 ]; then
+    echo "No changes detected"
+    exit 0
+fi
+set -o errexit
 
 git add .
 


### PR DESCRIPTION
## What this PR does / why we need it
When there are no changes detected, the GitHub workflow will
exit with an error and flag the action as failed. This
will detect if there are no changes and exit with a
status code of 0 so the action will not fail.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1619

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
