### PR TITLE
Add workflow config and script to test MacOS, Linux OS and Windows OS release builds

### DIFF
--- a/.github/workflows/release-gate-macos-linux-builds.yaml
+++ b/.github/workflows/release-gate-macos-linux-builds.yaml
@@ -1,0 +1,27 @@
+name: Release Gate - MacOS and Linux OS Release Builds
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Release version that has to be tested"
+        required: true
+
+jobs:
+  release-gate-macos-and-linux-release-builds:
+    name: Release Gate - MacOS and Linux OS Release Builds
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Release Gate - MacOS and Linux OS Release Builds
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
+        run: |
+          ./test/release-build-test/check-release-build.sh ${{ github.event.inputs.release_version }}

--- a/.github/workflows/release-gate-windows-build.yaml
+++ b/.github/workflows/release-gate-windows-build.yaml
@@ -1,0 +1,25 @@
+name: Release Gate - Windows OS Release Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Release version that has to be tested"
+        required: true
+
+jobs:
+  release-gate-windows-release-build:
+    name: Release Gate - Windows OS Release Build
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    runs-on: windows-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Release Gate - Windows OS Release Build
+        shell: powershell
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
+        run: |
+          .\test\release-build-test\check-release-build.ps1 -version ${{ github.event.inputs.release_version }} -signToolPath "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64\signtool.exe"

--- a/test/release-build-test/check-release-build.ps1
+++ b/test/release-build-test/check-release-build.ps1
@@ -1,0 +1,109 @@
+# Copyright 2020-2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+param (
+    # TCE release version argument
+    [Parameter(Mandatory=$True)]
+    [string]$version,
+
+    # Path to the signtool
+    [Parameter(Mandatory=$True)]
+    [string]$signToolPath
+)
+
+$ErrorActionPreference = 'Stop';
+
+if ((Test-Path env:GITHUB_TOKEN) -eq $False) {
+  throw "GITHUB_TOKEN environment variable is not set"
+}
+
+$tempFolderPath = Join-Path $Env:Temp $(New-Guid)
+New-Item -Type Directory -Path $tempFolderPath
+
+$TCE_REPO_URL = "https://github.com/vmware-tanzu/community-edition"
+
+gh release download $version --repo $TCE_REPO_URL --pattern "tce-windows-amd64-$version.zip" --dir $tempFolderPath
+
+Expand-Archive -LiteralPath "$tempFolderPath\tce-windows-amd64-$version.zip" -Destination $tempFolderPath
+
+# Check if the binaries are all signed
+Get-ChildItem -Path "$tempFolderPath\tce-windows-amd64-$version\bin\tanzu-*" -File -Recurse | Foreach-Object {
+  & $signToolPath verify /pa $_.FullName
+  if ($LastExitCode -ne 0) {
+    throw "Error verifying: " + $_.FullName
+  }
+}
+
+Push-Location "$tempFolderPath\tce-windows-amd64-$version"
+
+& ".\install.bat"
+
+Pop-Location
+
+$Env:Path += ";C:\Program Files\tanzu"
+
+tanzu version
+
+if ($LastExitCode -ne 0) {
+  throw "Error verifying tanzu CLI using version command: " + $_.FullName
+}
+
+tanzu cluster version
+
+if ($LastExitCode -ne 0) {
+  throw "Error verifying tanzu cluster plugin using version command: " + $_.FullName
+}
+
+tanzu conformance version
+
+if ($LastExitCode -ne 0) {
+  throw "Error verifying tanzu conformance plugin using version command: " + $_.FullName
+}
+
+tanzu diagnostics version
+
+if ($LastExitCode -ne 0) {
+  throw "Error verifying tanzu diagnostics plugin using version command: " + $_.FullName
+}
+
+tanzu kubernetes-release version
+
+if ($LastExitCode -ne 0) {
+  throw "Error verifying tanzu release plugin using version command: " + $_.FullName
+}
+
+tanzu management-cluster version
+
+if ($LastExitCode -ne 0) {
+  throw "Error verifying tanzu cluster plugin using version command: " + $_.FullName
+}
+
+tanzu package version
+
+if ($LastExitCode -ne 0) {
+  throw "Error verifying tanzu package plugin using version command: " + $_.FullName
+}
+
+tanzu standalone-cluster version
+
+if ($LastExitCode -ne 0) {
+  throw "Error verifying tanzu cluster plugin using version command: " + $_.FullName
+}
+
+tanzu pinniped-auth version
+
+if ($LastExitCode -ne 0) {
+  throw "Error verifying tanzu auth plugin using version command: " + $_.FullName
+}
+
+tanzu builder version
+
+if ($LastExitCode -ne 0) {
+  throw "Error verifying tanzu builder plugin using version command: " + $_.FullName
+}
+
+tanzu login version
+
+if ($LastExitCode -ne 0) {
+  throw "Error verifying tanzu login plugin using version command: " + $_.FullName
+}

--- a/test/release-build-test/check-release-build.sh
+++ b/test/release-build-test/check-release-build.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+version="${1:?TCE version argument empty. Example usage: ./test/release-build-test/check-release-build.sh v0.10.0}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is not set}"
+
+TCE_REPO_URL="https://github.com/vmware-tanzu/community-edition"
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH="amd64"
+
+temp_dir=$(mktemp -d)
+
+TCE_TAR_BALL="${temp_dir}/tce-${OS}-${ARCH}-${version}.tar.gz"
+TCE_INSTALLATION_DIR="${temp_dir}/tce-${OS}-${ARCH}-${version}"
+
+gh release download "${version}" --repo ${TCE_REPO_URL} --pattern "tce-${OS}-${ARCH}-${version}.tar.gz" --dir "${temp_dir}"
+
+tar xvzf "${TCE_TAR_BALL}" --directory "${temp_dir}"
+
+if [ "${OS}" == 'darwin' ]; then
+  for binary in "${TCE_INSTALLATION_DIR}"/bin/*; do
+    spctl -vv --type install --asses "${binary}"
+  done
+fi
+
+"${TCE_INSTALLATION_DIR}"/install.sh
+
+tanzu version
+
+tanzu cluster version
+
+tanzu conformance version
+
+tanzu diagnostics version
+
+tanzu kubernetes-release version
+
+tanzu management-cluster version
+
+tanzu package version
+
+tanzu standalone-cluster version
+
+tanzu pinniped-auth version
+
+tanzu builder version
+
+tanzu login version


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds workflow config and script to test MacOS, Linux OS and Windows OS release builds by
- Checking if the MacOS release build binaries are signed correctly using `spctl`
- Checking if the Windows release build binaries are signed correctly using `signtool`
- Installing the MacOS, Linux OS and Windows OS release builds
- Running the `version` command of all the plugins (TCE + TF) plugins and also `tanzu` CLI, to check if all the binaries are working

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Add workflow config and script to test MacOS, Linux OS and Windows OS release builds
```

## Which issue(s) this PR fixes

Fixes: #2302 
Fixes: #2354 
Fixes: #2355 
Fixes: #2269 

## Describe testing done for PR

- Demo of a failing pipeline where there's a signing issue in TCE v0.9.0 release darwin tar ball - https://github.com/karuppiah7890/community-edition/runs/4043000515?check_suite_focus=true . Note the error log -

```
+ spctl -vv --type install --asses /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmp.Oo4UK9zg/tce-darwin-amd64-v0.9.0/bin/tanzu-plugin-kubernetes-release
/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmp.Oo4UK9zg/tce-darwin-amd64-v0.9.0/bin/tanzu-plugin-kubernetes-release: rejected
source=Unnotarized Developer ID
origin=Developer ID Application: VMware, Inc. (EG7KH642X6)
```

The error also triggers a cancel on the linux job - https://github.com/karuppiah7890/community-edition/runs/4043000548?check_suite_focus=true due to a default fail fast strategy in a matrix. 

The pipeline was triggered using a `workflow_dispatch` event like this -

```bash
$ gh workflow run --repo https://github.com/karuppiah7890/community-edition/ --ref release-build-test-macos-trial e2e-release-macos-linux-builds.yaml -f release_version=v0.9.0 

✓ Created workflow_dispatch event for e2e-release-macos-linux-builds.yaml at release-build-test-macos-trial

To see runs for this workflow, try: gh run list --workflow=e2e-release-macos-linux-builds.yaml
```

- Demo of successful pipelines when there are no issues in TCE v0.9.1 release darwin and linux tar ball - https://github.com/karuppiah7890/community-edition/runs/4043000920?check_suite_focus=true and https://github.com/karuppiah7890/community-edition/runs/4043000945?check_suite_focus=true . The pipeline was triggered using a `workflow_dispatch` event like this -

```bash
$ gh workflow run --repo https://github.com/karuppiah7890/community-edition/ --ref release-build-test-macos-trial e2e-release-macos-linux-builds.yaml -f release_version=v0.9.1

✓ Created workflow_dispatch event for e2e-release-macos-linux-builds.yaml at release-build-test-macos-trial

To see runs for this workflow, try: gh run list --workflow=e2e-release-macos-linux-builds.yaml
```

- Demo of a pipeline running Windows OS release build test - https://github.com/karuppiah7890/community-edition/runs/4064876679?check_suite_focus=true (failure due to #2397 installation script issue in `v0.9.1` TCE release for Windows). It was triggered like this -

```bash
$ gh workflow run --repo https://github.com/karuppiah7890/community-edition/ --ref release-build-test-macos-trial e2e-release-windows-builds.yaml -f release_version=v0.9.1

✓ Created workflow_dispatch event for e2e-release-windows-builds.yaml at release-build-test-macos-trial

To see runs for this workflow, try: gh run list --workflow=e2e-release-windows-builds.yaml
```

## Special notes for your reviewer

This pipeline will be triggered from downstream pipeline once the downstream pipeline builds and signs the binaries and uploads the tar ball to the draft release. We can use `gh` CLI downstream to trigger the workflow

The script in this PR uses `gh` to download release assets which supports downloading both published and draft/unpublished release artifacts (tar balls). Of course the user authenticating using `gh` has to have enough access to view draft releases. I guess in our case that would be the release access token user (`GH_RELEASE_ACCESS_TOKEN`). Let me know if I need to use some other token

The workflow takes the version / tag as input from which the release artifact is downloaded