### PR TITLE
Fix `tanzu diagnostics collect` not respecting `--output-dir`

### DIFF
--- a/.github/workflows/e2e-diagnostics-plugin.yaml
+++ b/.github/workflows/e2e-diagnostics-plugin.yaml
@@ -1,0 +1,31 @@
+name: E2E Test - Diagnostics Plugin
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "cli/cmd/plugin/diagnostics/"
+      - "!cli/cmd/plugin/diagnostics/**.md"
+      - ".github/workflows/e2e-diagnostics-plugin.yaml"
+    tags-ignore:
+      - "**"
+
+jobs:
+  e2e-test-diagnostics-plugin:
+    name: E2E Test - Diagnostics Plugin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
+        id: go
+
+      - name: Run E2E Tests - Diagnostics Plugin
+        run: |
+          cd cli/cmd/plugin/diagnostics/
+          make e2e-test

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/site/resources
 # package configuration values files
 *-values.yaml
 .envrc
+
+# tar balls
+*.tar.gz

--- a/cli/cmd/plugin/diagnostics/Makefile
+++ b/cli/cmd/plugin/diagnostics/Makefile
@@ -19,8 +19,9 @@ endif
 test: ## Run unit testing suite
 	echo "N/A: No unit tests for hack/packages"
 
+.PHONY: e2e-test
 e2e-test: ## Run e2e testing suite
-	echo "N/A: No e2e tests for hack/packages"
+	./e2e-test/e2e-test.sh
 
 build: ## Build the executable
 	echo "N/A: Implement building"

--- a/cli/cmd/plugin/diagnostics/e2e-test/.gitignore
+++ b/cli/cmd/plugin/diagnostics/e2e-test/.gitignore
@@ -1,0 +1,2 @@
+tanzu-diagnostics-e2e-bin
+tce-installation

--- a/cli/cmd/plugin/diagnostics/e2e-test/README.md
+++ b/cli/cmd/plugin/diagnostics/e2e-test/README.md
@@ -1,0 +1,31 @@
+# E2E Test
+
+## How to run E2E test
+
+First go to diagnostics plugin directory
+
+```bash
+# if you are in TCE repo root, then
+$ cd cli/cmd/plugin/diagnostics
+```
+
+Then simply run
+
+```bash
+make e2e-test
+```
+
+Or you can directly invoke the E2E test script `e2e-test.sh`, present in this directory, from anywhere
+
+## Internals
+
+For testing `tanzu diagnostics collect` command, we use a `kind` cluster to quickly spin up a cluster and check if `tanzu diagnostics collect` can collect logs from the cluster. We use a single `kind` cluster and treat it as a bootstrap cluster, management cluster and a workload cluster. This is done just to keep the test simple and light weight and fast
+
+What we test as part of the E2E test currently - Does running the `tanzu diagnostics collect` command collect the diagnostics data from all the different kinds of clusters and create tar balls in the appropriate directory? We do this check at a very high level - check if the tar balls exist
+
+What we can test in the future
+
+- Check some of the contents of the tar ball
+  - Check if some files are present and have file size > 0
+  - Check if some logs are present in some log files by running some test apps in namespaces that `tanzu diagnostics collect` collects data from, for example `capi-system`
+- Check if the different flags of the `tanzu diagnostics collect` are working as expected

--- a/cli/cmd/plugin/diagnostics/e2e-test/e2e-test.sh
+++ b/cli/cmd/plugin/diagnostics/e2e-test/e2e-test.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+TCE_REPO_PATH=${MY_DIR}/../../../../..
+
+TCE_VERSION="v0.9.1"
+
+echo "Installing TCE ${TCE_VERSION}"
+
+BUILD_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+TCE_RELEASE_TAR_BALL="tce-${BUILD_OS}-amd64-${TCE_VERSION}.tar.gz"
+TCE_RELEASE_DIR="tce-${BUILD_OS}-amd64-${TCE_VERSION}"
+INSTALLATION_DIR="${MY_DIR}/tce-installation"
+
+"${TCE_REPO_PATH}"/hack/get-tce-release.sh ${TCE_VERSION} "${BUILD_OS}"-amd64
+
+mkdir -p "${INSTALLATION_DIR}"
+tar xzvf "${TCE_RELEASE_TAR_BALL}" --directory="${INSTALLATION_DIR}"
+
+"${INSTALLATION_DIR}"/"${TCE_RELEASE_DIR}"/install.sh || { error "Unexpected failure during TCE installation"; exit 1; }
+
+echo "TCE version: "
+tanzu standalone-cluster version || { error "Unexpected failure during TCE installation"; exit 1; }
+
+TANZU_DIAGNOSTICS_PLUGIN_DIR=${MY_DIR}/..
+TANZU_DIAGNOSTICS_BIN=${MY_DIR}/tanzu-diagnostics-e2e-bin
+
+echo "Entering ${TANZU_DIAGNOSTICS_PLUGIN_DIR} directory to build tanzu diagnostics plugin"
+pushd "${TANZU_DIAGNOSTICS_PLUGIN_DIR}"
+
+go build -o "${TANZU_DIAGNOSTICS_BIN}" -v
+
+echo "Finished building tanzu diagnostics plugin. Leaving ${TANZU_DIAGNOSTICS_PLUGIN_DIR}"
+popd
+
+CLUSTER_NAME_SUFFIX=${RANDOM}
+CLUSTER_NAME="e2e-diagnostics-${CLUSTER_NAME_SUFFIX}"
+CLUSTER_KUBE_CONTEXT="kind-${CLUSTER_NAME}"
+NEW_CLUSTER_KUBE_CONTEXT="${CLUSTER_NAME}-admin@${CLUSTER_NAME}"
+OUTPUT_DIR=$(mktemp -d)
+
+echo "Creating a kind cluster for the E2E test"
+
+kind create cluster --name ${CLUSTER_NAME} || {
+    echo "Error creating kind cluster!"
+    exit 1
+}
+
+# The context rename is required for workload cluster diagnostics data collection to work
+# as it expects the context name to be in a particular format based on cluster name
+# and --workload-cluster-context flag is not supported for now.
+kubectl config rename-context ${CLUSTER_KUBE_CONTEXT} ${NEW_CLUSTER_KUBE_CONTEXT} || {
+    echo "Error renaming kube context!"
+    exit 1
+}
+
+echo "Running tanzu diagnostics collect command"
+
+"${TANZU_DIAGNOSTICS_BIN}" collect --bootstrap-cluster-name ${CLUSTER_NAME} \
+    --management-cluster-kubeconfig "${HOME}/.kube/config" \
+    --management-cluster-context ${NEW_CLUSTER_KUBE_CONTEXT} \
+    --management-cluster-name ${CLUSTER_NAME} \
+    --workload-cluster-infra docker \
+    --workload-cluster-name ${CLUSTER_NAME} \
+    --output-dir "${OUTPUT_DIR}" || {
+        echo "Error running tanzu diagnostics collect command!"
+        exit 1
+    }
+
+echo "Checking if the diagnostics tar balls for the different clusters have been created"
+
+EXPECTED_BOOTSTRAP_CLUSTER_DIAGNOSTICS="${OUTPUT_DIR}/bootstrap.${CLUSTER_NAME}.diagnostics.tar.gz"
+EXPECTED_MANAGEMENT_CLUSTER_DIAGNOSTICS="${OUTPUT_DIR}/management-cluster.${CLUSTER_NAME}.diagnostics.tar.gz"
+EXPECTED_WORKLOAD_CLUSTER_DIAGNOSTICS="${OUTPUT_DIR}/workload-cluster.${CLUSTER_NAME}.diagnostics.tar.gz"
+
+errors=0
+
+if [ ! -f "$EXPECTED_BOOTSTRAP_CLUSTER_DIAGNOSTICS" ]; then
+    echo "$EXPECTED_BOOTSTRAP_CLUSTER_DIAGNOSTICS does not exist. Expected bootstrap cluster diagnostics tar ball to be present"
+    ((errors=errors+1))
+fi
+
+if [ ! -f "$EXPECTED_MANAGEMENT_CLUSTER_DIAGNOSTICS" ]; then
+    echo "$EXPECTED_MANAGEMENT_CLUSTER_DIAGNOSTICS does not exist. Expected management cluster diagnostics tar ball to be present"
+    ((errors=errors+1))
+fi
+
+if [ ! -f "$EXPECTED_WORKLOAD_CLUSTER_DIAGNOSTICS" ]; then
+    echo "$EXPECTED_WORKLOAD_CLUSTER_DIAGNOSTICS does not exist. Expected workload cluster diagnostics tar ball to be present"
+    ((errors=errors+1))
+fi
+
+if [[ ${errors} -gt 0 ]]; then
+    echo "Total E2E errors in tanzu diagnostics plugin: ${errors}"
+fi
+
+echo "Cleaning up"
+
+kind delete cluster --name ${CLUSTER_NAME} || {
+    echo "Failed deleting kind cluster. Please delete it manually"
+}
+
+# This deletion of context name is required as kind does not delete it
+# because we renamed the context to something different from kind's context
+# name convention
+kubectl config delete-context ${NEW_CLUSTER_KUBE_CONTEXT} || {
+    echo "Failed deleting kind cluster kube context. Please delete it manually"
+}
+
+rm -rfv "${OUTPUT_DIR}"
+
+if [[ ${errors} -gt 0 ]]; then
+    exit 1
+fi

--- a/cli/cmd/plugin/diagnostics/go.mod
+++ b/cli/cmd/plugin/diagnostics/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmware-tanzu/tanzu-framework/cmd/cli/plugin/diagnostics
+module github.com/vmware-tanzu/community-edition/cli/cmd/plugin/diagnostics
 
 go 1.16
 

--- a/cli/cmd/plugin/diagnostics/main.go
+++ b/cli/cmd/plugin/diagnostics/main.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"os"
 
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/diagnostics/pkg"
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
-	"github.com/vmware-tanzu/tanzu-framework/cmd/cli/plugin/diagnostics/pkg"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
 )

--- a/cli/cmd/plugin/diagnostics/pkg/collect_cmd.go
+++ b/cli/cmd/plugin/diagnostics/pkg/collect_cmd.go
@@ -128,6 +128,7 @@ func collectBoostrapDiags() error {
 		"workdir":                commonArgs.workDir,
 		"infra":                  "docker",
 		"bootstrap_cluster_name": bootstrapArgs.clusterName,
+		"outputdir":              commonArgs.outputDir,
 	}
 
 	return crashdexec.ExecuteWithModules(
@@ -159,6 +160,7 @@ func collectManagementDiags() error {
 		"management_cluster_name": mgmtArgs.clusterName,
 		"management_kubeconfig":   mgmtArgs.kubeconfig,
 		"management_context":      mgmtArgs.contextName,
+		"outputdir":               commonArgs.outputDir,
 	}
 
 	libScript := libScriptPath
@@ -195,6 +197,8 @@ func collectWorkloadDiags() error {
 		"workload_kubeconfig":   workloadArgs.kubeconfig,
 		"workload_cluster_name": workloadArgs.clusterName,
 		"workload_namespace":    workloadArgs.namespace,
+
+		"outputdir": commonArgs.outputDir,
 	}
 
 	scriptName := wcScriptPath

--- a/cli/cmd/plugin/diagnostics/scripts/bootstrap_cluster.star
+++ b/cli/cmd/plugin/diagnostics/scripts/bootstrap_cluster.star
@@ -40,7 +40,7 @@ def diagnose_bootstrap_clusters(workdir, clusters, outputdir):
         # remove kubeconfig before archiving
         run_local("rm {}".format(kind_cfg))
 
-        arc_file = "bootstrap.{}.diagnostics.tar.gz".format(kind_cluster)
+        arc_file = "{}/bootstrap.{}.diagnostics.tar.gz".format(outputdir, kind_cluster)
         log(prefix="Info", msg="Archiving: {}".format(arc_file))
         archive(output_file=arc_file, source_paths=[conf.workdir])
 

--- a/cli/cmd/plugin/diagnostics/scripts/management_cluster.star
+++ b/cli/cmd/plugin/diagnostics/scripts/management_cluster.star
@@ -21,7 +21,7 @@ def diagnose_management_cluster(workdir, kubeconfig, cluster_name, context_name,
 
     capture_k8s_objects(k8sconfig, cluster_name, nspaces)
 
-    arc_file = "management-cluster.{}.diagnostics.tar.gz".format(cluster_name)
+    arc_file = "{}/management-cluster.{}.diagnostics.tar.gz".format(outputdir, cluster_name)
     log(prefix="Info", msg="Archiving: {}".format(arc_file))
     archive(output_file=arc_file, source_paths=[conf.workdir])
 

--- a/cli/cmd/plugin/diagnostics/scripts/workload_cluster.star
+++ b/cli/cmd/plugin/diagnostics/scripts/workload_cluster.star
@@ -26,7 +26,7 @@ def diagnose_workload_cluster(workdir, infra, kubeconfig, cluster_name, context_
 
     capture_k8s_objects(k8sconfig, cluster_name, nspaces)
 
-    arc_file = "workload-cluster.{}.diagnostics.tar.gz".format(cluster_name)
+    arc_file = "{}/workload-cluster.{}.diagnostics.tar.gz".format(outputdir, cluster_name)
     log(prefix="Info", msg="Archiving: {}".format(arc_file))
     archive(output_file=arc_file, source_paths=[conf.workdir])
 


### PR DESCRIPTION
## What this PR does / why we need it

Recreation of #2079 

- Fixes golang module path of diagnostics plugin module
- Fixes `tanzu diagnostics collect` not respecting `--output-dir`
- Adds E2E tests

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Fix `tanzu diagnostics collect` not respecting `--output-dir`
```

## Which issue(s) this PR fixes

Fixes: #1750 

## Describe testing done for PR

Tested using the `e2e-test.sh` script in GitHub Actions using the workflow config present in this PR. Example run from my fork - https://github.com/karuppiah7890/community-edition/runs/3782918205?check_suite_focus=true

Tested locally too -

```bash
tce $ /Users/karuppiahn/projects/github.com/vmware-tanzu/tce/cli/cmd/plugin/diagnostics/e2e-test/e2e-test.sh 
Entering /Users/karuppiahn/projects/github.com/vmware-tanzu/tce/cli/cmd/plugin/diagnostics/e2e-test/.. directory to build tanzu diagnostics plugin
~/projects/github.com/vmware-tanzu/tce/cli/cmd/plugin/diagnostics ~/projects/github.com/vmware-tanzu/tce
Finished building tanzu diagnostics plugin. Leaving /Users/karuppiahn/projects/github.com/vmware-tanzu/tce/cli/cmd/plugin/diagnostics/e2e-test/..
~/projects/github.com/vmware-tanzu/tce
Creating a kind cluster for the E2E test
Creating cluster "e2e-diagnostics-181" ...
 ✓ Ensuring node image (kindest/node:v1.21.1) 🖼 
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Set kubectl context to "kind-e2e-diagnostics-181"
You can now use your cluster with:

kubectl cluster-info --context kind-e2e-diagnostics-181

Have a nice day! 👋
Context "kind-e2e-diagnostics-181" renamed to "e2e-diagnostics-181-admin@e2e-diagnostics-181".
Running tanzu diagnostics collect command
2021/10/01 20:00:27 Collecting bootstrap cluster diagnostics
2021/10/01 20:00:27 Info: Bootstrap cluster: name=e2e-diagnostics-181
2021/10/01 20:00:27 Warn: Bootstrap cluster: specified name may not be valid: e2e-diagnostics-181
2021/10/01 20:00:27 Info: Found bootstrap cluster(s): ["e2e-diagnostics-181"]
2021/10/01 20:00:27 Info: Bootstrap cluster: e2e-diagnostics-181: capturing node logs
2021/10/01 20:00:30 Info: Capturing pod logs: cluster=e2e-diagnostics-181
2021/10/01 20:00:30 Info: Capturing API objects: cluster=e2e-diagnostics-181
2021/10/01 20:00:33 Info: Archiving: /var/folders/4z/09jpfvfj6c19lxl7ch78pzvc0000gn/T/tmp.27exp3N5/bootstrap.e2e-diagnostics-181.diagnostics.tar.gz
2021/10/01 20:00:33 Info: Capturing management cluster diagnostics: cluster=e2e-diagnostics-181; context=e2e-diagnostics-181-admin@e2e-diagnostics-181; kubeconfig=/Users/karuppiahn/.kube/config;
2021/10/01 20:00:33 Info: Capturing pod logs: cluster=e2e-diagnostics-181
2021/10/01 20:00:33 Info: Capturing API objects: cluster=e2e-diagnostics-181
2021/10/01 20:00:36 Info: Archiving: /var/folders/4z/09jpfvfj6c19lxl7ch78pzvc0000gn/T/tmp.27exp3N5/management-cluster.e2e-diagnostics-181.diagnostics.tar.gz
2021/10/01 20:00:36 Info: Retrieving workload cluster credentials
2021/10/01 20:00:36 Info: Retrieving workload cluster: cluster=e2e-diagnostics-181; context=e2e-diagnostics-181-admin@e2e-diagnostics-181; kubeconfig=/Users/karuppiahn/.kube/config;
2021/10/01 20:00:36 Info: Capturing pod logs: cluster=e2e-diagnostics-181
2021/10/01 20:00:36 Info: Capturing API objects: cluster=e2e-diagnostics-181
2021/10/01 20:00:40 Info: Archiving: /var/folders/4z/09jpfvfj6c19lxl7ch78pzvc0000gn/T/tmp.27exp3N5/workload-cluster.e2e-diagnostics-181.diagnostics.tar.gz
Checking if the diagnostics tar balls for the different clusters have been created
Cleaning up
Deleting cluster "e2e-diagnostics-181" ...
warning: this removed your active context, use "kubectl config use-context" to select a different one
deleted context e2e-diagnostics-181-admin@e2e-diagnostics-181 from /Users/karuppiahn/.kube/config
/var/folders/4z/09jpfvfj6c19lxl7ch78pzvc0000gn/T/tmp.27exp3N5/bootstrap.e2e-diagnostics-181.diagnostics.tar.gz
/var/folders/4z/09jpfvfj6c19lxl7ch78pzvc0000gn/T/tmp.27exp3N5/management-cluster.e2e-diagnostics-181.diagnostics.tar.gz
/var/folders/4z/09jpfvfj6c19lxl7ch78pzvc0000gn/T/tmp.27exp3N5/workload-cluster.e2e-diagnostics-181.diagnostics.tar.gz
/var/folders/4z/09jpfvfj6c19lxl7ch78pzvc0000gn/T/tmp.27exp3N5
tce $ 
```

## Special notes for your reviewer

Check the `e2e-test/README.md` for understanding what has been done in the E2E test script
