### PR TITLE
Fix typo in docs table of contents

### DIFF
--- a/docs/site/data/docs/latest-toc.yml
+++ b/docs/site/data/docs/latest-toc.yml
@@ -161,7 +161,7 @@ toc:
             name: velero
             versions:
                 - 1.5.2
-    - title: Adminstration
+    - title: Administration
       subfolderitems:
         - page: Run Conformance Tests
           url: /sonobuoy


### PR DESCRIPTION
## What this PR does / why we need it

This commit corrects the typo in the table of contents for Adminstration
-> Administration.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

n/a

## Describe testing done for PR

n/a

## Special notes for your reviewer

n/a
