### PR TITLE
remove instruction to delete standard package repo

### DIFF
--- a/docs/site/content/docs/assets/package-installation.md
+++ b/docs/site/content/docs/assets/package-installation.md
@@ -12,15 +12,6 @@ Ensure you have deployed either a management/workload cluster or a standalone cl
     kubectl config use-context <CLUSTER-NAME>-admin@<CLUSTER-NAME>
     ```
     Where ``<CLUSTER-NAME>`` is the name of workload or standalone cluster where you want to install package.
-1. Delete the standard package repository
-
-
-    ```sh
-    tanzu package repository delete -n tanzu-package-repo-global tanzu-standard
-    ```
-
-    > This is a temporary workaround for a small regression introduced in
-    > tanzu-framework. This step will not be required in future releases.
 
 
 1. Install the Tanzu Community Edition package repository.


### PR DESCRIPTION
## What this PR does / why we need it

This removes deletion of the standard package repo from the getting
started guides. This is no longer needed as it's no longer installed by
default.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

NONE

## Describe testing done for PR

Run `hugo serve` and verify change.

## Special notes for your reviewer

None
