### PR TITLE
Remove ignoreImages from Imagelinter config

### DIFF
--- a/hack/.imagelintconfig.yaml
+++ b/hack/.imagelintconfig.yaml
@@ -7,13 +7,6 @@ includeLines:
 - FROM
 matchPattern:
 - "addons/packages/*/*/bundle/.imgpkg/*"
-ignoreImages:
-- "index.docker.io/grafana/grafana@sha256:4e5835bcfd55cf72563a06932f10c75d9d92a0e1334a4c83eaa9c5b897370b25"
-- "index.docker.io/rancher/local-path-provisioner@sha256:9666b1635fec95d4e2251661e135c90678b8f45fd0f8324c55db99c80e2a958c"
-- "k8s.gcr.io/external-dns/external-dns@sha256:e49f63e07498ce8484c9e9050c1dfbc2584f4c9c262433d80387e855725e6bce"
-- "index.docker.io/kiwigrid/k8s-sidecar@sha256:444be8cef8b25b4aaddea692ae09e3883d9064c0d31b43c4ba388a83c920552f"
-- "index.docker.io/minio/minio@sha256:e7e9a563f52bf95f614e8017c2da9bd5d9f2f1ae0dc1127767fa341b3ae22088"
-- "gcr.io/cadvisor/cadvisor@sha256:10638ceca79c01f4045f4a645242e763fe62eeb71d859ff93b09b0854a0d2220"
 succesValidators:
 - apt-get
 - apt

--- a/hack/imagelinter/config/imagelintconfig.yaml
+++ b/hack/imagelinter/config/imagelintconfig.yaml
@@ -7,13 +7,7 @@ includeLines:
 - FROM
 matchPattern:
 - "../../addons/packages/*/*/bundle/.imgpkg/*"
-ignoreImages:
-- "index.docker.io/grafana/grafana@sha256:4e5835bcfd55cf72563a06932f10c75d9d92a0e1334a4c83eaa9c5b897370b25"
-- "index.docker.io/rancher/local-path-provisioner@sha256:9666b1635fec95d4e2251661e135c90678b8f45fd0f8324c55db99c80e2a958c"
-- "k8s.gcr.io/external-dns/external-dns@sha256:e49f63e07498ce8484c9e9050c1dfbc2584f4c9c262433d80387e855725e6bce"
-- "index.docker.io/kiwigrid/k8s-sidecar@sha256:444be8cef8b25b4aaddea692ae09e3883d9064c0d31b43c4ba388a83c920552f"
-- "index.docker.io/minio/minio@sha256:e7e9a563f52bf95f614e8017c2da9bd5d9f2f1ae0dc1127767fa341b3ae22088"
-- "gcr.io/cadvisor/cadvisor@sha256:10638ceca79c01f4045f4a645242e763fe62eeb71d859ff93b09b0854a0d2220"
+ignoreImages: [] # ignoreImages key is to list down images that should be ignored during linting process.
 succesValidators:
 - apt-get
 - apt


### PR DESCRIPTION
As all images are successfully migrated, there is no need maintain ignoreImages from the ImageLinter config file.

Signed-off-by: Jiten Palaparthi <JPalaparthi@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
In order to imagelinter pass even before all the images were migrated we have added new key "ignoreImages" in config file.
As all the images were successfully migrated there is no need to maintain the list
## Details for the Release Notes (PLEASE PROVIDE)
None
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: # This does not fix any issue as such but this is because of the resolution of  https://github.com/vmware-tanzu/community-edition/pull/1970 

## Describe testing done for PR

ran `make imagelint` after https://github.com/vmware-tanzu/community-edition/pull/1970 is merged. Ran without any ignoreImages entries in the hack/.imagelintconfig.yaml file.

<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
