### PR TITLE
package windows bundle as .zip file

### DIFF
--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -132,9 +132,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
-          asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
-          asset_content_type: application/gzip
+          asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.zip
+          asset_content_type: application/zip
       - name: Checkout for Update
         uses: actions/checkout@v1
       - name: Commit Next Dev Version

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -133,9 +133,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
-          asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
-          asset_content_type: application/gzip
+          asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.zip
+          asset_content_type: application/zip
       - name: Upload Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -134,9 +134,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
-          asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
-          asset_content_type: application/gzip
+          asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.zip
+          asset_content_type: application/zip
       - name: Upload Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main

--- a/docs/site/content/docs/assets/cli-install-windows.md
+++ b/docs/site/content/docs/assets/cli-install-windows.md
@@ -2,11 +2,11 @@
 
 1. Download the release for [Windows](https://github.com/vmware-tanzu/community-edition/releases/download/v0.7.0/tce-windows-amd64-v0.7.0.tar.gz).
 
-1. Open a Command Prompt **as an administrator**, change to the download directory and unpack the release, for example,
+1. Open PowerShell **as an administrator**, change to the download directory and unpack the release, for example,
 
     ```sh
     cd <DOWNLOAD-DIR>
-    tar -xf tce-windows-amd64-v0.7.0.tar.gz
+    Expand-Archive -Path 'tce-windows-amd64-v0.7.0.tar.gz'
     ```
 
 1. Change to the extracted directory and run `install.bat`.

--- a/hack/asset/asset.go
+++ b/hack/asset/asset.go
@@ -141,7 +141,7 @@ func main() {
 		return
 	}
 
-	windowsAssetFilename := fmt.Sprintf("tce-windows-amd64-%s.tar.gz", tag)
+	windowsAssetFilename := fmt.Sprintf("tce-windows-amd64-%s.zip", tag)
 	windowsAsset := filepath.Join("..", "..", "build", windowsAssetFilename)
 	err = uploadToDraftRelease(draftRelease, windowsAsset)
 	if err != nil {

--- a/hack/package-release.sh
+++ b/hack/package-release.sh
@@ -154,5 +154,5 @@ pushd "${BUILD_ROOT_DIR}" || exit 1
 tar -czvf "tce-linux-amd64-${TCE_BUILD_VERSION}.tar.gz" "tce-linux-amd64-${BUILD_VERSION}"
 tar -czvf "tce-darwin-amd64-${TCE_BUILD_VERSION}.tar.gz" "tce-darwin-amd64-${BUILD_VERSION}"
 tar -czvf "tce-darwin-arm64-${TCE_BUILD_VERSION}.tar.gz" "tce-darwin-arm64-${BUILD_VERSION}"
-tar -czvf "tce-windows-amd64-${TCE_BUILD_VERSION}.tar.gz" "tce-windows-amd64-${BUILD_VERSION}"
+zip -r "tce-windows-amd64-${TCE_BUILD_VERSION}.zip" "tce-windows-amd64-${BUILD_VERSION}"
 popd || exit 1


### PR DESCRIPTION
## 🚨🚨🚨 Do not merge this PR without approval from @dvonthenen 🚨🚨🚨

## What this PR does / why we need it

This commit changes our package process to produce a .zip file for
windows bundles rather than .tar.gz. The decision to use .zip is based
on the fact that Windows users can more easily deal with .zip files and
it is a supported format for the chocolatey package manager.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Windows release are now produced in .zip format.
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1662

## Describe testing done for PR

Performed `make release` and saw results in build

```sh
 ls -la build/

total 1415400
drwxr-xr-x  10 josh  staff        320 Sep 11 21:28 .
drwxr-xr-x  26 josh  staff        832 Sep 11 21:27 ..
drwxr-xr-x   5 josh  staff        160 Sep 11 21:27 tce-darwin-amd64-v0.8.0-dev.2
-rw-r--r--   1 josh  staff  178047185 Sep 11 21:27 tce-darwin-amd64-v0.8.0-dev.2.tar.gz
drwxr-xr-x   5 josh  staff        160 Sep 11 21:27 tce-darwin-arm64-v0.8.0-dev.2
-rw-r--r--   1 josh  staff  168043754 Sep 11 21:27 tce-darwin-arm64-v0.8.0-dev.2.tar.gz
drwxr-xr-x   5 josh  staff        160 Sep 11 21:27 tce-linux-amd64-v0.8.0-dev.2
-rw-r--r--   1 josh  staff  170072659 Sep 11 21:27 tce-linux-amd64-v0.8.0-dev.2.tar.gz
drwxr-xr-x   5 josh  staff        160 Sep 11 21:27 tce-windows-amd64-v0.8.0-dev.2
-rw-r--r--   1 josh  staff  172341513 Sep 11 21:28 tce-windows-amd64-v0.8.0-dev.2.zip
```

## Special notes for your reviewer

🚨🚨🚨 Do not merge this PR without approval from @dvonthenen 🚨🚨🚨
