### PR TITLE
[Docs] github token is optional when using curl script

### DIFF
--- a/docs/site/content/docs/assets/cli-install-linux.md
+++ b/docs/site/content/docs/assets/cli-install-linux.md
@@ -41,9 +41,7 @@
     > - For example, to download {{< release_latest >}} for Linux, provide:  <br>`bash -s {{< release_latest >}} linux`
     > - This script requires `curl`, `grep`, `sed`, `tr`, and `jq` in order to work
     > - The release will be downloaded to the local directory as `tce-linux-amd64-{{< release_latest >}}.tar.gz`
-    > - *_Note:_* This _currently_ requires the use of a GitHub personal access token.
-
-    Follow [the GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to aquire and use a personal access token.
+    > - *_Note:_* A GitHub personal access token may be provided to the script as the `GITHUB_TOKEN` environment variable. This bypasses GitHub API rate limiting but is _not_ required. Follow [the GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to aquire and use a personal access token.
 
 1. Unpack the release.
 


### PR DESCRIPTION
## What this PR does / why we need it
The GitHub personal access token is _not_ required but is not optional when using the curl script. This PR correctly documents that.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Correctly document the github token via curl script for download
```

## Which issue(s) this PR fixes
N/a - followup to https://github.com/vmware-tanzu/community-edition/pull/1926

## Describe testing done for PR
`hugo serve` and looks good

## Special notes for your reviewer
N/a
