### PR TITLE
Suppress the tanzu init spinner for Windows

### DIFF
--- a/hack/choco/tools/chocolateyinstall.ps1
+++ b/hack/choco/tools/chocolateyinstall.ps1
@@ -92,7 +92,8 @@ function Install-TanzuEnvironment {
     $tanzuExe = "${toolsDir}\${packageFullName}\bin\tanzu.exe"
 
     # The & allows execution of a binary stored in a variable.
-    & $tanzuExe init
+    Write-Host "  - Initializing Tanzu configuration" -ForegroundColor Cyan
+    & $tanzuExe init | Out-Null
     & $tanzuExe plugin repo add --name tce --gcp-bucket-name tce-tanzu-cli-plugins --gcp-root-path artifacts
     & $tanzuExe plugin repo add --name core-admin --gcp-bucket-name tce-tanzu-cli-framework-admin --gcp-root-path artifacts-admin
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
The `tanzu init` command prints a spinner, which can break Windows
Console Host sometimes, causing it to wait for input. Suppress the
output so that installation doesn't pause.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Work around for #2132. A proper fix would be addressing [non-TTY hosts in framework](https://github.com/vmware-tanzu/tanzu-framework/issues/43)

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

On my local Windows VM:

```
PS Microsoft.PowerShell.Core\FileSystem::\\vmware-host\Shared Folders\projects\tce\hack\choco> rm .\tanzu-community-edition.0.9.1.nupkg; choco pack; choco uninstall tanzu-community-edition
PS Microsoft.PowerShell.Core\FileSystem::\\vmware-host\Shared Folders\projects\tce\hack\choco> choco install -s . tanzu-community-edition
```

## Special notes for your reviewer

<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

This is in an effort to unblock Chocolately package verification.
