### PR TITLE
docs: make note of core package repo

### DIFF
--- a/docs/site/content/docs/assets/package-installation.md
+++ b/docs/site/content/docs/assets/package-installation.md
@@ -33,6 +33,11 @@ documentation](../package-management).
       tce-repo  projects.registry.vmware.com/tce/main:stable  Reconcile succeeded
     ```
 
+    > A `tanzu-core` repository is also installed in the `tkg-system` namespace
+    > clusters. This repository holds lower-level components that are **not**
+    > meant to be installed by the user! These packages are used during cluster
+    > boostrapping.
+
     > It may take some time to see `Reconcile succeeded`. Until then, packages
     > won't show up in the available list described in the next step.
 

--- a/docs/site/content/docs/latest/package-management.md
+++ b/docs/site/content/docs/latest/package-management.md
@@ -14,6 +14,10 @@ at this relationship is as follows.
 
 ![tanzu packaging flow](/docs/img/pkg-mgmt-repo.png)
 
+The `tanzu-core` package repository will pre-exist on every cluster in the
+`tkg-system` namespace. Packages in this repository are exclusively for cluster
+bootstrapping. They should **not** be reinstalled by users.
+
 ### Adding a Package Repository
 
 To add a package repository to a cluster, run:


### PR DESCRIPTION


## What this PR does / why we need it

This instructs users that the core package repository is used
exclusively for cluster bootstrapping.


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1751

## Describe testing done for PR

Review `md` changes.

## Special notes for your reviewer

Review `md` changes.
