### PR TITLE
Canonicalize issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
-name: Bug report
-about: File a bug for something not working as expected
+name: Bug Report
+about: File a bug for something not working as expected.
 title: ''
 labels: kind/bug, triage/needs-triage
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,8 +1,8 @@
 ---
-name: Documentation issue or suggestion
-about: Use this for anything documentation related
-title: "[DOCS] <add descriptive title here>"
-labels: kind/docs
+name: Docs Request
+about: File a request for incorrect or suggested docs.
+title: ''
+labels: kind/docs, triage/needs-triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: File a new feature you'd like to see in TCE
+about: File a request for a new feature.
 title: ''
 labels: kind/feature, triage/needs-triage
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feedback-report.md
+++ b/.github/ISSUE_TEMPLATE/feedback-report.md
@@ -1,6 +1,6 @@
 ---
 name: Feedback report
-about: Provide feedback (not a bug or feature request)
+about: File general feedback on Tanzu Community Edition.
 title: ''
 labels: kind/feedback, triage/needs-triage
 assignees: ''


### PR DESCRIPTION
## What this PR does / why we need it

This commit ensures consistent of issue templates by:

* Adding triage/needs-triages to docs issues
* Remove `[DOCS]` from the title of docs issue; we have labels for this
* Simplifies the doc issue title and description
* Make issue descriptions consistent

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

n/a

## Describe testing done for PR

n/a

## Special notes for your reviewer

n/a
