### PR TITLE
Post MVP - Day 1: Update MacOS and Linux install documentation to `brew`

### DIFF
--- a/docs/site/content/docs/assets/cli-install-linux.md
+++ b/docs/site/content/docs/assets/cli-install-linux.md
@@ -1,5 +1,31 @@
 ## Installation Procedure
 
+1. You must download and install the latest version of `kubectl`. For more information, see [Install and Set Up kubectl on Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/) in the Kubernetes documentation.
+
+1. You must download and install the latest version of `docker`. For more information, see [Install Docker Engine](https://docs.docker.com/engine/install/) in the Docker documentation.
+
+### Option 1: Homebrew
+
+1. Make sure you have the [Homebrew package manager installed](https://brew.sh/)
+
+1. Run the following in your terminal:
+
+    ```sh
+    brew tap vmware-tanzu/tanzu
+    brew install tce
+    ```
+
+1. Run the post install configuration script. Note the output of the `brew install` step for the correct location of the configure script:
+
+    ```sh
+    {HOMEBREW-INSTALL-LOCATION}/configure-tce.sh
+    ```
+
+    > This puts all the Tanzu plugins in the correct location.
+    > The first time you run the `tanzu` command the installed plugins and plugin repositories are initialized. This action might take a minute.
+
+### Option 2: Curl GitHub release
+
 1. Download the release for [Linux](https://github.com/vmware-tanzu/community-edition/releases/download/{{< release_latest >}}/tce-linux-amd64-{{< release_latest >}}.tar.gz) via web browser.
 
 1. _[Alternative]_ Download the release using the CLI. You may download a release using the provided remote script piped into bash.

--- a/docs/site/content/docs/assets/cli-install-mac.md
+++ b/docs/site/content/docs/assets/cli-install-mac.md
@@ -1,21 +1,23 @@
 ## Installation Procedure
 
-1. Download the release for [macOS](https://github.com/vmware-tanzu/community-edition/releases/download/{{< release_latest >}}/tce-darwin-amd64-{{< release_latest >}}.tar.gz).
+1. Make sure you have the [Homebrew package manager installed](https://brew.sh/)
 
-1. Unpack the release.
+1. You must download and install the latest version of `kubectl`. For more information, see [Install and Set Up kubectl on MacOS](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/) in the Kubernetes documentation.
 
-    ```sh
-    tar xzvf ~/<DOWNLOAD-DIR>/tce-darwin-amd64-{{< release_latest >}}.tar.gz
-    ```
+1. You must download and install the latest version of `docker`. For more information, see [Install Docker Desktop on MacOS](https://docs.docker.com/desktop/mac/install/) in the Docker documentation.
 
-1. Run the install script.
+1. Run the following in your terminal:
 
     ```sh
-    cd tce-darwin-amd64-{{< release_latest >}}
-    ./install.sh
+    brew tap vmware-tanzu/tanzu
+    brew install tce
     ```
 
-    > This installs the `Tanzu` CLI and puts all the plugins in the correct location.
+1. Run the post install configuration script. Note the output of the `brew install` step for the correct location of the configure script:
+
+    ```sh
+    {HOMEBREW-INSTALL-LOCATION}/configure-tce.sh
+    ```
+
+    > This puts all the Tanzu plugins in the correct location.
     > The first time you run the `tanzu` command the installed plugins and plugin repositories are initialized. This action might take a minute.
-
-1. You must download and install the latest version of `kubectl`. For more information, see [Install and Set Up kubectl on macOS](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/) in the Kubernetes documentation.


### PR DESCRIPTION
⚠️ This PR is for post-launch. This will not work until Monday, Oct 4 when the repos are made public  ⚠️

## What this PR does / why we need it
Updates linux and macos documentation to perfer the `brew` method of install. 

Leaves the `curl` method of install for linux since users may perfer that over using the `brew` package manager

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Updates documentation for macos and linux to use `brew`
```

## Which issue(s) this PR fixes
Fixes: #2014

## Describe testing done for PR
`hugo serve` and all links look good

## Special notes for your reviewer
N/a
