### PR TITLE
Bump tce-main for standalone ux fixes

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/go.mod
+++ b/cli/cmd/plugin/standalone-cluster/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/spf13/cobra v1.2.0
-	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210912214555-32133a86029e
+	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210915174701-14fe0fdf4f0b
 	k8s.io/klog/v2 v2.8.0
 )
 

--- a/cli/cmd/plugin/standalone-cluster/go.sum
+++ b/cli/cmd/plugin/standalone-cluster/go.sum
@@ -1176,8 +1176,8 @@ github.com/vmware-tanzu/carvel-vendir v0.19.0 h1:4FTeDcxwEuZWdFlFqh+11NqnJciCkkO
 github.com/vmware-tanzu/carvel-vendir v0.19.0/go.mod h1:HF7iLB0NyEFHuCvM0EJ42fERk20l2ImpktJzhSEdqOU=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159 h1:c7sM3NrAQGmTvq57Aw96BBzBO67apYZpZs/51PfjddA=
 github.com/vmware-tanzu/cluster-api v0.3.23-0.20210722162135-d31e78c28159/go.mod h1:1DBZEj6GmcWxe77d8YOeac1JIa8ttP21uTHUlAyji2g=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210912214555-32133a86029e h1:XBUtzB2vPsFA6r5/N6PW+id53Citl8qSDSUWKsRjRYI=
-github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210912214555-32133a86029e/go.mod h1:xju1ilA4vCv591ZO9b/0y/Hg8X5MwsEZMLIXECqsJJk=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210915174701-14fe0fdf4f0b h1:dTcePzMpz0lpDxHEhLOF8K3qfzVk8sByHIlRcNRFpEc=
+github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210915174701-14fe0fdf4f0b/go.mod h1:xju1ilA4vCv591ZO9b/0y/Hg8X5MwsEZMLIXECqsJJk=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
 github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=


### PR DESCRIPTION

## What this PR does / why we need it

This bumps tce-main to include a cherry-picked commit for our standalone
cluster kickstart UI. It ensures cluster name is always required.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Cluster name is now required in the UI for all standalone cluster creations.
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1697
* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1698

## Describe testing done for PR

Build CLI and run kickstart UI.

## Special notes for your reviewer

Same as above
