### PR TITLE
Incorrect kernel parameter specified.

### DIFF
--- a/docs/site/content/docs/assets/prereq-linux.md
+++ b/docs/site/content/docs/assets/prereq-linux.md
@@ -24,7 +24,7 @@
     Cgroup Version: 1
     ```
 
-2. If your Linux distribution is configured to use cgroups v2, you will need to set the `system.unified_cgroup_hierarchy=0` kernel parameter to restore cgroups v1. See the instructions for setting kernel parameters for your Linux distribution, including:
+2. If your Linux distribution is configured to use cgroups v2, you will need to set the `systemd.unified_cgroup_hierarchy=0` kernel parameter to restore cgroups v1. See the instructions for setting kernel parameters for your Linux distribution, including:
 
     [Fedora 32+](https://fedoramagazine.org/docker-and-fedora-32/)  
     [Arch Linux](https://wiki.archlinux.org/title/Kernel_parameters)  


### PR DESCRIPTION
Modified the kernel parameter to change from cgroups v2 to v1. 

If committed this PR will change `system.unified_cgroup_hierarchy=0` to `systemd.unified_cgroup_hierarchy=0`

This correct setting can be verified [here](https://www.freedesktop.org/software/systemd/man/systemd.html#systemd.unified_cgroup_hierarchy) and  [here](https://wiki.archlinux.org/title/Cgroups#Enable_cgroup_v1).

Area affected docs:linux-prerequisites