### PR TITLE
Fix the path to gatekeeper e2e-test script in vSphere management cluster E2E test

### DIFF
--- a/test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
+++ b/test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
@@ -162,7 +162,7 @@ function list_packages {
 
 function test_gate_keeper_package {
     echo "Starting Gatekeeper test..."
-    "${TCE_REPO_PATH}"/test/aws/e2e-test.sh || {
+    "${TCE_REPO_PATH}"/test/gatekeeper/e2e-test.sh || {
         error "GATEKEEPER PACKAGE TEST FAILED!";
         return 1;
     }


### PR DESCRIPTION
## What this PR does / why we need it

This fixes the path to gatekeeper e2e-test script in vSphere management cluster E2E test, which is causing the error -

https://github.com/vmware-tanzu/community-edition/runs/3970387550?check_suite_focus=true#step:4:1769

```
test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh: line 165: /home/ubuntu/actions-runner/_work/community-edition/community-edition/test/vsphere/../../test/aws/e2e-test.sh: No such file or directory
```

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

~Fixes: #~

## Describe testing done for PR

-

## Special notes for your reviewer

None