### PR TITLE
addons/packages/pinniped: Update Pinniped cert-manager API version to v1

### DIFF
--- a/addons/packages/pinniped/0.4.4/bundle/config/certificates.lib.yaml
+++ b/addons/packages/pinniped/0.4.4/bundle/config/certificates.lib.yaml
@@ -3,7 +3,7 @@
 #@ load("@ytt:yaml", "yaml")
 
 #@ def get_issuer():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: "issuer"
@@ -47,7 +47,7 @@ spec:
 #@ end
 
 #@ def get_certificate():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "certificate"


### PR DESCRIPTION
## What this PR does / why we need it
The Pinniped package currently uses `cert-manager.io/v1alpha2` cert-manager APIs.  This version of cert-manager is deprecated and will be removed.  This PR updates Pinniped cert-manager API version to v1.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Update Pinniped cert-manager API version from v1alpha2 to v1
```

## Which issue(s) this PR fixes
None

## Describe testing done for PR
I built the Pinniped package revision from this PR into a core PackageRepository and deployed that into a 1.5 TKG environment. Then I configured OIDC on a management cluster, configured RBAC for the given user, successfully logged in and listed pods

## Special notes for your reviewer
Feel free to reach out with any questions!
