### PR TITLE
Fix missing local-path-provisioner image sha

### DIFF
--- a/addons/packages/local-path-storage/0.0.20/bundle/.imgpkg/images.yml
+++ b/addons/packages/local-path-storage/0.0.20/bundle/.imgpkg/images.yml
@@ -3,8 +3,8 @@ apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
     kbld.carvel.dev/id: busybox
-  image: index.docker.io/library/busybox@sha256:b5fc1d7b2e4ea86a06b0cf88de915a2c43a99a00b6b3c0af731e5f4c07ae8eff
+  image: index.docker.io/library/busybox@sha256:b37dd066f59a4961024cf4bed74cae5e68ac26b48807292bd12198afa3ecb778
 - annotations:
     kbld.carvel.dev/id: rancher/local-path-provisioner:v0.0.20
-  image: projects.registry.vmware.com/tce/local-path-provisioner@sha256:d5999b20a1b180940061677db3bdb48dd7eb432cd48147c4ff15469fb74ade80
+  image: projects.registry.vmware.com/tce/local-path-provisioner@sha256:6434e827349036958783c1f81b01838b5d7316c1275a25ba0f76ea7a89455231
 kind: ImagesLock

--- a/addons/packages/local-path-storage/0.0.20/package.yaml
+++ b/addons/packages/local-path-storage/0.0.20/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/local-path-storage@sha256:b7ae39d8abef2c169c2afb065b1b34603f513de9715ec24220ce321f13ae9481
+            image: projects.registry.vmware.com/tce/local-path-storage@sha256:e0db08cc6e83efb1f772ab9714d78900b5634146c266954abc805461a005beb1
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
Fixes a missing local-path-provisioner missing sha

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
Related: #1649

## Describe testing done for PR
Confirmed the bundle sha and the local-path-provisioner sha

## Special notes for your reviewer
cc @seemiller 
