### PR TITLE
Deprecate image settings in AKODeploymentConfig

### DIFF
--- a/addons/packages/ako-operator/1.5.0/bundle/config/upstream/akooperator/akodeploymentconfig.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/upstream/akooperator/akodeploymentconfig.yaml
@@ -24,10 +24,6 @@ spec:
         l4Config:
             advancedL4: false
             autoFQDN: "disabled"
-        image:
-            repository: projects.registry.vmware.com/tkg/ako
-            pullPolicy: IfNotPresent
-            version: v1.3.2_vmware.1
         ingress:
             disableIngressClass: true
             defaultIngressController: false
@@ -64,10 +60,6 @@ spec:
         l4Config:
             advancedL4: false
             autoFQDN: "disabled"
-        image:
-            repository: projects.registry.vmware.com/tkg/ako
-            pullPolicy: IfNotPresent
-            version: v1.3.2_vmware.1
         ingress:
             disableIngressClass: true
             defaultIngressController: false

--- a/addons/packages/ako-operator/1.5.0/bundle/config/upstream/akooperator/static.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/upstream/akooperator/static.yaml
@@ -152,22 +152,6 @@ spec:
                   fullSyncFrequency:
                     description: FullSyncFrequency controls how often AKO polls the Avi controller to update itself with cloud configurations. Default value is 1800
                     type: string
-                  image:
-                    description: Image specifies the configuration for AKO docker image
-                    properties:
-                      pullPolicy:
-                        enum:
-                        - Always
-                        - Never
-                        - IfNotPresent
-                        type: string
-                      repository:
-                        description: Repository is the AKO Docker image repository
-                        type: string
-                      version:
-                        description: Version is the AKO Docker image version
-                        type: string
-                    type: object
                   ingress:
                     description: IngressConfigs specifies ingress configuration for ako
                     properties:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Deprecate image settings in AKODeploymentConfig.
This PR removes image settings in akoo 1.4.0 and 1.5.0.


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Deprecate image settings in AKODeploymentConfig.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
