### PR TITLE
Enables installing TCE plugins with experimental versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,8 +167,7 @@ build-tce-cli-plugins: version clean-plugin build-cli-plugins ## builds the CLI 
 	@printf "\n[COMPLETE] built TCE-specific plugins at $(ARTIFACTS_DIR)\n"
 	@printf "To install these plugins, run \`make install-tce-cli-plugins\`\n"
 
-install-tce-cli-plugins: version clean-plugin build-cli-plugins install-plugins ## builds and installs CLI plugins found in artifacts directory
-	@printf "\n[COMPLETE] built and installed TCE-specific plugins at $${XDG_DATA_HOME}/tanzu-cli/. "
+install-tce-cli-plugins: version clean-plugin build-cli-plugins framework-set-unstable-versions install-plugins ## builds and installs CLI plugins found in artifacts directory @printf "\n[COMPLETE] built and installed TCE-specific plugins at $${XDG_DATA_HOME}/tanzu-cli/. "
 	@printf "These plugins will be automatically detected by your tanzu CLI.\n"	
 
 build-all-tanzu-cli-plugins: release-env-check version clean build-cli build-cli-plugins ## builds the Tanzu CLI and all CLI plugins that are used in TCE
@@ -250,6 +249,9 @@ clean-framework:
 	rm -rf ${TCE_RELEASE_DIR}
 	rm -rf ${XDG_DATA_HOME}/tanzu-cli
 	mkdir -p ${XDG_DATA_HOME}/tanzu-cli
+
+framework-set-unstable-versions:
+	@cd ./hack/builder/ && $(MAKE) framework-set-unstable-versions
 # TANZU CLI
 
 # PLUGINS

--- a/hack/builder/Makefile
+++ b/hack/builder/Makefile
@@ -17,6 +17,10 @@ ifndef BUILD_VERSION
 BUILD_VERSION ?= $$(git describe --tags --abbrev=0)
 endif
 
+ifndef TANZU_PLUGIN_UNSTABLE_VERSIONS
+TANZU_PLUGIN_UNSTABLE_VERSIONS = "experimental"
+endif
+
 ifeq ($(strip $(BUILD_VERSION)),)
 BUILD_VERSION = dev
 endif
@@ -74,6 +78,9 @@ ifeq ($(origin ARTIFACTS_DIR),undefined)
 endif
 
 check: check-go check-build-version check-ld-flags check-artifacts
+
+framework-set-unstable-versions:
+	TANZU_CLI_NO_INIT=true $(GO) run -ldflags "$(LD_FLAGS)" github.com/vmware-tanzu/tanzu-framework/cmd/cli/tanzu config set unstable-versions $(TANZU_PLUGIN_UNSTABLE_VERSIONS)
 
 # TODO: Post-MVP, this needs to be able to compile individual plugins with their own Makefiles.
 # As it stands, we cannot customize LDFLAGS per plugin


### PR DESCRIPTION
## What this PR does / why we need it
Fixes running `make install-all-tce-plugins` when the Tanzu CLI is _not_ already on the system. Before this PR, we'd see the following error:
```
✔  successfully built local repository 
make[1]: Leaving directory '/home/vonthd/go/src/github.com/vmware-tanzu/community-edition/hack/builder'
make[1]: Entering directory '/home/vonthd/go/src/github.com/vmware-tanzu/community-edition/hack/builder'
TANZU_CLI_NO_INIT=true GOPRIVATE="github.com/vmware-tanzu/*" go run -ldflags "-s -w -X "github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli.BuildDate=$(date -u +"%Y-%m-%d")" -X "github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli.BuildSHA=$(git rev-parse --short HEAD)" -X "github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli.BuildVersion=$(git describe --tags --abbrev=0)" -X 'main.BuildEdition=tce-standalone' -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/buildinfo.IsOfficialBuild=""' -X "github.com/vmware-tanzu/sonobuoy/pkg/buildinfo.Version=v0.53.2"" github.com/vmware-tanzu/tanzu-framework/cmd/cli/tanzu \
	plugin install all --local ../.././artifacts
Error: version cannot be empty for plugin "conformance"
```
Which was due to the missing call to Tanzu Framework's `make set-unstable-versions` call. This now enables maintainers / users to run `make install-all-tce-plugins` without error

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Running "make install-all-tce-plugins" works with experimental versions of TCE plugins
```

## Which issue(s) this PR fixes
Fixes: #1851

## Describe testing done for PR
`make install-all-tce-plugins` now passes!

## Special notes for your reviewer
N/a
