### PR TITLE
Remove Eli Wrenn from kapp-controller maintainers

### DIFF
--- a/addons/packages/kapp-controller/metadata.yaml
+++ b/addons/packages/kapp-controller/metadata.yaml
@@ -10,7 +10,6 @@ spec:
   maintainers:
     - name: Lucheng Bao
     - name: Vijay Katam
-    - name: Eli Wrenn
     - name: Shivaani Gupta
   categories:
     - "package management"


### PR DESCRIPTION
## What this PR does / why we need it

Eli Wrenn has left VMware so removing him as a maintainer for the kapp-controller package. 

Happy to add myself if we would like to have a maintainer from the kapp-controller team, but also fine with just removing as we are not involved in maintenance of this package at the moment.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

N/A

## Describe testing done for PR

N/A
