### PR TITLE
Add Slack link to Website

### DIFF
--- a/docs/site/content/community/_index.html
+++ b/docs/site/content/community/_index.html
@@ -27,7 +27,7 @@ layout: section
                 <img src="/img/illustrations/join-the-conversation.jpg" height="100" alt="" />
             </div>
             <div class="content">
-                <h3><a href="https://slack.com/">Join the conversation</a></h3>
+                <h3><a href="https://kubernetes.slack.com/archives/C02GY94A8KT">Join the conversation</a></h3>
                 <p>Need more help? Ready to help others? Join the <a href="https://groups.google.com/g/tanzu-community-edition">Tanzu Community Edition Google Group</a> and #tanzu-community-edition channel (coming soon) in the Kubernetes Slack workspace for expert advice and guidance on using Tanzu Community Edition. Help us grow and learn from each other by sharing your experiences, telling us about what you are building, and letting us know how we can improve Tanzu Community Edition.</p>
                 <p>(Note: If you aren't already a member of the Kubernetes Slack workspace, please <a href="https://slack.k8s.io/">request an invitation</a>.)</p>
             </div>


### PR DESCRIPTION
## What this PR does / why we need it
Adds Slack link to Community page on website.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```
