### PR TITLE
Make code blocks scroll horizontally rather than wrap

### DIFF
--- a/docs/site/themes/template/assets/scss/_components.scss
+++ b/docs/site/themes/template/assets/scss/_components.scss
@@ -771,14 +771,13 @@
             padding: 2px 8px;
         }
         pre {
-            white-space: pre-wrap;
             code {
                 color: $white;
                 display: block;
                 border: 15px solid #EFEFEF;
                 padding: 15px;
                 margin-bottom: 30px;
-                overflow-x: auto;
+                overflow-x: scroll;
             }
         }
         img {


### PR DESCRIPTION


## What this PR does / why we need it

This make code blocks far more readable as they will scroll horizontally
when occupying a lot of the x axis. Before this, they wrapped and were
hard to read.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Code blocks in documentation now scroll horizontally rather than wrap.
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1666

## Describe testing done for PR

Run `hugo serve` and observe code blocks.

**new state**

![after](https://user-images.githubusercontent.com/6200057/132970122-c2e0cfa3-e94b-4c10-ba63-90c081d11208.gif)

**old state**

![before](https://user-images.githubusercontent.com/6200057/132970034-39541d0e-fb24-4eaa-b848-64c5a9903437.gif)

## Special notes for your reviewer

Review the above and approve/deny.
