### PR TITLE
Support testing external-dns pkg in non-global namespace

### DIFF
--- a/addons/packages/external-dns/0.8.0/test/README.md
+++ b/addons/packages/external-dns/0.8.0/test/README.md
@@ -10,8 +10,8 @@ To run the `external-dns` end-to-end tests you need:
 
 * A TCE cluster and the cluster needs to be the current-context.
 * The cluster supports Service type `LoadBalancer`.
-* The `external-dns.tce.vmware.com` Package must exist on the cluster so it can
-  be installed by the test.
+* The `external-dns.community.tanzu.vmware.com` Package must exist on the
+  cluster so it can be installed by the test.
 
 From the root of this repo, you can run the following to setup a local cluster:
 
@@ -89,7 +89,7 @@ Set the `DOCKERHUB_PROXY` environment variable if you would like to override
 Run the tests from the e2e directory:
 
 ```bash
-$ cd addons/packages/external-dns/test/e2e
+$ cd addons/packages/external-dns/0.8.0/test/e2e
 $ ginkgo -v .
 ...
 External-dns Addon E2E Test

--- a/addons/packages/external-dns/0.8.0/test/e2e/fixtures/external-dns-values.yaml
+++ b/addons/packages/external-dns/0.8.0/test/e2e/fixtures/external-dns-values.yaml
@@ -1,0 +1,21 @@
+---
+namespace: PACKAGE_COMPONENTS_NAMESPACE
+
+deployment:
+  args:
+    - --source=service
+    - --txt-owner-id=k8s
+    - --domain-filter=k8s.example.org
+    - --namespace=EXTERNAL_DNS_SOURCES_NAMESPACE
+    - --provider=rfc2136
+    - --rfc2136-host=BIND_SERVER_ADDRESS
+    - --rfc2136-port=53
+    - --rfc2136-zone=k8s.example.org
+    - --rfc2136-tsig-secret=O0DhTJzZ0GjfuQmB9TBc1ELchv5oDMTlQs3NNOdMZJU=
+    - --rfc2136-tsig-secret-alg=hmac-sha256
+    - --rfc2136-tsig-keyname=externaldns-key
+    - --rfc2136-tsig-axfr
+  env: []
+  securityContext: {}
+  volumeMounts: []
+  volumes: []


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

The package repository may not be installed in the global namespace which doesn't work for the External-dns e2e tests. This change introduces a new environment variable to set the `PACKAGE_INSTALL_NAMESPACE` that lets you set the namespace the `tanzu package install` command runs with.

By default, when `PACKAGE_INSTALL_NAMESPACE` is not set we default to assuming the package is in the global namespace and we can create/test the package install in our own namespace.
When `PACKAGE_INSTALL_NAMESPACE` is set we assume the package is in that namespace and we should *also* install the package into the same namespace.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add PACKAGE_INSTALL_NAMESPACE environment variable to External-dns E2E test.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: n/a

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change. 
-->

Ran the test with both the package repository installed in the global namespace and in the `default` namespace.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
