### PR TITLE
Adding doc detail for Tanzu CLI uninstall

### DIFF
--- a/docs/site/content/docs/latest/cli-uninstall.md
+++ b/docs/site/content/docs/latest/cli-uninstall.md
@@ -10,6 +10,8 @@ Complete the following steps to uninstall the Tanzu CLI and any associated confi
     ~/.local/share/tce/uninstall.sh
     ```
 
+    The `~/.local/share/tce` folder is deleted.
+
 ## MacOS
 
 1. Run the following command to uninstall the Tanzu CLI:
@@ -18,6 +20,8 @@ Complete the following steps to uninstall the Tanzu CLI and any associated confi
     ~/Library/Application Support/tce/uninstall.sh
     ```
 
+    The `~/Library/Application Support/tce` folder is deleted.
+
 ## Windows
 
 1. Open a Command Prompt as an administrator and run the following command to uninstall the Tanzu CLI:
@@ -25,3 +29,10 @@ Complete the following steps to uninstall the Tanzu CLI and any associated confi
     ```sh
     run uninstall.bat
     ```
+
+    The `%LocalAppData%\tce` folder is deleted.
+
+For information about how to delete a management and workload cluster, see:
+
+[Delete Management Cluster](delete-mgmt)  
+[Delete Workload Cluster](delete-cluster)


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

Adds detail on paths uninsalled when Tanzu uninstall.sh is run
Adds links to uninstall standalone/management clusters
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```NONE

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1687

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
