### PR TITLE
Chocolatey enhancements

### DIFF
--- a/hack/choco/README.md
+++ b/hack/choco/README.md
@@ -43,13 +43,13 @@
 1. Create a package and upload it to this directory.
 
     ```sh
-    choco pack; choco push --source $HOME\tce-pkg
+    ./packpush.ps1
     ```
 
-1. Install the package by pointing to this directory
+1. Install the package by pointing to this directory (need to be an administrator)
 
     ```sh
-    choco install tanzu-community-edition --source $HOME\tce-choco
+    choco install tanzu-community-edition --source $HOME\tce-pkg
     ```
 
 1. Verify the package installs correctly
@@ -118,7 +118,7 @@
         Not logged in
     ```
 
-1. When done, uninstall the package.
+1. When done, uninstall the package. (need to be an administrator)
 
     ```sh
     PS C:\Users\joshr\community-edition\hack\choco> choco uninstall tanzu-community-edition --source $HOME\tce-pkg

--- a/hack/choco/packpush.ps1
+++ b/hack/choco/packpush.ps1
@@ -1,0 +1,20 @@
+# This script is for LOCAL DEVELOPMENT ONLY.
+# Use it after you've made changes to the powershell scripts to clean up artifacts and get ready for re-installing.
+# It assumes you are using a local directory in ${HOME}\tcerepo as a --source for `choco install`.
+# Invoke from hack/choco directory
+
+# Remove the nupkg file made by `choco pack` in the working dir
+Remove-Item *.nupkg -ErrorAction Continue
+
+# Remove the nupkgs from our local repo
+Remove-Item ${HOME}\tce-pkg\*.nupkg -ErrorAction Continue
+
+# Delete any versions that Chocolatey may have cached for us.
+Remove-Item ${env:LOCALAPPDATA}\Temp\chocolatey\tanzu-community-edition\ -Recurse -ErrorAction Continue
+
+# Bundle the powershell scripts and nuspec into a nupkg file
+choco pack
+# Upload the nupkg file to the directory we wanna use.
+choco push --source ${HOME}\tce-pkg
+
+# Now you can do `choco install tanzu-community-edition --source ${HOME}\tce-pkg`

--- a/hack/choco/tanzu-community-edition.nuspec
+++ b/hack/choco/tanzu-community-edition.nuspec
@@ -3,12 +3,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>tanzu-community-edition</id>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <owners>VMware</owners>
     <title>Tanzu Community Edition</title>
     <authors>VMware Tanzu</authors>
     <projectUrl>https://github.com/vmware-tanzu/community-edition</projectUrl>
-    <packageSourceUrl>https://github.com/vmware-tanzu/community-edition/blob/master/hack/choco</packageSourceUrl>
+    <packageSourceUrl>https://github.com/vmware-tanzu/community-edition/blob/main/hack/choco</packageSourceUrl>
     <!-- TODO:
     <iconUrl></iconUrl>
     -->
@@ -16,8 +16,8 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/vmware-tanzu/community-edition</projectSourceUrl>
     <docsUrl>https://tanzucommunityedition.io/docs</docsUrl>
-    <mailingListUrl>https://groups.google.com/group/project-octant</mailingListUrl>
-    <bugTrackerUrl>https://github.com/vmware-tanzu/octant/issues</bugTrackerUrl>
+    <mailingListUrl>https://groups.google.com/g/tanzu-community-edition</mailingListUrl>
+    <bugTrackerUrl>https://github.com/vmware-tanzu/community-edition/issues</bugTrackerUrl>
     <tags>tanzu community kubernetes</tags>
     <summary>Create Tanzu clusters and deploy packages</summary>
 <description><![CDATA[TODO]]></description>

--- a/hack/choco/tools/chocolateyUninstall.ps1
+++ b/hack/choco/tools/chocolateyUninstall.ps1
@@ -1,0 +1,19 @@
+# Copyright 2020-2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Clean out old runtime directories/files, but *keep configs*
+$deleteFiles = (
+    "${HOME}\.cache\tanzu\catalog.yaml",
+    "${HOME}\.config\tanzu\config.yaml",
+    "${HOME}\.config\tanzu\tkg\bom",
+    "${HOME}\.config\tanzu\tkg\providers",
+    "${HOME}\.config\tanzu\tkg\.tanzu.lock",
+    "${HOME}\.config\tanzu\tkg\compatibility\tkg-compatibility.yaml"
+)
+
+Write-Host "Removing catalog files" -ForegroundColor Green
+foreach ($file in $deleteFiles) {
+    # If the file doesn't exist, that's fine, just keep going.
+    Write-Host " - Removing file $file" -ForegroundColor Cyan
+    Remove-Item -Force -Recurse -Path $file -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
* Check for docker and kubectl when installing via Chocolatey
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1765 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

On a Windows machine, running in a PowerShell session as adminstrator
 
- Download latest v0.8.0 zip file to `$HOME` directory
- Uncomment and update the `$url64` line in `hack/choco/tools/chocolateyinstall.ps1` pointing to your local zip file. 
- Comment out the `$url64` line in `hack/choco/tools/chocolateyinstall.ps1` pointing to the github URL.
- `mkdir $HOME\tce-pkg`
- Run the `hack/choco/packpush.ps1` script to package the files and push them to a fake registry locally (`$HOME\tce-pkg\`)

```shell
PS C:\Users\nrb> choco install tanzu-community-edition --source $HOME\tce-pkg
Chocolatey v0.11.1
Installing the following packages:
tanzu-community-edition
By installing, you accept licenses for the packages.

tanzu-community-edition v0.8.0
tanzu-community-edition package files install completed. Performing other installation steps.

Checking Prerequisites
  - Docker CLI found, proceeding
  - kubectl found, proceeding
Attempt to use original download file name failed for 'C:\Users\nrb\tce-windows-amd64-v0.8.0.zip'.
Copying tanzu-community-edition
  from 'C:\Users\nrb\tce-windows-amd64-v0.8.0.zip'
Hashes match.
Extracting C:\Users\nrb\AppData\Local\Temp\chocolatey\tanzu-community-edition\0.8.0\tanzu-community-editionInstall.zip to C:\ProgramData\chocolatey\lib\tanzu-community-edition\tools...
C:\ProgramData\chocolatey\lib\tanzu-community-edition\tools

Started tanzu CLI environment setup
  - Created CLI plugin directory at C:\Users\nrb\AppData\Local\tanzu-cli
  - Moved CLI plugins to C:\Users\nrb\AppData\Local\tanzu-cli



| initializing

Γ£ö  successfully initialized CLI
 ShimGen has successfully created a shim for tanzu.exe
 The install of tanzu-community-edition was successful.
  Software installed to 'C:\ProgramData\chocolatey\lib\tanzu-community-edition\tools'

Chocolatey installed 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
PS C:\Users\nrb> tanzu
Tanzu CLI

Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components

  Run
    cluster                 Kubernetes cluster operations
    conformance             Run Sonobuoy conformance tests against clusters
    diagnostics             Cluster diagnostics
    kubernetes-release      Kubernetes release operations
    management-cluster      Kubernetes management cluster operations
    package                 Tanzu package management
    standalone-cluster      Create clusters without a dedicated management cluster

  System
    completion              Output shell completion code
    config                  Configuration for the CLI
    init                    Initialize the CLI
    login                   Login to the platform
    plugin                  Manage CLI plugins
    update                  Update the CLI
    version                 Version information


Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.

Not logged in
PS C:\Users\nrb> choco uninstall tanzu-community-edition
Chocolatey v0.11.1
Uninstalling the following packages:
tanzu-community-edition

tanzu-community-edition v0.8.0
Removing catalog files
 - Removing file C:\Users\nrb\.cache\tanzu\catalog.yaml
 - Removing file C:\Users\nrb\.config\tanzu\config.yaml
 - Removing file C:\Users\nrb\.config\tanzu\tkg\bom
 - Removing file C:\Users\nrb\.config\tanzu\tkg\providers
 - Removing file C:\Users\nrb\.config\tanzu\tkg\.tanzu.lock
 - Removing file C:\Users\nrb\.config\tanzu\tkg\compatibility\tkg-compatibility.yaml
 Skipping auto uninstaller - No registry snapshot.
 tanzu-community-edition has been successfully uninstalled.

Chocolatey uninstalled 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
```

## Special notes for your reviewer
Generated a local package by following the steps in hack/choco/README.md