### PR TITLE
Bump release-notes to version 3

### DIFF
--- a/hack/ensure-dependencies.sh
+++ b/hack/ensure-dependencies.sh
@@ -180,7 +180,7 @@ if [[ -z "$(command -v ${CMD})" ]]; then
 echo "Attempting install of ${CMD}..."
 case "${BUILD_OS}" in
   Linux)
-    curl -LO https://storage.googleapis.com/tce-tanzu-cli-plugins/build-tools/release-notes/v0.10.0-tce.2/release-notes-linux-amd64
+    curl -LO https://storage.googleapis.com/tce-tanzu-cli-plugins/build-tools/release-notes/v0.10.0-tce.3/release-notes-linux-amd64
     mv release-notes-linux-amd64 ${CMD}
     chmod +x ${CMD}
     sudo install ./${CMD} /usr/local/bin
@@ -189,14 +189,14 @@ case "${BUILD_OS}" in
   Darwin)
     case "${BUILD_ARCH}" in
       x86_64)
-        curl -LO https://storage.googleapis.com/tce-tanzu-cli-plugins/build-tools/release-notes/v0.10.0-tce.2/release-notes-darwin-amd64
+        curl -LO https://storage.googleapis.com/tce-tanzu-cli-plugins/build-tools/release-notes/v0.10.0-tce.3/release-notes-darwin-amd64
         mv release-notes-darwin-amd64 ${CMD}
         chmod +x ${CMD}
         sudo install ./${CMD} /usr/local/bin
         rm ./${CMD}
         ;;
      arm64)
-        curl -LO https://storage.googleapis.com/tce-tanzu-cli-plugins/build-tools/release-notes/v0.10.0-tce.2/release-notes-darwin-arm64
+        curl -LO https://storage.googleapis.com/tce-tanzu-cli-plugins/build-tools/release-notes/v0.10.0-tce.3/release-notes-darwin-arm64
         mv release-notes-darwin-arm64 ${CMD}
         chmod +x ${CMD}
         sudo install ./${CMD} /usr/local/bin


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This fixes an issue with the auto-generated release notes not including all contributions when PR authors didn't include all requirements. This updates does a pretty decent job trying to include at least a small blub of the contribution in the event the designated release notes field isn't used. Binaries have already been uploaded to the download location.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Bump utility that auto-generates the release-notes to version 3 to be more inclusive to all contributions.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested by hand

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
Will retroactively go back and edit releases going back to 0.7.0 with release notes generated by this version.