### PR TITLE
Fix for exit non failure on Fail(Alpine Image) status

### DIFF
--- a/hack/.imagelintconfig.yaml
+++ b/hack/.imagelintconfig.yaml
@@ -7,6 +7,7 @@ includeLines:
 - FROM
 matchPattern:
 - "addons/packages/*/*/bundle/.imgpkg/*"
+- "addons/packages/*/*/*.yaml"
 succesValidators:
 - apt-get
 - apt

--- a/hack/imagelinter/main.go
+++ b/hack/imagelinter/main.go
@@ -102,7 +102,7 @@ func IsAlpine(imc *imglint.ImageLintConfig, wrapper *imgwrapper.Wrapper, key str
 			imc.OnEvent("Fail", "Alpine Image", key)
 			_, err = wrapper.DeleteContainer()
 			if err != nil {
-				return false, false, err
+				return true, false, err
 			}
 			return true, true, nil
 		}
@@ -186,7 +186,9 @@ func LintAll(imc *imglint.ImageLintConfig, wrapper *imgwrapper.Wrapper, key stri
 		_, err := wrapper.ContainerCP("/etc/os-release", "./")
 		if err == nil {
 			fatal, cont, err := IsAlpine(imc, wrapper, key)
-			isFatal = fatal
+			if fatal {
+				isFatal = fatal
+			}
 			if cont {
 				return true, err
 			}
@@ -194,7 +196,9 @@ func LintAll(imc *imglint.ImageLintConfig, wrapper *imgwrapper.Wrapper, key stri
 		_, err = wrapper.ContainerCP("/usr/lib/os-release", "./")
 		if err == nil {
 			fatal, cont, err := IsAlpine(imc, wrapper, key)
-			isFatal = fatal
+			if fatal {
+				isFatal = fatal
+			}
 			if cont {
 				return true, err
 			}


### PR DESCRIPTION
This fixes issue as on fail instead of exit(1) linter is exit(0)
Add new item in matchPattern key in configuration file

Signed-off-by: Jiten Palaparthi <JPalaparthi@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This fixes issue as on fail instead of exit(1) linter is exit(0)
Add new item in matchPattern key in configuration file
## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: # N/A

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested on local machine
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
