### PR TITLE
Fix GCP upload to use correct folder structure

### DIFF
--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -169,15 +169,17 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: /tmp/tce-release/tanzu-framework/artifacts
-          destination: tce-tanzu-cli-framework
+          destination: tce-tanzu-cli-framework/artifacts
           credentials: ${{ secrets.GCP_BUCKET_SA }}
+          parent: false
       - name: Upload TF Artifacts-Admin to Release Bucket
         id: upload-tf-artifacts-admin-release
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: /tmp/tce-release/tanzu-framework/artifacts-admin
-          destination: tce-tanzu-cli-admin-plugins
+          destination: tce-tanzu-cli-admin-plugins/artifacts-admin
           credentials: ${{ secrets.GCP_BUCKET_SA }}
+          parent: false
       - name: Upload Cayman Trigger Asset
         id: upload-cayman-trigger-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -170,15 +170,17 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: /tmp/tce-release/tanzu-framework/artifacts
-          destination: tce-tanzu-cli-framework
+          destination: tce-tanzu-cli-framework/artifacts
           credentials: ${{ secrets.GCP_BUCKET_SA }}
+          parent: false
       - name: Upload TF Artifacts-Admin to Release Bucket
         id: upload-tf-artifacts-admin-release
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: /tmp/tce-release/tanzu-framework/artifacts-admin
-          destination: tce-tanzu-cli-admin-plugins
+          destination: tce-tanzu-cli-admin-plugins/artifacts-admin
           credentials: ${{ secrets.GCP_BUCKET_SA }}
+          parent: false
       - name: Upload Cayman Trigger Asset
         id: upload-cayman-trigger-asset
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
The old workflow uploaded the entire `/tmp/tce-release/tanzu-framework/artifacts` folder to the root of the GCP bucket... what this does is upload only `/tmp/tce-release/tanzu-framework/artifacts/<all these sub files/folders>` to the `tce-tanzu-cli-framework/artifacts` folder. The `parent: false` only uploads files inside the `artifacts` folder that's why the bucket needs to now include the `artifacts` folder in the bucket name.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Unfortunately, I can only test this change in production... but my description and reasoning for the change is above.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA