### PR TITLE
[Doc] Documentation for Cluster Debugging

### DIFF
--- a/docs/site/content/docs/latest/tanzu-debugging-tips.md
+++ b/docs/site/content/docs/latest/tanzu-debugging-tips.md
@@ -1,0 +1,92 @@
+# Cluster Debugging Tips
+
+This section is a collection of common issues and how to debug them.
+
+## Bootstrap cluster fails to successfully pivot to a management cluster
+
+### Problem
+
+The bootstrap cluster fails to successfully pivots to a management cluster by hanging or returning an error similar to the following:
+
+```shell
+Error: unable to set up management cluster: unable to wait for cluster and get the cluster kubeconfig: error waiting for cluster to be provisioned (this may take a few minutes): cluster creation failed, reason:'NatGatewaysReconciliationFailed', message:'3 of 8 completed'
+```
+
+### Solution
+
+Access the pod log for your respective provider to identify the problem.
+
+1. On the machine running the bootstrap cluster, run `docker ps` to list the control plane container(s):
+
+```sh
+docker ps
+CONTAINER ID        IMAGE                                                             COMMAND                  CREATED             STATUS              PORTS                       NAMES
+2f505b8b0c8a        projects-stg.registry.vmware.com/tkg/kind/node:v1.21.2_vmware.1   "/usr/local/bin/entr…"   17 minutes ago      Up 17 minutes       127.0.0.1:33876->6443/tcp   tkg-kind-c51pdgq1m0cj2rffu1d0-control-plane
+3dd82b26ac04        projects-stg.registry.vmware.com/tkg/kind/node:v1.21.2_vmware.1   "/usr/local/bin/entr…"   About an hour ago   Up About an hour    127.0.0.1:46450->6443/tcp   tkg-kind-c51oina1m0co5l1khoa0-control-plane
+```
+
+The previous shows a list of active containers in docker (the output for your environment will vary). Make note of the container ID as it will be used in the following steps.
+
+1. Next, identify the controller-manager pod for your provider (for instance, for AWS it is `capa-controller-manager-*` in the `capa-system` namespace)
+
+```sh
+docker exec <CONTAINER_ID> kubectl get po --namespace capa-system --kubeconfig /etc/kubernetes/admin.conf
+NAMESPACE                           NAME                                                                  READY   STATUS    RESTARTS   AGE
+capa-system                         capa-controller-manager-<UINQUE_ID>                              2/2     Running   0          19m
+```
+
+The previous command will vary depending on your management cluster provider, as shown below:
+
+* AWS: `capa-controller-manager` / `capa-system`
+* Azure: `capz-controller-manager` / `capz-system`
+* docker: `capd-controller-manager` / `capd-system`
+* vSphere: `capv-controller-manager` / `capv-system`
+
+1. Retrieve the log for that controller to verify why it is unable to complete the management cluster provision:
+
+```shell
+docker exec <CONTAINDER_ID> kubectl logs capa-controller-manager-<UNIQUE_ID> -n capa-system -c manager --kubeconfig /etc/kubernetes/admin.conf
+```
+
+The log from the command above should provide hints for why the provider is unable to complete the management cluster provision.
+
+## Cleanup after an unsuccessful management deployment
+
+### Problem
+
+When a management cluster fails to deploy successfully (or partially deploys), it may leave orphaned objects in your bootstrap environment.
+
+### Solution
+
+Clean the bootstrap environment prior to a subsequent attempt of redeploying the management cluster.
+
+1. If the management cluster got partially created, attempt to delete the resources for the failed cluster:
+
+```shell
+tanzu management-cluster delete <YOUR-CLUSTER-NAME>
+```
+
+1. Next, if the bootstrap cluster still exists, delete it:
+
+```shell
+kind get clusters
+tkg-kind-b4o9sn5948199qbgca8d
+```
+
+```sh
+kind delete cluster --name tkg-kind-b4o9sn5948199qbgca8d
+```
+
+1. Use `docker` to stop and remove any running containers related to the bootstrap process
+
+```shell
+docker ps
+CONTAINER ID        IMAGE                                                             COMMAND                  CREATED             STATUS              PORTS                       NAMES
+2f505b8b0c8a        projects-stg.registry.vmware.com/tkg/kind/node:v1.21.2_vmware.1   "/usr/local/bin/entr…"   17 minutes ago      Up 17 minutes       127.0.0.1:33876->6443/tcp   tkg-kind-c51pdgq1m0cj2rffu1d0-control-plane
+3dd82b26ac04        projects-stg.registry.vmware.com/tkg/kind/node:v1.21.2_vmware.1   "/usr/local/bin/entr…"   About an hour ago   Up About an hour    127.0.0.1:46450->6443/tcp   tkg-kind-c51oina1m0co5l1khoa0-control-plane
+```
+
+```shell
+docker stop 2f505b8b0c8a && docker rm 2f505b8b0c8a
+docker stop 3dd82b26ac04 && docker rm 3dd82b26ac04
+```

--- a/docs/site/content/docs/latest/tanzu-diagnostics.md
+++ b/docs/site/content/docs/latest/tanzu-diagnostics.md
@@ -1,0 +1,124 @@
+# Troubleshooting with Tanzu Diagnostics
+
+Tanzu Community Edition comes with a diagnostics CLI plugin that helps with the task of collecting diagnostics data when debugging installation issues.  The plugin (based on the [Crash-Diagnostics project](https://github.com/vmware-tanzu/crash-diagnostics)) can automatically collect diagnostics data from either the boostrap, management, or a workload cluster (or all three) using the `tanzu diagnostics collect` command.
+
+## Pre-requisites
+
+Prior to collecting diagnostics data, your local machine must have the following programs in its $PATH:
+
+* Tanzu CLI
+* kind (for troubleshooting bootstrap cluster issues)
+* kubectl
+
+Other requirements include:
+
+* Access to a bootstrap cluster machine (if diagnosing bootstrap cluster)
+* Access to a management cluster and its managed workload clusters (if needed)
+
+## Collecting diagnostics
+
+The diagnostics tool can automatically collect logs, and API resources data, for all cluster types including bootstrap, management, and workload clusters.  By default, the diagnostics plugin will attempt to automatically collect data in the following order:
+
+```text
+[bootstrap cluster] --> [management cluster] --> [workload cluster]
+```
+
+The diagnostics plugin will follow the order above unless the user specifically skips either the bootstrap or the management cluster using a CLI argument. If a cluster type is not available (i.e. bootstrap for instance) the tool will simply skip it.
+
+### What is collected?
+
+The diagnostics plugin collects a set of known resources to help troubleshoot bootstrap cluster problems, including:
+
+* Kind cluster logs (obtained with command kind export logs)
+* Pod logs from `capi*, capv*, capa*, tkg-system` namespaces (if they exist)
+* Pods, services, deployments, apps (from `capi*, capv*, capa*, tkg-system` namespaces)
+* Any other server resources in the `cluster-api` resource category
+
+No other cluster objects are collected.
+
+The `tanzu diagnostics` command automatically generates a tar file which you can unpack to analyze and troubleshoot your cluster.
+
+### The `tanzu diagnostics collect` command
+
+The diagnostics command makes it easy for users to collect diagnostics data by supporting sensible default values. However, the command allows its default values to be overridden using CLI argument flags as listed below:
+
+```sh
+tanzu diagnostics collect --help
+Collect cluster diagnostics for the specified cluster
+
+Usage:
+  tanzu diagnostics collect [flags]
+
+Flags:
+      --bootstrap-cluster-name string          A specific bootstrap cluster name to diagnose
+      --bootstrap-cluster-skip                 If true, skips bootstrap cluster diagnostics
+  -h, --help                                   help for collect
+      --management-cluster-context string      The context name of the management cluster (required) (default "mgmt-webtier-1-admin@mgmt-webtier-1")
+      --management-cluster-kubeconfig string   The management cluster config file (required) (default "${HOME}/.kube-tkg/config")
+      --management-cluster-name string         The name of the management cluster (required) (default "mgmt-webtier-1")
+      --management-cluster-skip                If true, skips management cluster diagnostics
+      --output-dir string                      Output directory for collected bundle (default "./")
+      --work-dir string                        Working directory for collected data (default "${HOME}/.config/tanzu/diagnostics")
+      --workload-cluster-infra string          Overrides the infrastructure type for the managed cluster (i.e. aws, azure, vsphere, etc) (default "docker")
+      --workload-cluster-name string           The name of the managed cluster for which to collect diagnostics (required)
+      --workload-cluster-namespace string      The namespace where managed workload resources are stored (required)
+      --workload-cluster-standalone            If true, workload cluster is treated as standalone
+```
+
+## Collecting boostrap cluster diagnostics
+
+When setting up a management cluster, for the first time, it is possible for things to go wrong during the bootstrap stage or while pivoting to the management cluster stage.  If the bootstrap process is stuck or did not finish successfully, use the diagnostics plugin to collect logs and cluster information:
+
+```sh
+tanzu diagnostics collect
+```
+
+This command searches for Tanzu bootstrap kind clusters (with tkg-kind-* prefix) and collects logs and API objects that can help diagnose the bootstrap issues. You should see output similar to the following:
+
+```sh
+tanzu diagnostics collect
+2021/09/20 11:05:17 Collecting bootstrap cluster diagnostics
+2021/09/20 11:05:17 Info: Found bootstrap cluster(s): ["tkg-kind-b4o9sn5948199qbgca8d"]
+2021/09/20 11:05:17 Info: Bootstrap cluster: tkg-kind-b4o9sn5948199qbgca8d: capturing node logs
+2021/09/20 11:05:22 Info: Capturing pod logs: cluster=tkg-kind-b4o9sn5948199qbgca8d
+2021/09/20 11:05:22 Info: Capturing API objects: cluster=tkg-kind-b4o9sn5948199qbgca8d
+2021/09/20 11:05:25 Info: Archiving: bootstrap.tkg-kind-b4o9sn5948199qbgca8d.diagnostics.tar.gz
+```
+
+For more bootstrap cluster debugging, see additional instructions [here](./tsg-bootstrap).
+
+## Collecting management cluster diagnostics
+
+When your management cluster is not deployed properly, you can use the diagnostics plugin to collect data to help debug the issue. As before, use the following command collect diagnostics data:
+
+```sh
+tanzu diagnostics collect
+```
+
+The plugin will attempt to collect diagnostics for any boostrap cluster that still exists and then continues to collect diagnostics for the current management cluster.  You can specifically skip collection of your bootstrap cluster (if it exists) using the following command:
+
+```shell
+tanzu diagnostics collect --bootstrap-cluster-skip
+```
+
+## Collecting workload cluster diagnostics
+
+The plugin can also automate the collection of diagnostics data to debug issues with a workload cluster setup. This can be done by invoking the `diagnostics collect` command with the name of the workload cluster:
+
+```sh
+tanzu diagnostics collect --workload-cluster-name=<WORKLOAD_CLUSTER_NAME>
+```
+
+This command will attempt to collect diagnostics data for any boostrap cluster that still exists, diagnostics for the current management cluster, and diagnostics for the named workload cluster.  It is possible to skip collection for both the bootstrap and the management cluster as follows:
+
+```sh
+tanzu diagnostics collect --bootstrap-cluster-skip --management-cluster-skip --workload-cluster-name=<WORKLOAD_CLUSTER_NAME>
+```
+
+## Collecting standalone cluster diagnostics
+
+The plugin supports the collection of diagnostics data for Tanzu Community Edition standalone clusters.  The following command uses argument `--workload-cluster-standalone` to indicate that the cluster should be treated as standalone:
+
+```sh
+tanzu diagnostics collect --workload-cluster-standalone --workload-cluster-name=<WORKLOAD_CLUSTER_NAME>
+```

--- a/docs/site/data/docs/latest-toc.yml
+++ b/docs/site/data/docs/latest-toc.yml
@@ -179,6 +179,12 @@ toc:
           url: /solutions-secure-ingress
         - page: Monitoring with Prometheus and Grafana on vSphere
           url: /vsphere-monitoring-stack
+    - title: Cluster Debugging
+      subfolderitems:
+        - page: Troubleshooting with Tanzu Diagnostics
+          url: /tanzu-diagnostics
+        - page: Cluster Debugging Tips
+          url: /tanzu-debugging-tips
     - title: Designs
       subfolderitems:
         - page: Package Management


### PR DESCRIPTION
This PR introduces a new doc section that focuses on cluster debugging.
Right now it contains troubleshooting with tanzu diagnostics plugin and
a page for debugging tips.  Additional content can be added later.

Signed-off-by: Vladimir Vivien <vivienv@vmware.com>

## What this PR does / why we need it
To provide a top-level documentation for debugging/troubleshooting cluster issues.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```
