### PR TITLE
doc- add doc to prune system for docker standalone

### DIFF
--- a/docs/site/content/docs/assets/capd-standalone-clusters.md
+++ b/docs/site/content/docs/assets/capd-standalone-clusters.md
@@ -32,6 +32,25 @@ docker pull kindest/haproxy:v20210715-a6da3463
 This behavior will eventually be addressed in
 [https://github.com/vmware-tanzu/community-edition/issues/897](https://github.com/vmware-tanzu/community-edition/issues/897).
 
+### Before You Begin
+
+To optimise your Docker system and ensure a successful deployment, you may wish to complete the next two optional steps.
+
+1. (Optional): Stop all existing containers.
+
+   ```shell
+   docker kill $(docker ps -q)
+   ```
+
+1. (Optional): Run the following command to prune all existing containers, volumes, and images.
+
+   Warning: Read the prompt carefully before running the command, as it erases the majority of what is cached in your Docker environment.
+While this ensures your environment is clean before starting, it also significantly increases bootstrapping time if you already had the Docker images downloaded.
+
+   ```sh
+    docker system prune -a --volumes
+   ```
+
 ### Local Docker Bootstrapping
 
 1. Create the standalone cluster.


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
Adds a Before You Begin section to the Docker Standalone doc with instructions for pruning the docker system before attempting standalone cluster deployment.

## Details for the Release Notes (PLEASE PROVIDE)

```NONE

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2191 

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
