### PR TITLE
Add Google Tag Manager for analytics

### DIFF
--- a/docs/site/themes/template/layouts/_default/baseof.html
+++ b/docs/site/themes/template/layouts/_default/baseof.html
@@ -18,6 +18,13 @@
 	{{ with .OutputFormats.Get "RSS" -}}
 		{{ printf `<link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
 	{{- end }}
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','dataLayer','GTM-P2JHB4R');</script>
+	<!-- End Google Tag Manager -->
 </head>
 <body>
 	{{ partial "header" . }}


### PR DESCRIPTION
Signed-off-by: Jonas Rosland <jrosland@vmware.com>

## What this PR does / why we need it
This adds a default Google Tag Manager function, so we can prep for Google Analytics implementation of https://tanzucommunityedition.io.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
