### PR TITLE
Update `local-path-storage` package with values schema in `Package`

### DIFF
--- a/addons/packages/local-path-storage/0.0.19/package.yaml
+++ b/addons/packages/local-path-storage/0.0.19/package.yaml
@@ -5,9 +5,19 @@ metadata:
 spec:
   refName: local-path-storage.community.tanzu.vmware.com
   version: 0.0.19
+  releasedAt: 2021-09-15T00:00:00Z
   releaseNotes: "local-path-storage 0.0.19 https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.19"
+  capacityRequirementsDescription: "Only suitable for local node storage. Does not provide distributed, reliable storage"
   licenses:
     - "Apache 2.0"
+  valuesSchema:
+    openAPIv3:
+      title: local-path-storage.community.tanzu.vmware.com.0.0.19 values schema
+      properties:
+        namespace:
+          type: string
+          description: The namespace in which to deploy the local-path-storage package
+          default: local-path-storage
   template:
     spec:
       fetch:

--- a/addons/packages/local-path-storage/0.0.20/package.yaml
+++ b/addons/packages/local-path-storage/0.0.20/package.yaml
@@ -6,9 +6,19 @@ metadata:
 spec:
   refName: local-path-storage.community.tanzu.vmware.com
   version: 0.0.20
+  releasedAt: 2021-09-15T00:00:00Z
   releaseNotes: "local-path-storage 0.0.20 https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.20"
+  capacityRequirementsDescription: "Only suitable for local node storage. Does not provide distributed, reliable storage"
   licenses:
     - "Apache 2.0"
+  valuesSchema:
+    openAPIv3:
+      title: local-path-storage.community.tanzu.vmware.com.0.0.20 values schema
+      properties:
+        namespace:
+          type: string
+          description: The namespace in which to deploy the local-path-storage package
+          default: local-path-storage
   template:
     spec:
       fetch:


### PR DESCRIPTION
## What this PR does / why we need it
Adds the `ValuesSchema` metadata in the local-path-storage package (along with a few other missing peices of metadata

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
local-path-storage has ValuesSchema in package description
```

## Which issue(s) this PR fixes
Fixes: #1921

## Describe testing done for PR
N/a

## Special notes for your reviewer
N/a - cc @seemiller. I didn't push new `local-path-storage` package images since the `package.yaml` doesn't exist in the config bundle. Let me know if this needs something else