### PR TITLE
Fix release token when cutting release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ package-release:
 
 # IMPORTANT: This should only ever be called CI/github-action
 .PHONY: cut-release
-cut-release: version
+cut-release: release-env-check version
 	TCE_RELEASE_DIR=${TCE_RELEASE_DIR} FRAMEWORK_BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} \
 	BUILD_VERSION=$(BUILD_VERSION) FAKE_RELEASE=$(shell expr $(BUILD_VERSION) | grep fake) \
 	hack/release/cut-release.sh

--- a/hack/release/cut-release.sh
+++ b/hack/release/cut-release.sh
@@ -92,7 +92,7 @@ echo "VERSION_PROPER: ${VERSION_PROPER}"
 
 # login
 set +x
-echo "${GH_ACCESS_TOKEN}" | gh auth login --with-token
+echo "${GITHUB_TOKEN}" | gh auth login --with-token
 set -x
 
 # is this a fake release to test the process?

--- a/hack/release/release/release.go
+++ b/hack/release/release/release.go
@@ -24,12 +24,12 @@ const (
 	DefaultTagVersion string = "dev.1"
 
 	// DevFullPathFilename filename
-	DevFullPathFilename string = "../DEV_BUILD_VERSION.yaml"
+	DevFullPathFilename string = "../../DEV_BUILD_VERSION.yaml"
 	// FakeFullPathFilename filename
-	FakeFullPathFilename string = "../FAKE_BUILD_VERSION.yaml"
+	FakeFullPathFilename string = "../../FAKE_BUILD_VERSION.yaml"
 
 	// NewVersionFullPathFilename filename
-	NewVersionFullPathFilename string = "../NEW_BUILD_VERSION"
+	NewVersionFullPathFilename string = "../../NEW_BUILD_VERSION"
 
 	// NumberOfSemVerSeparators is 3
 	NumberOfSemVerSeparators int = 3


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Fix the gh login with using the "actual" token. I'm not actually sure how the release worked considering that token doesn't exist anymore.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA