### PR TITLE
Add chocolately instructions with explicit version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,10 @@ After install, homebrew will prompt you with a configure script, run it.
 
 ### Windows via chocolatey
 
-⚠️ chocolatey package is finishing approval. Until available, please use manual
-steps below.
-
 ```sh
-choco install tanzu-community-edition
+choco install tanzu-community-edition --version=0.9.1
 ```
+
 
 ### Manual (Mac/Linux/Windows)
 
@@ -64,6 +62,8 @@ choco install tanzu-community-edition
 1. Run the install script.
     * `install.bat` on Windows as Administrator.
     * `install.sh` on Mac/Linux
+
+
 
 ## Packages
 
@@ -117,3 +117,4 @@ If you have any questions about Tanzu Community Edition, please join [#tanzu-com
 
 Please submit [bugs or enhancements requests](https://github.com/vmware-tanzu/community-edition/issues/new/choose) in GitHub.
 More information about troubleshooting and our triage process is available [here](https://tanzucommunityedition.io/docs/latest/trouble-faq/).
+

--- a/docs/site/content/docs/assets/cli-install-windows.md
+++ b/docs/site/content/docs/assets/cli-install-windows.md
@@ -1,7 +1,21 @@
 ## Installation Procedure
 
-1. [Download the release zip](https://github.com/vmware-tanzu/community-edition/releases) for Windows.
-1. Unpack the release zip.
-1. Enter the directory of the unpacked release.
-1. Run the install script.
-    * `install.bat` on Windows (run as Administrator).
+1. Make sure you have the [Chocolatey package manager installed](https://chocolatey.org/install).
+
+1. You must download and install the latest version of `kubectl`. For more information, see [Install and Set Up kubectl on Windows](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/) in the Kubernetes documentation.
+
+1. You must download and install the latest version of `docker`. For more information, see [Install Docker Desktop on Windows](https://docs.docker.com/desktop/windows/install/) in the Docker documentation.
+
+1. Open PowerShell **as an administrator** and run the following:
+
+    ```sh
+    choco install tanzu-community-edition --version={{<  release_latest >}}
+
+    ```
+
+    > Both `docker` and `kubectl` are required to be present on the system, but are not explicit Chocolatey dependencies.
+    > Installing the Tanzu Community Edition package will extract the binaries and configure the plugin repositories. This might take a minute.
+    > Using an explicit version is required for now.
+
+1. The `tanzu` command will be added to your `$PATH` variable automatically by Chocolatey.
+


### PR DESCRIPTION
This reverts commit 8edb7529f2c0293cefa8bac60d84f4908cb8c97d.

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

The [Chocolatey package](https://community.chocolatey.org/packages/tanzu-community-edition/0.9.1) is still unlisted, but it can be accessed by providing the version explicitly.

This docs change will make sure that the version flag is kept up-to-date with the docs, too.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

`hugo server --disableFastRenderer`
