### PR TITLE
doc: bootstrap prereq for linux cgroup1

### DIFF
--- a/docs/site/content/docs/assets/prereq-linux.md
+++ b/docs/site/content/docs/assets/prereq-linux.md
@@ -7,3 +7,25 @@
 |[Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/) |
 |Latest version of Chrome, Firefox, Safari, Internet Explorer, or  Edge|
 |System time is synchronized with a Network Time Protocol (NTP) server.|
+|Ensure your Linux bootstrap machine is using cgroup v1, for more information, see **Check and set the cgroup** below.|
+
+#### Check and set the cgroup 
+
+1. Check the cgroup by running the following command:
+
+    ```sh
+    docker info | grep -i cgroup 
+    ```
+
+    You should see the following output:
+
+    ```sh
+    Cgroup Driver: cgroupfs
+    Cgroup Version: 1
+    ```
+
+2. If your Linux distribution is configured to use cgroups v2, you will need to set the `system.unified_cgroup_hierarchy=0` kernel parameter to restore cgroups v1. See the instructions for setting kernel parameters for your Linux distribution, including:
+
+    [Fedora 32+](https://fedoramagazine.org/docker-and-fedora-32/)  
+    [Arch Linux](https://wiki.archlinux.org/title/Kernel_parameters)  
+    [OpenSUSE](https://doc.opensuse.org/documentation/leap/reference/html/book-reference/cha-grub2.html)


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
Adds documentation to the following topics detailing the Linux  group1 prerequisite.
 [Linux Local Bootstrap Machine Prerequisites](https://tanzucommunityedition.io/docs/latest/support-matrix/#local-clientbootstrap-machine-prerequisites)  
 [Install Tanzu Community Edition ](https://tanzucommunityedition.io/docs/latest/cli-installation/)  
 [Getting Started](http://localhost:1313/docs/latest/getting-started/)


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```Adds documentation detailing the Linux  group1 prerequisite.

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2138 

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
