### PR TITLE
Documents linting targets for contributors in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,22 @@ To run tests on TCE-specific CLI plugins, run the following.
 make test-plugins
 ```
 
+### Linting
+
+Several linters are in place to ensure conformant Go code and documentation is written.
+
+To run all linters for the entire project, run:
+
+```shell
+make lint
+```
+
+To lint just Markdown files (including documentation markdown found under the `docs/` directory), run:
+
+```shell
+make mdlint
+```
+
 ## Contribution workflow
 
 This section describes the process for contributing a bug fix or new feature.


### PR DESCRIPTION
## What this PR does / why we need it
Calls out how contributors can lint the TCE project (and it's docs specifically) via the `make` targets

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Document linting the TCE project and the docs/ directory for contributors
```

## Which issue(s) this PR fixes
A quick followup to the PR that enabled linting for the `docs/` directory
Related: https://github.com/vmware-tanzu/community-edition/issues/1759
Related: https://github.com/vmware-tanzu/community-edition/pull/1790

## Describe testing done for PR
`make mdlint` passes

## Special notes for your reviewer
N/a
