### PR TITLE
[Docs] Removes references to `--config` for `tanzu package` command

### DIFF
--- a/addons/packages/harbor/2.2.3/README.md
+++ b/addons/packages/harbor/2.2.3/README.md
@@ -60,7 +60,7 @@ The Harbor package requires use of Contour for ingress, cert-manager for certifi
    1. Run the following command to apply the configuration:
 
       ```sh
-      tanzu package install contour.community.tanzu.vmware.com --config contour.community.tanzu.vmware.com-values.yaml
+      tanzu package install contour -p contour.community.tanzu.vmware.com -v 1.17.1 --values-file contour-values.yaml
       ```
 
 1. Configure Harbor Package


### PR DESCRIPTION
## What this PR does / why we need it

- There are still a few references to `--config` when instructing users to configure a package install. This flag has been replaced by the `--values-file` flag.

- Removes another reference found the the `config` argument which would download the values.yaml file from the package bundle. This no longer exists and users should be instructed to use the `--values-schema` flag

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Bump docs to not include --config flag for package install
```

## Which issue(s) this PR fixes
Related: https://github.com/vmware-tanzu/community-edition/issues/1993

## Describe testing done for PR
`hugo serve` and 👍 

## Special notes for your reviewer
n/a
