### PR TITLE
Post MVP - Day 1: `get-tce-release.sh` script for public repo

### DIFF
--- a/docs/site/content/docs/assets/cli-install-linux.md
+++ b/docs/site/content/docs/assets/cli-install-linux.md
@@ -5,8 +5,7 @@
 1. _[Alternative]_ Download the release using the CLI. You may download a release using the provided remote script piped into bash.
 
     ```sh
-    curl -H "Authorization: token ${GITHUB_TOKEN}" \
-        -H "Accept: application/vnd.github.v3.raw" \
+    curl -H "Accept: application/vnd.github.v3.raw" \
         -L https://api.github.com/repos/vmware-tanzu/community-edition/contents/hack/get-tce-release.sh | \
         bash -s <RELEASE-VERSION> <RELEASE-OS-DISTRIBUTION>
     ```


### PR DESCRIPTION
## What this PR does / why we need it
Modifies the docs and the `get-tce-release` script to work for a public repo

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
get-tce-release script works for the community edition public repo
```

## Which issue(s) this PR fixes
Follow up to #1855 as we get the auth ready for public release
Follow up to https://github.com/vmware-tanzu/community-edition/issues/1442 in order to remove the unnecessary auth steps in the script

## Describe testing done for PR
Changed this line:
```
GH_REPO="$GH_API/repos/vmware-tanzu/community-edition"
```
to be
```
GH_REPO="$GH_API/repos/BurntSushi/ripgrep"
```
and verified the script works to download an asset without the `GITHUB_TOKEN` env variable for a public repo:
```bash
# unset my current token in the env
❯ unset GITHUB_TOKEN

# Use the tweeked script to test downloading an asset without a github access token
❯ hack/get-tce-release.sh 13.0.0 ripgrep-13.0.0-x86_64-unknown-linux-musl
Validating dependencies ...
curl is /usr/bin/curl
grep is /usr/bin/grep
sed is /usr/bin/sed
tr is /usr/bin/tr
jq is /usr/bin/jq
Warning: No GITHUB_TOKEN variable defined - requests to the GitHub API may be rate limited
Downloading asset ...
################################################################################# 100.0%

# eagle landed successfully
❯ ls -la 
...
-rw-rw-r--  1 jmcb jmcb 2.1M Sep 23 08:54 ripgrep-13.0.0-x86_64-unknown-linux-musl.tar.gz
```

We should merge once the repo is public and then verify at that time as well

## Special notes for your reviewer
N/a
