### PR TITLE
Implements getting TKR bom from registry

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/tkr/image.go
+++ b/cli/cmd/plugin/standalone-cluster/tkr/image.go
@@ -28,9 +28,16 @@ type TkrImageReader interface {
 	// GetRegistryUrl returns the bundle's registry URL
 	GetRegistryUrl() string
 
-	// DownloadBundleImage downloads the OCI image bundle using imgpkg libraries.
+	// DownloadBundleImage downloads the OCI image bundle using imgpkg libraries (use DownloadImage for a regular image).
 	// The unpacked bundle's files are stored in a temporary directory
 	DownloadBundleImage() error
+
+	// DownloadImage downloads a plain, regular image using imgpkg libraries (use DownloadBundleImage for a bundle image).
+	// The unpacked image file is stored in a temporary directory
+	DownloadImage() error
+
+	// GetDownloadPath returns the path to the local filesystem where the OCI image is/will be downloaded
+	GetDownloadPath() string
 
 	// SetRelativeConfigPath sets the _relative_ path for the YTT config bundle in the downloaded OCI image.
 	// Example: kapp controller stores it's YTT bundle under "config/" in it's bundle.
@@ -91,6 +98,28 @@ func (t *TkrImage) DownloadBundleImage() error {
 	}
 
 	return nil
+}
+
+func (t *TkrImage) DownloadImage() error {
+	po := NewPullOptions(goUi.NewNoopUI())
+	po.ImageFlags = ImageFlags{
+		Image: t.RegistryUrl,
+	}
+	po.BundleRecursiveFlags = BundleRecursiveFlags{
+		Recursive: true,
+	}
+	po.OutputPath = t.DownloadPath
+
+	err := po.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *TkrImage) GetDownloadPath() string {
+	return t.DownloadPath
 }
 
 func (t *TkrImage) SetRelativeConfigPath(configPath string) {


### PR DESCRIPTION
## What this PR does / why we need it

All work associated with the standalone-cluster / local cluster overhaul

- Implements `DownloadImage` for `TkrImageReader` which gets a normal, non-bundle image
- The `tanzu` package now has `getTkrBom` function which uses `TkrImageReader` to pull in the bom image file. It then does some plumbing to get that file into the correct location
- Implements `getTkgBomPath` in the tanzu package which gets the desired tanzu bom directory. This is reused in several spots
- Implements `GetDownloadPath` for the `TkrImageReader` which returns the path to where a image is / will be downloaded

## Details for the Release Notes (PLEASE PROVIDE)
N/a

## Which issue(s) this PR fixes
N/a - related to proposal #

## Describe testing done for PR
- Remove tanzu config directory: `rm -rf ~/.config/tanzu`
- Built the binary
- Ran `./local create hello-world` and the `~/.config/tanzu/tkg/bom/tkr...yaml` file is correctly populated

## Special notes for your reviewer
N/a
