### PR TITLE
Use VMware built image for `external-dns` in external-dns package

### DIFF
--- a/addons/packages/external-dns/0.8.0/bundle/.imgpkg/images.yml
+++ b/addons/packages/external-dns/0.8.0/bundle/.imgpkg/images.yml
@@ -2,6 +2,9 @@
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
+    kbld.carvel.dev/id: bitnami/external-dns:0.8.0
+  image: index.docker.io/bitnami/external-dns@sha256:1a26ba96760f5f488be15a08070254de9705893bbddd4ec51f40cc6f2cc1ecfd
+- annotations:
     kbld.carvel.dev/id: k8s.gcr.io/external-dns/external-dns
   image: k8s.gcr.io/external-dns/external-dns@sha256:e49f63e07498ce8484c9e9050c1dfbc2584f4c9c262433d80387e855725e6bce
 kind: ImagesLock

--- a/addons/packages/external-dns/0.8.0/bundle/config/overlays/overlay-deployment.yaml
+++ b/addons/packages/external-dns/0.8.0/bundle/config/overlays/overlay-deployment.yaml
@@ -46,4 +46,14 @@ spec:
       #@ if/end data.values.deployment.volumes:
       volumes: #@ data.values.deployment.volumes
 
-
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata": {"name": "external-dns"}})
+#@overlay/match-child-defaults missing_ok=True
+---
+spec:
+  template:
+    spec:
+      containers:
+      #@overlay/match by=overlay.map_key("name")
+      - name: external-dns
+        #@overlay/replace
+        image: #@ data.values.deployment.image

--- a/addons/packages/external-dns/0.8.0/bundle/config/values.yaml
+++ b/addons/packages/external-dns/0.8.0/bundle/config/values.yaml
@@ -34,3 +34,5 @@ deployment:
   volumeMounts: []
   #! Volume of the external-dns pod
   volumes: []
+  #! Use the VMware built image
+  image: bitnami/external-dns:0.8.0

--- a/addons/packages/external-dns/0.8.0/package.yaml
+++ b/addons/packages/external-dns/0.8.0/package.yaml
@@ -76,7 +76,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/external-dns@sha256:fe2c6bd55910fa8353e6a7f65706850a59fe78a3015eddbf2df2bfa0853662ff
+            image: projects.registry.vmware.com/tce/external-dns@sha256:f2f996c5683d0892ae3a4c133c8c844cc49e12791dbf2df3103db86b3430b62c
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
Uses the VMware built `external-dns` image (from bitnami which is based on debian) for the external-dns package

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
- Use vmware built image for external-dns image in external-dns package
```

## Which issue(s) this PR fixes
Related: #1553

## Describe testing done for PR
`ytt -f bundle config` (and provided some `args` to get it to pass) and the image field is populated correctly

## Special notes for your reviewer
N/a
