### PR TITLE
Remove unncessary GitHub Token #2270

### DIFF
--- a/.github/workflows/package-copy-readmes-to-docs.yaml
+++ b/.github/workflows/package-copy-readmes-to-docs.yaml
@@ -26,8 +26,6 @@ jobs:
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
       - name: Check out code into the Go module directory
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PACKAGING_ACCESS_TOKEN }}
         uses: actions/checkout@v1
       - name: Copy Package Readme Files
         run: |


### PR DESCRIPTION
## What this PR does / why we need it

With TCE now public, a GITHUB_TOKEN is no longer needed to clone the repo.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Remove unnecessary GitHub Token #2270 
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2270

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
