### PR TITLE
Add automation to update TCE homebrew formula on release

### DIFF
--- a/.github/workflows/update-homebrew-package.yaml
+++ b/.github/workflows/update-homebrew-package.yaml
@@ -1,0 +1,34 @@
+name: Update Homebrew Package
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  update-homebrew-package:
+    name: Update Homebrew Package
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Config credentials
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
+        run: |
+          git config --global pull.rebase true
+          git config --global url."https://git:${GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global user.name github-actions
+          git config --global user.email github-actions@github.com
+
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Update Homebrew Package
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
+        shell: bash
+        run: |
+          GITHUB_REF="${{ github.ref }}"
+          version=${GITHUB_REF/refs\/tags\//}
+          ./hack/homebrew/update-homebrew-package.sh ${version}

--- a/hack/homebrew/update-homebrew-package.sh
+++ b/hack/homebrew/update-homebrew-package.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+version="${1:?TCE version argument empty. Example usage: ./hack/homebrew/update-homebrew-package.sh v0.10.0}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is not set}"
+
+temp_dir=$(mktemp -d)
+
+pushd "${temp_dir}"
+
+TCE_REPO_RELEASES_URL="https://github.com/vmware-tanzu/community-edition/releases"
+TCE_DARWIN_TAR_BALL_FILE="tce-darwin-amd64-${version}.tar.gz"
+TCE_LINUX_TAR_BALL_FILE="tce-linux-amd64-${version}.tar.gz"
+TCE_CHECKSUMS_FILE="tce-checksums.txt"
+TCE_HOMEBREW_TAP_REPO="https://github.com/vmware-tanzu/homebrew-tanzu"
+
+echo "Checking if the necessary files exist for the TCE ${version} release"
+
+curl -f -I -L \
+    "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_DARWIN_TAR_BALL_FILE}" > /dev/null || {
+        echo "${TCE_DARWIN_TAR_BALL_FILE} is not accessible in TCE ${version} release"
+        exit 1
+    }
+
+curl -f -I -L \
+    "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_LINUX_TAR_BALL_FILE}" > /dev/null || {
+        echo "${TCE_LINUX_TAR_BALL_FILE} is not accessible in TCE ${version} release"
+        exit 1
+    }
+
+wget "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_CHECKSUMS_FILE}" || {
+    echo "${TCE_CHECKSUMS_FILE} is not accessible in TCE ${version} release"
+    exit 1
+}
+
+darwin_amd64_shasum=$(grep "${TCE_DARWIN_TAR_BALL_FILE}" ${TCE_CHECKSUMS_FILE} | cut -d ' ' -f 1)
+
+linux_amd64_shasum=$(grep "${TCE_LINUX_TAR_BALL_FILE}" ${TCE_CHECKSUMS_FILE} | cut -d ' ' -f 1)
+
+git clone ${TCE_HOMEBREW_TAP_REPO}
+
+cd homebrew-tanzu
+
+# make sure we are on main branch before checking out
+git checkout main
+
+PR_BRANCH="update-tce-to-${version}-${RANDOM}"
+
+# Random number in branch name in case there's already some branch for the version update,
+# though there shouldn't be one. There could be one if the other branch's PR tests failed and didn't merge
+git checkout -b "${PR_BRANCH}"
+
+# Replacing old version with the latest stable released version.
+# Using -i so that it works on Mac and Linux OS, so that it's useful for local development.
+sed -i.bak "s/version \"v.*/version \"${version}\"/" tanzu-community-edition.rb
+rm -fv tanzu-community-edition.rb.bak
+
+# First occurrence of sha256 is for MacOS SHA sum
+awk "/sha256 \".*/{c+=1}{if(c==1){sub(\"sha256 \\\".*\",\"sha256 \\\"${darwin_amd64_shasum}\\\"\",\$0)};print}" tanzu-community-edition.rb > tanzu-community-edition-updated.rb
+mv tanzu-community-edition-updated.rb tanzu-community-edition.rb
+
+# Second occurrence of sha256 is for Linux SHA sum
+awk "/sha256 \".*/{c+=1}{if(c==2){sub(\"sha256 \\\".*\",\"sha256 \\\"${linux_amd64_shasum}\\\"\",\$0)};print}" tanzu-community-edition.rb > tanzu-community-edition-updated.rb
+mv tanzu-community-edition-updated.rb tanzu-community-edition.rb
+
+git add tanzu-community-edition.rb
+
+git commit -m "auto-generated - update tce homebrew formula for version ${version}"
+
+git push origin "${PR_BRANCH}"
+
+gh pr create --repo ${TCE_HOMEBREW_TAP_REPO} --title "auto-generated - update tce homebrew formula for version ${version}" --body "auto-generated - update tce homebrew formula for version ${version}"
+
+gh pr merge --repo ${TCE_HOMEBREW_TAP_REPO} "${PR_BRANCH}" --squash --delete-branch --auto
+
+popd


### PR DESCRIPTION
## What this PR does / why we need it

This is to add automation to update TCE homebrew formula on release. More details - https://github.com/vmware-tanzu/homebrew-tanzu/issues/19

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Add automation to update TCE homebrew formula on release
```

## Which issue(s) this PR fixes

Fixes: https://github.com/vmware-tanzu/homebrew-tanzu/issues/19
Part of https://github.com/vmware-tanzu/community-edition/issues/1663

## Describe testing done for PR

Sample dummy release - https://github.com/karuppiah7890/community-edition/releases/tag/v0.51.0
Sample workflow triggered after dummy release - https://github.com/karuppiah7890/community-edition/runs/3936479124?check_suite_focus=true
Sample dummy PR in dummy Homebrew Tanzu repo - https://github.com/karuppiah7890/homebrew-tanzu/pull/3
Sample dummy automated commit after PR merge - https://github.com/karuppiah7890/homebrew-tanzu/commit/2daf14df9f252d194f6c49212b27679d9fdb3d86

## Special notes for your reviewer

Some things in my mind
- The automated commit currently shows my account along with a dummy bot account name - https://github.com/karuppiah7890/homebrew-tanzu/commit/2daf14df9f252d194f6c49212b27679d9fdb3d86 . When we use https://github.com/tce-automation account, we could maybe ensure this doesn't happen. I'll check more on this. I think this is due to the git config used. The PR uses git config (user name and email) similar to the one used for package docs automation - https://github.com/vmware-tanzu/community-edition/blob/5ac772b04237a8180a4b9ac365000bd82a0761cc/.github/workflows/package-copy-readmes-to-docs.yaml#L20-L27 and there too the commit https://github.com/vmware-tanzu/community-edition/commit/57154910d389cc1b36e1d46f8a04097b7203238b shows both tce-automation account name and github-actions account name. I think we need to fix the git config and use proper user name and email in it according to the tce-automation account, I'll try it out and check if the git config change works
- Currently the script works as shown in the demo. The script does have little complicated code to update the Homebrew formula file (ruby file). It uses `sed` and `awk`, and I have tried to ensure that it works on Mac (my local environment) and Linux too, in the CI environment. I know it's a bit complicated, I'll try to see if I can simplify it further or change the whole approach itself. A few other ideas for different approaches - 
  - Parse ruby code and modify the formula to update the version and SHAs, for example using AST etc. This might be complex though
  - Use brew CLI tool to do the task, but not sure if it can handle the if-else for the Mac and Linux SHA sums https://github.com/vmware-tanzu/homebrew-tanzu/blob/452e0ad1f3ddebc25a4b545b5f0390339777aca6/tanzu-community-edition.rb#L10-L16 , gotta check more. As of now based on whatever I have checked I can't seem to find any such options in `brew bump-formula-pr --help` or any commands to help with it in `brew commands`
- I'm also looking to add E2E tests to homebrew tap repo to test if the the Homebrew formula update is correct. Check https://github.com/vmware-tanzu/homebrew-tanzu/issues/20 . These tests would run when the automation in this PR raise PR in homebrew tap repo. We also need to ensure that the PR is automatically merged only when the PR checks pass or it should Not be merged. Currently this PR has code which merges automation PRs automatically and immediately, the same is true for package docs automation which merges the PR before checks pass, for example - https://github.com/vmware-tanzu/community-edition/pull/2238 . There are failing checks https://github.com/vmware-tanzu/community-edition/pull/2238/checks , I think the failure is due to the fact that the PR got merged immediately and didn't wait for checks to finish with a result - a success or a failure and then accordingly merge (on success) and do nothing (on failure) and exit with non-zero code to show that the workflow / pipeline / automation failed when the checks fail