### PR TITLE
Display errors when shell commands fail generating a package repo #1991

### DIFF
--- a/hack/packages/generate-package-repository.go
+++ b/hack/packages/generate-package-repository.go
@@ -7,6 +7,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -102,8 +103,10 @@ func main() {
 }
 
 func execCommand(command string, commandArgs []string) {
-	_, err := exec.Command(command, commandArgs...).CombinedOutput()
-	check(err)
+	output, err := exec.Command(command, commandArgs...).CombinedOutput()
+	if err != nil {
+		log.Fatal(string(output))
+	}
 }
 
 func copyYaml(packageFilepath string, outputFile *os.File) {


### PR DESCRIPTION
Signed-off-by: Nicholas Seemiller <nseemiller@vmware.com>

## What this PR does / why we need it

When generating a package repo using the make task, `make generate-package-repo CHANNEL=foo`, and an error occurs, display the error from the shell'ed command.

At the moment, the program panics and displays a stack trace. It is difficult to debug at this point.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Display better error message when generating a package repo fails.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1991 

## Describe testing done for PR

1. Create a new repo yaml file.
```
cat <<EOF >addons/repos/test.yaml
---
packages:
  - name: velero
    versions:
      - 1.6.3
EOF
```

1. Manually introduce an error in to the Velero 1.6.3 `package.yaml` file
1. Attempt to generate a package repo
```sh
make generate-package-repo CHANNEL=test
```
1. Observe message that `kbld` encountered an error

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
