### PR TITLE
bump tanzu-framework to include addons-mgr delete

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/go.mod
+++ b/cli/cmd/plugin/standalone-cluster/go.mod
@@ -4,12 +4,13 @@ go 1.16
 
 require (
 	github.com/spf13/cobra v1.2.0
-	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210909135501-d143f231734a
+	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210911013455-be0b859cf6ec
 	k8s.io/klog/v2 v2.8.0
 )
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.3.1 // indirect
+
 	k8s.io/api => k8s.io/api v0.17.11
 	k8s.io/apimachinery => k8s.io/apimachinery v0.17.11
 	k8s.io/client-go => k8s.io/client-go v0.17.11

--- a/cli/cmd/plugin/standalone-cluster/go.sum
+++ b/cli/cmd/plugin/standalone-cluster/go.sum
@@ -1176,8 +1176,8 @@ github.com/vmware-tanzu/carvel-vendir v0.19.0 h1:4FTeDcxwEuZWdFlFqh+11NqnJciCkkO
 github.com/vmware-tanzu/carvel-vendir v0.19.0/go.mod h1:HF7iLB0NyEFHuCvM0EJ42fERk20l2ImpktJzhSEdqOU=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159 h1:c7sM3NrAQGmTvq57Aw96BBzBO67apYZpZs/51PfjddA=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159/go.mod h1:1DBZEj6GmcWxe77d8YOeac1JIa8ttP21uTHUlAyji2g=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210909135501-d143f231734a h1:um8uU67Gjbqf5eH6CRbvF0i2+SzX5GuP2Ehz/C3icJQ=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210909135501-d143f231734a/go.mod h1:xju1ilA4vCv591ZO9b/0y/Hg8X5MwsEZMLIXECqsJJk=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210911013455-be0b859cf6ec h1:WBY7/K0iYhEHPCWsyqdW6S9bkFrH/b0rjl175Df06qA=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210911013455-be0b859cf6ec/go.mod h1:xju1ilA4vCv591ZO9b/0y/Hg8X5MwsEZMLIXECqsJJk=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
 github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=


### PR DESCRIPTION
## What this PR does / why we need it

This commit bumps the tanzu-framework version for standalone clusters.
This includes the fix that will delete the tanzu-addons-manager as a
final step during bootstrap. The controller is not needed for standalone
clusters and will be in a state of CrashLoopBackoff.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
tanzu-addons-manager is not longer included in standalone cluster bootstraps.
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1251

## Describe testing done for PR

Resting completed here:

* https://github.com/vmware-tanzu/tanzu-framework/pull/599

## Special notes for your reviewer

Review testing above.
