### PR TITLE
Fix GITHUB_TOKEN variable in velero e2e test

### DIFF
--- a/addons/packages/velero/1.5.2/test/install-velero-cli.sh
+++ b/addons/packages/velero/1.5.2/test/install-velero-cli.sh
@@ -65,5 +65,5 @@ GH_ASSET="$GH_REPO/releases/assets/$id"
 
 # Download asset file
 echo "Downloading asset ..."
-curl $CURL_ARGS -H "Authorization: token $GH_ACCESS_TOKEN" -H 'Accept: application/octet-stream' "$GH_ASSET"
+curl $CURL_ARGS -H "Authorization: token $GITHUB_TOKEN" -H 'Accept: application/octet-stream' "$GH_ASSET"
 tar xvzf velero-"$tag"-"$name"-amd64.tar.gz


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Fixes GITHUB_TOKEN variable in velero e2e test
## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
Ran `make e2e-test` from `addons/packages/velero/1.5.2/test` dir
```
 ➜ make e2e-test
sh -c "rm -rf /tmp/velero-e2e-test &&\
        mktemp -d /tmp/velero-e2e-test &&\
        git clone https://github.com/vmware-tanzu/velero /tmp/velero-e2e-test/velero &&\
        cd /tmp/velero-e2e-test &&\
        /Users/rkakodkar/git/repos/vmware-tanzu/community-edition/addons/packages/velero/1.5.2/test/install-velero-cli.sh v1.5.2 darwin &&\
        GOPATH="~/go" CLOUD_PROVIDER="minio" \
        OBJECT_STORE_PROVIDER=minio \
        CREDS_FILE=/tmp/credential BSL_BUCKET=velero \
        GINKGO_FOCUS=Basic INSTALL_VELERO=false VELERO_CLI=/tmp/velero-e2e-test/velero-v1.5.2-darwin-amd64/velero  \
        make -C /tmp/velero-e2e-test/velero/test/e2e run"
/tmp/velero-e2e-test
Cloning into '/tmp/velero-e2e-test/velero'...
remote: Enumerating objects: 36736, done.
remote: Counting objects: 100% (1708/1708), done.
remote: Compressing objects: 100% (743/743), done.
remote: Total 36736 (delta 1061), reused 1371 (delta 879), pack-reused 35028
Receiving objects: 100% (36736/36736), 33.59 MiB | 8.27 MiB/s, done.
Resolving deltas: 100% (24089/24089), done.
Validating dependencies ...
curl is /usr/bin/curl
grep is /usr/bin/grep
sed is /usr/bin/sed
tr is /usr/bin/tr
jq is /usr/local/bin/jq
Downloading asset ...
################################################################################################################################## 100.0%curl: Saved to filename 'velero-v1.5.2-darwin-amd64.tar.gz'

x velero-v1.5.2-darwin-amd64/LICENSE
x velero-v1.5.2-darwin-amd64/examples/README.md
x velero-v1.5.2-darwin-amd64/examples/minio
x velero-v1.5.2-darwin-amd64/examples/minio/00-minio-deployment.yaml
x velero-v1.5.2-darwin-amd64/examples/nginx-app
x velero-v1.5.2-darwin-amd64/examples/nginx-app/README.md
x velero-v1.5.2-darwin-amd64/examples/nginx-app/base.yaml
x velero-v1.5.2-darwin-amd64/examples/nginx-app/with-pv.yaml
x velero-v1.5.2-darwin-amd64/velero
go get github.com/onsi/ginkgo/ginkgo
Using credentials from /tmp/credential
Using bucket velero to store backups from E2E tests
Using cloud provider minio
Running Suite: E2e Suite
========================
Random Seed: 1631623792
Will run 1 of 9 specs

SSSSSSS
------------------------------
[Basic] Backup/restore of 2 namespaces When I create 2 namespaces
  should be successfully backed up and restored
  /private/tmp/velero-e2e-test/velero/test/e2e/multiple_namespaces_test.go:44
Creating namespaces ...
backup cmd =/tmp/velero-e2e-test/velero-v1.5.2-darwin-amd64/velero --namespace velero create backup backup-b7e17cff-7a4b-4188-b7a0-241701778730 --exclude-namespaces default,kube-node-lease,kube-public,kube-system,tanzu-package-repo-global,tkg-system,tkg-system-public,tkr-system,velero --default-volumes-to-restic --wait
Backup request "backup-b7e17cff-7a4b-4188-b7a0-241701778730" submitted successfully.
Waiting for backup to complete. You may safely press ctrl-c to stop waiting - your backup will continue in the background.
....
Backup completed with status: Completed. You may check for more information using the commands `velero backup describe backup-b7e17cff-7a4b-4188-b7a0-241701778730` and `velero backup logs backup-b7e17cff-7a4b-4188-b7a0-241701778730`.
get backup cmd =/tmp/velero-e2e-test/velero-v1.5.2-darwin-amd64/velero --namespace velero backup get -o json backup-b7e17cff-7a4b-4188-b7a0-241701778730
Cleaning up namespaces ...
restore cmd =/tmp/velero-e2e-test/velero-v1.5.2-darwin-amd64/velero --namespace velero create restore restore-b7e17cff-7a4b-4188-b7a0-241701778730 --from-backup backup-b7e17cff-7a4b-4188-b7a0-241701778730 --wait
Restore request "restore-b7e17cff-7a4b-4188-b7a0-241701778730" submitted successfully.
Waiting for restore to complete. You may safely press ctrl-c to stop waiting - your restore will continue in the background.
......
Restore completed with status: Completed. You may check for more information using the commands `velero restore describe restore-b7e17cff-7a4b-4188-b7a0-241701778730` and `velero restore logs restore-b7e17cff-7a4b-4188-b7a0-241701778730`.
get restore cmd =/tmp/velero-e2e-test/velero-v1.5.2-darwin-amd64/velero --namespace velero restore get -o json restore-b7e17cff-7a4b-4188-b7a0-241701778730
Cleaning up namespaces ...

• [SLOW TEST:12.050 seconds]
[Basic] Backup/restore of 2 namespaces
/private/tmp/velero-e2e-test/velero/test/e2e/multiple_namespaces_test.go:19
  When I create 2 namespaces
  /private/tmp/velero-e2e-test/velero/test/e2e/multiple_namespaces_test.go:43
    should be successfully backed up and restored
    /private/tmp/velero-e2e-test/velero/test/e2e/multiple_namespaces_test.go:44
------------------------------
S
JUnit report was created: /private/tmp/velero-e2e-test/velero/test/e2e/report.xml

Ran 1 of 9 Specs in 12.051 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 8 Skipped
PASS
You're using deprecated Ginkgo functionality:
=============================================
Ginkgo 2.0 is under active development and will introduce (a small number of) breaking changes.
To learn more, view the migration guide at https://github.com/onsi/ginkgo/blob/v2/docs/MIGRATING_TO_V2.md
To comment, chime in at https://github.com/onsi/ginkgo/issues/711

  You are using a custom reporter.  Support for custom reporters will likely be removed in V2.  Most users were using them to generate junit or teamcity reports and this functionality will be merged into the core reporter.  In addition, Ginkgo 2.0 will support emitting a JSON-formatted report that users can then manipulate to generate custom reports.

  If this change will be impactful to you please leave a comment on https://github.com/onsi/ginkgo/issues/711
  Learn more at: https://github.com/onsi/ginkgo/blob/v2/docs/MIGRATING_TO_V2.md#removed-custom-reporters

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=1.16.4


Ginkgo ran 1 suite in 19.011472344s
Test Suite Passed
```
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
