### PR TITLE
Do not lint upstream package yaml files #1854

### DIFF
--- a/hack/.yamllintconfig.yaml
+++ b/hack/.yamllintconfig.yaml
@@ -10,3 +10,6 @@ rules:
   empty-lines: enable
   colons: disable
   commas: disable
+
+ignore: |
+  /community-edition/addons/packages/**/*/upstream/


### PR DESCRIPTION
## What this PR does / why we need it

Upstream package yaml files should not be lint'ed.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Do not lint upstream package yaml files
```

## Which issue(s) this PR fixes

Fixes: #1854

## Describe testing done for PR

Ran `./hack/check-yaml.sh`

## Special notes for your reviewer
-