### PR TITLE
Update MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,11 +4,12 @@
 
 | Maintainer | GitHub ID | Affiliation |
 |------------|-----------|-------------|
-|Josh Rosso | [Joshrosso](https://github.com/joshrosso) | [VMware](https://www.github.com/vmware/) |
-|Nicholas Seemiller | [seemiller](https://github.com/seemiller) | [VMware](https://www.github.com/vmware/) |
-|Sean McGinnis | [stmcginnis](https://github.com/stmcginnis) | [VMware](https://www.github.com/vmware/) |
-|David vonThenen | [dvonthenen](https://github.com/dvonthenen) | [VMware](https://www.github.com/vmware/) |
-|John McBride | [jpmcb](https://github.com/jpmcb) | [VMware](https://www.github.com/vmware/) |
+| Josh Rosso | [joshrosso](https://github.com/joshrosso) | [VMware](https://www.github.com/vmware/) |
+| Nicholas Seemiller | [seemiller](https://github.com/seemiller) | [VMware](https://www.github.com/vmware/) |
+| Sean McGinnis | [stmcginnis](https://github.com/stmcginnis) | [VMware](https://www.github.com/vmware/) |
+| David vonThenen | [dvonthenen](https://github.com/dvonthenen) | [VMware](https://www.github.com/vmware/) |
+| John McBride | [jpmcb](https://github.com/jpmcb) | [VMware](https://www.github.com/vmware/) |
+| Nolan Brubaker | [nrb](https://github.com/nrb) | [VMware](https://www.github.com/vmware/) |
 
 ## Emeritus Maintainers
 
@@ -20,18 +21,17 @@
 | Feature Area | Lead |
 |--------------|------|
 | Product Lead | Roger Klorese [qnetter](https://github.com/qnetter) |
-|Engineering Lead | Amanda Katona [amandakatona](https://github.com/amandakatona) |
-|Tech Lead | Josh Rosso [Joshrosso](https://github.com/joshrosso) |
+| Engineering Lead | Amanda Katona [amandakatona](https://github.com/amandakatona) |
+| Tech Lead | Josh Rosso [joshrosso](https://github.com/joshrosso) |
+| Engineering Manager | Kavi Daula [kdaula](https://github.com/kdaula) |
 | Engineering | David vonThenen  [dvonthenen](https://github.com/dvonthenen) |
 | Engineering | Nicholas Seemiller [seemiller](https://github.com/seemiller) |
 | Engineering | John McBride [jpmcb](https://github.com/jpmcb) |
-| Program Manager | Kristine Scott [kriscott](https://github.com/kriscott) |
-| Program Manager | Adam Kane [adamkane13](https://github.com/adamkane13) |
+| Engineering | Nolan Brubaker [nrb](https://github.com/nrb) |
 | Community Relations Staff Engineer | Sean McGinnis [stmcginnis](https://github.com/stmcginnis) |
 | Community Relations Staff Engineer | Steven Wong [cantbewong](https://github.com/cantbewong)|
 | Developer Experience | Jorge Morales [jorgemoralespou](https://github.com/jorgemoralespou) |
 | Developer Advocacy | Tiffany Jernigan [tiffanyfay](https://github.com/tiffanyfay) |
 | KubeAcademy | Jonathan Smith |
-| KubeAcademy | Hart Hoover [hhoover](https://github.com/hhoover) |
 | Community Management | Nigel Brown [pnbrown](https://github.com/pnbrown) |
-| Community Marketing | Scott Buchanan |
+| Product Marketing Manager | Jennifer Kotzen [jkotzen](https://github.com/jkotzen) |


### PR DESCRIPTION
Auditing MAINTAINERS.md

## What this PR does / why we need it
Updates the maintainers page to bring it current.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
N/A

## Describe testing done for PR
N/A

## Special notes for your reviewer
The bottom area needs more auditing that I cannot do alone. The top line of the table lists leads, however all engineers are present down there as well as maintainers. We also need to validate that some of the other titles and roles have not changed.
