### PR TITLE
fix ako 1.5.3 configmap data value format error

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.5.3/bundle/config/overlays/overlay-configmap.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.5.3/bundle/config/overlays/overlay-configmap.yaml
@@ -10,89 +10,89 @@ metadata:
   name: avi-k8s-config
   namespace: #@ values.loadBalancerAndIngressService.namespace
 data:
-  controllerIP: #@ values.loadBalancerAndIngressService.config.controller_settings.controller_ip
+  controllerIP: #@ "{}".format(values.loadBalancerAndIngressService.config.controller_settings.controller_ip)
 #@ if values.loadBalancerAndIngressService.config.controller_settings.controller_version:
   #@overlay/match missing_ok=True
-  controllerVersion: #@ values.loadBalancerAndIngressService.config.controller_settings.controller_version
+  controllerVersion: #@ "{}".format(values.loadBalancerAndIngressService.config.controller_settings.controller_version)
 #@ end
 #@ if values.loadBalancerAndIngressService.config.ako_settings.cni_plugin:
   #@overlay/match missing_ok=True
-  cniPlugin: #@ values.loadBalancerAndIngressService.config.ako_settings.cni_plugin
+  cniPlugin: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.cni_plugin)
 #@ end
 #@ if values.loadBalancerAndIngressService.config.l7_settings.shard_vs_size:
   #@overlay/match missing_ok=True
-  shardVSSize: #@ values.loadBalancerAndIngressService.config.l7_settings.shard_vs_size
+  shardVSSize: #@ "{}".format(values.loadBalancerAndIngressService.config.l7_settings.shard_vs_size)
 #@ end
 #@ if values.loadBalancerAndIngressService.config.l7_settings.pass_through_shardsize:
   #@overlay/match missing_ok=True
-  passthroughShardSize: #@ values.loadBalancerAndIngressService.config.l7_settings.pass_through_shardsize
+  passthroughShardSize: #@ "{}".format(values.loadBalancerAndIngressService.config.l7_settings.pass_through_shardsize)
 #@ end
-  fullSyncFrequency: #@ values.loadBalancerAndIngressService.config.ako_settings.full_sync_frequency
-  cloudName: #@ values.loadBalancerAndIngressService.config.controller_settings.cloud_name
-  clusterName: #@ values.loadBalancerAndIngressService.config.ako_settings.cluster_name
+  fullSyncFrequency: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.full_sync_frequency)
+  cloudName: #@ "{}".format(values.loadBalancerAndIngressService.config.controller_settings.cloud_name)
+  clusterName: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.cluster_name)
 #@ if values.loadBalancerAndIngressService.config.ako_settings.services_api:
   #@overlay/match missing_ok=True
-  servicesAPI: #@ values.loadBalancerAndIngressService.config.ako_settings.services_api
+  servicesAPI: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.services_api).lower()
 #@ end
 #@ if values.loadBalancerAndIngressService.config.ako_settings.enable_EVH:
   #@overlay/match missing_ok=True
-  enableEVH: #@ values.loadBalancerAndIngressService.config.ako_settings.enable_EVH
+  enableEVH: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.enable_EVH).lower()
 #@ end
 #@ if values.loadBalancerAndIngressService.config.ako_settings.layer_7_only:
   #@overlay/match missing_ok=True
-  layer7Only: #@ values.loadBalancerAndIngressService.config.ako_settings.layer_7_only
+  layer7Only: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.layer_7_only).lower()
 #@ end
 #@ if values.loadBalancerAndIngressService.config.l4_settings.default_domain:
   #@overlay/match missing_ok=True
-  defaultDomain: #@ values.loadBalancerAndIngressService.config.l4_settings.default_domain
+  defaultDomain: #@ "{}".format(values.loadBalancerAndIngressService.config.l4_settings.default_domain)
 #@ end
-  disableStaticRouteSync: #@ values.loadBalancerAndIngressService.config.ako_settings.disable_static_route_sync
-  defaultIngController: #@ "{}".format(values.loadBalancerAndIngressService.config.l7_settings.default_ing_controller)
+  disableStaticRouteSync: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.disable_static_route_sync).lower()
+  defaultIngController: #@ "{}".format(values.loadBalancerAndIngressService.config.l7_settings.default_ing_controller).lower()
 #@ if values.loadBalancerAndIngressService.config.l7_settings.no_pg_for_SNI:
   #@overlay/match missing_ok=True
-  noPGForSNI: #@ values.loadBalancerAndIngressService.config.l7_settings.no_pg_for_SNI
+  noPGForSNI: #@ "{}".format(values.loadBalancerAndIngressService.config.l7_settings.no_pg_for_SNI).lower()
 #@ end
 #@ if values.loadBalancerAndIngressService.config.network_settings.enable_rhi:
   #@overlay/match missing_ok=True
-  enableRHI: #@ values.loadBalancerAndIngressService.config.network_settings.enable_rhi
+  enableRHI: #@ "{}".format(values.loadBalancerAndIngressService.config.network_settings.enable_rhi).lower()
 #@ end
 #@ if values.loadBalancerAndIngressService.config.ako_settings.log_level:
   #@overlay/match missing_ok=True
-  logLevel: #@ values.loadBalancerAndIngressService.config.ako_settings.log_level
+  logLevel: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.log_level)
 #@ end
-  deleteConfig: #@ values.loadBalancerAndIngressService.config.ako_settings.delete_config
+  deleteConfig: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.delete_config).lower()
 #@ if values.loadBalancerAndIngressService.config.l4_settings.advanced_l4:
   #@overlay/match missing_ok=True
-  advancedL4: #@ values.loadBalancerAndIngressService.config.l4_settings.advanced_l4
+  advancedL4: #@ "{}".format(values.loadBalancerAndIngressService.config.l4_settings.advanced_l4).lower()
 #@ end
 #@ if values.loadBalancerAndIngressService.config.l4_settings.auto_fqdn :
   #@overlay/match missing_ok=True
-  autoFQDN: #@ values.loadBalancerAndIngressService.config.l4_settings.auto_fqdn
+  autoFQDN: #@ "{}".format(values.loadBalancerAndIngressService.config.l4_settings.auto_fqdn)
 #@ end
 #@ if values.loadBalancerAndIngressService.config.ako_settings.sync_namespace:
   #@overlay/match missing_ok=True
-  syncNamespace: #@ values.loadBalancerAndIngressService.config.ako_settings.sync_namespace
+  syncNamespace: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.sync_namespace)
 #@ end
 #@ if values.loadBalancerAndIngressService.config.ako_settings.namespace_selector.label_key:
   #@overlay/match missing_ok=True
-  nsSyncLabelKey: #@ values.loadBalancerAndIngressService.config.ako_settings.namespace_selector.label_key
+  nsSyncLabelKey: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.namespace_selector.label_key)
 #@ end
 #@ if values.loadBalancerAndIngressService.config.ako_settings.namespace_selector.label_value:
   #@overlay/match missing_ok=True
-  nsSyncLabelValue: #@ values.loadBalancerAndIngressService.config.ako_settings.namespace_selector.label_value
+  nsSyncLabelValue: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.namespace_selector.label_value)
 #@ end
-  serviceType:  #@ values.loadBalancerAndIngressService.config.l7_settings.service_type
+  serviceType:  #@ "{}".format(values.loadBalancerAndIngressService.config.l7_settings.service_type)
 #@ if values.loadBalancerAndIngressService.config.l7_settings.service_type == "NodePort":
   #@ if values.loadBalancerAndIngressService.config.nodeport_selector.key:
   #@overlay/match missing_ok=True
-  nodeKey: #@ values.loadBalancerAndIngressService.config.nodeport_selector.key
+  nodeKey: #@ "{}".format(values.loadBalancerAndIngressService.config.nodeport_selector.key)
   #@ end
   #@ if values.loadBalancerAndIngressService.config.nodeport_selector.value:
   #@overlay/match missing_ok=True
-  nodeValue: #@ values.loadBalancerAndIngressService.config.nodeport_selector.value
+  nodeValue: #@ "{}".format(values.loadBalancerAndIngressService.config.nodeport_selector.value)
   #@ end
 #@ end
-  serviceEngineGroupName: #@ values.loadBalancerAndIngressService.config.controller_settings.service_engine_group_name
+  serviceEngineGroupName: #@ "{}".format(values.loadBalancerAndIngressService.config.controller_settings.service_engine_group_name)
 #@ if values.loadBalancerAndIngressService.config.network_settings.node_network_list:
   #@overlay/match missing_ok=True
   nodeNetworkList: #@ values.loadBalancerAndIngressService.config.network_settings.node_network_list


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Kubernetes' `configmap` object should only contain string type data values, this PR is to fix the invalid data type in ako's `avi-k8s-config` .

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
