### PR TITLE
Use elvated access token for lint check in GitHub Actions

### DIFF
--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -27,8 +27,10 @@ jobs:
         id: go
 
       - name: Config credentials
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         run: |
-          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
 
       - name: Run golangci-lint
         run: |


### PR DESCRIPTION
## What this PR does / why we need it
Since we still need to pull in code from the (currently) private `tanzu-framework` repository, we need to use an elevated token in the Lint check for pull requests

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
Follow up to: https://github.com/vmware-tanzu/community-edition/pull/1855
and is related to failures in: https://github.com/vmware-tanzu/community-edition/pull/1909

## Describe testing done for PR
Will run pull requests in PR to see passing lint check for go code

## Special notes for your reviewer
N/a
