### PR TITLE
Glob for `Makefiles` in GitHub actions shellcheck linter & fix linting issue on `main`

### DIFF
--- a/.github/workflows/check-shell.yaml
+++ b/.github/workflows/check-shell.yaml
@@ -8,6 +8,7 @@ on:
       - synchronize
       - reopened
     paths:
+      - "**/Makefile"
       - "**.sh"
       - "hack/check-shell.sh"
 

--- a/addons/packages/harbor/2.2.3/test/Makefile
+++ b/addons/packages/harbor/2.2.3/test/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message


### PR DESCRIPTION
## What this PR does / why we need it
- Glob for `Makefiles` in Github actions `shellcheck` for linting in PRs
- Fixes linting issue with makefile in Harbor tests without licenses header

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
Followup to https://github.com/vmware-tanzu/community-edition/pull/1893
and fixes linting errors found on main: https://github.com/vmware-tanzu/community-edition/runs/3689956675

## Describe testing done for PR
`make check` passes

## Special notes for your reviewer
N/a
