### PR TITLE
Add E2E test for Chocolatey package for PR changes

### DIFF
--- a/.github/workflows/e2e-chocolatey-package.yaml
+++ b/.github/workflows/e2e-chocolatey-package.yaml
@@ -1,0 +1,27 @@
+name: E2E Test - Chocolatey package
+
+on:
+  pull_request:
+    types:
+      - assigned
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - "hack/choco/"
+      - "!hack/choco/**.md"
+      - ".github/workflows/e2e-chocolatey-package.yaml"
+
+jobs:
+  e2e-chocolatey-package-test:
+    name: E2E Chocolatey package test
+    runs-on: windows-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Run E2E Tests
+        shell: powershell
+        run: |
+          cd hack\choco
+          .\test\e2e-test.ps1

--- a/hack/choco/packpush.ps1
+++ b/hack/choco/packpush.ps1
@@ -1,6 +1,6 @@
 # This script is for LOCAL DEVELOPMENT ONLY.
 # Use it after you've made changes to the powershell scripts to clean up artifacts and get ready for re-installing.
-# It assumes you are using a local directory in ${HOME}\tcerepo as a --source for `choco install`.
+# It assumes you are using a local directory in ${HOME}\tce-pkg as a --source for `choco install`.
 # Invoke from hack/choco directory
 
 # Remove the nupkg file made by `choco pack` in the working dir

--- a/hack/choco/test/e2e-test.ps1
+++ b/hack/choco/test/e2e-test.ps1
@@ -1,0 +1,32 @@
+# Copyright 2020-2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+$ErrorActionPreference = 'Stop';
+
+New-Item -ItemType Directory -Force -Path $HOME\tce-pkg
+
+$parentDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+Write-Host "${parentDir}" -ForegroundColor Cyan
+
+$packAndPushScriptPath = "${parentDir}\..\packpush.ps1"
+
+Unblock-File -LiteralPath $packAndPushScriptPath
+
+$packAndPushScriptBlock  =  [scriptblock]::Create($packAndPushScriptPath)
+
+Invoke-Command -ScriptBlock $packAndPushScriptBlock
+
+choco install tanzu-community-edition --source $HOME\tce-pkg -y
+
+tanzu
+
+tanzu version
+
+tanzu standalone-cluster version
+
+tanzu conformance version
+
+tanzu diagnostics version
+
+choco uninstall tanzu-community-edition --source $HOME\tce-pkg -y


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #2229 

The test checks
- TCE installation using Chocolatey
- TCE uninstallation using Chocolatey

## Details for the Release Notes

```release-note
E2E test for PR changes to Chocolatey package
```

## Which issue(s) this PR fixes

Fixes: #2229 

## Describe testing done for PR

Sample pipelines testing the script are here -

https://github.com/karuppiah7890/community-edition/runs/3881589631

https://github.com/karuppiah7890/community-edition/runs/3871557248

## Special notes for your reviewer

I have some more ideas to improve this E2E test. Let me know what you folks think -
- In `packpush.ps1`, we can add a feature to override the local directory it pushes the chocolatey package to. Currently it pushes to one directory - https://github.com/vmware-tanzu/community-edition/blob/5ac772b04237a8180a4b9ac365000bd82a0761cc/hack/choco/packpush.ps1#L18 We can add the `${HOME}\tce-pkg` as a default and allow overrides. With the directory path override feature in place, in the E2E tests we can use a temporary directory to push the chocolatey package to and use that temporary directory for installation too. This can keep the E2E test related files in a separate place not affecting the user's / developer's workflow of using `${HOME}\tce-pkg` by default for their manual testing etc.