### PR TITLE
Trivial: Clean up LICENSE.md references

### DIFF
--- a/docs/site/data/downloads/0-9-1.yml
+++ b/docs/site/data/downloads/0-9-1.yml
@@ -1,7 +1,7 @@
 version: V0.9.1
 date: 2021-09-30
 release_notes_link: https://github.com/vmware-tanzu/community-edition/releases/tag/v0.9.1
-license_link: https://github.com/vmware-tanzu/community-edition/blob/main/LICENSE.md
+license_link: https://github.com/vmware-tanzu/community-edition/blob/main/LICENSE
 guide_link: https://tanzucommunityedition.io/docs/latest/
 installer:
   - client: MacOS/amd64

--- a/hack/check-mdlint.sh
+++ b/hack/check-mdlint.sh
@@ -20,4 +20,4 @@ docker run --rm -v "$(pwd)":/build \
   -i docs/site/content/plugins \
   -i docs/site/content/docs/assets \
   -i docs/site/content/contributors \
-  -i LICENSE.md .
+  -i LICENSE .


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We renamed the LICENSE file from LICENSE.md to LICENSE. There were a
couple references to the old name left over. This updates those
instances to use the new extension-less name.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```