### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/site/content/docs/assets/aws-clusters.md
+++ b/docs/site/content/docs/assets/aws-clusters.md
@@ -163,7 +163,7 @@ Kubernetes.
     For example, if your management cluster is called 'mtce', you will see a message similar to:
 
     ```sh
-    Credentials of workload cluster 'mtce' have been saved.
+    Credentials of cluster 'mtce' have been saved.
     You can now access the cluster by running 'kubectl config use-context mtce-admin@mtce'
     ```
 

--- a/docs/site/content/docs/assets/capd-clusters-windows.md
+++ b/docs/site/content/docs/assets/capd-clusters-windows.md
@@ -123,7 +123,7 @@ test, the entry would now look as follows.
     * For example, if your management cluster is called 'mtce', you will see a message similar to:
 
     ```sh
-    Credentials of workload cluster 'mtce' have been saved.
+    Credentials of cluster 'mtce' have been saved.
     You can now access the cluster by running 'kubectl config use-context mtce-admin@mtce'
     ```
 

--- a/docs/site/content/docs/assets/capd-clusters.md
+++ b/docs/site/content/docs/assets/capd-clusters.md
@@ -113,7 +113,7 @@ To optimise your Docker system and ensure a successful deployment, you may wish 
     * For example, if your management cluster is called 'mtce', you will see a message similar to:
 
     ```sh
-    Credentials of workload cluster 'mtce' have been saved.
+    Credentials of cluster 'mtce' have been saved.
     You can now access the cluster by running 'kubectl config use-context mtce-admin@mtce'
     ```
 

--- a/docs/site/content/docs/assets/vsphere-clusters.md
+++ b/docs/site/content/docs/assets/vsphere-clusters.md
@@ -170,7 +170,7 @@ Kubernetes.
    For example, if your management cluster is called 'mtce', you will see a message similar to:
 
    ```sh
-   Credentials of workload cluster 'mtce' have been saved.
+   Credentials of cluster 'mtce' have been saved.
    You can now access the cluster by running 'kubectl config use-context mtce-admin@mtce'
    ```
 

--- a/docs/site/content/docs/latest/package-management.md
+++ b/docs/site/content/docs/latest/package-management.md
@@ -417,7 +417,7 @@ the following diagram that shows what is created when a package is installed.
 If packages are failing to install, you can view the following resources:
 
 ```sh
-kubectl get packageinstall, app --namespace ${NS}
+kubectl get packageinstall,app --namespace ${NS}
 ```
 
 * `packageinstall` is the object created by `tanzu package install`, it declares


### PR DESCRIPTION
## What this PR does / why we need it
The docs say workload cluster when the actual output does not and it is also supposed to be for a management cluster. 
```
tanzu management-cluster kubeconfig get <MGMT-CLUSTER-NAME> --admin

Credentials of **workload** cluster 'mtce' have been saved.
You can now access the cluster by running 'kubectl config use-context mtce-admin@mtce'
```
---
The following command has a space which breaks the command.
```
kubectl get packageinstall,[EXTRA-SPACE]app --namespace default
```
Found by Cyrille Lebas.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
Ran the commands

This does not say workload
```
tanzu management-cluster kubeconfig get tce-mgmt --admin
Credentials of cluster 'tce-mgmt' have been saved
You can now access the cluster by running 'kubectl config use-context tce-mgmt-admin@tce-mgmt'
```

---
Current:
```
kubectl get packageinstall, app --namespace default
error: arguments in resource/name form must have a single resource and name
```

Fix:
```
kubectl get packageinstall,app --namespace default
NAME                                               PACKAGE NAME                              PACKAGE VERSION   DESCRIPTION           AGE
packageinstall.packaging.carvel.dev/cert-manager   cert-manager.community.tanzu.vmware.com   1.5.3             Reconcile succeeded   5d2h
packageinstall.packaging.carvel.dev/contour        contour.community.tanzu.vmware.com        1.18.1            Reconcile succeeded   5d2h
packageinstall.packaging.carvel.dev/grafana        grafana.community.tanzu.vmware.com        7.5.7             Reconcile succeeded   5d2h
packageinstall.packaging.carvel.dev/prometheus     prometheus.community.tanzu.vmware.com     2.27.0            Reconcile succeeded   5d2h

NAME                                DESCRIPTION           SINCE-DEPLOY   AGE
app.kappctrl.k14s.io/cert-manager   Reconcile succeeded   11s            5d2h
app.kappctrl.k14s.io/contour        Reconcile succeeded   7s             5d2h
app.kappctrl.k14s.io/grafana        Reconcile succeeded   28s            5d2h
app.kappctrl.k14s.io/prometheus     Reconcile succeeded   34s            5d2h
```

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
