### PR TITLE
Add a schema to gatekeeper package

### DIFF
--- a/addons/packages/gatekeeper/3.2.3/package.yaml
+++ b/addons/packages/gatekeeper/3.2.3/package.yaml
@@ -6,6 +6,16 @@ spec:
   refName: gatekeeper.community.tanzu.vmware.com
   version: 1.0.0
   releaseNotes: "gatekeeper 3.2.3 https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.2.3"
+  valuesSchema:
+    openAPIv3:
+      title: gatekeeper.community.tanzu.vmware.com.1.0.0 values schema
+      properties:
+        namespace:
+          type: string
+          description: The namespace in which to deploy gatekeeper.
+          default: gatekeeper-system
+          examples:
+          - custom-namespace
   licenses:
     - "Apache 2.0"
   template:


### PR DESCRIPTION
## What this PR does / why we need it

This adds a schema defintion to the gatekeeper package, which enables
the tanzu CLI to provide a list of configurable values.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Schema added to the gatekeeper package. This is now exposed via `tanzu package
available get gatekeeper.community.tanzu.vmware.com/1.0.0 --values-schema`.
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/1938

## Describe testing done for PR

1. Bootstrap a cluster.

    ```sh
    tanzu standalone-cluster create -i docker test
    ```

1. Apply the package.

    ```sh
    kubectl apply -f addons/packages/gatekeeper/metadata.yaml
    kubectl apply -f addons/packages/gatekeeper/3.2.3/package.yaml
    ```

1. Verify values are now exposed.

    ```sh
    tanzu package available get gatekeeper.community.tanzu.vmware.com/1.0.0 --values-schema

    | Retrieving package details for gatekeeper.community.tanzu.vmware.com/1.0.0...
      KEY        DEFAULT            TYPE    DESCRIPTION
      namespace  gatekeeper-system  string  The namespace in which to deploy gatekeeper.
    ```

1. Verify the package installs

    ```sh
    tanzu package install gk --package-name gatekeeper.community.tanzu.vmware.com --version 1.0.0
    ```

    ```sh
    $ kubectl get po -A
    NAMESPACE           NAME                                                     READY   STATUS    RESTARTS   AGE
    gatekeeper-system   gatekeeper-audit-7fdbcfdb8-jl8ft                         1/1     Running   0          38s
    gatekeeper-system   gatekeeper-controller-manager-f8887b97d-hjxnj            1/1     Running   0          38s
    kube-system         antrea-agent-fq7gs                                       2/2     Running   0          11m
    kube-system         antrea-agent-xftl2                                       2/2     Running   0          11m
    kube-system         antrea-controller-86f8988c5f-tbbqk                       1/1     Running   0          11m
    kube-system         coredns-8dcb5c56b-482kd                                  1/1     Running   0          11m
    kube-system         coredns-8dcb5c56b-zmfm6                                  1/1     Running   0          11m
    kube-system         etcd-henro-control-plane-qq6cn                           1/1     Running   0          11m
    kube-system         kube-apiserver-henro-control-plane-qq6cn                 1/1     Running   0          11m
    kube-system         kube-controller-manager-henro-control-plane-qq6cn        1/1     Running   0          11m
    kube-system         kube-proxy-2lhmf                                         1/1     Running   0          11m
    kube-system         kube-proxy-qvzv7                                         1/1     Running   0          11m
    kube-system         kube-scheduler-henro-control-plane-qq6cn                 1/1     Running   0          11m
    tkg-system          kapp-controller-6499b8866-fhlmv                          1/1     Running   0          11m
    tkg-system          tanzu-capabilities-controller-manager-6ff97656b8-z7dcb   1/1     Running   0          11m
    tkr-system          tkr-controller-manager-6bc455b5d4-w8thd                  1/1     Running   0          11m
    ```

## Special notes for your reviewer

Alone with reviewing the diff, please validate the testing described above.
