### PR TITLE
[WIP] Add update strategy overlay to all core packages

### DIFF
--- a/addons/packages/ako-operator/1.5.0/bundle/config/overlays/update_overlay.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/overlays/update_overlay.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    #@overlay/match missing_ok=True
+    type: OnDelete
+
+#@overlay/match by=overlay.subset({"kind":"Deployment"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    #@overlay/match missing_ok=True
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      #@overlay/match missing_ok=True
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+    #@ if data.values.tanzuKubernetesRelease and data.values.tanzuKubernetesRelease != "":
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@overlay/match missing_ok=True
+        tanzuKubernetesRelease: #@ data.values.tanzuKubernetesRelease
+    #@ end

--- a/addons/packages/ako-operator/1.5.0/bundle/config/values.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/values.yaml
@@ -1,6 +1,7 @@
 #@data/values
 #@overlay/match-child-defaults missing_ok=True
 ---
+tanzuKubernetesRelease: null
 akoOperator:
   avi_enable: true
   namespace: tkg-system-networking

--- a/addons/packages/ako-operator/1.5.0/package.yaml
+++ b/addons/packages/ako-operator/1.5.0/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/ako-operator@sha256:c21d1af3909cc1b679acb3c2db8f384fa478784f4fec7f7d58b3b087922db023
+            image: projects.registry.vmware.com/tce/ako-operator@sha256:ebe610f9df2df64b4a18481cabf1b85b44a969dd8b2af5ea1f513ffdb34c8654
       template:
         - ytt:
             paths:

--- a/addons/packages/antrea/0.13.3/bundle/config/overlay/update_overlay.yaml
+++ b/addons/packages/antrea/0.13.3/bundle/config/overlay/update_overlay.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    #@overlay/match missing_ok=True
+    type: OnDelete
+
+#@overlay/match by=overlay.subset({"kind":"Deployment"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    #@overlay/match missing_ok=True
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      #@overlay/match missing_ok=True
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+    #@ if data.values.tanzuKubernetesRelease and data.values.tanzuKubernetesRelease != "":
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@overlay/match missing_ok=True
+        tanzuKubernetesRelease: #@ data.values.tanzuKubernetesRelease
+    #@ end

--- a/addons/packages/antrea/0.13.3/bundle/config/values.yaml
+++ b/addons/packages/antrea/0.13.3/bundle/config/values.yaml
@@ -2,6 +2,7 @@
 #@overlay/match-child-defaults missing_ok=True
 
 ---
+tanzuKubernetesRelease: null
 infraProvider: vsphere
 antrea:
   config:

--- a/addons/packages/antrea/0.13.3/package.yaml
+++ b/addons/packages/antrea/0.13.3/package.yaml
@@ -13,7 +13,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/antrea@sha256:bf80a1114ac0dda12753ac4d7d34e1ff34052f9228636df823a5852480bf0be2
+            image: projects.registry.vmware.com/tce/antrea@sha256:14294c577af686c721468d797248118bd771a15787a4294efd26dbe72240d348
       template:
         - ytt:
             paths:

--- a/addons/packages/calico/3.19.1/bundle/config/overlay/update_overlay.yaml
+++ b/addons/packages/calico/3.19.1/bundle/config/overlay/update_overlay.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    #@overlay/match missing_ok=True
+    type: OnDelete
+
+#@overlay/match by=overlay.subset({"kind":"Deployment"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    #@overlay/match missing_ok=True
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      #@overlay/match missing_ok=True
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+    #@ if data.values.tanzuKubernetesRelease and data.values.tanzuKubernetesRelease != "":
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@overlay/match missing_ok=True
+        tanzuKubernetesRelease: #@ data.values.tanzuKubernetesRelease
+    #@ end

--- a/addons/packages/calico/3.19.1/bundle/config/values.yaml
+++ b/addons/packages/calico/3.19.1/bundle/config/values.yaml
@@ -1,6 +1,6 @@
 #@data/values
 ---
-
+tanzuKubernetesRelease: null
 namespace: kube-system
 infraProvider: vsphere
 ipFamily: null

--- a/addons/packages/calico/3.19.1/package.yaml
+++ b/addons/packages/calico/3.19.1/package.yaml
@@ -14,7 +14,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/calico@sha256:dac539d2ae4477bbbd570008cdc34e3a580b58a60e36ae60a1d55b434faf5bf6
+            image: projects.registry.vmware.com/tce/calico@sha256:a9a13e895a3fac1152b21a0ef3d649ed033ab68e9a7833be1a6c43d59d69aaf3
       template:
         - ytt:
             paths:

--- a/addons/packages/kapp-controller/0.25.0/bundle/config/overlays/update_overlay.yaml
+++ b/addons/packages/kapp-controller/0.25.0/bundle/config/overlays/update_overlay.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    #@overlay/match missing_ok=True
+    type: OnDelete
+
+#@overlay/match by=overlay.subset({"kind":"Deployment"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    #@overlay/match missing_ok=True
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      #@overlay/match missing_ok=True
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+    #@ if data.values.tanzuKubernetesRelease and data.values.tanzuKubernetesRelease != "":
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@overlay/match missing_ok=True
+        tanzuKubernetesRelease: #@ data.values.tanzuKubernetesRelease
+    #@ end

--- a/addons/packages/kapp-controller/0.25.0/bundle/config/values.yaml
+++ b/addons/packages/kapp-controller/0.25.0/bundle/config/values.yaml
@@ -1,6 +1,7 @@
 #@data/values
 #@overlay/match-child-defaults missing_ok=True
 ---
+tanzuKubernetesRelease: null
 namespace: kapp-controller
 kappController:
   namespace: null

--- a/addons/packages/kapp-controller/0.25.0/package.yaml
+++ b/addons/packages/kapp-controller/0.25.0/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:55a5f32f93af75246ea73b59f52bd89e864c094b5722db7346bf4bcfb282eeb2
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:2911c7edae2b00a15b452929bbc1bfa6b04f31eb45537840db75df4b44c2032a
       template:
         - ytt:
             paths:

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/overlays/update_overlay.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/overlays/update_overlay.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    #@overlay/match missing_ok=True
+    type: OnDelete
+
+#@overlay/match by=overlay.subset({"kind":"Deployment"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    #@overlay/match missing_ok=True
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      #@overlay/match missing_ok=True
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+    #@ if data.values.tanzuKubernetesRelease and data.values.tanzuKubernetesRelease != "":
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@overlay/match missing_ok=True
+        tanzuKubernetesRelease: #@ data.values.tanzuKubernetesRelease
+    #@ end

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/values.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/values.yaml
@@ -1,6 +1,7 @@
 #@data/values
 #@overlay/match-child-defaults missing_ok=True
 ---
+tanzuKubernetesRelease: null
 loadBalancerAndIngressService:
   name: ako-default-wc-1
   namespace: avi-system

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/package.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/load-balancer-and-ingress-service@sha256:d81cf5cc2d2f57a49191c50e5da9161e779e39f68783551b946f8a888aa18ab7
+            image: projects.registry.vmware.com/tce/load-balancer-and-ingress-service@sha256:a15c498ab6320cb1c2403a453b45a1401e3d86f34d76bc4f14cec3c2434dd4b5
       template:
         - ytt:
             paths:

--- a/addons/packages/metrics-server/0.5.1/bundle/config/overlays/update_overlay.yaml
+++ b/addons/packages/metrics-server/0.5.1/bundle/config/overlays/update_overlay.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    #@overlay/match missing_ok=True
+    type: OnDelete
+
+#@overlay/match by=overlay.subset({"kind":"Deployment"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    #@overlay/match missing_ok=True
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      #@overlay/match missing_ok=True
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+    #@ if data.values.tanzuKubernetesRelease and data.values.tanzuKubernetesRelease != "":
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@overlay/match missing_ok=True
+        tanzuKubernetesRelease: #@ data.values.tanzuKubernetesRelease
+    #@ end

--- a/addons/packages/metrics-server/0.5.1/bundle/config/values.yaml
+++ b/addons/packages/metrics-server/0.5.1/bundle/config/values.yaml
@@ -1,6 +1,7 @@
 #@data/values
 #@overlay/match-child-defaults missing_ok=True
 ---
+tanzuKubernetesRelease: null
 namespace: kube-system
 metricsServer:
   namespace: null

--- a/addons/packages/metrics-server/0.5.1/package.yaml
+++ b/addons/packages/metrics-server/0.5.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/metrics-server@sha256:393e7aa6c89f55229e9559f82165c3a51fe408c4c7dd4b72409844513b8caf83
+            image: projects.registry.vmware.com/tce/metrics-server@sha256:8e2e69ca8f4904967a11e06aa182192f57645b284c854f38a139fe92b2916e89
       template:
         - ytt:
             paths:

--- a/addons/packages/pinniped/0.4.4/bundle/config/overlay/update_overlay.yaml
+++ b/addons/packages/pinniped/0.4.4/bundle/config/overlay/update_overlay.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    #@overlay/match missing_ok=True
+    type: OnDelete
+
+#@overlay/match by=overlay.subset({"kind":"Deployment"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    #@overlay/match missing_ok=True
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      #@overlay/match missing_ok=True
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+    #@ if data.values.tanzuKubernetesRelease and data.values.tanzuKubernetesRelease != "":
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@overlay/match missing_ok=True
+        tanzuKubernetesRelease: #@ data.values.tanzuKubernetesRelease
+    #@ end

--- a/addons/packages/pinniped/0.4.4/bundle/config/values.yaml
+++ b/addons/packages/pinniped/0.4.4/bundle/config/values.yaml
@@ -1,6 +1,7 @@
 #@data/values
 #@overlay/match-child-defaults missing_ok=True
 ---
+tanzuKubernetesRelease: null
 imageInfo:
   imageRepository: projects-stg.registry.vmware.com/tkg
   imagePullPolicy: IfNotPresent

--- a/addons/packages/pinniped/0.4.4/package.yaml
+++ b/addons/packages/pinniped/0.4.4/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/pinniped@sha256:f1a8f9bf0e871fe1f0b04578c71b76bab9b6953b585c5ce1dc68ba521545355e
+            image: projects.registry.vmware.com/tce/pinniped@sha256:54fd56a1843cd9ce58647c63d01a9c4b46e2b183d0d66d1cc36b5a91edfc202e
       template:
         - ytt:
             paths:

--- a/addons/packages/vsphere-cpi/1.21.0/bundle/config/overlays/update_overlay.yaml
+++ b/addons/packages/vsphere-cpi/1.21.0/bundle/config/overlays/update_overlay.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    #@overlay/match missing_ok=True
+    type: OnDelete
+
+#@overlay/match by=overlay.subset({"kind":"Deployment"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    #@overlay/match missing_ok=True
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      #@overlay/match missing_ok=True
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+    #@ if data.values.tanzuKubernetesRelease and data.values.tanzuKubernetesRelease != "":
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@overlay/match missing_ok=True
+        tanzuKubernetesRelease: #@ data.values.tanzuKubernetesRelease
+    #@ end

--- a/addons/packages/vsphere-cpi/1.21.0/bundle/config/values.yaml
+++ b/addons/packages/vsphere-cpi/1.21.0/bundle/config/values.yaml
@@ -2,6 +2,7 @@
 #@overlay/match-child-defaults missing_ok=True
 
 ---
+tanzuKubernetesRelease: null
 vsphereCPI:
   tlsThumbprint: ""
   server: null

--- a/addons/packages/vsphere-cpi/1.21.0/package.yaml
+++ b/addons/packages/vsphere-cpi/1.21.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:7c9d83092f79589bbfb401203668e0f80a9f6c08a84dd70422d5689593cae960
+            image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:2918ec5e2610be6801fb38db4a0f0f5e7bb537a6b07260d6b295e2315224540a
       template:
         - ytt:
             paths:

--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/overlays/update_overlay.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/overlays/update_overlay.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    #@overlay/match missing_ok=True
+    type: OnDelete
+
+#@overlay/match by=overlay.subset({"kind":"Deployment"}), expects="0+"
+---
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    #@overlay/match missing_ok=True
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      #@overlay/match missing_ok=True
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+    #@ if data.values.tanzuKubernetesRelease and data.values.tanzuKubernetesRelease != "":
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@overlay/match missing_ok=True
+        tanzuKubernetesRelease: #@ data.values.tanzuKubernetesRelease
+    #@ end

--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/values.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/values.yaml
@@ -2,6 +2,7 @@
 #@overlay/match-child-defaults missing_ok=True
 
 ---
+tanzuKubernetesRelease: null
 vsphereCSI:
   namespace: kube-system
   clusterName: null

--- a/addons/packages/vsphere-csi/2.3.0/package.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:ac8e916b88755b67058515b5eafff8d29afdea7d92c7c74195833718ee6d7f89
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:460d853332976baa5bf3e695dade685e6d5fd3e1b73173d0cc8ab9965a99c6ae
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Given that forwards compatibility with a particular Kubernetes version is not enforceable, and that certain add-ons like CNI are developed upstream, add-on updates are rollout first so that backwards compatible versions can roll out in synchronization with the new nodes joining the cluster.

It's important to prevent theadd-ons' `Pods` from being spun down and replaced with `Pods` that is intended for next release. To that end, built-in update strategies are applied and configured on the applications.

##### `DaemonSets`

For `DaemonSets`, we configure the [`.spec.updateStrategy.type`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#daemonsetupdatestrategy-v1-apps) to `OnDelete`. This ensures that the existing `Pods` will not be spun down on older nodes (thereby keeping the application available), but that new nodes entering the cluster will receive the new configuration and spin up the appropriate `Pods`. As the old nodes exit the cluster, so too will the `Pods` containing the stale configuration.

##### `Deployments`

For `Deployments` we configure four things:

* [`.spec.strategy.type`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#deploymentstrategy-v1-apps)
  is configured to `RollingUpdate`
* [`.spec.strategy.rollingUpdate.maxUnavailable`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#rollingupdatedeployment-v1-apps) is set to `0`.
* [`.spec.strategy.rollingUpdate.maxSurge`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#rollingupdatedeployment-v1-apps)
  is set to `1`.
* [`.spec.template.spec.nodeSelector`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podspec-v1-core) is set to target only `Nodes` where the label
  `tanzuKubernetesVersion` contains the appropriate
  distribution version (i.e.
  `tanzuKubernetesVersion=v1.21.5---vmware.1-tkg.1-zshippable`). This label is set at creation time for every node in the cluster and will not be mutated (short of an end-user `cluster-admin` overwriting the label).

The `nodeSelector` ensures that the new `Pods` only target the nodes which will have the container image available, while the `maxUnavailable` and `maxSurge` settings ensure that the old `Pods` will not be spun down until there is a viable replacement.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
