### PR TITLE
Fix github action name consistency [trivial]

### DIFF
--- a/.github/workflows/check-actionlint.yaml
+++ b/.github/workflows/check-actionlint.yaml
@@ -1,4 +1,4 @@
-name: Check actionlint
+name: Check - actionlint
 
 on:
   pull_request:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Just a name change to be consistent. Could be very helpful when scraping these jobs since the github API is filterable by name.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA
