### PR TITLE
Remote path-node-for-antrea shell script

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/create.go
+++ b/cli/cmd/plugin/standalone-cluster/create.go
@@ -232,7 +232,7 @@ func create(cmd *cobra.Command, args []string) error {
 	// run the antrea patch for kind-specific deployments
 	nodes := ListNodes(clusterName)
 	for _, node := range nodes {
-		err := patchNodeForAntrea(node)
+		err := cluster.PatchForAntrea(node)
 		if err != nil {
 			log.Errorf("Failed to patch node!!! %s\n", err.Error())
 		}
@@ -318,20 +318,6 @@ infraProvider: docker
 	}
 
 	return createdSecret, err
-}
-
-// this needs to happen for antrea running on kind or else you'll lose network connectivity
-// see: https://github.com/antrea-io/antrea/blob/main/hack/kind-fix-networking.sh
-// TODO(joshrosso): I noticed the kind image has the `ethtool` inside of it. Could we do this by executing in the
-// containers created rather than doing this hack?
-func patchNodeForAntrea(nodeName string) error {
-	// TODO(joshrosso): This is not portable for windows! We need to bring this into go.
-	_, err := exec.Command("/bin/sh", "cli/cmd/plugin/standalone-cluster/hack/patch-node-for-antrea.sh", nodeName).Output()
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // getTkgConfigDir returns the configuration directory used by tce.

--- a/cli/cmd/plugin/standalone-cluster/hack/patch-node-for-antrea.sh
+++ b/cli/cmd/plugin/standalone-cluster/hack/patch-node-for-antrea.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-peerIdx=$(docker exec $1 ip link | grep eth0 | awk -F[@:] '{ print $3 }' | cut -c 3-)
-peerName=$(docker run --rm --net=host antrea/ethtool:latest ip link | grep ^"$peerIdx": | awk -F[:@] '{ print $2 }' | cut -c 2-)
-docker run --rm --net=host --privileged antrea/ethtool:latest ethtool -K "$peerName" tx off
-docker exec "$1" sysctl -w net.ipv4.conf.all.route_localnet=1


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This removes the platform-dependent shell script we were using to patch
the node networking for Antrea. These changes are now called from the go
code, making it possible to run on any platform with a docker
executable.