### PR TITLE
Remove sonobuoy from getting started guide

### DIFF
--- a/docs/site/content/docs/latest/getting-started-standalone.md
+++ b/docs/site/content/docs/latest/getting-started-standalone.md
@@ -60,6 +60,5 @@ Tanzu Community Edition consists of the Tanzu CLI and a select set of plugins. Y
 {{< /tabs >}}
 
 {{% include "/docs/assets/package-installation.md" %}}
-{{% include "/docs/assets/sonobuoy.md" %}}
 {{% include "/docs/assets/octant-install.md" %}}
 {{% include "/docs/assets/clean-up-standalone.md" %}}

--- a/docs/site/content/docs/latest/getting-started.md
+++ b/docs/site/content/docs/latest/getting-started.md
@@ -60,6 +60,5 @@ Tanzu Community Edition consists of the Tanzu CLI and a select set of plugins. Y
 {{< /tabs >}}
 
 {{% include "/docs/assets/package-installation.md" %}}
-{{% include "/docs/assets/sonobuoy.md" %}}
 {{% include "/docs/assets/octant-install.md" %}}
 {{% include "/docs/assets/clean-up.md" %}}

--- a/docs/site/content/docs/latest/sonobuoy.md
+++ b/docs/site/content/docs/latest/sonobuoy.md
@@ -1,12 +1,12 @@
-## Run Tanzu conformance command
+# Run Conformance Tests
 
 Tanzu Community Edition has an integrated Sonobuoy plugin. The Tanzu CLI uses the conformance command (powered by Sonobuoy) to run tests against clusters.  Use the ``tanzu conformance`` command to run diagnostic tests to help you to  understand the state of a  cluster.   The ``tanzu conformance`` runs the [CNCF conformance tests](https://github.com/cncf/k8s-conformance#certified-kubernetes) by default. For more information, see [Sonobuoy](https://sonobuoy.io/).
 
-### Before you Begin
+## Before you Begin
 
 Ensure the Tanzu CLI is installed.
 
-### Procedure
+## Procedure
 
 1. To see a list of the conformance commands, run:
 
@@ -44,4 +44,4 @@ Ensure the Tanzu CLI is installed.
     watch kubectl get po -A
     ```
 
-    You should see Sonobuoy containers starting or running.
+    > You should see Sonobuoy containers starting or running.

--- a/docs/site/data/docs/latest-toc.yml
+++ b/docs/site/data/docs/latest-toc.yml
@@ -163,6 +163,8 @@ toc:
                 - 1.5.2
     - title: Adminstration
       subfolderitems:
+        - page: Run Conformance Tests
+          url: /sonobuoy
         - page: Scale Management Cluster
           url: /scale-mgmt
         - page: Register a Management cluster with Tanzu Mission Control


### PR DESCRIPTION
## What this PR does / why we need it

This removes the conformance documentation from the getting started
guide and puts the full documentation in the Administration section.

## Details for the Release Notes (PLEASE PROVIDE)


```release-note
NONE
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1688

## Describe testing done for PR

Run `hugo serve`

## Special notes for your reviewer

Run `hugo serve`
