### PR TITLE
add faq cluster bootstrapping

### DIFF
--- a/docs/site/content/docs/latest/faq-cluster-bootstrapping.md
+++ b/docs/site/content/docs/latest/faq-cluster-bootstrapping.md
@@ -1,0 +1,27 @@
+# FAQ on Cluster Bootstrapping
+
+## x509: certificate signed by unknown authority when deploying Management Cluster from Windows
+
+Upon completion of [Install Tanzu Community Edition](getting-started) steps for Windows, you may encounter the following when performing `tanzu management-cluster create --ui`:
+
+```
+PS > tanzu management-cluster create --ui
+Downloading TKG compatibility file from 'projects.registry.vmware.com/tkg/framework-zshippable/tkg-compatibility'
+Error: unable to ensure prerequisites: unable to ensure tkg BOM file: failed to download TKG compatibility file from the registry: failed to list TKG compatibility image tags: Get "https://projects.registry.vmware.com/v2/": x509: certificate signed by unknown authority
+Usage:
+  tanzu management-cluster create [flags]
+  ...
+```
+
+To workaround this, edit `%USERPROFILE%\.config\tanzu\tkg\config.yaml` with the following, then retry management cluster setup:
+```
+release:
+    version: ""
+TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY: true
+```
+
+|||
+|:---------------- | --- |
+|Bootstrap platform| Windows |
+|Target platform   | Any |
+|Affected versions | v0.2.1 |

--- a/docs/site/content/docs/latest/faq-cluster-bootstrapping.md
+++ b/docs/site/content/docs/latest/faq-cluster-bootstrapping.md
@@ -4,7 +4,7 @@
 
 Upon completion of [Install Tanzu Community Edition](getting-started) steps for Windows, you may encounter the following when performing `tanzu management-cluster create --ui`:
 
-```
+```powershell
 PS > tanzu management-cluster create --ui
 Downloading TKG compatibility file from 'projects.registry.vmware.com/tkg/framework-zshippable/tkg-compatibility'
 Error: unable to ensure prerequisites: unable to ensure tkg BOM file: failed to download TKG compatibility file from the registry: failed to list TKG compatibility image tags: Get "https://projects.registry.vmware.com/v2/": x509: certificate signed by unknown authority
@@ -14,7 +14,8 @@ Usage:
 ```
 
 To workaround this, edit `%USERPROFILE%\.config\tanzu\tkg\config.yaml` with the following, then retry management cluster setup:
-```
+
+```yaml
 release:
     version: ""
 TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY: true

--- a/docs/site/content/docs/latest/faq.md
+++ b/docs/site/content/docs/latest/faq.md
@@ -1,3 +1,3 @@
 # FAQ
 
-This page is still work in progress, check back soon. This page will contain FAQ and common errors messages as they are contributed.
+The following are answers to frequently asked questions and common errors messages you may encounter with Tanzu Community Edition.

--- a/docs/site/data/docs/latest-toc.yml
+++ b/docs/site/data/docs/latest-toc.yml
@@ -195,6 +195,9 @@ toc:
               suburl: /tanzu-debugging-tips
         - page: FAQ
           url: /faq
+          subitems:
+            - subpage: Cluster Bootstrapping
+              suburl: /faq-cluster-bootstrapping
         - page: File a Bug or Feature
           url: /file-bug
         - page: Our Triage Process


### PR DESCRIPTION
## What this PR does / why we need it
Adding cluster bootstrapping FAQ along with workaround for a common Windows bootstrapping error.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
- Creating new FAQ cluster bootstrapping subpage
- Adding new FAQ cluster bootstrapping entry for x509: certificate signed by unknown authority when downloading TKG compatibility file error on Windows
```

## Which issue(s) this PR addresses
Addresses: #1398 , #2139 

## Describe testing done for PR
Tested FAQ successfully on a Windows 10 x64 and Windows Server 2019 x64 host.