### PR TITLE
Clean boostrap kind cluster kubeconfig file

### DIFF
--- a/cli/cmd/plugin/diagnostics/pkg/collect_cmd.go
+++ b/cli/cmd/plugin/diagnostics/pkg/collect_cmd.go
@@ -90,15 +90,15 @@ func collectFunc(cmd *cobra.Command, args []string) error {
 	defer os.RemoveAll(commonArgs.workDir)
 
 	if err := collectBoostrapDiags(); err != nil {
-		log.Printf("Error: skipping bootstrap cluster diagnostics: %s", err)
+		log.Printf("Warn: skipping bootstrap cluster diagnostics: %s", err)
 	}
 
 	if err := collectManagementDiags(); err != nil {
-		log.Printf("Error: skipping management cluster diagnostics: %s", err)
+		log.Printf("Warn: skipping management cluster diagnostics: %s", err)
 	}
 
 	if err := collectWorkloadDiags(); err != nil {
-		log.Printf("Error: skipping workload cluster diagnostics: %s", err)
+		log.Printf("Warn: skipping workload cluster diagnostics: %s", err)
 	}
 
 	return nil

--- a/cli/cmd/plugin/diagnostics/scripts/bootstrap_cluster.star
+++ b/cli/cmd/plugin/diagnostics/scripts/bootstrap_cluster.star
@@ -36,6 +36,10 @@ def diagnose_bootstrap_clusters(workdir, clusters, outputdir):
         k8sconf = kube_config(path=kind_cfg)
 
         capture_k8s_objects(k8sconf, kind_cluster, nspaces)
+
+        # remove kubeconfig before archiving
+        run_local("rm {}".format(kind_cfg))
+
         arc_file = "bootstrap.{}.diagnostics.tar.gz".format(kind_cluster)
         log(prefix="Info", msg="Archiving: {}".format(arc_file))
         archive(output_file=arc_file, source_paths=[conf.workdir])


### PR DESCRIPTION
This fix ensures that the generated kubeconfig for the bootstrap kind cluster
is deleted properly so that it is not included in the diagnostics tar file.

Signed-off-by: Vladimir Vivien <vivienv@vmware.com>

## What this PR does / why we need it
This fix ensures that the generated kubeconfig for the bootstrap kind cluster
is deleted properly so that it is not included in the diagnostics tar file.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes
Fixes: #1906 

## Describe testing done for PR
- Created a local kind-cluster as a fake boostrap cluster.
- Then run command `tanzu diagnostics collect`
- `Untar` the generated `boostrap.tkg-kind-xxxxx.targ.gz` file and ensure that it does not contain a kubeconfig file

