### PR TITLE
Removed unneded namespace from packages and template. #2306

### DIFF
--- a/addons/packages/contour/1.17.1/package.yaml
+++ b/addons/packages/contour/1.17.1/package.yaml
@@ -2,7 +2,6 @@ apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: contour.community.tanzu.vmware.com.1.17.1
-  namespace: contour
 spec:
   refName: contour.community.tanzu.vmware.com
   version: 1.17.1

--- a/addons/packages/contour/1.17.2/package.yaml
+++ b/addons/packages/contour/1.17.2/package.yaml
@@ -2,7 +2,6 @@ apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: contour.community.tanzu.vmware.com.1.17.2
-  namespace: contour
 spec:
   refName: contour.community.tanzu.vmware.com
   version: 1.17.2

--- a/addons/packages/contour/1.18.1/package.yaml
+++ b/addons/packages/contour/1.18.1/package.yaml
@@ -2,7 +2,6 @@ apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: contour.community.tanzu.vmware.com.1.18.1
-  namespace: contour
 spec:
   refName: contour.community.tanzu.vmware.com
   version: 1.18.1

--- a/addons/packages/contour/1.18.2/package.yaml
+++ b/addons/packages/contour/1.18.2/package.yaml
@@ -2,7 +2,6 @@ apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: contour.community.tanzu.vmware.com.1.18.2
-  namespace: contour
 spec:
   refName: contour.community.tanzu.vmware.com
   version: 1.18.2

--- a/addons/packages/local-path-storage/0.0.20/package.yaml
+++ b/addons/packages/local-path-storage/0.0.20/package.yaml
@@ -2,7 +2,6 @@ apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: local-path-storage.community.tanzu.vmware.com.0.0.20
-  namespace: local-path-storage
 spec:
   refName: local-path-storage.community.tanzu.vmware.com
   version: 0.0.20

--- a/addons/packages/velero/1.6.3/package.yaml
+++ b/addons/packages/velero/1.6.3/package.yaml
@@ -2,7 +2,6 @@ apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: velero.community.tanzu.vmware.com.1.6.3
-  namespace: velero
 spec:
   refName: velero.community.tanzu.vmware.com
   version: 1.6.3

--- a/hack/packages/templates/metadata.yaml
+++ b/hack/packages/templates/metadata.yaml
@@ -2,7 +2,6 @@ apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: PackageMetadata
 metadata:
   name: PACKAGE_NAME.community.tanzu.vmware.com
-  namespace: PACKAGE_NAME
 spec:
   displayName: "PACKAGE_NAME"
   longDescription: ""

--- a/hack/packages/templates/package.yaml
+++ b/hack/packages/templates/package.yaml
@@ -2,7 +2,6 @@ apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: PACKAGE_NAME.community.tanzu.vmware.com.VERSION
-  namespace: PACKAGE_NAME
 spec:
   refName: PACKAGE_NAME.community.tanzu.vmware.com
   version: VERSION


### PR DESCRIPTION
## What this PR does / why we need it
Removes unnecesary namespace declaration from some packages (contour, velero and local-path-storage) as well from the templates so that any new package bootstrapped does not include the reference.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
Fixes: #2306

## Describe testing done for PR
make build-tce-cli-plugins ENVS=darwin-amd64
k apply -f addons/packages/contour/1.18.2/package.yaml -n tanzu-package-repo-global
...


## Special notes for your reviewer
NONE

Signed-off-by: Jorge Morales Pou jomorales@vmware.com