### PR TITLE
Run package tests using make e2e-test

### DIFF
--- a/addons/packages/external-dns/0.8.0/test/Makefile
+++ b/addons/packages/external-dns/0.8.0/test/Makefile
@@ -1,6 +1,9 @@
 # Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+ROOT_DIR := $(shell git rev-parse --show-toplevel)
+VERSION ?= 0.8.0
+EXTERNAL_DNS_E2E_TEST_ROOT := "${ROOT_DIR}"/addons/packages/external-dns/"${VERSION}"/test/e2e
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message
@@ -22,7 +25,7 @@ test: ## Run unit testing suite
 	@echo "TODO: implement unit tests"
 
 e2e-test: ## Run e2e testing suite
-	CGO_ENABLED=0 go run github.com/onsi/ginkgo/ginkgo -v e2e
+	cd "${EXTERNAL_DNS_E2E_TEST_ROOT}" && CGO_ENABLED=0 go run github.com/onsi/ginkgo/ginkgo -v .
 
 build: ## Build the executable
 	@echo "TODO: implement building"

--- a/test/e2e/Readme.md
+++ b/test/e2e/Readme.md
@@ -23,15 +23,15 @@ This is the folder in which we can invoke e2e tests for tce addons packages.
 
 ## How to run framework to install TCE release from github page, provision cluster and test
 
-   ```ginkgo -v -- --kubeconfig=$KUBECONFIG --packages="external-dns" --version="0.8.0" --provider-name="docker" --cluster-type="standalone" --guest-cluster-name="tce-mycluster" --create-cluster --tce-version="v0.7.0"```
+   ```ginkgo -v -- --kubeconfig=$KUBECONFIG --packages="external-dns" --version="0.8.0" --provider="docker" --cluster-type="standalone" --guest-cluster-name="tce-mycluster" --create-cluster --tce-version="v0.7.0"```
 
 ## How to create management cluster on docker
 
-   ```ginkgo -v -- --kubeconfig=$KUBECONFIG --packages="external-dns" --version="0.8.0" --provider-name="docker" --cluster-type="managed" --tce-version="v0.7.0" --management-cluster-name="tce-management-cluster" --create-cluster --guest-cluster-name="tce-workload-cluster"```
+   ```ginkgo -v -- --kubeconfig=$KUBECONFIG --packages="external-dns" --version="0.8.0" --provider="docker" --cluster-type="managed" --tce-version="v0.7.0" --management-cluster-name="tce-management-cluster" --create-cluster --guest-cluster-name="tce-workload-cluster"```
 
 ## How to run framework to install TCE by building release from source code, provision cluster and test
 
-   ```ginkgo -v -- --kubeconfig=$KUBECONFIG --packages="all" --provider-name="docker" --cluster-type="standalone" --guest-cluster-name="tce-mycluster" --create-cluster```
+   ```ginkgo -v -- --kubeconfig=$KUBECONFIG --packages="all" --provider="docker" --cluster-type="standalone" --guest-cluster-name="tce-mycluster" --create-cluster```
 
 ## How to run addons package test if cluster is already available
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -34,8 +34,8 @@ var _ = Describe("E2E tests", func() {
 			err := e2e.RunAddonsTests()
 			if err != nil {
 				log.Println("error while running package test, deleting cluster", err)
-				Expect(err).NotTo(HaveOccurred())
-				err = e2e.DeleteCluster()
+				err1 := e2e.DeleteCluster()
+				Expect(err1).NotTo(HaveOccurred())
 			}
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/install.go
+++ b/test/e2e/install.go
@@ -23,7 +23,7 @@ func installTCE() error {
 
 		log.Println("start building a tce release and install ....")
 		// build make release and install
-		err = os.Chdir(u.Gopath + u.SourcePath)
+		err = os.Chdir(u.WorkingDir + "/../../")
 		if err != nil {
 			log.Println("error while changing directory :", err)
 			return err
@@ -33,7 +33,7 @@ func installTCE() error {
 		runDeployScript("build-tce.sh", "")
 		log.Println("Time taken for build and install TCE release from source code: ", time.Since(start))
 
-		err = os.Chdir(u.Gopath + u.SourcePath + "/test/e2e")
+		err = os.Chdir(u.WorkingDir)
 		if err != nil {
 			log.Println("error while changing directory :", err)
 			return err
@@ -65,7 +65,7 @@ func installCluster() error {
 
 func runDeployScript(filename, releaseVersion string) {
 	mwriter := io.MultiWriter(os.Stdout)
-	cmd := exec.Command("/bin/sh", u.Gopath+u.SourcePath+"/test/"+filename, releaseVersion) //nolint:gosec
+	cmd := exec.Command("/bin/sh", u.WorkingDir+"/../"+filename, releaseVersion) //nolint:gosec
 	cmd.Stderr = mwriter
 	cmd.Stdout = mwriter
 	err := cmd.Run() // blocks until sub process is complete

--- a/test/e2e/testdata/install_dependencies.go
+++ b/test/e2e/testdata/install_dependencies.go
@@ -10,19 +10,19 @@ import (
 )
 
 func InstallMetallb() error {
-	_,err := u.Kubectl(nil, "apply", "-f", u.Gopath+u.SourcePath+"/test/e2e/testdata/metal-lb/namespace.yaml")
+	_, err := u.Kubectl(nil, "apply", "-f", u.WorkingDir+"/testdata/metal-lb/namespace.yaml")
 	if err != nil {
 		fmt.Printf("%s", err)
 		return err
 	}
 
-	_,err = u.Kubectl(nil, "apply", "-f", u.Gopath+u.SourcePath+"/test/e2e/testdata/metal-lb/metallb.yaml")
+	_, err = u.Kubectl(nil, "apply", "-f", u.WorkingDir+"/testdata/metal-lb/metallb.yaml")
 	if err != nil {
 		fmt.Printf("%s", err)
 		return err
 	}
 
-	_,err = u.Kubectl(nil, "apply", "-f", u.Gopath+u.SourcePath+"/test/e2e/testdata/metal-lb/metallb_cm.yaml")
+	_, err = u.Kubectl(nil, "apply", "-f", u.WorkingDir+"/testdata/metal-lb/metallb_cm.yaml")
 	if err != nil {
 		fmt.Printf("%s", err)
 		return err
@@ -32,7 +32,7 @@ func InstallMetallb() error {
 }
 
 func UninstallMetallb() error {
-	_,err := u.Kubectl(nil, "delete", "-f", u.Gopath+u.SourcePath+"/test/e2e/testdata/metal-lb/namespace.yaml")
+	_, err := u.Kubectl(nil, "delete", "-f", u.WorkingDir+"/testdata/metal-lb/namespace.yaml")
 	if err != nil {
 		fmt.Printf("%s", err)
 	}

--- a/test/e2e/utils/cli.go
+++ b/test/e2e/utils/cli.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -15,13 +16,14 @@ import (
 )
 
 var (
-	SourcePath string
-	Gopath     string
+	WorkingDir string
 )
 
 func init() {
-	SourcePath = "/src/github.com/vmware-tanzu/community-edition"
-	Gopath = os.Getenv("GOPATH")
+	WorkingDir = getCurrentDir()
+	if WorkingDir == "" {
+		log.Fatal("current working directory is empty")
+	}
 }
 
 func Kubectl(input io.Reader, args ...string) (string, error) {
@@ -58,4 +60,13 @@ func cliRunner(name string, input io.Reader, args ...string) (string, error) {
 func GetClusterContext(clusterName string) string {
 	clusterContext := clusterName + "-admin@" + clusterName
 	return clusterContext
+}
+
+func getCurrentDir() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Println("error while getting current working directory", err)
+	}
+
+	return wd
 }


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR handles running addons package testing by triggering `make e2e-test` inside addons/packages/{packagename}/{version}/test folder.
## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```
Automation framework to trigger addons package testing by running `make e2e-test`

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: none

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Run `ginkgo -v -- --kubeconfig="$KUBE_CONFIG" --packages="external-dns" --version="0.8.0" --provider="docker" --cluster-type="standalone" --guest-cluster-name="tce-cluster-1" --create-cluster --tce-version="{vx.x.x}"`

The above command will create a standalone cluster and runs external-dns test by triggering `make e2e-test` command. 
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA