### PR TITLE
Contour: add docs for envs without LoadBalancer

### DIFF
--- a/addons/packages/contour/1.15.1/README.md
+++ b/addons/packages/contour/1.15.1/README.md
@@ -8,44 +8,51 @@ The following tables shows the providers this package can work with.
 
 | AWS  |  Azure  | vSphere  | Docker |
 |:---:|:---:|:---:|:---:|
-| ✅  |  ✅  | ✅  | ❌  |
+| ✅  |  ✅  | ✅  | ✅  |
 
 ## Components
 
 * Contour controller
 * Envoy reverse proxy and load balancer
 
-## Configuration
+## Installation
 
-You can configure the following:
+### Environments with support for LoadBalancer services (AWS, Azure, vSphere)
 
-| Config | Default | Description |
-|--------|---------|-------------|
-| `namespace` | `projectcontour` | The namespace in which to deploy Contour and Envoy. |
-| `contour.configFileContents` | (none) | The YAML contents of the Contour config file. See [the Contour configuration documentation](https://projectcontour.io/docs/v1.15.1/configuration/#configuration-file) for more information. |
-| `contour.replicas` | `2` | How many Contour pod replicas to have. |
-| `contour.useProxyProtocol` | `false` | Whether to enable PROXY protocol for all Envoy listeners. |
-| `contour.logLevel` | `info` | The Contour log level. Valid values are `info` and `debug`. |
-| `envoy.service.type` | `LoadBalancer` | The type of Kubernetes service to provision for Envoy. Valid values are `LoadBalancer`, `NodePort`, and `ClusterIP`. |
-| `envoy.service.externalTrafficPolicy` | `Local` | The external traffic policy for the Envoy service. Valid values are `Local` and `Cluster`.  If `envoy.service.type` is `ClusterIP`, this field is ignored. |
-| `envoy.service.annotations` | (none) | Annotations to set on the Envoy service. |
-| `envoy.service.nodePorts.http` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
-| `envoy.service.nodePorts.https` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
-| `envoy.hostPorts.enable` | `false` | Whether to enable host ports for the Envoy pods. If false, `envoy.hostPorts.http` and `envoy.hostPorts.https` are ignored. |
-| `envoy.hostPorts.http` | `80` | If `envoy.hostPorts.enable` == true, the host port number to expose Envoy's HTTP listener on. |
-| `envoy.hostPorts.https` | `443` | If `envoy.hostPorts.enable` == true, the host port number to expose Envoy's HTTPS listener on. |
-| `envoy.hostNetwork` | `false` | Whether to enable host networking for the Envoy pods. |
-| `envoy.terminationGracePeriodSeconds` | `300` | The termination grace period, in seconds, for the Envoy pods. |
-| `envoy.logLevel` | `info` | The Envoy log level. Valid values are `trace`, `debug`, `info`, `warn`, `error`, `critical`, and `off`. |
-| `certificates.useCertManager` | `false` | Whether to use cert-manager to provision TLS certificates for securing communication between Contour and Envoy. If false, the upstream Contour certgen job will be used to provision certificates. If true, the `cert-manager` addon must be installed in the cluster. |
-| `certificates.duration` | `8760h` |  If using cert-manager, how long the certificates should be valid for. If useCertManager is false, this field is ignored. |
-| `certificates.renewBefore` | `360h` |  If using cert-manager, how long before expiration the certificates should be renewed. If useCertManager is false, this field is ignored. |
+1. Install the Contour package using default configuration options:
+
+    ```shell
+    tanzu package install contour \
+      --package-name contour.community.tanzu.vmware.com \
+      --version 1.15.1
+    ```
+
+### Environments without support for LoadBalancer services (Docker)
+
+1. Create a configuration file that sets the Envoy service type to `ClusterIP`:
+
+    ```shell
+    cat <<EOF >contour-values.yaml
+    envoy:
+      service:
+        type: ClusterIP
+    EOF
+    ```
+
+1. Install the Contour package using the configuration file:
+
+    ```shell
+    tanzu package install contour \
+      --package-name contour.community.tanzu.vmware.com \
+      --version 1.15.1 \
+      --values-file contour-values.yaml
+    ```
+
+For additional configuration options, see the [Configuration Reference section](#configuration-reference).
 
 ## Usage Example
 
 The follow is a basic guide for getting started with Contour. You must deploy the package before attempting this walkthrough.
-
-This example assumes you have used a `LoadBalancer` service for Envoy. If that's not the case, see the [Contour documentation](https://projectcontour.io/docs/v1.15.1/deploy-options/#running-without-a-kubernetes-loadbalancer) for more information.
 
 ⚠️ Note: For more advanced use cases and documentation, see the official Contour [documentation](https://projectcontour.io/docs/).
 
@@ -90,17 +97,56 @@ This example assumes you have used a `LoadBalancer` service for Envoy. If that's
     EOF
     ```
 
-1. Get the external address of your Envoy service:
+1. Get the address to send traffic to. If you are using a `LoadBalancer` Envoy service, get the service's external IP:
 
     ```shell
-    kubectl --namespace projectcontour get service envoy -o wide
-    NAME    TYPE           CLUSTER-IP    EXTERNAL-IP            PORT(S)                      AGE    SELECTOR
-    envoy   LoadBalancer   10.12.10.93   <ENVOY-EXTERNAL-IP>    80:31232/TCP,443:32459/TCP   1h     app=envoy
+    kubectl --namespace projectcontour get service envoy
+    NAME    TYPE           CLUSTER-IP    EXTERNAL-IP            PORT(S)                      AGE
+    envoy   LoadBalancer   10.12.10.93   <ENVOY-EXTERNAL-IP>    80:31232/TCP,443:32459/TCP   1h
     ```
 
-1. Make a request:
+   If you are using a `NodePort` or `ClusterIP` Envoy service, in a separate terminal, set up a port forward from your local machine to the service:
 
     ```shell
-    curl -s -H "Host: nginx-example.projectcontour.io" <ENVOY-EXTERNAL-IP> | grep title
-    <title>Welcome to nginx!</title>
+    kubectl --namespace projectcontour port-forward svc/envoy <LOCAL-PORT>:80
     ```
+
+1. Make a request. If you are using a `LoadBalancer` Envoy service:
+
+   ```shell
+   curl -s -H "Host: nginx-example.projectcontour.io" <ENVOY-EXTERNAL-IP> | grep title
+   <title>Welcome to nginx!</title>
+   ```
+
+   If you are using a `NodePort` or `ClusterIP` Envoy service:
+
+   ```shell
+   curl -s -H "Host: nginx-example.projectcontour.io" http://localhost:<LOCAL-PORT> | grep title
+   <title>Welcome to nginx!</title>
+   ```
+
+## Configuration Reference
+
+You can configure the following:
+
+| Config | Default | Description |
+|--------|---------|-------------|
+| `namespace` | `projectcontour` | The namespace in which to deploy Contour and Envoy. |
+| `contour.configFileContents` | (none) | The YAML contents of the Contour config file. See [the Contour configuration documentation](https://projectcontour.io/docs/v1.15.1/configuration/#configuration-file) for more information. |
+| `contour.replicas` | `2` | How many Contour pod replicas to have. |
+| `contour.useProxyProtocol` | `false` | Whether to enable PROXY protocol for all Envoy listeners. |
+| `contour.logLevel` | `info` | The Contour log level. Valid values are `info` and `debug`. |
+| `envoy.service.type` | `LoadBalancer` | The type of Kubernetes service to provision for Envoy. Valid values are `LoadBalancer`, `NodePort`, and `ClusterIP`. |
+| `envoy.service.externalTrafficPolicy` | `Local` | The external traffic policy for the Envoy service. Valid values are `Local` and `Cluster`.  If `envoy.service.type` is `ClusterIP`, this field is ignored. |
+| `envoy.service.annotations` | (none) | Annotations to set on the Envoy service. |
+| `envoy.service.nodePorts.http` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
+| `envoy.service.nodePorts.https` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
+| `envoy.hostPorts.enable` | `false` | Whether to enable host ports for the Envoy pods. If false, `envoy.hostPorts.http` and `envoy.hostPorts.https` are ignored. |
+| `envoy.hostPorts.http` | `80` | If `envoy.hostPorts.enable` == true, the host port number to expose Envoy's HTTP listener on. |
+| `envoy.hostPorts.https` | `443` | If `envoy.hostPorts.enable` == true, the host port number to expose Envoy's HTTPS listener on. |
+| `envoy.hostNetwork` | `false` | Whether to enable host networking for the Envoy pods. |
+| `envoy.terminationGracePeriodSeconds` | `300` | The termination grace period, in seconds, for the Envoy pods. |
+| `envoy.logLevel` | `info` | The Envoy log level. Valid values are `trace`, `debug`, `info`, `warn`, `error`, `critical`, and `off`. |
+| `certificates.useCertManager` | `false` | Whether to use cert-manager to provision TLS certificates for securing communication between Contour and Envoy. If false, the upstream Contour certgen job will be used to provision certificates. If true, the `cert-manager` addon must be installed in the cluster. |
+| `certificates.duration` | `8760h` |  If using cert-manager, how long the certificates should be valid for. If useCertManager is false, this field is ignored. |
+| `certificates.renewBefore` | `360h` |  If using cert-manager, how long before expiration the certificates should be renewed. If useCertManager is false, this field is ignored. |

--- a/addons/packages/contour/1.17.1/README.md
+++ b/addons/packages/contour/1.17.1/README.md
@@ -8,44 +8,51 @@ The following tables shows the providers this package can work with.
 
 | AWS  |  Azure  | vSphere  | Docker |
 |:---:|:---:|:---:|:---:|
-| ✅  |  ✅  | ✅  | ❌  |
+| ✅  |  ✅  | ✅  | ✅  |
 
 ## Components
 
 * Contour controller
 * Envoy reverse proxy and load balancer
 
-## Configuration
+## Installation
 
-You can configure the following:
+### Environments with support for LoadBalancer services (AWS, Azure, vSphere)
 
-| Config | Default | Description |
-|--------|---------|-------------|
-| `namespace` | `projectcontour` | The namespace in which to deploy Contour and Envoy. |
-| `contour.configFileContents` | (none) | The YAML contents of the Contour config file. See [the Contour configuration documentation](https://projectcontour.io/docs/v1.17.1/configuration/#configuration-file) for more information. |
-| `contour.replicas` | `2` | How many Contour pod replicas to have. |
-| `contour.useProxyProtocol` | `false` | Whether to enable PROXY protocol for all Envoy listeners. |
-| `contour.logLevel` | `info` | The Contour log level. Valid values are `info` and `debug`. |
-| `envoy.service.type` | `LoadBalancer` | The type of Kubernetes service to provision for Envoy. Valid values are `LoadBalancer`, `NodePort`, and `ClusterIP`. |
-| `envoy.service.externalTrafficPolicy` | `Local` | The external traffic policy for the Envoy service. Valid values are `Local` and `Cluster`.  If `envoy.service.type` is `ClusterIP`, this field is ignored. |
-| `envoy.service.annotations` | (none) | Annotations to set on the Envoy service. |
-| `envoy.service.nodePorts.http` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
-| `envoy.service.nodePorts.https` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
-| `envoy.hostPorts.enable` | `false` | Whether to enable host ports for the Envoy pods. If false, `envoy.hostPorts.http` and `envoy.hostPorts.https` are ignored. |
-| `envoy.hostPorts.http` | `80` | If `envoy.hostPorts.enable` == true, the host port number to expose Envoy's HTTP listener on. |
-| `envoy.hostPorts.https` | `443` | If `envoy.hostPorts.enable` == true, the host port number to expose Envoy's HTTPS listener on. |
-| `envoy.hostNetwork` | `false` | Whether to enable host networking for the Envoy pods. |
-| `envoy.terminationGracePeriodSeconds` | `300` | The termination grace period, in seconds, for the Envoy pods. |
-| `envoy.logLevel` | `info` | The Envoy log level. Valid values are `trace`, `debug`, `info`, `warn`, `error`, `critical`, and `off`. |
-| `certificates.useCertManager` | `false` | Whether to use cert-manager to provision TLS certificates for securing communication between Contour and Envoy. If false, the upstream Contour certgen job will be used to provision certificates. If true, the `cert-manager` addon must be installed in the cluster. |
-| `certificates.duration` | `8760h` |  If using cert-manager, how long the certificates should be valid for. If useCertManager is false, this field is ignored. |
-| `certificates.renewBefore` | `360h` |  If using cert-manager, how long before expiration the certificates should be renewed. If useCertManager is false, this field is ignored. |
+1. Install the Contour package using default configuration options:
+
+    ```shell
+    tanzu package install contour \
+      --package-name contour.community.tanzu.vmware.com \
+      --version 1.17.1
+    ```
+
+### Environments without support for LoadBalancer services (Docker)
+
+1. Create a configuration file that sets the Envoy service type to `ClusterIP`:
+
+    ```shell
+    cat <<EOF >contour-values.yaml
+    envoy:
+      service:
+        type: ClusterIP
+    EOF
+    ```
+
+1. Install the Contour package using the configuration file:
+
+    ```shell
+    tanzu package install contour \
+      --package-name contour.community.tanzu.vmware.com \
+      --version 1.17.1 \
+      --values-file contour-values.yaml
+    ```
+
+For additional configuration options, see the [Configuration Reference section](#configuration-reference).
 
 ## Usage Example
 
 The follow is a basic guide for getting started with Contour. You must deploy the package before attempting this walkthrough.
-
-This example assumes you have used a `LoadBalancer` service for Envoy. If that's not the case, see the [Contour documentation](https://projectcontour.io/docs/v1.17.1/deploy-options/#running-without-a-kubernetes-loadbalancer) for more information.
 
 ⚠️ Note: For more advanced use cases and documentation, see the official Contour [documentation](https://projectcontour.io/docs/).
 
@@ -90,17 +97,56 @@ This example assumes you have used a `LoadBalancer` service for Envoy. If that's
     EOF
     ```
 
-1. Get the external address of your Envoy service:
+1. Get the address to send traffic to. If you are using a `LoadBalancer` Envoy service, get the service's external IP:
 
     ```shell
-    kubectl --namespace projectcontour get service envoy -o wide
-    NAME    TYPE           CLUSTER-IP    EXTERNAL-IP            PORT(S)                      AGE    SELECTOR
-    envoy   LoadBalancer   10.12.10.93   <ENVOY-EXTERNAL-IP>    80:31232/TCP,443:32459/TCP   1h     app=envoy
+    kubectl --namespace projectcontour get service envoy
+    NAME    TYPE           CLUSTER-IP    EXTERNAL-IP            PORT(S)                      AGE
+    envoy   LoadBalancer   10.12.10.93   <ENVOY-EXTERNAL-IP>    80:31232/TCP,443:32459/TCP   1h
     ```
 
-1. Make a request:
+   If you are using a `NodePort` or `ClusterIP` Envoy service, in a separate terminal, set up a port forward from your local machine to the service:
 
     ```shell
-    curl -s -H "Host: nginx-example.projectcontour.io" <ENVOY-EXTERNAL-IP> | grep title
-    <title>Welcome to nginx!</title>
+    kubectl --namespace projectcontour port-forward svc/envoy <LOCAL-PORT>:80
     ```
+
+1. Make a request. If you are using a `LoadBalancer` Envoy service:
+
+   ```shell
+   curl -s -H "Host: nginx-example.projectcontour.io" <ENVOY-EXTERNAL-IP> | grep title
+   <title>Welcome to nginx!</title>
+   ```
+
+   If you are using a `NodePort` or `ClusterIP` Envoy service:
+
+   ```shell
+   curl -s -H "Host: nginx-example.projectcontour.io" http://localhost:<LOCAL-PORT> | grep title
+   <title>Welcome to nginx!</title>
+   ```
+
+## Configuration Reference
+
+You can configure the following:
+
+| Config | Default | Description |
+|--------|---------|-------------|
+| `namespace` | `projectcontour` | The namespace in which to deploy Contour and Envoy. |
+| `contour.configFileContents` | (none) | The YAML contents of the Contour config file. See [the Contour configuration documentation](https://projectcontour.io/docs/v1.17.1/configuration/#configuration-file) for more information. |
+| `contour.replicas` | `2` | How many Contour pod replicas to have. |
+| `contour.useProxyProtocol` | `false` | Whether to enable PROXY protocol for all Envoy listeners. |
+| `contour.logLevel` | `info` | The Contour log level. Valid values are `info` and `debug`. |
+| `envoy.service.type` | `LoadBalancer` | The type of Kubernetes service to provision for Envoy. Valid values are `LoadBalancer`, `NodePort`, and `ClusterIP`. |
+| `envoy.service.externalTrafficPolicy` | `Local` | The external traffic policy for the Envoy service. Valid values are `Local` and `Cluster`.  If `envoy.service.type` is `ClusterIP`, this field is ignored. |
+| `envoy.service.annotations` | (none) | Annotations to set on the Envoy service. |
+| `envoy.service.nodePorts.http` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
+| `envoy.service.nodePorts.https` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
+| `envoy.hostPorts.enable` | `false` | Whether to enable host ports for the Envoy pods. If false, `envoy.hostPorts.http` and `envoy.hostPorts.https` are ignored. |
+| `envoy.hostPorts.http` | `80` | If `envoy.hostPorts.enable` == true, the host port number to expose Envoy's HTTP listener on. |
+| `envoy.hostPorts.https` | `443` | If `envoy.hostPorts.enable` == true, the host port number to expose Envoy's HTTPS listener on. |
+| `envoy.hostNetwork` | `false` | Whether to enable host networking for the Envoy pods. |
+| `envoy.terminationGracePeriodSeconds` | `300` | The termination grace period, in seconds, for the Envoy pods. |
+| `envoy.logLevel` | `info` | The Envoy log level. Valid values are `trace`, `debug`, `info`, `warn`, `error`, `critical`, and `off`. |
+| `certificates.useCertManager` | `false` | Whether to use cert-manager to provision TLS certificates for securing communication between Contour and Envoy. If false, the upstream Contour certgen job will be used to provision certificates. If true, the `cert-manager` addon must be installed in the cluster. |
+| `certificates.duration` | `8760h` |  If using cert-manager, how long the certificates should be valid for. If useCertManager is false, this field is ignored. |
+| `certificates.renewBefore` | `360h` |  If using cert-manager, how long before expiration the certificates should be renewed. If useCertManager is false, this field is ignored. |


### PR DESCRIPTION
Updates Contour docs to cover environments
both with and without LoadBalancer support.

Closes #1744.
Closes #1247.

Signed-off-by: Steve Kriss <krisss@vmware.com>

## What this PR does / why we need it
Updates Contour docs to cover environments both with and without LoadBalancer support.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1744.
Fixes #1247.


## Describe testing done for PR
Deployed standalone AWS and Docker clusters, ran through instructions for each manually.

## Special notes for your reviewer
Note that the version of the Contour package in `projects.registry.vmware.com/tce/main:stable` still has issues with ClusterIP services (fix has been merged but not promoted to the stable repo), so if you're testing this in Docker, you'll need to use a `NodePort` service instead of `ClusterIP`.