### PR TITLE
Change release-notes to downloadable from GCP bucket

### DIFF
--- a/hack/ensure-dependencies.sh
+++ b/hack/ensure-dependencies.sh
@@ -180,7 +180,7 @@ if [[ -z "$(command -v ${CMD})" ]]; then
 echo "Attempting install of ${CMD}..."
 case "${BUILD_OS}" in
   Linux)
-    curl -LO https://github.com/dvonthenen/release/releases/download/v0.10.0-tce.1/release-notes-linux-amd64
+    curl -LO https://storage.googleapis.com/tce-tanzu-cli-plugins/build-tools/release-notes/v0.10.0-tce.2/release-notes-linux-amd64
     mv release-notes-linux-amd64 ${CMD}
     chmod +x ${CMD}
     sudo install ./${CMD} /usr/local/bin
@@ -189,15 +189,18 @@ case "${BUILD_OS}" in
   Darwin)
     case "${BUILD_ARCH}" in
       x86_64)
-        curl -LO https://github.com/dvonthenen/release/releases/download/v0.10.0-tce.1/release-notes-darwin-amd64
+        curl -LO https://storage.googleapis.com/tce-tanzu-cli-plugins/build-tools/release-notes/v0.10.0-tce.2/release-notes-darwin-amd64
         mv release-notes-darwin-amd64 ${CMD}
         chmod +x ${CMD}
         sudo install ./${CMD} /usr/local/bin
         rm ./${CMD}
         ;;
      arm64)
-        go install k8s.io/release/cmd/release-notes@master
-        sudo install "${GOBINDIR}"/${CMD} /usr/local/bin
+        curl -LO https://storage.googleapis.com/tce-tanzu-cli-plugins/build-tools/release-notes/v0.10.0-tce.2/release-notes-darwin-arm64
+        mv release-notes-darwin-arm64 ${CMD}
+        chmod +x ${CMD}
+        sudo install ./${CMD} /usr/local/bin
+        rm ./${CMD}
         ;;
     esac
     ;;


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This changes release-notes to be downloadable from the public-facing GCP bucket for TCE instead of downloading off the release page on the repo. This is in preparation for moving the repo to a common shared location.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA