### PR TITLE
Doc - adds supported providers to external-dns readme

### DIFF
--- a/addons/packages/external-dns/0.8.0/README.md
+++ b/addons/packages/external-dns/0.8.0/README.md
@@ -2,6 +2,19 @@
 
 [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 
+## Supported Providers
+
+The following tables shows the providers this package can work with.
+
+| AWS  |  Azure  | vSphere  | Docker |
+|:---:|:---:|:---:|:---:|
+| ✅  |  ✅  | ✅  | ⚠️  |
+
+Notes:  
+
+* On vSphere, a load balancer must be installed, for example, NSX ALB.
+* Docker provider is only used in end to end tests which require MetalLB to be installed and configured and install BIND as a DNS provider.
+
 ## Components
 
 * ExternalDNS deployment


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
Adds table of supported providers to exteranal-dns readme as suggested here:
#1801

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1801

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
