### PR TITLE
Adjust nuspec URLs for chocolatey validation

### DIFF
--- a/hack/choco/tanzu-community-edition.nuspec
+++ b/hack/choco/tanzu-community-edition.nuspec
@@ -12,10 +12,10 @@
     <!-- TODO:
     <iconUrl></iconUrl>
     -->
-    <licenseUrl>https://github.com/vmware-tanzu/community-edition/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/vmware-tanzu/community-edition/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/vmware-tanzu/community-edition</projectSourceUrl>
-    <docsUrl>https://tanzucommunityedition.io/docs</docsUrl>
+    <docsUrl>https://github.com/vmware-tanzu/community-edition/blob/main/README</docsUrl>
     <mailingListUrl>https://groups.google.com/g/tanzu-community-edition</mailingListUrl>
     <bugTrackerUrl>https://github.com/vmware-tanzu/community-edition/issues</bugTrackerUrl>
     <tags>tanzu community kubernetes</tags>


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Fixes validation issues with the chocolatey packages.

The previous URLs were not accessible by the chocolatey validation services.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```