### PR TITLE
Don't fail chocolatey install on missing dependencies

### DIFF
--- a/hack/choco/tools/chocolateyinstall.ps1
+++ b/hack/choco/tools/chocolateyinstall.ps1
@@ -30,13 +30,11 @@ function Test-Prereqs {
 
     if ( -not (Get-Command docker -ErrorAction SilentlyContinue)) {
         Write-Host -ForegroundColor Red "  - Docker CLI not present! This is required to create bootstrap clusters`n"
-        exit 1
     }
     Write-Host "  - Docker CLI found, proceeding" -ForegroundColor Cyan
 
     if ( -not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
         Write-Host -ForegroundColor Red "  - kubectl not present! This is required to create bootstrap clusters`n"
-        exit 1
     }
     Write-Host "  - kubectl found, proceeding`n" -ForegroundColor Cyan
 }


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
The chocolatey verification process happens on environments without
Docker and kubectl[1]. Failing verification prevents the package from
being listed publicly.

1: https://github.com/chocolatey-community/chocolatey-test-environment

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```