### PR TITLE
Update docs on using the `hack/get-tce-release.sh` scipt via CLI

### DIFF
--- a/docs/site/content/docs/assets/cli-install-linux.md
+++ b/docs/site/content/docs/assets/cli-install-linux.md
@@ -1,16 +1,18 @@
 ## Installation Procedure
 1. Download the release for [Linux](https://github.com/vmware-tanzu/community-edition/releases/download/v0.7.0/tce-linux-amd64-v0.7.0.tar.gz) via web browser.
 
-1. _[Alternative]_ Download the release using CLI. Alternatively, you may download a release using the provided remote script.
+1. _[Alternative]_ Download the release using the CLI. You may download a release using the provided remote script piped into bash.
 
     ```sh
     curl -H "Authorization: token ${GITHUB_TOKEN}" \
         -H "Accept: application/vnd.github.v3.raw" \
         -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/get-tce-release.sh | \
-        bash -s <RELEASE-VERSION-DISTRIBUTION>
+        bash -s <RELEASE-VERSION> <RELEASE-OS-DISTRIBUTION>
     ```
 
-    > - Where ``<RELEASE-VERSION-DISTRIBUTION>`` is the Tanzu Community Edition release version and distribution. This is a required argument for `bash` to download a releases. For example, to download v0.7.0 for Linux, provide:  <br>`bash -s v0.7.0 linux`
+    > - Where ``<RELEASE-VERSION>`` is the Tanzu Community Edition release version. This is a required argument.
+    > - Where ``<RELEASE-OS-DISTRIBUTION>`` is the Tanzu Community Edition release version and distribution. This is a required argument.
+    > - For example, to download v0.7.0 for Linux, provide:  <br>`bash -s v0.7.0 linux`
     > - This script requires `curl`, `grep`, `sed`, `tr`, and `jq` in order to work
     > - The release will be downloaded to the local directory as `tce-linux-amd64-v0.7.0.tar.gz`
     > - *_Note:_* This _currently_ requires the use of a GitHub personal access token.

--- a/hack/get-tce-release.sh
+++ b/hack/get-tce-release.sh
@@ -12,8 +12,8 @@ set -e
 # Inspired by: http://stackoverflow.com/a/35688093/55075
 
 # Validate GitHub access token
-if [ -z "$GH_ACCESS_TOKEN" ]; then
-    echo "Error: Please define GH_ACCESS_TOKEN variable!"
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "Error: Please define GITHUB_TOKEN variable!"
     exit 1
 fi
 
@@ -35,7 +35,7 @@ name=$2
 GH_API="https://api.github.com"
 GH_REPO="$GH_API/repos/vmware-tanzu/community-edition"
 GH_TAGS="$GH_REPO/releases/tags/$tag"
-AUTH="Authorization: token $GH_ACCESS_TOKEN"
+AUTH="Authorization: token $GITHUB_TOKEN"
 CURL_ARGS="-LJO#"
 
 # Validate GH token.
@@ -65,5 +65,5 @@ GH_ASSET="$GH_REPO/releases/assets/$id"
 
 # Download asset file
 echo "Downloading asset ..."
-curl $CURL_ARGS -H "Authorization: token $GH_ACCESS_TOKEN" -H 'Accept: application/octet-stream' "$GH_ASSET"
+curl $CURL_ARGS -H "Authorization: token $GITHUB_TOKEN" -H 'Accept: application/octet-stream' "$GH_ASSET"
 


### PR DESCRIPTION
## What this PR does / why we need it
- Updates docs to correctly reflect how to use the `hack/get-tce-release.sh` script
- Uses the `GITHUB_TOKEN` env var which we use now instead of `GH_ACCESS_TOKEN`. This is also what the docs where using.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
- Update docs for using the get-tce-release.sh script via the CLI
- Uses the GITHUB_TOKEN via CLI for the get-tce-release.sh script
```

## Which issue(s) this PR fixes
Fixes: #1622

## Describe testing done for PR
`hugo serve` and looks good!

## Special notes for your reviewer
N/a
