### PR TITLE
Post MVP - Day 1: Removes secrets being used in pull-request action runs

### DIFF
--- a/.github/workflows/check-actionlint.yaml
+++ b/.github/workflows/check-actionlint.yaml
@@ -21,10 +21,6 @@ jobs:
           go-version: "1.16"
         id: go
 
-      - name: Config credentials
-        run: |
-          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
 

--- a/.github/workflows/check-imagelint.yaml
+++ b/.github/workflows/check-imagelint.yaml
@@ -22,10 +22,6 @@ jobs:
           go-version: "1.16"
         id: go
 
-      - name: Config credentials
-        run: |
-          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
 

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -26,12 +26,6 @@ jobs:
           go-version: "1.16"
         id: go
 
-      - name: Config credentials
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
-        run: |
-          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
-
       - name: Run golangci-lint
         run: |
           make lint

--- a/.github/workflows/check-mdlint.yaml
+++ b/.github/workflows/check-mdlint.yaml
@@ -16,10 +16,6 @@ jobs:
     name: Check mdlint
     runs-on: ubuntu-latest
     steps:
-      - name: Config credentials
-        run: |
-          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
-
       - name: Check out code
         uses: actions/checkout@v1
 

--- a/.github/workflows/check-misspell.yaml
+++ b/.github/workflows/check-misspell.yaml
@@ -13,10 +13,6 @@ jobs:
     name: Check - misspell
     runs-on: ubuntu-latest
     steps:
-      - name: Config credentials
-        run: |
-          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
-
       - name: Check out code
         uses: actions/checkout@v1
 

--- a/.github/workflows/check-shell.yaml
+++ b/.github/workflows/check-shell.yaml
@@ -16,10 +16,6 @@ jobs:
     name: Check shell
     runs-on: ubuntu-latest
     steps:
-      - name: Config credentials
-        run: |
-          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
-
       - name: Check out code
         uses: actions/checkout@v1
 

--- a/.github/workflows/check-urllint.yaml
+++ b/.github/workflows/check-urllint.yaml
@@ -23,10 +23,6 @@ jobs:
           go-version: "1.16"
         id: go
 
-      - name: Config credentials
-        run: |
-          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
 

--- a/.github/workflows/check-yaml.yaml
+++ b/.github/workflows/check-yaml.yaml
@@ -17,10 +17,6 @@ jobs:
     name: Check - yaml
     runs-on: ubuntu-latest
     steps:
-      - name: Config credentials
-        run: |
-          git config --global url."https://git:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
-
       - name: Check out code
         uses: actions/checkout@v1
 


### PR DESCRIPTION
## What this PR does / why we need it
Removes any secrets or using SSH with an access token from use in the GitHub actions. Once this repo (and `tanzu-framework`) is made public, this should be merged and verified

- [ ] Verify no secrets are being sent to pull request targets

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
Followup to: https://github.com/vmware-tanzu/community-edition/pull/1855

## Describe testing done for PR
N/a - will test in GH actions after merge

## Special notes for your reviewer
N/a
