### PR TITLE
Update Velero documentation

### DIFF
--- a/addons/packages/velero/1.6.3/README.md
+++ b/addons/packages/velero/1.6.3/README.md
@@ -2,7 +2,18 @@
 
 This package provides safe operations to backup, restore, perform disaster recovery, and migrate TCE cluster resources and persistent volumes using the open source tool [Velero](https://velero.io/).
 
+## Supported Providers
+
+The following table shows the providers this package can work with.
+
+| AWS  |  Azure  | vSphere  | Docker |
+|:---:|:---:|:---:|:---:|
+| ✅  |  ✅  | 🚫  | ✅  |
+
 ## Components
+
+* Velero Deployment
+* Restic DaemonSet
 
 ### Custom Resources
 
@@ -24,9 +35,9 @@ Velero treats object storage as the source of truth. It continuously checks to s
 
 Velero runs on the cluster as a deployment alongside installed plugins that are specific to storage providers for backup and snapshot operations. It also includes controllers that process the custom resources to perform backups, restores, and all related operations.
 
-## Supported Providers
+## Providers
 
-The TCE Velero package provides support for these providers out of the box with minimum configuration.
+The TCE Velero package provides support for these providers out of the box with minimal configuration.
 
 | Provider                          | Object Store        | Volume Snapshotter           | Plugin Provider Repo                    | Setup Instructions            |
 |-----------------------------------|---------------------|------------------------------|-----------------------------------------|-------------------------------|
@@ -60,10 +71,14 @@ The following configuration values can be set to customize the Velero installati
 
 #### AWS storage
 
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
 | `backupStorageLocation.configAWS.region` | Required | The AWS region where the S3 bucket is located. |
 
 #### Azure storage
 
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
 | `backupStorageLocation.configAzure.resourceGroup` | Required | The name of the resource group containing the storage account for this backup storage location. |
 | `backupStorageLocation.configAzure.storageAccount` | Required | The name of the storage account for this backup storage location. |
 | `backupStorageLocation.configAzure.storageAccountKeyEnvVar` | Required | Required if using a storage account access key to authenticate rather than a service principal. |
@@ -73,9 +88,27 @@ The following configuration values can be set to customize the Velero installati
 
 #### Global configurations for snapshotting
 
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `volumeSnapshotLocation.snapshotsEnabled` | Required | Indicates whether to create a volumesnapshotlocation CR. If false => disable the snapshot feature. |
+| `volumeSnapshotLocation.name` | Required | The name of the volume snapshot location where snapshots are being taken. |
+| `volumeSnapshotLocation.spec.provider` | Required | The name for the volume snapshot provider. Required if snapshots are enabled. Valid values are `aws` and `azure` |
+
 #### AWS volumes
 
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `volumeSnapshotLocation.spec.configAWS.region` | Required | The AWS region where the volumes/snapshots are located |
+| `volumeSnapshotLocation.spec.configAWS.profile` | Optional | The AWS profile within the credentials file to use for the volume snapshot location. Default is "default". |
+
 #### Azure volumes
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `volumeSnapshotLocation.spec.configAzure.apiTimeout` | Optional | Indicates how long to wait for an Azure API request to complete before timeout. Defaults to 2m0s. |
+| `volumeSnapshotLocation.spec.configAzure.resourceGroup` | Optional | The name of the resource group where volume snapshots should be stored, if different from the cluster's resource group. |
+| `volumeSnapshotLocation.spec.configAzure.subscriptionId` | Optional | The ID of the subscription where volume snapshots should be stored, if different from the cluster's subscription. Requires "resourceGroup" to also be set. |
+| `volumeSnapshotLocation.spec.configAzure.incremental` | Optional | Azure offers the option to take full or incremental snapshots of managed disks. Set this parameter to true, to take incremental snapshots. If the parameter is omitted or set to false, full snapshots are taken (default). |
 
 ### Advanced
 
@@ -91,34 +124,173 @@ The following configuration values can be set to customize the Velero installati
 | `serviceAccount.annotations` | Optional |  Annotations for the ServiceAccount the RoleBinding should reference. |
 | `serviceAccount.labels` | Optional |  Labels for the ServiceAccount the RoleBinding should reference. |
 
-## Install and update
+## Installation
 
-Steps to install and configure:
+The Velero package can easily be installed to a cluster. However, for the package to function, you must configure settings for your cloud provider.
 
-- Install the package:
+### AWS Configuration
 
-Set `pkgname` to any name to identify the package by.
-Set `namespace` to any existing namespace.
+To configure Velero for AWS, you will first need to setup your AWS account. Your account will need the
+following:
 
-```sh
-tanzu package install $pkgname --package-name velero.community.tanzu.vmware.com --version 1.6.3 --namespace $namespace
-```
+* An S3 bucket to store the backups
+* IAM user with permissions to access EC2 and S3
 
-- Verify it was properly installed:
+There are multiple ways to configure your AWS account. Detailed instructions and other options can be found in the [velero-plugin-for-aws](https://github.com/vmware-tanzu/velero-plugin-for-aws#setup) setup instructions. This guide follows
+the first option in those instructions.
 
-```sh
-tanzu package installed list -A
-```
+> You will also need the AWS CLI to complete these steps. Follow the [user guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) to install it if needed.
 
-It should be installed in the namespace specified in the configuration. The default is `velero`.
+1. Create an S3 bucket to store backups.
 
-- Download and alter the ``values.yaml`` file from the TCE repository. Delete the first line the file starting with  `#@`, as this will cause an error when updating the package.
+    ```shell
+    export BUCKET=<< bucket name >>
+    export REGION=<< region >>
+    aws s3api create-bucket \
+        --bucket ${BUCKET} \
+        --region ${REGION}
+    ```
 
-- Update the package:
+1. Create an IAM user. This user will be explicitly for use with Velero, and given the appropriate permissions to perform backups.
 
-```sh
-tanzu package installed update $pkgname --version 1.6.3 --namespace $namespace --values-file $path/values.yaml
-```
+    ```shell
+    aws iam create-user --user-name velero
+    ```
+
+1. Create the policy that gives the necessary S3 and EC2 permissions.
+
+    ```shell
+    cat > velero-policy.json <<EOF
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:DescribeVolumes",
+                    "ec2:DescribeSnapshots",
+                    "ec2:CreateTags",
+                    "ec2:CreateVolume",
+                    "ec2:CreateSnapshot",
+                    "ec2:DeleteSnapshot"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:DeleteObject",
+                    "s3:PutObject",
+                    "s3:AbortMultipartUpload",
+                    "s3:ListMultipartUploadParts"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::${BUCKET}/*"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListBucket"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::${BUCKET}"
+                ]
+            }
+        ]
+    }
+    EOF
+    ```
+
+    Apply the policy to the `velero` IAM user.
+
+    ```shell
+    aws iam put-user-policy \
+      --user-name velero \
+      --policy-name velero \
+      --policy-document file://velero-policy.json
+    ```
+
+1. Create an access key for the `velero` user.
+
+    ```shell
+    aws iam create-access-key --user-name velero
+    ```
+
+    The response will look like the following:
+
+    ```json
+    {
+        "AccessKey": {
+            "UserName": "velero",
+            "AccessKeyId": "AKIA4CRA12345EXAMPLE",
+            "Status": "Active",
+            "SecretAccessKey": "RbJSykwB1Z3c094BKgfJi2YzBCG12345EXAMPLE",
+            "CreateDate": "2021-09-23T15:32:15+00:00"
+        }
+    }
+    ```
+
+    > Be sure to save the `AccessKeyId` and `SecretAccessKey` values in a safe place. This is the only time that you will
+    > have access to these values.
+
+1. Create a `values.yaml` file to configure the package to use AWS. Values that you will need to provide are:
+
+    * Bucket name
+    * Region
+    * AWS Access Key
+    * AWS Secret Access Key
+
+    ```shell
+    export AWS_ACCESS_KEY=<< AWS ACCESS KEY >>
+    export AWS_SECRET_ACCESS_KEY=<< AWS SECRET ACCESS KEY >>
+
+    cat > values.yaml <<EOF
+    ---
+    namespace: velero
+    deployRestic: false
+    credential:
+      useDefaultSecret: true
+      name: cloud-credentials
+      secretContents:
+        cloud: |
+          aws_access_key_id=${AWS_ACCESS_KEY}
+          aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    backupStorageLocation:
+      name: backup
+      spec:
+        provider: aws
+        default: true
+        objectStorage:
+          bucket: ${BUCKET}
+          prefix: backup
+        configAWS:
+          region: ${REGION}
+    volumeSnapshotLocation:
+      snapshotsEnabled: true
+      name: default
+      spec:
+        provider: aws
+        configAWS:
+          region: ${REGION}
+    EOF
+    ```
+
+1. Install the Velero package.
+
+    ```sh
+    tanzu package install velero --package-name velero.community.tanzu.vmware.com --version 1.6.3 --values-file values.yaml
+    ```
+
+1. Verify that the Velero package was properly installed.
+
+    ```sh
+    tanzu package installed list
+    | Retrieving installed packages...
+      NAME    PACKAGE-NAME                       PACKAGE-VERSION  STATUS
+      velero  velero.community.tanzu.vmware.com  1.6.3            Reconcile succeeded
+    ```
 
 ## Usage Example
 
@@ -128,73 +300,73 @@ This walkthrough guides you through an example disaster recovery scenario that l
 
 In the following steps, you will simulate a disaster scenario. Specifically, you will deploy a stateless workload, create a backup, delete the workload, and restore it from the backup.
 
-- Download the Velero CLI from the GitHub [releases](https://github.com/vmware-tanzu/velero/releases/latest) page. The following steps assume you have installed Velero into your PATH.
+1. Download the Velero CLI from the GitHub [releases](https://github.com/vmware-tanzu/velero/releases/latest) page. The following steps assume you have installed Velero into your PATH.
 
-- Create a new namespace for this example:
+1. Create a new namespace for this example:
 
-```sh
-kubectl create ns velero-example
-```
+    ```sh
+    kubectl create ns velero-example
+    ```
 
-- Deploy a sample workload into the new namespace:
+1. Deploy a sample workload into the new namespace:
 
-```sh
-kubectl create deploy -n velero-example nginx --image=nginx
-```
+    ```sh
+    kubectl create deploy -n velero-example nginx --image=nginx
+    ```
 
-- Verify the workload is up and running:
+1. Verify the workload is up and running:
 
-```sh
-kubectl get pods -n velero-example
-```
+    ```sh
+    kubectl get pods -n velero-example
+    ```
 
-The output should be similar to the following:
+    The output should be similar to the following:
 
-```sh
-NAME                     READY   STATUS    RESTARTS   AGE
-nginx-6799fc88d8-mm47k   1/1     Running   0          7s
-```
+    ```sh
+    NAME                     READY   STATUS    RESTARTS   AGE
+    nginx-6799fc88d8-mm47k   1/1     Running   0          7s
+    ```
 
-- Create a backup of the `velero-example` namespace:
+1. Create a backup of the `velero-example` namespace:
 
-```sh
-velero create backup velero-example --include-namespaces velero-example
-```
+    ```sh
+    velero create backup velero-example --include-namespaces velero-example
+    ```
 
-- Verify the backup completed successfully:
+1. Verify the backup completed successfully:
 
-```sh
-velero describe backup velero-example
-```
+    ```sh
+    velero describe backup velero-example
+    ```
 
-The output shows the "Phase" of the backup, which should be `Completed`.
+    The output shows the "Phase" of the backup, which should be `Completed`.
 
-- Delete the `velero-example` namespace to simulate a disaster scenario:
+1. Delete the `velero-example` namespace to simulate a disaster scenario:
 
-```sh
-kubectl delete ns velero-example
-```
+    ```sh
+    kubectl delete ns velero-example
+    ```
 
-- Verify that the namespace has been deleted:
+1. Verify that the namespace has been deleted:
 
-```sh
-kubectl get ns
-```
+    ```sh
+    kubectl get ns
+    ```
 
-- Restore the namespace from the velero backup:
+1. Restore the namespace from the velero backup:
 
-```sh
-velero create restore --from-backup velero-example
-```
+    ```sh
+    velero create restore --from-backup velero-example
+    ```
 
-- Validate that the `velero-example` namespace has been restored:
+1. Validate that the `velero-example` namespace has been restored:
 
-```sh
-kubectl get ns velero-example
-```
+    ```sh
+    kubectl get ns velero-example
+    ```
 
-- Validate that the workload has been restored:
+1. Validate that the workload has been restored:
 
-```sh
-kubectl get pods -n velero-example
-```
+    ```sh
+    kubectl get pods -n velero-example
+    ```

--- a/addons/packages/velero/1.6.3/bundle/config/values.yaml
+++ b/addons/packages/velero/1.6.3/bundle/config/values.yaml
@@ -119,7 +119,7 @@ backupStorageLocation:
 #! in the cluster via the VolumeSnapshotLocation CRD.
 #! For documentation, see https://velero.io/docs/v1.6/api-types/volumesnapshotlocation/.
 volumeSnapshotLocation:
-  #! snapshotsEnabled indicatges whether to create a volumesnapshotlocation CR. If false => disable the snapshot feature.
+  #! snapshotsEnabled Indicates whether to create a volumesnapshotlocation CR. If false => disable the snapshot feature.
   snapshotsEnabled: true
   #! name is the name of the volume snapshot location where snapshots are being taken. Required.
   name: default

--- a/addons/packages/velero/1.6.3/package.yaml
+++ b/addons/packages/velero/1.6.3/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/velero@sha256:99e3f74701420432d6657aa344fc4c8da89d54fe812d23baa445461ec9e73e0f
+            image: projects.registry.vmware.com/tce/velero@sha256:1f60610466619928d0e54eaac4bc4f43c7cb8752077ecd2d507bfcd81d480c2d
       template:
         - ytt:
             paths:
@@ -24,3 +24,353 @@ spec:
               - .imgpkg/images.yml
       deploy:
         - kapp: {}
+  valuesSchema:
+    openAPIv3:
+      title: velero.community.tanzu.vmware.com.1.6.3 values schema
+      properties:
+        namespace:
+          type: string
+          description: The namespace in which to deploy Velero.
+          default: velero
+        deployRestic:
+          type: boolean
+          description:  Whether to deploy the restic daemonset
+          default: false
+        credential:
+          type: object
+          description: >
+            Configuration for the secret to be used by the Velero deployment and the restic Daemonset,
+            which should contain credentials for the cloud provider IAM account set up for Velero.
+            For full documentation, see: https://velero.io/docs/v1.6/locations/#create-a-storage-location-that-uses-unique-credentials.
+          properties:
+            useDefaultSecret:
+              type: boolean
+              description: >
+                Whether the secret created by default should be used as the source of IAM account credentials.
+                If not set to `true`, the secret to be used must be indicated in the
+                `backupStorageLocation.spec.existingSecret`. If set to `true`, the raw content must be specified below
+                in the `credential.secretContents.cloud`.
+              default: true
+            name:
+              type: string
+              description: >
+                The name of the secret to configure if `credential.useDefaultSecret` is true.
+                Required if `useDefaultSecret` is true.
+              default: cloud-credentials
+            secretContents:
+              type: string
+              description: |
+                secretContents is the data to be stored in the default Velero secret. For the default secret, the key
+                must be named `cloud`, and the value corresponds to the entire content of your IAM credentials file.
+                Note that the format will be different for different providers, please check their documentation.
+                Required if `useDefaultSecret` is true.
+                Example:
+                cloud: |
+                  aws_access_key_id=<redacted>
+                  aws_secret_access_key=<redacted>
+              default: ""
+            extraEnvVars:
+              type: string
+              description: >
+                additional key/value pairs to be used as environment variables such as "DIGITALOCEAN_TOKEN: <your-key>".
+                Values will be stored in the secret.
+              default: ""
+            extraSecretRef:
+              type: string
+              description: >
+                extraSecretRef is the name of any pre-existing secret (if any) in the namespace where Velero is installed
+                and that will be used to load environment variables into velero and restic. Secret should be in format -
+                https://kubernetes.io/docs/concepts/configuration/secret/#use-case-as-container-environment-variables
+              default: ""
+        backupStorageLocation:
+          type: object
+          description: >
+            Configuration for locations where Velero can store backups represented in the cluster via the
+            BackupStorageLocation CRD. Backups can be stored in a number of locations, and Velero must have at least one
+            BackupStorageLocation. For documentation, see https://velero.io/docs/v1.6/api-types/backupstoragelocation/.
+          properties:
+            name:
+              type: string
+              description: >
+                The name of the backup storage location where backups should be stored. If a name is not provided,
+                a backup storage location will be created with the name "default". Required.
+              default: default
+            spec:
+              type: object
+              description: >
+                Configurations for a backup storage location.
+              properties:
+                provider:
+                  type: string
+                  description: |
+                    The name of the object store plugin used to connect to this location. Required.
+                    Valid values: `aws`, `azure`
+                default:
+                  type: boolean
+                  description:  Indicates if this location is the default backup storage location. Optional.
+                  default: true
+                backupSyncPeriod:
+                  type: string
+                  description: |
+                    Indicates how frequently Velero should synchronize backups in object storage.
+                    Set this to 0s to disable sync.
+                  default: 1m
+                validationFrequency:
+                  type: string
+                  description: |
+                    Indicates how frequently Velero should validate the object storage (if it is still connected, for example).
+                    Set this to 0s to disable validation.
+                  default: 1m
+                accessMode:
+                  type: string
+                  description: |
+                    How Velero can access the backup storage location.
+                    Valid values are `ReadWrite` and `ReadOnly`
+                    Set this to 0s to disable sync.
+                  default: ReadWrite
+                existingSecret:
+                  type: object
+                  description: |
+                    existingSecret should be a secret separately created in the namespace where Velero is installed.
+                    Applies only if `credential.useDefaultSecret` is set to `false`. Optional.
+                    For documentation on how to use: https://velero.io/docs/v1.6/locations/#create-a-storage-location-that-uses-unique-credentials.
+                  properties:
+                    name:
+                      type: string
+                      description: The name of the secret
+                      default: ""
+                    key:
+                      type: string
+                      description: Key used within the secret
+                      default: ""
+                objectStorage:
+                  type: object
+                  description: |
+                    A set of configurations specific to the object store
+                  properties:
+                    bucket:
+                      type: string
+                      description: The name of the bucket to store backups in. Required.
+                      default: ""
+                    caCert:
+                      type: string
+                      description: defines a base64 encoded CA bundle to use when verifying TLS connections to the provider. Optional.
+                      default: ""
+                    prefix:
+                      type: string
+                      description: The directory under which all Velero data should be stored within the bucket. Optional.
+                      default: ""
+                configAWS:
+                  type: object
+                  description: Configuration specific to the AWS plugin.
+                  properties:
+                    region:
+                      type: string
+                      description: |
+                        Region is the AWS region where the bucket is located. Queried from the AWS S3 API if not provided.
+                        Set to  "minio" if using a local storage service like MinIO.
+                        Note: when used, MinIO must be run as a standalone. See the documentation:
+                        https://docs.min.io/minio/baremetal/installation/deploy-minio-standalone.html
+                        Required.
+                      default: ""
+                    s3ForcePathStyle:
+                      type: boolean
+                      description: >
+                        Indicates whether to use path-style addressing instead of virtual hosted bucket addressing. Set to "true"
+                        if using a local storage service like MinIO.
+                      default: false
+                    s3Url:
+                      type: string
+                      description: >
+                        You can specify the AWS S3 URL here for explicitness, but Velero can already generate it from
+                        "region" and "bucket". This field is primarily for local storage services like MinIO. Optional.
+                      default: ""
+                    publicUrl:
+                      type: string
+                      description: >
+                        If specified, use this instead of "s3Url" when generating download URLs (e.g., for logs). This
+                        field is primarily for local storage services like MinIO. Optional.
+                      default: ""
+                    serverSideEncryption:
+                      type: string
+                      description: >
+                        The name of the server-side encryption algorithm to use for uploading objects, e.g. "AES256".
+                        If using SSE-KMS and "kmsKeyId" is specified, this field will automatically be set to "aws:kms"
+                        so does not need to be specified by the user. Optional.
+                      default: "aws:kms"
+                    kmsKeyId:
+                      type: string
+                      description: >
+                        Specifies an AWS KMS key ID (formatted per the example) or alias (formatted as "alias/<KMS-key-alias-name>")
+                        to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly
+                        granting key usage rights. Optional.
+                      default: ""
+                    signatureVersion:
+                      type: string
+                      description: >
+                        The version of the signature algorithm used to create signed URLs that are used by Velero CLI to
+                        download backups or fetch logs. Possible versions are "1" and "4". Usually the default version
+                        4 is correct, but some S3-compatible providers like Quobyte only support version 1.
+                      default: "4"
+                    profile:
+                      type: string
+                      description: The AWS profile within the credentials file to use for the backup storage location.
+                      default: "default"
+                    insecureSkipTLSVerify:
+                      type: boolean
+                      description: >
+                        Set to "true" if you do not want to verify the TLS certificate when connecting to the
+                        object store -- like for self-signed certs with MinIO. This is susceptible to man-in-the-middle
+                        attacks and is not recommended for production.
+                      default: false
+                configAzure:
+                  type: object
+                  description: >
+                    Configuration specific to the Azure plugin. For the original documentation: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/v1.2.1/backupstoragelocation.md.
+                  properties:
+                    resourceGroup:
+                      type: string
+                      description: >
+                        The name of the resource group containing the storage account for this backup storage location. Required.
+                      default: ""
+                    storageAccount:
+                      type: string
+                      description: >
+                        The name of the storage account for this backup storage location. Required.
+                      default: ""
+                    storageAccountKeyEnvVar:
+                      type: string
+                      description: |
+                        The environment variable in $AZURE_CREDENTIALS_FILE that contains storage account key for this backup storage location.
+                        Required if using a storage account access key to authenticate rather than a service principal.
+                      default: ""
+                    subscriptionId:
+                      type: string
+                      description: >
+                        The ID of the subscription for this backup storage location. Optional.
+                      default: ""
+                    blockSizeInBytes:
+                      type: integer
+                      description: |
+                        The block size, in bytes, to use when uploading objects to Azure blob storage.
+                        See https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs#about-block-blobs
+                        for more information on block blobs.
+                      default: 104857600
+        volumeSnapshotLocation:
+          type: object
+          description: >
+            Configuration for volume snapshot location in which to store the volume snapshots created for a backup in
+            the cluster via the VolumeSnapshotLocation CRD. For documentation, see
+            https://velero.io/docs/v1.6/api-types/volumesnapshotlocation/.
+          properties:
+            snapshotEnabled:
+              type: boolean
+              description: >
+                Indicates whether to create a volumesnapshotlocation CR. If false => disable the snapshot feature.
+              default: true
+            name:
+              type: string
+              description: >
+                The name of the volume snapshot location where snapshots are taken. Required.
+              default: "default"
+            provider:
+              type: string
+              description: |
+                The name for the volume snapshot provider.
+                Valid values: `aws`, `azure`
+            configAWS:
+              type: object
+              description: >
+                configAWS contains configuration specific to the AWS plugin. For the original documentation:
+                https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.2.1/backupstoragelocation.md.
+              properties:
+                region:
+                  type: string
+                  description: >
+                    The AWS region where the volumes/snapshots are located. Required.
+                  default: ""
+                profile:
+                  type: string
+                  description: >
+                    The AWS profile within the credentials file to use for the volume snapshot location.
+                  default: "default"
+            configAzure:
+              type: object
+              description: >
+                Configuration specific to the Azure plugin
+              properties:
+                apiTimeout:
+                  type: string
+                  description: >
+                    Indicates how long to wait for an Azure API request to complete before timeout. Defaults to 2m0s.
+                  default: "2m0s"
+                resourceGroup:
+                  type: string
+                  description: >
+                    The name of the resource group where volume snapshots should be stored, if different from the
+                    cluster's resource group. Optional.
+                  default: ""
+                subscriptionId:
+                  type: string
+                  description: >
+                    The ID of the subscription where volume snapshots should be stored, if different from the cluster's
+                    subscription. Requires "resourceGroup" to also be set. Optional.
+                  default: ""
+                incremental:
+                  type: boolean
+                  description: |
+                    Azure offers the option to take full or incremental snapshots of managed disks.
+                    - Set this parameter to true, to take incremental snapshots.
+                    - If the parameter is omitted or set to false, full snapshots are taken (default).
+                    Optional.
+                  default: false
+        rbac:
+          type: object
+          description: Role based access controls for Velero.
+          properties:
+            create:
+              type: boolean
+              description:
+              default: false
+            clusterAdministrator:
+              type: boolean
+              description:
+              default: false
+            name:
+              type: string
+              description: The name of the cluster role binding.
+              default: velero
+            roleRefName:
+              type: string
+              description: The name of the role.
+              default: velero
+            clusterRoleAPIGroups:
+              type: array
+              description: Array of the cluster role API groups.
+              items:
+                type: string
+            clusterRoleVerbs:
+              type: array
+              description: Array of the cluster role verbs.
+              default: ["get", "watch", "list"]
+              items:
+                type: string
+        serviceAccount:
+          type: object
+          description: Information about the Kubernetes service account Velero uses.
+          properties:
+            name:
+              type: string
+              description: The name for the service account
+              default: velero
+            annotations:
+              type: object
+              additionalProperties: string
+              description: Annotations to set on the Velero service account.
+              default: {}
+            labels:
+              type: object
+              additionalProperties: array
+              description: Labels to set on the Velero service account.
+              items:
+                type: string


### PR DESCRIPTION
## What this PR does / why we need it

This adds AWS configuration instructions to the Velero 1.6.3 readme.
Adds OpenAPI Schema to Velero 1.6.3 `package.yaml`

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Updates Velero documentation to include AWS configuration and OpenAPI Schema information.
```

## Which issue(s) this PR fixes
Fixes: #1914

## Describe testing done for PR

- Installed and configured the Velero package according to the steps.
- Created a package repository and viewed the values schema.

## Special notes for your reviewer

-