### PR TITLE
Updates to replace github runner when doing creating TCE release

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -19,13 +19,15 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
@@ -94,13 +96,15 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh

--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -14,13 +14,15 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
@@ -122,13 +124,15 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh

--- a/.github/workflows/check-pr-docker-management.yaml
+++ b/.github/workflows/check-pr-docker-management.yaml
@@ -19,13 +19,15 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
@@ -169,13 +171,15 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh

--- a/.github/workflows/check-pr-docker-standalone.yaml
+++ b/.github/workflows/check-pr-docker-standalone.yaml
@@ -21,13 +21,15 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
@@ -171,13 +173,15 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh

--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -15,20 +15,22 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-west-2
@@ -143,6 +145,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           ACTUAL_COMMIT_SHA: ${{ github.sha }}
+          TCE_CI_BUILD: true
         shell: bash
         run: make cut-release
       - name: Upload Cayman Trigger Asset
@@ -164,20 +167,22 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-west-2

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -16,20 +16,22 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-west-2
@@ -158,6 +160,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           ACTUAL_COMMIT_SHA: ${{ github.sha }}
+          TCE_CI_BUILD: true
         shell: bash
         run: make cut-release
       - name: Upload Cayman Trigger Asset
@@ -179,20 +182,22 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-west-2

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -17,20 +17,22 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-west-2
@@ -159,6 +161,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           ACTUAL_COMMIT_SHA: ${{ github.sha }}
+          TCE_CI_BUILD: true
         shell: bash
         run: make cut-release
       - name: Upload Cayman Trigger Asset
@@ -180,20 +183,22 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${GITHUB_TOKEN}' \
             -H 'Accept: application/vnd.github.v3.raw' -O \
             -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.RUNNER_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNNER_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-west-2

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ endif
 
 #INSTALLED_CLI_DIR
 
-ifeq ($(GITLAB_CI_BUILD), true)
+ifeq ($(TCE_CI_BUILD), true)
 XDG_DATA_HOME := /tmp/mylocal
 SED := sed -i
 endif
@@ -183,7 +183,7 @@ release-docker: release-env-check ### builds and produces the release packaging/
 	docker run --rm \
 		-e HOME=/go \
 		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
-		-e GITLAB_CI_BUILD=true \
+		-e TCE_CI_BUILD=true \
 		-w /go/src/community-edition \
 		-v ${PWD}:/go/src/community-edition \
 		-v /tmp:/tmp \

--- a/cli/cmd/plugin/conformance/go.mod
+++ b/cli/cmd/plugin/conformance/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/spf13/cobra v1.1.3
-	github.com/vmware-tanzu/sonobuoy v0.53.2 // indirect
+	github.com/vmware-tanzu/sonobuoy v0.53.2
 	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2
 	k8s.io/klog/v2 v2.9.0
 )

--- a/cli/cmd/plugin/conformance/go.sum
+++ b/cli/cmd/plugin/conformance/go.sum
@@ -1036,8 +1036,6 @@ github.com/vmware-tanzu/carvel-kapp-controller v0.20.0-rc.1/go.mod h1:QI4z6DehAO
 github.com/vmware-tanzu/carvel-vendir v0.19.0/go.mod h1:HF7iLB0NyEFHuCvM0EJ42fERk20l2ImpktJzhSEdqOU=
 github.com/vmware-tanzu/sonobuoy v0.53.2 h1:BUhUpguquk22034b9VPP0VqY5td9a4hQvjnLpnV1FhU=
 github.com/vmware-tanzu/sonobuoy v0.53.2/go.mod h1:VN3+v6dc8g3rU25U+xgi28JATPSWQmNTfVRhg+Y2RBQ=
-github.com/vmware-tanzu/sonobuoy v1.11.5-prerelease.1.0.20210902172338-90abde64caf1 h1:4MKRSzqH3TxhYb5RoNqIplb5SqJp5/wdc3gXzS5IUMY=
-github.com/vmware-tanzu/sonobuoy v1.11.5-prerelease.1.0.20210902172338-90abde64caf1/go.mod h1:VN3+v6dc8g3rU25U+xgi28JATPSWQmNTfVRhg+Y2RBQ=
 github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2 h1:0dhcRgcC1TTEHeHjndGb81kO9MbnqJJl3AJ0ldNS0hk=
 github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2/go.mod h1:c8BGfEs/pKUpwmhfS1CvNt+zr8pmVIZ4LDfa8rAvFvU=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/hack/cut-release.sh
+++ b/hack/cut-release.sh
@@ -10,6 +10,7 @@ set -o xtrace
 
 FAKE_RELEASE="${FAKE_RELEASE:-""}"
 BUILD_VERSION="${BUILD_VERSION:-""}"
+TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
 
 # required input
 if [[ -z "${BUILD_VERSION}" ]]; then
@@ -18,8 +19,7 @@ if [[ -z "${BUILD_VERSION}" ]]; then
 fi
 
 # we only allow this to run from GitHub CI/Action
-WHOAMI=$(whoami)
-if [[ "${WHOAMI}" != "runner" ]]; then
+if [[ "${TCE_CI_BUILD}" != "true" ]]; then
     echo "This is only meant to be run within GitHub Actions CI"
     exit 1
 fi

--- a/hack/fix-for-ci-build.sh
+++ b/hack/fix-for-ci-build.sh
@@ -9,19 +9,8 @@ set -o pipefail
 set -o xtrace
 
 # make user CI directory
-if [[ "${GITLAB_CI_BUILD}" == "true" ]]; then
 apt update
 apt install zip unzip
 
-rm -rf /tmp/tce-release
-rm -rf /tmp/mylocal/tanzu-cli
-mkdir -p /tmp/tce-release
-mkdir -p /tmp/mylocal/tanzu-cli
-fi
-
 # override https
 git config --global url."https://git:${GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
-
-# docker container has no user account
-sed -i.bak -e "s/\"\$(id -g -n \"\$USER\")\"/\$(id -g -n)/g" ./hack/package-release.sh && rm ./hack/package-release.sh.bak
-sed -i.bak -e "s/\"\$USER\"/\$(id -u -n)/g" ./hack/package-release.sh && rm ./hack/package-release.sh.bak


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This replaces the release logic that was previously using the github "runner" account and natively uses the self-hosted runner. This also updates tokens required for access.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Improvements in the CI process for making TCE releases.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA