### PR TITLE
Fix aligned AKO 1.6.1 template.

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.5.3/bundle/config/overlays/overlay-configmap.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.5.3/bundle/config/overlays/overlay-configmap.yaml
@@ -64,9 +64,9 @@ data:
   #@overlay/match missing_ok=True
   enableRHI: #@ "{}".format(values.loadBalancerAndIngressService.config.network_settings.enable_rhi).lower()
 #@ end
-#@ if values.loadBalancerAndIngressService.config.ako_settings.nsxt_t1_lr:
+#@ if values.loadBalancerAndIngressService.config.network_settings.nsxt_t1_lr:
   #@overlay/match missing_ok=True
-  nsxtT1LR: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.nsxt_t1_lr)
+  nsxtT1LR: #@ "{}".format(values.loadBalancerAndIngressService.config.network_settings.nsxt_t1_lr)
 #@ end
 #@ if values.loadBalancerAndIngressService.config.ako_settings.log_level:
   #@overlay/match missing_ok=True

--- a/addons/packages/load-balancer-and-ingress-service/1.5.3/bundle/config/overlays/overlay-statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.5.3/bundle/config/overlays/overlay-statefulset.yaml
@@ -141,7 +141,7 @@ spec:
                   name: avi-k8s-config
                   key: syncNamespace
 #@ end
-#@ if values.loadBalancerAndIngressService.config.ako_settings.nsxt_t1_lr:
+#@ if values.loadBalancerAndIngressService.config.network_settings.nsxt_t1_lr:
 #@overlay/append
             - name: NSXT_T1_LR
               valueFrom:


### PR DESCRIPTION
## What this PR does / why we need it
This PR fixes the ytt rendering error for 1.6.1 manifest due to incorrect field of key `nsxt_t1_lr`. 


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
