### PR TITLE
Bumps the labels in `labels.yml` based on current labels used

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,7 +1,4 @@
 # Data for the pr_labeler action
-area/design:
-- "docs/designs/**/*"
-
 area/docs:
 - "docs/**/*"
 - "**/*.md"
@@ -24,24 +21,21 @@ area/release-eng:
 # Labels in the form of "area/<label>"
 # that can be applied with the "/area <label>" prow chatop command
 area:
-- "advocacy"
-- "cicd"
-- "cli"
-- "cluster-lifecycle"
-- "community"
-- "core"
-- "design"
-- "developer-workstation"
-- "docs"
-- "observability"
+- "core-eng"
 - "packages"
+- "docs"
 - "release-eng"
+- "community"
+- "framework"
+- "carvel"
+- "upstream"
 
 # Labels in the form of "kind/<label>"
 # that can be applied with the "/kind <label>" prow chat-op command
 kind:
 - "bug"
-- "docs-troubleshooting"
-- "enhancement"
 - "feature"
+- "enhancement"
+- "docs"
+- "test-release"
 - "feedback"


### PR DESCRIPTION
## What this PR does / why we need it
Bumps the labels we are currently using. Since our workflows have changed abit going into releasing the project publicly, this bumps the codified labels in the `labels.yml`

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
These labels are all associated with what is proposed in #1829. If that issues changes, we should also change this PR

## Describe testing done for PR
N/a

## Special notes for your reviewer
N/a
