### PR TITLE
Remove unnecessary GitHub token usage

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -19,13 +19,11 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -54,12 +52,6 @@ jobs:
         with:
           go-version: "1.16"
         id: go
-      - name: Config credentials
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
-        shell: bash
-        run: |
-          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
       - name: Check out code
         uses: actions/checkout@v1
       - name: Restore Go Cache
@@ -92,13 +84,11 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -14,13 +14,11 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -49,12 +47,6 @@ jobs:
         with:
           go-version: "1.16"
         id: go
-      - name: Config credentials
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
-        shell: bash
-        run: |
-          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
       - name: Check out code
         uses: actions/checkout@v1
       - name: Restore Go Cache
@@ -74,8 +66,6 @@ jobs:
           make get-deps
       - name: Build
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         run: |
           make ensure-deps
           make release
@@ -120,13 +110,11 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/.github/workflows/check-pr-docker-management.yaml
+++ b/.github/workflows/check-pr-docker-management.yaml
@@ -14,13 +14,11 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -49,12 +47,6 @@ jobs:
         with:
           go-version: "1.16"
         id: go
-      - name: Config credentials
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
-        shell: bash
-        run: |
-          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
       - name: Check out code
         uses: actions/checkout@v1
       - name: Restore Go Cache
@@ -70,8 +62,6 @@ jobs:
           make get-deps
       - name: Build
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         run: |
           make ensure-deps
           make release
@@ -162,13 +152,11 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/.github/workflows/check-pr-docker-standalone.yaml
+++ b/.github/workflows/check-pr-docker-standalone.yaml
@@ -16,13 +16,11 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -51,12 +49,6 @@ jobs:
         with:
           go-version: "1.16"
         id: go
-      - name: Config credentials
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
-        shell: bash
-        run: |
-          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
       - name: Check out code
         uses: actions/checkout@v1
       - name: Restore Go Cache
@@ -72,8 +64,6 @@ jobs:
           make get-deps
       - name: Build
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         run: |
           make ensure-deps
           make release
@@ -164,13 +154,11 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CHECKS_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/.github/workflows/e2e-aws-management-cluster.yaml
+++ b/.github/workflows/e2e-aws-management-cluster.yaml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Run E2E Tests
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_E2E_ACCESS_TOKEN }}
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/e2e-aws-standalone-cluster.yaml
+++ b/.github/workflows/e2e-aws-standalone-cluster.yaml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Run E2E Tests
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_E2E_ACCESS_TOKEN }}
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Run Azure Management and Workload Cluster E2E Tests
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_E2E_ACCESS_TOKEN }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/e2e-azure-standalone-cluster.yaml
+++ b/.github/workflows/e2e-azure-standalone-cluster.yaml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Run Azure Standalone Cluster E2E Tests
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_E2E_ACCESS_TOKEN }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/e2e-vsphere-standalone-cluster.yaml
+++ b/.github/workflows/e2e-vsphere-standalone-cluster.yaml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Run TCE vSphere Standalone Cluster E2E Test
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_E2E_ACCESS_TOKEN }}
           VSPHERE_CONTROL_PLANE_ENDPOINT: ${{ secrets.VSPHERE_CONTROL_PLANE_ENDPOINT }}
           VSPHERE_SERVER: ${{ secrets.VSPHERE_SERVER }}
           VSPHERE_SSH_AUTHORIZED_KEY: ${{ secrets.VSPHERE_SSH_AUTHORIZED_KEY }}

--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -15,13 +15,11 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -75,8 +73,6 @@ jobs:
         run: |
           make get-deps
       - name: Build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
           make ensure-deps
@@ -161,13 +157,11 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -16,13 +16,11 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -76,8 +74,6 @@ jobs:
         run: |
           make get-deps
       - name: Build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
           make ensure-deps
@@ -199,13 +195,11 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -17,13 +17,11 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/setup.sh
           chmod +x ./setup.sh
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -77,8 +75,6 @@ jobs:
         run: |
           make get-deps
       - name: Build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
           make ensure-deps
@@ -200,13 +196,11 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Download Dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/ensure-dependencies.sh
           chmod +x ./ensure-dependencies.sh
-          curl -O -L https://${GITHUB_TOKEN}@raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
+          curl -O -L https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/hack/runner/teardown.sh
           chmod +x ./teardown.sh
       - name: Stop EC2 runner
         id: stop-ec2-runner

--- a/test/build-tce.sh
+++ b/test/build-tce.sh
@@ -17,17 +17,6 @@ source "${MY_DIR}"/util/utils.sh
 BUILD_OS=$(uname -s)
 export BUILD_OS
 
-if [[ -z "$GITHUB_TOKEN" ]]; then
-    echo "Access to GitHub private repo requires a token."
-    echo "Please create a token (Settings > Developer Settings > Personal Access Tokens)"
-
-    read -r -p "Please enter your GitHub token: " GITHUB_TOKEN
-    echo
-    export GITHUB_TOKEN=$GITHUB_TOKEN
-fi
-
-git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
-
 # Build TCE
 echo "Building TCE release..."
 make release || { error "TCE BUILD FAILED!"; exit 1; }


### PR DESCRIPTION
## What this PR does / why we need it

Removes unnecessary GitHub token usage in GitHub Actions CI config and in a build script. Every commit message in the PR has details as to why the GitHub tokens were removed. Let me know if something is not clear as to why the token usage was removed

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Remove unnecessary GitHub token usage in GitHub Actions CI config and in a build script
```

## Which issue(s) this PR fixes

There's no issue tracking this. Let me know if we want to create one

## Describe testing done for PR

I'll post a link here when I'm done testing some of the changes. I don't think I can test the workflows using self-hosted runner though since I'm not sure exactly how the AMI image used to create the self hosted runner has been built. I have some sense of it though, which I jotted down here - https://github.com/vmware-tanzu/community-edition/issues/1583 . If I get around to creating such an image or if I have access to the AMI image referenced in the scripts, I'll test that out too

## Special notes for your reviewer

None as of now. I'll update here if I have any later
