### PR TITLE
doc: remove doc ref to ytt in package documentation.

### DIFF
--- a/docs/site/content/docs/latest/package-management.md
+++ b/docs/site/content/docs/latest/package-management.md
@@ -330,7 +330,7 @@ tanzu package install ${NAME} \
       --values-file values.yaml
     ```
 
-    > Note: Value files are expected to use `ytt` syntax. Please refer to the [Carvel `ytt` documentation for further details](https://carvel.dev/ytt/docs/latest/)
+    > Note: Value files are expected to be plain YAML and not YTT Data Values files.
 
 ### Listing Installed Packages
 


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
Remove doc ref to ytt in package documentation:
[Work with packages](https://tanzucommunityedition.io/docs/latest/package-management/)

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```NONE

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2222 

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
