### PR TITLE
Remove links to tags in blog posts to avoid confusion

### DIFF
--- a/docs/site/themes/template/layouts/_default/single.html
+++ b/docs/site/themes/template/layouts/_default/single.html
@@ -10,7 +10,7 @@
 				<div class="blog-post">
 					<h2>{{ .Title }}</h2>
 					<p class="author">
-						<a href="/tags/{{ .Params.author | urlize }}">{{ .Params.author }}</a>
+						{{ .Params.author }}
 					</p>
 					<p class="date">{{ dateFormat "Jan 2, 2006" .Date }}</p>
 					{{ .Content }}


### PR DESCRIPTION
Signed-off-by: Jonas Rosland <jrosland@vmware.com>

## What this PR does / why we need it
Remove links to tags in blog posts to avoid confusion when using multiple authors.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
