### PR TITLE
Use VMware built images for `k8s-sidecar` and `grafana` in the Grafana package

### DIFF
--- a/addons/packages/grafana/7.5.7/bundle/.imgpkg/images.yml
+++ b/addons/packages/grafana/7.5.7/bundle/.imgpkg/images.yml
@@ -7,4 +7,10 @@ images:
 - annotations:
     kbld.carvel.dev/id: kiwigrid/k8s-sidecar:1.12.1
   image: index.docker.io/kiwigrid/k8s-sidecar@sha256:444be8cef8b25b4aaddea692ae09e3883d9064c0d31b43c4ba388a83c920552f
+- annotations:
+    kbld.carvel.dev/id: projects.registry.vmware.com/tkg/grafana/grafana:v7.5.7_vmware.1
+  image: projects.registry.vmware.com/tkg/grafana/grafana@sha256:df8f25cc9ee43d6ea4c22f9c6c46644e2b9a485562dd0dafe831b5b582ac0a71
+- annotations:
+    kbld.carvel.dev/id: projects.registry.vmware.com/tkg/grafana/k8s-sidecar:v1.12.1_vmware.1
+  image: projects.registry.vmware.com/tkg/grafana/k8s-sidecar@sha256:9f1ad1e5e404bc43f9591b1189c187f535d6f61769468c49b4fc97add803d7b9
 kind: ImagesLock

--- a/addons/packages/grafana/7.5.7/bundle/config/overlays/overlay-grafana-image.yaml
+++ b/addons/packages/grafana/7.5.7/bundle/config/overlays/overlay-grafana-image.yaml
@@ -1,0 +1,14 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata": {"name": "grafana"}})
+---
+spec:
+  template:
+    spec:
+      containers:
+      #@overlay/match by=overlay.map_key("name")
+      - name: grafana
+        #@overlay/replace
+        image: #@ data.values.grafana.image
+

--- a/addons/packages/grafana/7.5.7/bundle/config/overlays/overlay-k8s-sidecar-image.yaml
+++ b/addons/packages/grafana/7.5.7/bundle/config/overlays/overlay-k8s-sidecar-image.yaml
@@ -1,0 +1,19 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata": {"name": "grafana"}})
+---
+spec:
+  template:
+    spec:
+      initContainers:
+      #@overlay/match by=overlay.map_key("name")
+      - name: grafana-sc-datasources
+        #@overlay/replace
+        image: #@ data.values.k8sSidecar.image
+      containers:
+      #@overlay/match by=overlay.map_key("name")
+      - name: grafana-sc-dashboard
+        #@overlay/replace
+        image: #@ data.values.k8sSidecar.image
+

--- a/addons/packages/grafana/7.5.7/bundle/config/values.yaml
+++ b/addons/packages/grafana/7.5.7/bundle/config/values.yaml
@@ -5,6 +5,8 @@
 namespace: grafana
 
 grafana:
+  #! Use the VMware built image
+  image: projects.registry.vmware.com/tkg/grafana/grafana:v7.5.7_vmware.1
   #! Grafana deployment configuration
   deployment:
     replicas: 1
@@ -85,4 +87,8 @@ ingress:
     tls.key:
     #! [Optional] the CA certificate
     ca.crt:
+
+k8sSidecar:
+  #! Use the VMware built image
+  image: projects.registry.vmware.com/tkg/grafana/k8s-sidecar:v1.12.1_vmware.1
 

--- a/addons/packages/grafana/7.5.7/package.yaml
+++ b/addons/packages/grafana/7.5.7/package.yaml
@@ -174,7 +174,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/grafana@sha256:d9df65992e99d004c846304843179586a04ae9b68b36f069a577392ef686d4a1
+            image: projects.registry.vmware.com/tce/grafana@sha256:3f5435c81d0e163036171a2b44cbf92325b47c282fcfcdb70ceab25f0cd6fe8b
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
Uses VMware built images for `k8s-sidecar` and `grafana` in the Grafana package

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
- Use vmware based images in the grafana package for k8s-sidecar and grafana containers
```

## Which issue(s) this PR fixes
Related: #1553

## Describe testing done for PR
`ytt -f bundle/config` and all looks well

## Special notes for your reviewer
N/a
