### PR TITLE
fix ako 1.5.3 template format error

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.5.3/bundle/config/overlays/overlay-secret.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.5.3/bundle/config/overlays/overlay-secret.yaml
@@ -14,4 +14,4 @@ type: Opaque
 data:
   username: #@ base64.encode(values.loadBalancerAndIngressService.config.avi_credentials.username)
   password: #@ base64.encode(values.loadBalancerAndIngressService.config.avi_credentials.password)
-  certificate_authority_data: #@ base64.encode(values.loadBalancerAndIngressService.config.avi_credentials.certificate_authority_data)
+  certificateAuthorityData: #@ base64.encode(values.loadBalancerAndIngressService.config.avi_credentials.certificate_authority_data)

--- a/addons/packages/load-balancer-and-ingress-service/1.5.3/bundle/config/overlays/overlay-statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.5.3/bundle/config/overlays/overlay-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
 #@overlay/append
             - name: CTRL_CA_DATA
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   name: avi-secret
                   key: certificateAuthorityData
 #@ end

--- a/addons/packages/load-balancer-and-ingress-service/1.5.3/bundle/config/upstream/loadbalancerandingressservice/secret.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.5.3/bundle/config/upstream/loadbalancerandingressservice/secret.yaml
@@ -8,4 +8,4 @@ type: Opaque
 data:
   username: ""
   password: ""
-  certificate_authority_data: ""
+  certificateAuthorityData: ""


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Fix ako 1.5.3 package's  `statefulset` and `avi-secret` format error. 

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
