### PR TITLE
fix inconsistent font size in docs code blocks

### DIFF
--- a/docs/site/themes/template/assets/scss/_components.scss
+++ b/docs/site/themes/template/assets/scss/_components.scss
@@ -778,6 +778,7 @@
                 padding: 15px;
                 margin-bottom: 30px;
                 overflow-x: scroll;
+                font-size: 14px;
             }
         }
         img {


### PR DESCRIPTION
## What this PR does / why we need it

This commit ensures the code blocks set the font size. With out it, font
sizes were inherited by parent CSS classes. This made code blocks that
were indented under a step (ie `<ul>` or `<ol>`) to take on that style and
have a larger font that other code blocks on the page.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Canonicalized font size for all code blocks in docs site
```

## Which issue(s) this PR fixes

None

## Describe testing done for PR

**before:**
<img width="1237" alt="image" src="https://user-images.githubusercontent.com/6200057/133317814-ff0c5914-3193-4b94-b109-408c4c0b93fe.png">


**after:**
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/6200057/133317609-dadb8743-1f61-4087-81b6-264bcf3ac955.png">


## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
