### PR TITLE
WIP: vSphere CPI ipFamily validation allows dualstack

### DIFF
--- a/addons/packages/vsphere-cpi/1.18.1/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.18.1/bundle/config/values.star
@@ -9,8 +9,8 @@ def validate_vsphereCPI():
    if not data.values.vsphereCPI.insecureFlag:
      data.values.vsphereCPI.tlsThumbprint or assert.fail("vsphereCPI tlsThumbprint should be provided when insecureFlag is False")
    end
-   if data.values.vsphereCPI.ipFamily and (data.values.vsphereCPI.ipFamily not in ["ipv4", "ipv6"]):
-     assert.fail("vsphereCPI ipFamily should be either ipv4 or ipv6 if provided")
+   if data.values.vsphereCPI.ipFamily and (data.values.vsphereCPI.ipFamily not in ["ipv4", "ipv6", "ipv4,ipv6", "ipv6,ipv4"]):
+     assert.fail("vsphereCPI ipFamily should be \"ipv4\", \"ipv6\", \"ipv4,ipv6\", \"ipv6,ipv4\" if provided")
    end
 end
 

--- a/addons/packages/vsphere-cpi/1.19.1/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.19.1/bundle/config/values.star
@@ -9,8 +9,8 @@ def validate_vsphereCPI():
    if not data.values.vsphereCPI.insecureFlag:
      data.values.vsphereCPI.tlsThumbprint or assert.fail("vsphereCPI tlsThumbprint should be provided when insecureFlag is False")
    end
-   if data.values.vsphereCPI.ipFamily and (data.values.vsphereCPI.ipFamily not in ["ipv4", "ipv6"]):
-     assert.fail("vsphereCPI ipFamily should be either ipv4 or ipv6 if provided")
+   if data.values.vsphereCPI.ipFamily and (data.values.vsphereCPI.ipFamily not in ["ipv4", "ipv6", "ipv4,ipv6", "ipv6,ipv4"]):
+     assert.fail("vsphereCPI ipFamily should be \"ipv4\", \"ipv6\", \"ipv4,ipv6\", \"ipv6,ipv4\" if provided")
    end
 end
 

--- a/addons/packages/vsphere-cpi/1.20.0/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.20.0/bundle/config/values.star
@@ -9,8 +9,8 @@ def validate_vsphereCPI():
    if not data.values.vsphereCPI.insecureFlag:
      data.values.vsphereCPI.tlsThumbprint or assert.fail("vsphereCPI tlsThumbprint should be provided when insecureFlag is False")
    end
-   if data.values.vsphereCPI.ipFamily and (data.values.vsphereCPI.ipFamily not in ["ipv4", "ipv6"]):
-     assert.fail("vsphereCPI ipFamily should be either ipv4 or ipv6 if provided")
+   if data.values.vsphereCPI.ipFamily and (data.values.vsphereCPI.ipFamily not in ["ipv4", "ipv6", "ipv4,ipv6", "ipv6,ipv4"]):
+     assert.fail("vsphereCPI ipFamily should be \"ipv4\", \"ipv6\", \"ipv4,ipv6\", \"ipv6,ipv4\" if provided")
    end
 end
 

--- a/addons/packages/vsphere-cpi/1.21.0/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.21.0/bundle/config/values.star
@@ -9,8 +9,8 @@ def validate_vsphereCPI():
    if not data.values.vsphereCPI.insecureFlag:
      data.values.vsphereCPI.tlsThumbprint or assert.fail("vsphereCPI tlsThumbprint should be provided when insecureFlag is False")
    end
-   if data.values.vsphereCPI.ipFamily and (data.values.vsphereCPI.ipFamily not in ["ipv4", "ipv6"]):
-     assert.fail("vsphereCPI ipFamily should be either ipv4 or ipv6 if provided")
+   if data.values.vsphereCPI.ipFamily and (data.values.vsphereCPI.ipFamily not in ["ipv4", "ipv6", "ipv4,ipv6", "ipv6,ipv4"]):
+     assert.fail("vsphereCPI ipFamily should be \"ipv4\", \"ipv6\", \"ipv4,ipv6\", \"ipv6,ipv4\" if provided")
    end
 end
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We are working on dual-stack support in https://github.com/vmware-tanzu/tanzu-framework/pull/617. That PR allows configuring the TKG_IP_FAMILY to `ipv4,ipv6` or `ipv6,ipv4`. To support that we must also allow the vSphere CPI ipFamily to allow the same configuration.

We made the change to all the versions of `vsphere-cpi`. Not sure if this is necessary, it is unclear to me what versions may get used in a version of tanzu-framework that would support the dual-stack change.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
vSphere CPI ipFamily validation passes with ipv4,ipv6 or ipv6,ipv4
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of https://github.com/vmware-tanzu/tanzu-framework/issues/616

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Deployed a dual-stack management cluster with changes from https://github.com/vmware-tanzu/tanzu-framework/pull/617 and validation change from this PR.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
