### PR TITLE
Add links to mdlint rules documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,8 @@ lint: tools get-deps
 	done
 
 mdlint:
+	# mdlint rules with common errors and possible fixes can be found here:
+	# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
 	hack/check-mdlint.sh
 
 shellcheck:

--- a/hack/check-mdlint.sh
+++ b/hack/check-mdlint.sh
@@ -11,6 +11,8 @@ set -o pipefail
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
+# mdlint rules with common errors and possible fixes can be found here:
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
 docker run --rm -v "$(pwd)":/build \
   gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.23.2 -- /md/lint \
   -i docs/site/themes/template/static/fonts \


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

When errors are encountered in the mdlint jobs, if you aren't very
familiar with markdown it can be confusing understanding what the error
is and how you are supposed to fix it. This adds a couple breadcrumbs to
the make target and mdlinting script to point to documentation that goes
over what each error is, with examples of formatting that can cause them
and suggestions on how to fix them.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related: #1759