### PR TITLE
Fixes autogen docs code populating a TOC link for "packages-intro"

### DIFF
--- a/docs/site/content/docs/latest/aws-intro.md
+++ b/docs/site/content/docs/latest/aws-intro.md
@@ -16,4 +16,4 @@ Complete the following steps for a full Tanzu Community Edition implementation t
 
 1. [Examine the cluster](verify-deployment)
 
-1. [Deploy packages](packages-intro)
+1. [Work with Packages](package-management)

--- a/docs/site/content/docs/latest/azure-intro.md
+++ b/docs/site/content/docs/latest/azure-intro.md
@@ -15,4 +15,4 @@ Complete the following steps for a full Tanzu Community Edition implementation t
 
 1. [Examine the cluster](verify-deployment)
 
-1. [Deploy packages](packages-intro)
+1. [Work with Packages](package-management)

--- a/docs/site/content/docs/latest/designs/package-process.md
+++ b/docs/site/content/docs/latest/designs/package-process.md
@@ -32,7 +32,7 @@ $ tanzu package install gatekeeper --package-name gatekeeper.community.tanzu.vmw
 > This experience is specific to user-managed packages
 
 For details on how these packages are discovered, deployed, and managed, see
-[Packages Introduction](/docs/latest/packages-intro.md).
+[Package Management](/docs/latest/package-management.md).
 
 ### Packaging Workflow
 

--- a/docs/site/content/docs/latest/docker-intro.md
+++ b/docs/site/content/docs/latest/docker-intro.md
@@ -11,4 +11,4 @@ Complete the following steps for a full Tanzu Community Edition implementation t
 
 1. [Examine the cluster](verify-deployment)
 
-1. [Deploy packages](packages-intro)
+1. [Work with Packages](package-management)

--- a/docs/site/content/docs/latest/vsphere-intro.md
+++ b/docs/site/content/docs/latest/vsphere-intro.md
@@ -16,4 +16,4 @@ Complete the following steps for a full Tanzu Community Edition implementation t
 
 3. [Examine the cluster](verify-deployment)
 
-4. [Deploy packages](packages-intro)
+1. [Work with Packages](package-management)

--- a/docs/site/content/packages/_index.html
+++ b/docs/site/content/packages/_index.html
@@ -9,7 +9,7 @@ layout: section
     </div>
 </div>
 <div class="wrapper subpage packages">
-    <p>Only you know what you need in a Kubernetes platform, and with VMware Tanzu you can get exactly what you are looking for. It's fast and easy to customize your platform by adding optional packages to your cluster. Learn more about VMware Tanzu's flexible packaging strategy and implementation <a href="/docs/latest/packages-intro/">in our docs</a>.</p>
+    <p>Only you know what you need in a Kubernetes platform, and with VMware Tanzu you can get exactly what you are looking for. It's fast and easy to customize your platform by adding optional packages to your cluster. Learn more about VMware Tanzu's flexible packaging strategy and implementation <a href="/docs/latest/package-management/">in our docs</a>.</p>
     <p>Packages are currently available for all of the projects listed here.</p>
     <div class="grid three">
         <div class="col">

--- a/docs/site/data/docs/latest-toc.yml
+++ b/docs/site/data/docs/latest-toc.yml
@@ -95,8 +95,8 @@ toc:
           url: /ref-windows-capd
     - title: Packages
       subfolderitems:
-        - page: Packages Introduction
-          url: /packages-intro
+        - page: Work with Packages
+          url: /package-management
         - package:
             displayName: Cert Manager
             name: cert-manager

--- a/hack/workflows/packages/copy-package-readmes-to-docs.go
+++ b/hack/workflows/packages/copy-package-readmes-to-docs.go
@@ -102,8 +102,8 @@ func main() {
 	// Create a new array with the new version information
 	newPackageVersions := []SubFolderItem{}
 	newPackageVersions = append(newPackageVersions, SubFolderItem{
-		Page:    "Packages Introduction",
-		URL:     "/packages-intro",
+		Page:    "Work with Packages",
+		URL:     "/package-management",
 		Package: MyPackage{},
 	})
 	for key, value := range currentPackageVersions {


### PR DESCRIPTION
## What this PR does / why we need it
- Fixes the autogen docs Go code which had `packages-intro` hardcoded. Switched that to the new `package-management`
- Ran the `copy` go program to capture these changes
- Fixed any other references to `packages-intro` throughout the docs

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Removed references to "packages-intro" in docs
```

## Which issue(s) this PR fixes
Quickfix followup to https://github.com/vmware-tanzu/community-edition/pull/1691

## Describe testing done for PR
`hugo serve` after running the `copy` program and see that it correctly autogen the left navigation bar

## Special notes for your reviewer
N/a
