### PR TITLE
Harden GitHub workflows for `pull_request` targets

### DIFF
--- a/.github/workflows/check-actionlint.yaml
+++ b/.github/workflows/check-actionlint.yaml
@@ -22,10 +22,8 @@ jobs:
         id: go
 
       - name: Config credentials
-        env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: |
-          git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/.github/workflows/check-imagelint.yaml
+++ b/.github/workflows/check-imagelint.yaml
@@ -23,10 +23,8 @@ jobs:
         id: go
 
       - name: Config credentials
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         run: |
-          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -27,10 +27,8 @@ jobs:
         id: go
 
       - name: Config credentials
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         run: |
-          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
 
       - name: Run golangci-lint
         run: |

--- a/.github/workflows/check-mdlint.yaml
+++ b/.github/workflows/check-mdlint.yaml
@@ -17,10 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Config credentials
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         run: |
-          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
 
       - name: Check out code
         uses: actions/checkout@v1

--- a/.github/workflows/check-misspell.yaml
+++ b/.github/workflows/check-misspell.yaml
@@ -14,10 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Config credentials
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: |
-          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
 
       - name: Check out code
         uses: actions/checkout@v1

--- a/.github/workflows/check-pr-docker-management.yaml
+++ b/.github/workflows/check-pr-docker-management.yaml
@@ -1,16 +1,11 @@
 name: Check - Management Docker Cluster
 on:
-  pull_request:
+  push:
     branches:
       - main
     paths:
       - "Makefile"
       - ".github/workflows/check-pr-docker-management.yaml"
-    types:
-      - assigned
-      - opened
-      - synchronize
-      - reopened
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner

--- a/.github/workflows/check-pr-docker-standalone.yaml
+++ b/.github/workflows/check-pr-docker-standalone.yaml
@@ -1,6 +1,6 @@
 name: Check - Standalone Docker Cluster
 on:
-  pull_request:
+  push:
     branches:
       - main
     paths:
@@ -8,11 +8,6 @@ on:
       - "cli/cmd/plugin/**/go.mod"
       - "**.sh"
       - ".github/workflows/check-pr-docker-standalone.yaml"
-    types:
-      - assigned
-      - opened
-      - synchronize
-      - reopened
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner

--- a/.github/workflows/check-shell.yaml
+++ b/.github/workflows/check-shell.yaml
@@ -17,10 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Config credentials
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         run: |
-          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
 
       - name: Check out code
         uses: actions/checkout@v1

--- a/.github/workflows/check-urllint.yaml
+++ b/.github/workflows/check-urllint.yaml
@@ -24,10 +24,8 @@ jobs:
         id: go
 
       - name: Config credentials
-        env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: |
-          git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/.github/workflows/check-yaml.yaml
+++ b/.github/workflows/check-yaml.yaml
@@ -18,10 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Config credentials
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
 
       - name: Check out code
         uses: actions/checkout@v1


### PR DESCRIPTION
## What this PR does / why we need it
- Don't populate the environment with secrets which could potentially be printed to the environment when not needed [0]
- Use the autogenerated `GITHUB_TOKEN` which is read only and populated by GitHub workflows on each run [1]
- Don't run workflows from our self hosted runners on Pull Requests as it's possible for attackers to introduce malicious code from opening a pull request [2]. Further, when `community-edition` is public, secrets being sent to workflows that originate from for pull requests are not enabled. So the workflows that broker a EC2 runner won't work as those secrets will be missing []. This changes those workflows to be post merge on the `main` branch

[0] [Limitations of secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#limits-for-secrets)
[1] [About the `GITHUB_TOKEN` secret](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret)
[2] [Self hosted runner security with public repositories](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners#self-hosted-runner-security-with-public-repositories)
[3] [GitHub Actions improvement for fork and pull req workflows](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/)

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Harden pull requests workflow runs
```

## Which issue(s) this PR fixes
Fixes: #1023

## Describe testing done for PR
This PR should be ok to merge and try on main as it stands but may need a followup for going public

## Special notes for your reviewer
N/a
