### PR TITLE
Fix incorrect 1.5.0 ako-operator image tag.

### DIFF
--- a/addons/packages/ako-operator/1.5.0/bundle/.imgpkg/images.yml
+++ b/addons/packages/ako-operator/1.5.0/bundle/.imgpkg/images.yml
@@ -2,7 +2,7 @@
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
-    kbld.carvel.dev/id: projects-stg.registry.vmware.com/tkg/ako-operator:v1.4.0_vmware.1
+    kbld.carvel.dev/id: projects-stg.registry.vmware.com/tkg/ako-operator:v1.5.0_vmware.1
   image: projects-stg.registry.vmware.com/tkg/ako-operator@sha256:53926b85c969126fb9893c45e6d8fee29bb1d1b082b27946a72c2dd8b2d26442
 - annotations:
     kbld.carvel.dev/id: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2

--- a/addons/packages/ako-operator/1.5.0/bundle/config/overlays/overlay-deployment.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/overlays/overlay-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - --metrics-addr=127.0.0.1:8080
           command:
             - /manager
-          image: projects-stg.registry.vmware.com/tkg/ako-operator:v1.4.0_vmware.1
+          image: projects-stg.registry.vmware.com/tkg/ako-operator:v1.5.0_vmware.1
           name: manager
           env:
             - name: bootstrap_cluster

--- a/addons/packages/ako-operator/1.5.0/bundle/config/upstream/akooperator/deployment.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/upstream/akooperator/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - --metrics-addr=127.0.0.1:8080
           command:
             - /manager
-          image: projects-stg.registry.vmware.com/tkg/ako-operator:v1.4.0_vmware.1
+          image: projects-stg.registry.vmware.com/tkg/ako-operator:v1.5.0_vmware.1
           name: manager
           env:
             - name: bootstrap_cluster


### PR DESCRIPTION
## What this PR does / why we need it
Currently, the image tag of the ako-operator 1.5.0 has wrong tag `1.4.0`, which leads to erroneous kbld translation when going downstream.  This PR fixes this problem by aligning the version.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: # None

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
