### PR TITLE
Use VMware built `cadvisor` image for prometheus package

### DIFF
--- a/addons/packages/prometheus/2.27.0/bundle/.imgpkg/images.yml
+++ b/addons/packages/prometheus/2.27.0/bundle/.imgpkg/images.yml
@@ -8,6 +8,9 @@ images:
     kbld.carvel.dev/id: jimmidyson/configmap-reload:v0.5.0
   image: index.docker.io/jimmidyson/configmap-reload@sha256:904d08e9f701d3d8178cb61651dbe8edc5d08dd5895b56bdcac9e5805ea82b52
 - annotations:
+    kbld.carvel.dev/id: projects.registry.vmware.com/tkg/prometheus/cadvisor:v0.39.1_vmware.1
+  image: projects.registry.vmware.com/tkg/prometheus/cadvisor@sha256:b4cd4cc0ef05630f70d621420ad1316f631f35cef21edb7a62fff7bd787bbfd3
+- annotations:
     kbld.carvel.dev/id: prom/alertmanager:v0.22.2
   image: index.docker.io/prom/alertmanager@sha256:624c1a5063c7c80635081a504c3e1b020d89809651978eb5d0b652a394f3022d
 - annotations:

--- a/addons/packages/prometheus/2.27.0/bundle/config/overlays/overlay-cadvisor.yaml
+++ b/addons/packages/prometheus/2.27.0/bundle/config/overlays/overlay-cadvisor.yaml
@@ -17,4 +17,6 @@ spec:
       #@overlay/match by="name"
       - name: prometheus-cadvisor
         #@overlay/replace
+        image: #@ data.values.cadvisor.daemonset.image
+        #@overlay/replace
         resources: #@ data.values.cadvisor.daemonset.containers.resources

--- a/addons/packages/prometheus/2.27.0/bundle/config/values.yaml
+++ b/addons/packages/prometheus/2.27.0/bundle/config/values.yaml
@@ -765,6 +765,7 @@ pushgateway:
 
 cadvisor:
   daemonset:
+    image: projects.registry.vmware.com/tkg/prometheus/cadvisor:v0.39.1_vmware.1
     updatestrategy: RollingUpdate
     containers:
       resources: {}

--- a/addons/packages/prometheus/2.27.0/package.yaml
+++ b/addons/packages/prometheus/2.27.0/package.yaml
@@ -463,7 +463,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/prometheus@sha256:39324692165b84a1657ac6e422a84f8b50b278579b3ebd526abdb7552945afc2
+            image: projects.registry.vmware.com/tce/prometheus@sha256:a1d024f38ff70e776c7e0434f4fa7f97b72e8c18b75ffe5bf2bff199779cd8a6
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
Uses the VMware built `cadvisor` image for the prometheus package

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
- For the prometheus package, uses the vmware built cadvisor image
```

## Which issue(s) this PR fixes
Fixes: #1553

## Describe testing done for PR
`ytt -f bundle/config` and see image is replaced

## Special notes for your reviewer
N/a 
