### PR TITLE
Move antrea network patching to kind create

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/cluster/cluster.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/cluster.go
@@ -35,10 +35,6 @@ type ClusterManager interface {
 	List() ([]*KubernetesCluster, error)
 	// Delete will destroy a cluster or return an error indicating a problem.
 	Delete(clusterName string) error
-	// ListNodes returns an array of the node names of the cluster.
-	// TODO(stmcginnis): Determine if we need to keep this after we sort out the
-	// antrea hack (hack/patch-node-for-antrea.sh)
-	ListNodes(clusterName string) []string
 }
 
 // NewClusterManager gets a ClusterManager implementation.

--- a/cli/cmd/plugin/standalone-cluster/list.go
+++ b/cli/cmd/plugin/standalone-cluster/list.go
@@ -41,10 +41,3 @@ func list(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
-
-// ListNodes returns a list of nodes for the current cluster.
-// If the cluster doesn't exist, an empty list is returned.
-func ListNodes(clusterName string) []string {
-	clusterManager := cluster.NewClusterManager()
-	return clusterManager.ListNodes(clusterName)
-}

--- a/cli/cmd/plugin/standalone-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/standalone-cluster/tanzu/tanzu.go
@@ -3,6 +3,10 @@ package tanzu
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/cluster"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/kapp"
@@ -10,11 +14,7 @@ import (
 	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/log"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/packages"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/tkr"
-	"io/ioutil"
 	v1 "k8s.io/api/apps/v1"
-	"os"
-	"path/filepath"
-	"time"
 )
 
 type TanzuCluster struct {
@@ -221,7 +221,7 @@ func installKappController(t *TanzuLocal, kc kapp.KappManager) (*v1.Deployment, 
 	}
 
 	t.kappControllerBundle.SetRelativeConfigPath("config/")
-	kappValues, err := ioutil.ReadFile("cli/cmd/plugin/standalone-cluster/hack/kapp-values.yaml")
+	kappValues, err := os.ReadFile("cli/cmd/plugin/standalone-cluster/hack/kapp-values.yaml")
 	if err != nil {
 		return nil, err
 	}
@@ -328,11 +328,4 @@ func mergeKubeconfigAndSetContext(mgr kubeconfig.KubeConfigMgr, t *TanzuLocal) e
 	}
 
 	return nil
-}
-
-// ListNodes returns a list of nodes for the current cluster.
-// If the cluster doesn't exist, an empty list is returned.
-func ListNodes(clusterName string) []string {
-	clusterManager := cluster.NewClusterManager()
-	return clusterManager.ListNodes(clusterName)
 }


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This moves the step for patching the container networks to happen during
creation of the cluster. This keeps low level steps together as part of
that process and will make it easier to add conditional handling once we
start working with other CNIs and providers.
