### PR TITLE
Add chocolatey package for tce

### DIFF
--- a/hack/choco/README.md
+++ b/hack/choco/README.md
@@ -1,0 +1,138 @@
+# TCE Choco Package
+
+## Local Development / Validation
+
+1. Clone this repository
+
+1. Move into this directory
+
+1. Download the relevant Windows release you'd like to test from [https://github.com/vmware-tanzu/community-edition/releases](https://github.com/vmware-tanzu/community-edition/releases)
+
+1. Unpack and repack the file as `.zip` (if the bundle wasn't already a `.zip`)
+
+    > Moving to `.zip` is covered in [https://github.com/vmware-tanzu/community-edition/issues/1662](https://github.com/vmware-tanzu/community-edition/pull/1661/files#diff-9508030a41d1dcf13745795c27d65381fef43477b98a526545eeba25f5b9f457)
+
+1. Store the `sha256` of the newly created zip, for example:
+
+    ```sh
+    josh@DESKTOP-4T1VL4L:/mnt/c/Users/joshr/Downloads$ sha256sum tce-windows-amd64-v0.8.0-rc.1.zip
+    38ddc27423130469ba6e1b1fb6b8eed07fd08ccd92cda0dd9114e3211ec24d05  tce-windows-amd64-v0.8.0-rc.1.zip
+    ```
+
+1. Alter `tools/chocolateyinstall.ps1` to point at the local `.zip` bundle and update the SHA, for example:
+
+    ```diff
+    $ErrorActionPreference = 'Stop';
+    $packageName = 'tanzu-community-edition'
+    $packageFullName = 'tce-windows-amd64-v0.8.0-rc.1'
+    $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+    #This line is here for doing local testing
+    +$url64 = 'C:\Users\<your_user>\Downloads\tce-windows-amd64-v0.8.0-rc.1.zip'
+    -$url64 = 'https://github.com/vmware-tanzu/community-edition/releases/download/v0.8.0-rc.1/tce-windows-amd64-v0.8.0-rc.1.zip'
+    +$checksum64 = '38ddc27423130469ba6e1b1fb6b8eed07fd08ccd92cda0dd9114e3211ec24d05'
+    -$checksum64 = '2131332321321469ba6e1b1fb6b8eed07fd08ccd92cda0dd9114e3211ec24d05'
+    $checksumType64= 'sha256'
+    ```
+
+1. Create an arbitrary directory on your computer to upload the package to, for example
+
+    ```sh
+    mkdir $HOME\tce-pkg
+    ```
+
+1. Create a package and upload it to this directory.
+
+    ```sh
+    choco pack; choco push --source $HOME\tce-pkg
+    ```
+
+1. Install the package by pointing to this directory
+
+    ```sh
+    choco install tanzu-community-edition --source $HOME\tce-choco
+    ```
+
+1. Verify the package installs correctly
+
+    ```sh
+    Attempt to use original download file name failed for 'C:\Users\joshr\Downloads\tce-windows-amd64-v0.8.0-rc.1.zip'.
+    Copying tanzu-community-edition
+    from 'C:\Users\joshr\Downloads\tce-windows-amd64-v0.8.0-rc.1.zip'
+    Hashes match.
+    Extracting C:\Users\joshr\AppData\Local\Temp\chocolatey\tanzu-community-edition\0.7.0\tanzu-community-editionInstall.zip to C:\ProgramData\chocolatey\lib\tanzu-community-edition\tools...
+    C:\ProgramData\chocolatey\lib\tanzu-community-edition\tools
+
+    Started tanzu CLI environment setup
+    - Removed existing CLI config at C:\Users\joshr\.config\tanzu\config.yaml
+    - Removed existing tanzu plugin cache file at C:\Users\joshr\.cache\tanzu\catalog.yaml
+    - Created CLI plugin directory at C:\Users\joshr\AppData\Local\tanzu-cli
+    - Moved CLI plugins to C:\Users\joshr\AppData\Local\tanzu-cli
+    - Initializing tanzu CLI and plugin repository
+    Completed tanzu CLI environment setup
+
+    ShimGen has successfully created a shim for tanzu.exe
+    The install of tanzu-community-edition was successful.
+    Software installed to 'C:\ProgramData\chocolatey\lib\tanzu-community-edition\tools'
+
+    Chocolatey installed 1/1 packages.
+    See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log)
+    ```
+
+    ```sh
+    PS C:\Users\joshr\community-edition\hack\choco> tanzu
+
+    Tanzu CLI
+
+    Usage:
+      tanzu [command]
+
+        Available command groups:
+
+        Admin
+            builder                 Build Tanzu components
+
+        Run
+            cluster                 Kubernetes cluster operations
+            conformance             Run Sonobuoy conformance tests against clusters
+            diagnostics             Cluster diagnostics
+            kubernetes-release      Kubernetes release operations
+            management-cluster      Kubernetes management cluster operations
+            package                 Tanzu package managemen
+            standalone-cluster      Create clusters without a dedicated management cluster
+
+        System
+            completion              Output shell completion code
+            config                  Configuration for the CLI
+            init                    Initialize the CLI
+            login                   Login to the platform
+            plugin                  Manage CLI plugins
+            update                  Update the CLI
+            version                 Version information
+
+
+        Flags:
+        -h, --help   help for tanzu
+
+        Use "tanzu [command] --help" for more information about a command.
+
+        Not logged in
+    ```
+
+1. When done, uninstall the package.
+
+    ```sh
+    PS C:\Users\joshr\community-edition\hack\choco> choco uninstall tanzu-community-edition --source $HOME\tce-pkg
+
+    Chocolatey v0.10.15
+    Uninstalling the following packages:
+    tanzu-community-edition
+
+    tanzu-community-edition v0.7.0
+    Skipping auto uninstaller - No registry snapshot.
+    tanzu-community-edition has been successfully uninstalled.
+
+    Chocolatey uninstalled 1/1 packages.
+    See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
+    ```
+
+1. The `tanzu` command should no longer be accessible.

--- a/hack/choco/tanzu-community-edition.nuspec
+++ b/hack/choco/tanzu-community-edition.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>tanzu-community-edition</id>
+    <version>0.7.0</version>
+    <owners>VMware</owners>
+    <title>Tanzu Community Edition</title>
+    <authors>VMware Tanzu</authors>
+    <projectUrl>https://github.com/vmware-tanzu/community-edition</projectUrl>
+    <packageSourceUrl>https://github.com/vmware-tanzu/community-edition/blob/master/hack/choco</packageSourceUrl>
+    <!-- TODO:
+    <iconUrl></iconUrl>
+    -->
+    <licenseUrl>https://github.com/vmware-tanzu/community-edition/blob/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/vmware-tanzu/community-edition</projectSourceUrl>
+    <docsUrl>https://tanzucommunityedition.io/docs</docsUrl>
+    <mailingListUrl>https://groups.google.com/group/project-octant</mailingListUrl>
+    <bugTrackerUrl>https://github.com/vmware-tanzu/octant/issues</bugTrackerUrl>
+    <tags>tanzu community kubernetes</tags>
+    <summary>Create Tanzu clusters and deploy packages</summary>
+<description><![CDATA[TODO]]></description>
+    <releaseNotes>Release notes are available at https://github.com/vmware-tanzu/community-edition/releases</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/hack/choco/tools/chocolateyinstall.ps1
+++ b/hack/choco/tools/chocolateyinstall.ps1
@@ -1,0 +1,80 @@
+# Copyright 2020-2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+$ErrorActionPreference = 'Stop';
+$packageName = 'tanzu-community-edition'
+$packageFullName = 'tce-windows-amd64-v0.8.0-rc.1'
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+# This line is here for doing local testing
+#$url64 = 'C:\Users\<user>\Downloads\tce-windows-amd64-v0.8.0-rc.1.zip'
+$url64 = 'https://github.com/vmware-tanzu/community-edition/releases/download/v0.8.0-rc.1/tce-windows-amd64-v0.8.0-rc.1.tar.gz'
+$checksum64 = '38ddc27423130469ba6e1b1fb6b8eed07fd08ccd92cda0dd9114e3211ec24d05'
+$checksumType64= 'sha256'
+
+$packageArgs = @{
+  packageName   = $packageName
+  unzipLocation = $toolsDir
+  url64bit      = $url64
+
+  softwareName  = 'tanzu-community-edition'
+
+  checksum64    = $checksum64
+  checksumType64= 'sha256'
+}
+
+function Setup-TanzuEnvironment {
+    # important locations
+    $PluginDir = "${env:LOCALAPPDATA}\tanzu-cli"
+    $CacheLocation = "${HOME}\.cache\tanzu\catalog.yaml"
+    $CLIConfigLocation = "${HOME}\.config\tanzu\config.yaml"
+    $CompatabilityLocation = "${HOME}\.config\tanzu\tkg\compatibility\tkg-compatibility.yaml"
+
+    Write-Host "`nStarted tanzu CLI environment setup" -ForegroundColor Green
+
+    ## begin env clean up ##
+
+    # if an existing compatibility file exists, remove it; the cli will redownload it
+    if (Test-Path -Path $CompatabilityLocation -PathType Leaf) {
+        Remove-Item -Path ${CompatabilityLocation} -Force
+        Write-Host "  - Removed stale compatibility file at ${CompatabilityLocation}" -ForegroundColor Cyan      
+    }
+
+    # if an existing config file exists, remove it in favor of a newly initialized one
+    if (Test-Path -Path $CLIConfigLocation -PathType Leaf) {
+        Remove-Item -Path ${CLIConfigLocation} -Force
+        Write-Host "  - Removed existing CLI config at ${CLIConfigLocation}" -ForegroundColor Cyan      
+    }
+    
+    # if plugin cache exists, remove it; this ensures stale commands don't show up when running tanzu
+    if (Test-Path -Path $CacheLocation -PathType Leaf) {
+        Remove-Item -Path ${CacheLocation} -Force
+        Write-Host "  - Removed existing tanzu plugin cache file at ${CacheLocation}" -ForegroundColor Cyan
+    }
+
+    ## end env clean up ##
+
+    ## begin env setup ##
+
+    # create the plugin directory for tanzu CLI
+    New-Item -Path ${PluginDir} -ItemType directory -Force | Out-Null
+    Write-Host "  - Created CLI plugin directory at ${pluginDir}" -ForegroundColor Cyan
+
+    # for every plugin (syntax == "tanzu-*"), move it to ${XDG_DATA_HOME}/tanzu-cli
+    # this is where tanzu CLI will lookup the plugin to wire into its command
+    Get-ChildItem -Path "${toolsDir}\${packageFullName}\bin\tanzu-*" -Recurse | Move-Item -Destination ${PluginDir} -Force
+    Write-Host "  - Moved CLI plugins to ${pluginDir}" -ForegroundColor Cyan
+
+
+    # initialize CLI and add TCE plugin repo (bucket)
+    Write-Host "  - Initializing tanzu CLI and plugin repository" -ForegroundColor Cyan
+    & "${toolsDir}\${packageFullName}\bin\tanzu.exe" plugin repo add --name tce --gcp-bucket-name tce-cli-plugins --gcp-root-path artifacts
+
+    ## end env setup ##
+
+    Write-Host "Completed tanzu CLI environment setup`n" -ForegroundColor Green
+}
+
+# this is a built-in function, read https://docs.chocolatey.org/en-us/create/functions/install-chocolateyzippackage
+Install-ChocolateyZipPackage @packageArgs
+
+Setup-TanzuEnvironment


### PR DESCRIPTION
## What this PR does / why we need it

This commit adds the source for the chocolatey package so that Windows
users can easily install TCE.

Eventually, the upgrading of this package definition should be updated.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Adds chocolatey package for users of tce
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1640

## Describe testing done for PR

![choco-tce](https://user-images.githubusercontent.com/6200057/132962538-4b297bde-a7e5-47cc-8f56-d9cd82edf62c.gif)

## Special notes for your reviewer

Please [review the local development steps found in the README](https://github.com/vmware-tanzu/community-edition/blob/f9b9542658cf1ef0544226eb17c2869bcceb298b/hack/choco/README.md).

If you are able to install the CLI, we can merge this PR.
