### PR TITLE
Remove github action checkout and use fullpath for push

### DIFF
--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -135,8 +135,6 @@ jobs:
           asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.zip
           asset_content_type: application/zip
-      - name: Checkout for Update
-        uses: actions/checkout@v1
       - name: Commit Next Dev Version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -150,8 +150,6 @@ jobs:
           path: ./artifacts
           destination: tce-cli-plugins
           credentials: ${{ secrets.GCP_BUCKET_SA }}
-      - name: Checkout for Update
-        uses: actions/checkout@v1
       - name: Commit Next Dev Version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -151,8 +151,6 @@ jobs:
           path: ./artifacts
           destination: tce-cli-plugins
           credentials: ${{ secrets.GCP_BUCKET_SA }}
-      - name: Checkout for Update
-        uses: actions/checkout@v1
       - name: Commit Next Dev Version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}

--- a/hack/release/cut-release.sh
+++ b/hack/release/cut-release.sh
@@ -13,6 +13,7 @@ BUILD_VERSION="${BUILD_VERSION:-""}"
 FRAMEWORK_BUILD_VERSION="${FRAMEWORK_BUILD_VERSION:-""}"
 TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
 TCE_RELEASE_DIR="${TCE_RELEASE_DIR:-""}"
+GITHUB_WORKSPACE="${GITHUB_WORKSPACE:-""}"
 
 # required input
 if [[ -z "${BUILD_VERSION}" ]]; then
@@ -26,6 +27,10 @@ fi
 if [[ -z "${TCE_RELEASE_DIR}" ]]; then
     echo "TCE_RELEASE_DIR is not set"
     exit 1
+fi
+if [[ -z "${GITHUB_WORKSPACE}" ]]; then
+    echo "Use current working directory..."
+    GITHUB_WORKSPACE=$(pwd)
 fi
 
 # we only allow this to run from GitHub CI/Action
@@ -163,7 +168,7 @@ fi
 # this needs to be done for both tce and tanzu framework
 
 # do this on TCE
-pushd "./artifacts" || exit 1
+pushd "${GITHUB_WORKSPACE}/artifacts" || exit 1
 
 for dir in ./*/
 do
@@ -171,8 +176,8 @@ do
   echo "dir: ${dir}"
   pushd "${dir}/${BUILD_VERSION}" || exit 1
   # delete all binaries
-  rm -f ./*
   rm -rf ./test
+  rm -f ./*
   # drop a no-op file
   echo "empty" | tee .empty
   popd || exit 1
@@ -189,8 +194,8 @@ do
   echo "dir: ${dir}"
   pushd "${dir}/${FRAMEWORK_BUILD_VERSION}" || exit 1
   # delete all binaries
-  rm -f ./*
   rm -rf ./test
+  rm -f ./*
   # drop a no-op file
   echo "empty" | tee .empty
   popd || exit 1
@@ -206,8 +211,8 @@ do
   echo "dir: ${dir}"
   pushd "${dir}/${FRAMEWORK_BUILD_VERSION}" || exit 1
   # delete all binaries
-  rm -f ./*
   rm -rf ./test
+  rm -f ./*
   # drop a no-op file
   echo "empty" | tee .empty
   popd || exit 1


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
The github action for `checkout` might actually be deleting the `./artifacts` directory. Remove that just in case... we do a `git reset --hard` in the cut-release script anyways before modifying the repo.

Additionally, explicitly use the fullpath of the repo folder when passing into pop/push. The github action was erroring out because it couldn't find `./artifacts` directory.

Also change the order of the delete directory and delete files to prevent the "error" of unable to delete the file because it's really a directory.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA