### PR TITLE
Use a semantic version instead of stable tag for installing pkg repo …

### DIFF
--- a/docs/site/content/docs/assets/package-installation.md
+++ b/docs/site/content/docs/assets/package-installation.md
@@ -14,7 +14,7 @@ detailed instruction on package management, see [Work with Packages](../package-
 1. Install the Tanzu Community Edition package repository into the `tanzu-package-repo-global` namespace.
 
     ```sh
-    tanzu package repository add tce-repo --url projects.registry.vmware.com/tce/main:stable --namespace tanzu-package-repo-global
+    tanzu package repository add tce-repo --url projects.registry.vmware.com/tce/main:0.9.1 --namespace tanzu-package-repo-global
     ```
 
     > Repositories installed into the `tanzu-package-repo-global` namespace will provide their packages to the entire
@@ -34,7 +34,7 @@ detailed instruction on package management, see [Work with Packages](../package-
     / Retrieving repositories...
       NAME      REPOSITORY                                    STATUS
     DETAILS
-      tce-repo  projects.registry.vmware.com/tce/main:stable  Reconcile succeeded
+      tce-repo  projects.registry.vmware.com/tce/main:0.9.1  Reconcile succeeded
     ```
 
     > A `tanzu-core` repository is also installed in the `tkg-system` namespace

--- a/docs/site/content/docs/latest/designs/package-repositories-and-versioning.md
+++ b/docs/site/content/docs/latest/designs/package-repositories-and-versioning.md
@@ -109,7 +109,7 @@ when it is, we'll try to use the first case as a reference implementation.
 
 ### Package Promotion in Repositories
 
-For a package to be promoted in the `main:stable` community package repository,
+For a package to be promoted in the `main` community package repository,
 the following must be true.
 
 1. A pull request incrementing the available package versioning the package

--- a/docs/site/content/docs/latest/docker-monitoring-stack.md
+++ b/docs/site/content/docs/latest/docker-monitoring-stack.md
@@ -68,7 +68,7 @@ By default, only the `tanzu core` packages are available on the standalone clust
 To access the community packages, you will first need to add the `tce` repository.
 
 ```sh
-% tanzu package repository add tce-repo --url projects.registry.vmware.com/tce/main:stable
+% tanzu package repository add tce-repo --url projects.registry.vmware.com/tce/main:0.9.1
 / Adding package repository 'tce-repo'...
 Added package repository 'tce-repo'
  ```
@@ -79,13 +79,13 @@ Monitor the repo until the STATUS changes to `Reconcile succeeded`. The communit
 % tanzu package repository list -A
 / Retrieving repositories...
   NAME        REPOSITORY                                                                                 STATUS               DETAILS  NAMESPACE
-  tce-repo    projects.registry.vmware.com/tce/main:stable                                               Reconciling                   default
+  tce-repo    projects.registry.vmware.com/tce/main:0.9.1                                               Reconciling                   default
   tanzu-core  projects-stg.registry.vmware.com/tkg/packages/core/repo:v1.21.2_vmware.1-tkg.1-zshippable  Reconcile succeeded           tkg-system
 
 % tanzu package repository list -A
 / Retrieving repositories...
   NAME        REPOSITORY                                                                                 STATUS               DETAILS  NAMESPACE
-  tce-repo    projects.registry.vmware.com/tce/main:stable                                               Reconcile succeeded           default
+  tce-repo    projects.registry.vmware.com/tce/main:0.9.1                                               Reconcile succeeded           default
   tanzu-core  projects-stg.registry.vmware.com/tkg/packages/core/repo:v1.21.2_vmware.1-tkg.1-zshippable  Reconcile succeeded           tkg-system
   ```
 

--- a/docs/site/content/docs/latest/package-management.md
+++ b/docs/site/content/docs/latest/package-management.md
@@ -53,7 +53,7 @@ tanzu package repository \
 
     ```sh
     tanzu package repository add tce-repo \
-      --url projects.registry.vmware.com/tce/main:stable \
+      --url projects.registry.vmware.com/tce/main:0.9.1 \
       --namespace tanzu-package-repo-global
     ```
 
@@ -62,7 +62,7 @@ tanzu package repository \
 
     ```sh
     tanzu package repository add tce-repo \
-      --url projects.registry.vmware.com/tce/main:stable
+      --url projects.registry.vmware.com/tce/main:0.9.1
     ```
 
 ### Discovering Package Repositories

--- a/docs/site/content/docs/latest/vsphere-monitoring-stack.md
+++ b/docs/site/content/docs/latest/vsphere-monitoring-stack.md
@@ -52,7 +52,7 @@ To access the community packages, you will first need to add the `tce` repositor
 
 ```sh
 % tanzu package repository add tce-repo \
-  --url projects.registry.vmware.com/tce/main:stable
+  --url projects.registry.vmware.com/tce/main:0.9.1
 / Adding package repository 'tce-repo'...
  Added package repository 'tce-repo'
  ```
@@ -63,7 +63,7 @@ Monitor the repo until the STATUS changes to `Reconcile succeeded`. The communit
 % tanzu package repository list -A
 | Retrieving repositories...
   NAME        REPOSITORY                                                                                 STATUS               DETAILS  NAMESPACE
-  tce-repo    projects.registry.vmware.com/tce/main:stable                                               Reconcile succeeded           default
+  tce-repo    projects.registry.vmware.com/tce/main:0.9.1                                               Reconcile succeeded           default
   tanzu-core  projects-stg.registry.vmware.com/tkg/packages/core/repo:v1.21.2_vmware.1-tkg.1-zshippable  Reconcile succeeded           tkg-system
   ```
 

--- a/test/add-tce-package-repo.sh
+++ b/test/add-tce-package-repo.sh
@@ -13,7 +13,7 @@ MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo "Adding TCE package repository..."
 
 REPO_NAME="tce-main-latest"
-REPO_URL="projects.registry.vmware.com/tce/main:stable"
+REPO_URL="projects.registry.vmware.com/tce/main:0.9.1"
 REPO_NAMESPACE="default"
 
 # TODO: Use stable version of the tce/main repo once https://github.com/vmware-tanzu/community-edition/issues/1250 is fixed


### PR DESCRIPTION
## What this PR does / why we need it

Due to garbage collection and caching issues with our OCI Registry, it is not advisable to (re)use a tag like `stable` or `latest` in installation instructions for the package repository. Instead, we should reference a semantic version of the repo.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Use a semantic version instead of stable in package repo installation docs
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2084 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
