### PR TITLE
Hide header link symbols by default

### DIFF
--- a/docs/site/themes/template/assets/scss/_base.scss
+++ b/docs/site/themes/template/assets/scss/_base.scss
@@ -170,6 +170,12 @@ a {
     color: $blue;
     font-family: $metropolis-medium
 }
+a.section-link {
+  color: $white;
+}
+a.section-link:hover {
+  color: $blue;
+}
 button {
     background-color: unset;
     border: none;


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We currently show the paragraph symbol on all headers to indicate they
are directly linkable. This is great, but can add a lot of visual
clutter to the screen when reading the docs.

Following what I've seen work well for other docs sites, this changes
those links to be "hidden" by being set to the same color as the
background until hovering over the title. On hover, the symbol becomes
visible as a link.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```