### PR TITLE
Replace the default image from docker library to ghcr for multus

### DIFF
--- a/addons/packages/multus-cni/3.7.1/bundle/config/values.yaml
+++ b/addons/packages/multus-cni/3.7.1/bundle/config/values.yaml
@@ -5,9 +5,9 @@
 namespace: kube-system
 
 image:
-  repository: docker.io/nfvpe
-  name: multus
-  tag: stable
+  repository: ghcr.io/k8snetworkplumbingwg
+  name: multus-cni
+  tag: v3.7.1
 
 #! DaemonSet related configuration
 #@overlay/replace

--- a/addons/packages/multus-cni/3.7.1/package.yaml
+++ b/addons/packages/multus-cni/3.7.1/package.yaml
@@ -48,7 +48,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/multus-cni@sha256:d60722bfbc865cb61faee1115455806af7b5a25f2224ed7031a6411fb62c76a9
+            image: projects.registry.vmware.com/tce/multus-cni@sha256:c2f76e193746de752a7387f6068293af649a5ddf9492d80b66f46f266af8c770
       template:
         - ytt:
             paths:

--- a/addons/packages/multus-cni/3.7.1/test/Makefile
+++ b/addons/packages/multus-cni/3.7.1/test/Makefile
@@ -3,6 +3,7 @@
 
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
 VERSION ?= 3.7.1
+USE_CONF_FILE ?= true
 MULTUS_E2E_TEST_ROOT := "${ROOT_DIR}"/addons/packages/multus-cni/"${VERSION}"/test/e2e
 
 .DEFAULT_GOAL := help
@@ -19,7 +20,7 @@ test: ## unit tests
 
 e2e-test: ## e2e tests
 	@printf "\ne2e tests for multus.${VERSION}\n\n"; \
-	cd "${MULTUS_E2E_TEST_ROOT}" && ginkgo -v . -- --version ${VERSION}
+	cd "${MULTUS_E2E_TEST_ROOT}" && ginkgo --flakeAttempts=2 -v . -- --version=${VERSION} --use-conf=${USE_CONF_FILE}
 
 lint: ## lint check for tests files
 	@printf "\nlint check for tests files\n\n"; \

--- a/addons/packages/multus-cni/3.7.1/test/e2e/multihomed-testfiles/cni-install.yaml
+++ b/addons/packages/multus-cni/3.7.1/test/e2e/multihomed-testfiles/cni-install.yaml
@@ -40,7 +40,7 @@ spec:
         command: ["/bin/bash", "/scripts/install_cni.sh"]
         resources:
           requests:
-            cpu: "100m"
+            cpu: "20m"
             memory: "50Mi"
           limits:
             cpu: "100m"

--- a/addons/packages/multus-cni/3.7.1/test/e2e/multihomed-testfiles/simple-macvlan.yaml
+++ b/addons/packages/multus-cni/3.7.1/test/e2e/multihomed-testfiles/simple-macvlan.yaml
@@ -35,7 +35,7 @@ metadata:
 spec:
   containers:
   - name: macvlan-worker
-    image: docker.io/library/centos:8
+    image: quay.io/centos/centos:8
     command: ["/bin/sleep", "10000"]
     securityContext:
       privileged: true

--- a/addons/packages/multus-cni/3.7.1/test/e2e/multuscni_suite_test.go
+++ b/addons/packages/multus-cni/3.7.1/test/e2e/multuscni_suite_test.go
@@ -24,10 +24,13 @@ var (
 	packageInstalledNamespace string
 	// package installed name.
 	packageInstalledName string
+	// Use configuration file or not.
+	useConfFile bool
 )
 
 func init() {
 	flag.StringVar(&packageVersion, "version", "3.7.1", "the version of the package to test")
+	flag.BoolVar(&useConfFile, "use-conf", true, "use configuration file or not")
 }
 
 func TestMultusCNIE2E(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: chenliu1993 <13630583107@163.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This PR replace the values image from docker to ghcr.io as multus community does after 3.7.1 release
Add one option to e2e test and modify validation position on tests

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #
[
1798](https://github.com/vmware-tanzu/community-edition/issues/1798)

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

package can be installed successfully
Ytt generates the right template.
test passes

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
