### PR TITLE
Contour: remove externalTrafficPolicy for ClusterIP services

### DIFF
--- a/addons/packages/contour/1.15.1/README.md
+++ b/addons/packages/contour/1.15.1/README.md
@@ -19,7 +19,7 @@ You can configure the following:
 | `contour.useProxyProtocol` | `false` | Whether to enable PROXY protocol for all Envoy listeners. |
 | `contour.logLevel` | `info` | The Contour log level. Valid values are `info` and `debug`. |
 | `envoy.service.type` | `LoadBalancer` | The type of Kubernetes service to provision for Envoy. Valid values are `LoadBalancer`, `NodePort`, and `ClusterIP`. |
-| `envoy.service.externalTrafficPolicy` | `Local` | The external traffic policy for the Envoy service. Valid values are `Local` and `Cluster`. |
+| `envoy.service.externalTrafficPolicy` | `Local` | The external traffic policy for the Envoy service. Valid values are `Local` and `Cluster`.  If `envoy.service.type` is `ClusterIP`, this field is ignored. |
 | `envoy.service.annotations` | (none) | Annotations to set on the Envoy service. |
 | `envoy.service.nodePorts.http` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
 | `envoy.service.nodePorts.https` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes. |

--- a/addons/packages/contour/1.15.1/bundle/config/overlays/update-envoy-service.yaml
+++ b/addons/packages/contour/1.15.1/bundle/config/overlays/update-envoy-service.yaml
@@ -25,5 +25,10 @@ spec:
     #@ end
   #@ end
 
+  #@ if data.values.envoy.service.type == "NodePort" or data.values.envoy.service.type == "LoadBalancer":
   #@ if/end data.values.envoy.service.externalTrafficPolicy:
   externalTrafficPolicy: #@ data.values.envoy.service.externalTrafficPolicy
+  #@ else:
+  #@overlay/remove
+  externalTrafficPolicy: Local
+  #@ end

--- a/addons/packages/contour/1.15.1/bundle/config/values.yaml
+++ b/addons/packages/contour/1.15.1/bundle/config/values.yaml
@@ -26,7 +26,7 @@ envoy:
     #! The type of Kubernetes service to provision for Envoy.
     type: LoadBalancer
 
-    #! The external traffic policy for the Envoy service.
+    #! The external traffic policy for the Envoy service. If type is "ClusterIP", this field is ignored.
     externalTrafficPolicy: Local
 
     #! Annotations to set on the Envoy service.

--- a/addons/packages/contour/1.15.1/package.yaml
+++ b/addons/packages/contour/1.15.1/package.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/contour@sha256:869a67e25a798b17531cc035de68c5080da3d9577aefb499385edcf2ec8db463
+            image: projects.registry.vmware.com/tce/contour@sha256:b25d4739cc178dfe1bdbe52ad02ef91c984326993944d54dd68eb649364760c8
       template:
         - ytt:
             paths:

--- a/addons/packages/contour/1.17.1/README.md
+++ b/addons/packages/contour/1.17.1/README.md
@@ -19,7 +19,7 @@ You can configure the following:
 | `contour.useProxyProtocol` | `false` | Whether to enable PROXY protocol for all Envoy listeners. |
 | `contour.logLevel` | `info` | The Contour log level. Valid values are `info` and `debug`. |
 | `envoy.service.type` | `LoadBalancer` | The type of Kubernetes service to provision for Envoy. Valid values are `LoadBalancer`, `NodePort`, and `ClusterIP`. |
-| `envoy.service.externalTrafficPolicy` | `Local` | The external traffic policy for the Envoy service. Valid values are `Local` and `Cluster`. |
+| `envoy.service.externalTrafficPolicy` | `Local` | The external traffic policy for the Envoy service. Valid values are `Local` and `Cluster`.  If `envoy.service.type` is `ClusterIP`, this field is ignored. |
 | `envoy.service.annotations` | (none) | Annotations to set on the Envoy service. |
 | `envoy.service.nodePorts.http` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
 | `envoy.service.nodePorts.https` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes. |

--- a/addons/packages/contour/1.17.1/bundle/config/overlays/update-envoy-service.yaml
+++ b/addons/packages/contour/1.17.1/bundle/config/overlays/update-envoy-service.yaml
@@ -25,5 +25,10 @@ spec:
     #@ end
   #@ end
 
+  #@ if data.values.envoy.service.type == "NodePort" or data.values.envoy.service.type == "LoadBalancer":
   #@ if/end data.values.envoy.service.externalTrafficPolicy:
   externalTrafficPolicy: #@ data.values.envoy.service.externalTrafficPolicy
+  #@ else:
+  #@overlay/remove
+  externalTrafficPolicy: Local
+  #@ end

--- a/addons/packages/contour/1.17.1/bundle/config/values.yaml
+++ b/addons/packages/contour/1.17.1/bundle/config/values.yaml
@@ -26,7 +26,7 @@ envoy:
     #! The type of Kubernetes service to provision for Envoy.
     type: LoadBalancer
 
-    #! The external traffic policy for the Envoy service.
+    #! The external traffic policy for the Envoy service. If type is "ClusterIP", this field is ignored.
     externalTrafficPolicy: Local
 
     #! Annotations to set on the Envoy service.

--- a/addons/packages/contour/1.17.1/package.yaml
+++ b/addons/packages/contour/1.17.1/package.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/contour@sha256:6a90a760b8851a23527bd778b4470cc6982bf5d6e27cd828c004b2ad1b634ccc
+            image: projects.registry.vmware.com/tce/contour@sha256:0c3d0f33c171e437268e57bdbe0d83feb1606362d8235f1b656556da8c944e18
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Removes spec.externalTrafficPolicy from the Envoy
service when the type is set to ClusterIP since
it's not valid.

Closes #1675.

Signed-off-by: Steve Kriss <krisss@vmware.com>

## What this PR does / why we need it
Removes spec.externalTrafficPolicy from the Envoy
service when the type is set to ClusterIP since
it's not valid.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Contour package: removes spec.externalTrafficPolicy from the Envoy
service when the type is set to ClusterIP since it's not valid.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1675

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->
Ran `ytt -f addons/packages/contour/1.17.1/bundle/config/` and `ytt -f addons/packages/contour/1.15.1/bundle/config/` and verified output manually.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
