### PR TITLE
update optional step 9 in deploying workload cluster procedure

### DIFF
--- a/docs/site/content/docs/latest/workload-clusters.md
+++ b/docs/site/content/docs/latest/workload-clusters.md
@@ -40,7 +40,7 @@ For specific configuration parameters, see:
 1. Optional: Specify the number of worker nodes for the cluster in the `WORKER_MACHINE_COUNT` variable.
 1. Optional: Deploy a workload cluster in a specific namespace.
 If you have created namespaces, you can deploy workload clusters to those namespaces by specifying the `NAMESPACE` variable. If you do not specify the `NAMESPACE` variable, Tanzu Community Edition places clusters in the `default` namespace. Any namespace that you identify in the `NAMESPACE` variable must exist in the management cluster before you run the command. You must provide a unique name for all workload clusters across all namespaces. If you provide a workload cluster name that is already in use in another namespace in the same instance, the deployment fails with an error.
-1. Optional: To configure a workload cluster to use an OS other than the default Ubuntu v21.04, you must set the `OS_NAME` and `OS_VERSION` values in the cluster configuration file. The installer interface does not include node VM OS values in the management cluster configuration files that it saves to `~/.config/tanzu/tkg/clusterconfigs`.
+1. Optional: To configure a workload cluster to use an OS different from the management cluster, you must set the `OS_NAME` and `OS_VERSION` values in the cluster configuration file.
 1. Run the following command to deploy the workload cluster:
 
    ```sh


### PR DESCRIPTION
## What this PR does / why we need it
Updates workload cluster deployment procedure.
Step #9 of workload-clusters is incorrect - OS_NAME and OS_VERSION are defined in the management cluster config, which is copied in Step #1. As such, they should only be updated if the user wishes to differ node image from management cluster nodes.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
correct workload cluster deployment procedure step 9
```

## Which issue(s) this PR fixes
Fixes: #2248

## Describe testing done for PR
Refer to issue for generated management cluster config.

## Special notes for your reviewer
None.