### PR TITLE
Update Azure image ID to latest used

### DIFF
--- a/docs/site/content/docs/latest/azure-mgmt.md
+++ b/docs/site/content/docs/latest/azure-mgmt.md
@@ -82,10 +82,10 @@ To run management cluster VMs on Microsoft Azure, accept the license for their b
 
 1. Run the `az vm image terms accept` command, specifying the `--plan` and your Subscription ID.
 
-   In Tanzu Community Edition v1.3.1, the default cluster image `--plan` value is `k8s-1dot20dot5-ubuntu-2004`, based on Kubernetes version 1.20.5 and the  machine OS, Ubuntu 20.04. Run the following command:
+   In Tanzu Community Edition v0.9.1, the default cluster image `--plan` value is `k8s-1dot21dot2-ubuntu-2004`, based on Kubernetes version 1.21 and the  machine OS, Ubuntu 20.04. Run the following command:
 
    ```sh
-   az vm image terms accept --publisher vmware-inc --offer tkg-capi --plan k8s-1dot20dot5-ubuntu-2004 --subscription AZURE_SUBSCRIPTION_ID
+   az vm image terms accept --publisher vmware-inc --offer tkg-capi --plan k8s-1dot21dot2-ubuntu-2004 --subscription AZURE_SUBSCRIPTION_ID
    ```
 
    Where `AZURE_SUBSCRIPTION_ID` is your Azure subscription ID.


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We had a stale reference to an older Azure image ID in our instructions
for preparing to deploy to Azure. This updates the docs to refer to the
current image ID used.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Azure image ID has been updated to k8s-1dot21dot2-ubuntu-2004.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2120