### PR TITLE
Fix `make generate-package-repo` to use `CHANNEL` instead of `REPO`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,8 +324,8 @@ push-package: check-carvel # Build and push a package template. Tag will default
 	@printf "\n===> pushing $${PACKAGE}/$${VERSION}\n";\
 	cd addons/packages/$${PACKAGE}/$${VERSION} && imgpkg push --bundle $(OCI_REGISTRY)/$${PACKAGE}:$${VERSION} --file bundle/;\
 
-export REPO
-generate-package-repo: check-carvel # Generate and push the package repository. Usage: make generate-package-repo REPO=main
+export CHANNEL
+generate-package-repo: check-carvel # Generate and push the package repository. Usage: make generate-package-repo CHANNEL=main
 	cd ./hack/packages/ && $(MAKE) run
 
 get-package-config: # Extracts the package values.yaml file. Usage: make get-package-config PACKAGE=foo VERSION=1.0.0

--- a/docs/site/content/docs/latest/designs/package-process.md
+++ b/docs/site/content/docs/latest/designs/package-process.md
@@ -483,7 +483,7 @@ packages:
 
 There is a makefile task, `generate-package-repo`, that generates the package repository from this file. `kapp-controller`
 currently expects the package repositories to be in the format of an imgpkgBundle. This task will generate that bundle.
-When the task is executed, `make generate-package-repo REPO=main`, the following steps are performed:
+When the task is executed, `make generate-package-repo CHANNEL=main`, the following steps are performed:
 
 * Create `addons/repos/generated/main` directory
 * Create `addons/repos/generated/main/.imgpkg` for imgpkg


### PR DESCRIPTION
## What this PR does / why we need it
- As `make run` under `./hack/package` depends on `CHANNEL`, update the
  documentation to use `CHANNEL` variable instead of `REPO`

Signed-off-by: Anuj Chaudhari <anujc@vmware.com>

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
