### PR TITLE
Switch to production harbor instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ FRAMEWORK_BUILD_VERSION=$$(cat "./hack/FRAMEWORK_BUILD_VERSION")
 TANZU_FRAMEWORK_REPO_BRANCH ?= v0.2.1
 # if the hash below is set, this overrides the value of TANZU_FRAMEWORK_REPO_BRANCH
 TANZU_FRAMEWORK_REPO_HASH ?=
+ifndef TKG_DEFAULT_IMAGE_REPOSITORY
+TKG_DEFAULT_IMAGE_REPOSITORY = "projects.registry.vmware.com/tkg"
+endif
 
 ARTIFACTS_DIR ?= ./artifacts
 TCE_RELEASE_DIR ?= /tmp/tce-release
@@ -236,7 +239,7 @@ clean-release:
 .PHONY: build-cli
 build-cli:
 	TCE_RELEASE_DIR=${TCE_RELEASE_DIR} \
-	TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH="tkg-compatibility" TANZU_FRAMEWORK_REPO_BRANCH=$(TANZU_FRAMEWORK_REPO_BRANCH) \
+	TKG_DEFAULT_IMAGE_REPOSITORY=${TKG_DEFAULT_IMAGE_REPOSITORY} TANZU_FRAMEWORK_REPO_BRANCH=$(TANZU_FRAMEWORK_REPO_BRANCH) \
 	TANZU_FRAMEWORK_REPO_HASH=$(TANZU_FRAMEWORK_REPO_HASH) BUILD_EDITION=tce TCE_BUILD_VERSION=$(BUILD_VERSION) \
 	FRAMEWORK_BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} ENVS="${ENVS}" hack/build-tanzu.sh
 
@@ -277,7 +280,7 @@ build-cli-plugins-%: prep-build-cli
 
 	@printf "===> Building with ${OS}-${ARCH}\n";
 
-	@cd ./hack/builder/ && $(MAKE) compile OS=${OS} ARCH=${ARCH}
+	@cd ./hack/builder/ && $(MAKE) compile OS=${OS} ARCH=${ARCH} TKG_DEFAULT_IMAGE_REPOSITORY=${TKG_DEFAULT_IMAGE_REPOSITORY}
 
 .PHONY: build-cli-plugins-local
 build-cli-plugins-local: build-cli-plugins-${GOHOSTOS}-${GOHOSTARCH}

--- a/hack/build-tanzu.sh
+++ b/hack/build-tanzu.sh
@@ -60,7 +60,7 @@ fi
 # make configure-bom
 # build all "tanzu-framework" CLI plugins
 # (e.g. management-cluster, cluster, etc)
-BUILD_SHA=${BUILD_SHA} BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} make ENVS="${ENVS}" clean-catalog-cache clean-cli-plugins build-cli
+TKG_DEFAULT_IMAGE_REPOSITORY=${TKG_DEFAULT_IMAGE_REPOSITORY} BUILD_SHA=${BUILD_SHA} BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} make ENVS="${ENVS}" clean-catalog-cache clean-cli-plugins configure-bom build-cli
 
 # by default, tanzu-framework only builds admins plugins for the current platform. we need darwin also.
 BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} GOHOSTOS=linux GOHOSTARCH=amd64 make ENVS="${ENVS}" build-plugin-admin

--- a/hack/builder/Makefile
+++ b/hack/builder/Makefile
@@ -8,6 +8,9 @@ BUILD_SHA ?= $$(git rev-parse --short HEAD)
 BUILD_EDITION=tce-standalone
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
+ifndef TKG_DEFAULT_IMAGE_REPOSITORY
+TKG_DEFAULT_IMAGE_REPOSITORY = "projects.registry.vmware.com/tkg"
+endif
 
 ifndef IS_OFFICIAL_BUILD
 IS_OFFICIAL_BUILD = ""
@@ -26,6 +29,7 @@ endif
 SONO_VERSION := $(shell working_dir=`pwd`; cd ../../cli/cmd/plugin/conformance; $(GO) list -f '{{.Version}}' -m github.com/vmware-tanzu/sonobuoy; cd $$working_dir;)
 
 LD_FLAGS = -s -w
+LD_FLAGS += -X "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgconfigpaths.TKGDefaultImageRepo=$(TKG_DEFAULT_IMAGE_REPOSITORY)"
 LD_FLAGS += -X "github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli.BuildDate=$(BUILD_DATE)"
 LD_FLAGS += -X "github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli.BuildSHA=$(BUILD_SHA)"
 LD_FLAGS += -X "github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli.BuildVersion=$(BUILD_VERSION)"


### PR DESCRIPTION
## What this PR does / why we need it

This commit updates the building of our CLI plugins to ensure those that
grab compatibility files grab them from the production harbor instance.
Compatibility files in production will point to tkg and tkr-boms in
production as well.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
TCE now uses projects.registry.vmware.com for all OCI assets.
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1853

## Describe testing done for PR

Removed all contents in `~/.config/tanzu` then opened the management cluster UI

```sh
$ tanzu management-cluster create --ui
!  Configuration is now stored in /home/josh/.config/tanzu. Legacy configuration directory /home/josh/.tanzu is deprecated and will be removed in a future release.
!  To complete migration, please remove legacy configuration directory /home/josh/.tanzu and adjust your script(s), if any, to point to the new location.
Downloading TKG compatibility file from 'projects.registry.vmware.com/tkg/framework-zshippable/tkg-compatibility'
Downloading the TKG Bill of Materials (BOM) file from 'projects.registry.vmware.com/tkg/tkg-bom:v1.4.0'
Downloading the TKr Bill of Materials (BOM) file from 'projects.registry.vmware.com/tkg/tkr-bom:v1.21.2_vmware.1-tkg.1'
the old providers folder /home/josh/.config/tanzu/tkg/providers is backed up to /home/josh/.config/tanzu/tkg/providers-20210920202955-3t3e92ca

Validating the pre-requisites...
Serving kickstart UI at http://127.0.0.1:8080
unable to open browser: exit status 3
^CShutting down...
HTTP server Shutdown: context deadline exceeded
Stopped serving kickstart UI at http://127.0.0.1:8080
```

Removed all contents in `~/.config/tanzu` then created a standalone cluster.

```sh
$ tanzu standalone-cluster create -i docker henro
!  Configuration is now stored in /home/josh/.config/tanzu. Legacy configuration directory /home/josh/.tanzu is deprecated and will be removed in a future release.
!  To complete migration, please remove legacy configuration directory /home/josh/.tanzu and adjust your script(s), if any, to point to the new location.
Downloading TKG compatibility file from 'projects.registry.vmware.com/tkg/framework-zshippable/tkg-compatibility'
Downloading the TKG Bill of Materials (BOM) file from 'projects.registry.vmware.com/tkg/tkg-bom:v1.4.0'
Downloading the TKr Bill of Materials (BOM) file from 'projects.registry.vmware.com/tkg/tkr-bom:v1.21.2_vmware.1-tkg.1'
the old providers folder /home/josh/.config/tanzu/tkg/providers is backed up to /home/josh/.config/tanzu/tkg/providers-20210920204735-oftccvpn

Validating the pre-requisites...
Identity Provider not configured. Some authentication features won't work.

Setting up standalone cluster...
Validating configuration...
Using infrastructure provider docker:v0.3.23
Generating cluster configuration...
Setting up bootstrapper...
Bootstrapper created. Kubeconfig: /home/josh/.kube-tkg/tmp/config_NhbbCDye
Installing providers on bootstrapper...
Start creating standalone cluster...
Saving standalone cluster kubeconfig into /home/josh/.kube/config
Waiting for bootstrap cluster to get ready for save ...
Waiting for addons installation...
Moving all Cluster API objects from bootstrap cluster to standalone cluster...
Context set for standalone cluster henro as 'henro-admin@henro'.
Cleaning up unneeded resources (for standalone clusters)...

Standalone cluster created!
```

## Special notes for your reviewer

n/a