### PR TITLE
Remove duplicate TOCs

### DIFF
--- a/docs/site/content/docs/latest/ref-azure.md
+++ b/docs/site/content/docs/latest/ref-azure.md
@@ -1,10 +1,7 @@
 # Reference for Azure account
 
-If you encounter issues deploying a cluster to Azure, review the following troubleshooting and reference content:
-
-[Network Security Groups on Azure](ref-azure/#a-idnsgsa-network-security-groups-on-azure)
-
-[Microsoft Azure account](ref-azure/#microsoft-azure-account)
+If you encounter issues deploying a cluster to Azure, review the following
+troubleshooting and reference content.
 
 ## Network Security Groups on Azure {#nsgs}
 

--- a/docs/site/content/docs/latest/workload-clusters.md
+++ b/docs/site/content/docs/latest/workload-clusters.md
@@ -8,13 +8,6 @@ Tanzu Community Edition automatically deploys clusters from whichever management
 
 To deploy a workload cluster, you create a configuration file. You then run the `tanzu cluster create` command, specifying the configuration file in the `--file` option. To see an example of a workload cluster configuration file template, see [Amazon EC2 Workload Cluster Template](../aws-wl-template), [Azure Workload Cluster Template](../azure-wl-template), or  [vSphere Workload Cluster Template](../vsphere-wl-template).
 
-This topic describes:
-
-* [Deploying a Workload cluster](#procedure)
-* [Viewing a Workload cluster](#view)
-* [Set the Kubectl Context to the Workload Cluster](#context)
-* [Deploying a Workload Cluster from a Saved Manifest File](#manifest)
-
 For specific configuration parameters, see:
 
 * [Amazon EC2 Workload Cluster Template](aws-wl-template)


### PR DESCRIPTION

## What this PR does / why we need it

This removes the TOC's that were put at the header of some docs. This is
not needed because the TOC is generated in the right nav bar.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1761

## Describe testing done for PR

Run hugo serve

## Special notes for your reviewer

I clicked through the website and these were the only ones I could find.