### PR TITLE
support localappdata path with spaces for windows install.bat

### DIFF
--- a/hack/install.bat
+++ b/hack/install.bat
@@ -14,9 +14,9 @@ set PATH=%PATH%;%TANZU_CLI_DIR%
 :: end copy tanzu cli
 
 :: start copy plugins
-SET PLUGIN_DIR=%LocalAppData%\tanzu-cli
-SET TCE_DIR=%LocalAppData%\tce
-SET TANZU_CACHE_DIR=%LocalAppData%\.cache\tanzu
+SET PLUGIN_DIR="%LocalAppData%\tanzu-cli"
+SET TCE_DIR="%LocalAppData%\tce"
+SET TANZU_CACHE_DIR="%LocalAppData%\.cache\tanzu"
 mkdir %PLUGIN_DIR%
 mkdir %TCE_DIR%
 :: delete the plugin cache if it exists, before installing new plugins

--- a/hack/uninstall.bat
+++ b/hack/uninstall.bat
@@ -16,7 +16,7 @@ if exist "%TANZU_CLI_DIR%" (
 )
 
 :: start delete plugins
-SET PLUGIN_DIR=%LocalAppData%\tanzu-cli
+SET PLUGIN_DIR="%LocalAppData%\tanzu-cli"
 if exist "%PLUGIN_DIR%" (
   rmdir /Q /S %PLUGIN_DIR%
 )
@@ -43,7 +43,7 @@ if exist "%TANZU_CACHE_DIR%" (
 )
 
 :: start delete tce
-SET TCE_DIR=%LocalAppData%\tce
+SET TCE_DIR="%LocalAppData%\tce"
 if exist "%TCE_DIR%" (
   rmdir /Q /S %TCE_DIR%
 )


### PR DESCRIPTION
## What this PR does / why we need it
Supporting `%LocalAppData%` when it expands to a path with spaces (i.e. if user has space in their username) on Windows.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
- install.bat for Windows now supports usernames with spaces
```

## Which issue(s) this PR fixes
Fixes: #2140

## Describe testing done for PR
1. Run `install.bat` while logged in as a user that contains a space in their username.
2. Ensure that `%LocalAppData%` contains `tanzu-cli` and `tce` directories
Tested on Windows 10 x64, Windows Server 2019 x64

Also updated uninstall script.