### PR TITLE
Implements package `README.md` copy utility program also copying images

### DIFF
--- a/docs/site/content/docs/latest/package-readme-external-dns-0.8.0.md
+++ b/docs/site/content/docs/latest/package-readme-external-dns-0.8.0.md
@@ -110,29 +110,29 @@ As outlined in the official [documentation](https://github.com/kubernetes-sigs/e
 
 > Note that this policy allows updating of any hosted zone. You can limit the zones effected by replacing the wildcard with the hosted zone you will be using for this example.
 
-![Create Policy Step 1](images/create-policy-step1.png)
+![Create Policy Step 1](../../img/create-policy-step1.png)
 
 Continue through the wizard and complete the policy. For simplicity, name the policy as the documentation suggests, as `AllowExternalDNSUpdates` and create the policy.
 
-![Create Policy Step 2](images/create-policy-step2.png)
+![Create Policy Step 2](../../img/create-policy-step2.png)
 
 ### 2. AWS User
 
 Create a new user in IAM. This user will have the sole permission of updating DNS. You can go directly to creating a new user [here](https://console.aws.amazon.com/iam/home#/users$new?step=details). In this example, we called the user `external-dns-user`. Check the box to only allow programmatic access.
 
-![Create User Step 1](images/create-user-step1.png)
+![Create User Step 1](../../img/create-user-step1.png)
 
 Attach the `AllowExternalDNSUpdates` permission to the new user. Select the box to `Attach existings policies directly`. Then search for the policy, and be sure to check the box.
 
-![Create User Step 2](images/create-user-step2.png)
+![Create User Step 2](../../img/create-user-step2.png)
 
 Continue on to the review page and make sure everything is correct. Then create the user.
 
-![Create User Step 3](images/create-user-step3.png)
+![Create User Step 3](../../img/create-user-step3.png)
 
 The final step in creating the user is to copy the access keys. These credentials will be used to give ExternalDNS access to this user and permission to modify your DNS settings. This will be your only opportunity to see the `secret-access-key`. Make a note of the Access Key ID and Secret access key.
 
-![Create User Step 4](images/create-user-step4.png)
+![Create User Step 4](../../img/create-user-step4.png)
 
 ### 3. Hosted Zone
 
@@ -159,7 +159,7 @@ Take note of the new hosted zone id and name servers.
 
 "Hook up your DNS zone with is parent zone", as the official documentation cryptically suggests. Go to the [AWS Route 53 Console](https://console.aws.amazon.com/route53/v2/hostedzones#) and select your domain. Create a new record. Enter the desired subdomain, select NS for the record type, and paste in the list of name servers from the previous step into the Value field.
 
-![Create NS Record](images/create-ns-record.png)
+![Create NS Record](../../img/create-ns-record.png)
 
 After creating the NS record on the hosted zone for your new subdomain, you've completed the prerequisites on AWS for this example.
 


### PR DESCRIPTION
## What this PR does / why we need it
This PR accomplishes 2 things 
- Finds any files found in a package's `images/` directory and copies them to the `docs/ site/content/docs/latest/images/` directory, keeping the image name intact 
- Modifies the copies package readme to allow for hugo to properly render any images that are referenced. Primarily, with how the docs are structured as of this writing, it replaces
```
[My image link](images/my-informative-image.jpeg
```
with the following
```
[My image link](../images/my-informative-image.jpeg)
```

We can see this now rendering correctly for the external dns package docs:
![Screen Shot 2021-09-16 at 1 28 43 PM](https://user-images.githubusercontent.com/23109390/133675423-e52914ac-ae86-4942-94b7-080aaff388c6.png)

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Docs now correctly render images in package readmes
```

## Which issue(s) this PR fixes
Fixes: https://github.com/vmware-tanzu/community-edition/issues/1739

## Describe testing done for PR
Ran locally with `hugo serve` and verified the external-dns readme has it's imaged served (see screenshot above)

## Special notes for your reviewer
Note: this _does_ create a precidence that if package authors want to include images in their readmes and want them rendered correctly in the docs, they _must_ place those JPEGs or PNGs under an `images/` directory [much like external DNS is doing at the time of this writing](https://github.com/vmware-tanzu/community-edition/tree/main/addons/packages/external-dns/0.8.0/images)

Therefore, the convention would be to have images under
```
addons/packages/{PACKAGE-NAME}/{PACKAGE-VERSION}/images
```
and to be referenced in their readmes as
```
[Link to image](images/{IMAGE-NAME}.jpeg)
```