### PR TITLE
Bump kapp controller to version 0.28.0

### DIFF
--- a/addons/packages/kapp-controller/0.28.0/README.md
+++ b/addons/packages/kapp-controller/0.28.0/README.md
@@ -26,7 +26,7 @@ The following configuration values can be set to customize the kapp-controller i
 | `kappController.deployment.priorityClassName` | Optional | priorityClassName of kapp-controller deployment. Default value is `null`. |
 | `kappController.deployment.concurrency` | Optional | concurrency of kapp-controller deployment. Default is `4`. |
 | `kappController.deployment.apiPort` | Optional | Bind port for kapp-controller API. Default is `10350`. |
-| `kappController.deployment.metricsServerPort` | Optional | Address for metrics server. Default is `:8080`. If 0, then metrics server doesnt listen on any port. |
+| `kappController.deployment.metricsBindAddress` | Optional | Address for metrics server. Default is `:8080`. If 0, then metrics server doesnt listen on any port. |
 | `kappController.config.caCerts` | Optional | A cert chain of trusted ca certs. These will be added to the system-wide cert pool of trusted ca's. Default value is `""`. |
 | `kappController.config.httpProxy` | Optional | The url/ip of a proxy for kapp controller to use when making network requests. Default is `""`. |
 | `kappController.config.httpsProxy` | Optional | The url/ip of a tls capable proxy for kapp controller to use when making network requests. Default value is `""`. |

--- a/addons/packages/kapp-controller/0.28.0/README.md
+++ b/addons/packages/kapp-controller/0.28.0/README.md
@@ -26,6 +26,7 @@ The following configuration values can be set to customize the kapp-controller i
 | `kappController.deployment.priorityClassName` | Optional | priorityClassName of kapp-controller deployment. Default value is `null`. |
 | `kappController.deployment.concurrency` | Optional | concurrency of kapp-controller deployment. Default is `4`. |
 | `kappController.deployment.apiPort` | Optional | Bind port for kapp-controller API. Default is `10350`. |
+| `kappController.deployment.metricsServerPort` | Optional | Address for metrics server. Default is `:8080`. If 0, then metrics server doesnt listen on any port. |
 | `kappController.config.caCerts` | Optional | A cert chain of trusted ca certs. These will be added to the system-wide cert pool of trusted ca's. Default value is `""`. |
 | `kappController.config.httpProxy` | Optional | The url/ip of a proxy for kapp controller to use when making network requests. Default is `""`. |
 | `kappController.config.httpsProxy` | Optional | The url/ip of a tls capable proxy for kapp controller to use when making network requests. Default value is `""`. |

--- a/addons/packages/kapp-controller/0.28.0/README.md
+++ b/addons/packages/kapp-controller/0.28.0/README.md
@@ -1,0 +1,37 @@
+# Kapp Controller Package
+
+This package provides app/package lifecycle management using [kapp-controller](https://carvel.dev/kapp-controller/).
+
+## Components
+
+* kapp-controller
+
+## Configuration
+
+The following configuration values can be set to customize the kapp-controller installation.
+
+### Global
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `namespace` | Optional | The namespace in which to deploy kapp-controller. |
+
+### Kapp Controller Configuration
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `kappController.createNamespace` | Optional | A boolean that indicates whether to create the namespace specified. Default value is `true`. |
+| `kappController.namespace` | Optional | The namespace value used by older templates, will overwrite will top level namespace of present, keep for backward compatibility. Default value is `null`. |
+| `kappController.deployment.hostNetwork` | Optional | HostNetwork of kapp-controller deployment. Default is `null`. |
+| `kappController.deployment.priorityClassName` | Optional | priorityClassName of kapp-controller deployment. Default value is `null`. |
+| `kappController.deployment.concurrency` | Optional | concurrency of kapp-controller deployment. Default is `4`. |
+| `kappController.deployment.apiPort` | Optional | Bind port for kapp-controller API. Default is `10350`. |
+| `kappController.config.caCerts` | Optional | A cert chain of trusted ca certs. These will be added to the system-wide cert pool of trusted ca's. Default value is `""`. |
+| `kappController.config.httpProxy` | Optional | The url/ip of a proxy for kapp controller to use when making network requests. Default is `""`. |
+| `kappController.config.httpsProxy` | Optional | The url/ip of a tls capable proxy for kapp controller to use when making network requests. Default value is `""`. |
+| `kappController.config.noProxy` | Optional | A comma delimited list of domain names which kapp controller should bypass the proxy for when making requests. Default is `""`. |
+| `kappController.config.dangerousSkipTLSVerify` | Optional | A comma delimited list of hostnames for which kapp controller should skip TLS verification. Default value is `""`. |
+
+## Usage Example
+
+To learn more about how to use kapp-controller refer to [kapp-controller website](https://carvel.dev/kapp-controller/)

--- a/addons/packages/kapp-controller/0.28.0/bundle/.imgpkg/bundle.yml
+++ b/addons/packages/kapp-controller/0.28.0/bundle/.imgpkg/bundle.yml
@@ -1,0 +1,9 @@
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: Bundle
+metadata:
+  name: kapp-controller
+authors:
+- name: Shivaani Gupta
+  email: gshivaani@vmware.com
+websites:
+- url: https://github.com/vmware-tanzu/carvel-kapp-controller

--- a/addons/packages/kapp-controller/0.28.0/bundle/.imgpkg/images.yml
+++ b/addons/packages/kapp-controller/0.28.0/bundle/.imgpkg/images.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- annotations:
+    kbld.carvel.dev/id: ghcr.io/vmware-tanzu/carvel-kapp-controller@sha256:083f0f526c4f9b5cb6e6506ad0a9c54a9b73209ab06906a6b6ae5872351048a0
+    kbld.carvel.dev/origins: |
+      - preresolved:
+          url: ghcr.io/vmware-tanzu/carvel-kapp-controller@sha256:083f0f526c4f9b5cb6e6506ad0a9c54a9b73209ab06906a6b6ae5872351048a0
+  image: ghcr.io/vmware-tanzu/carvel-kapp-controller@sha256:083f0f526c4f9b5cb6e6506ad0a9c54a9b73209ab06906a6b6ae5872351048a0
+kind: ImagesLock

--- a/addons/packages/kapp-controller/0.28.0/bundle/config/overlays/change-namespace.yaml
+++ b/addons/packages/kapp-controller/0.28.0/bundle/config/overlays/change-namespace.yaml
@@ -1,0 +1,58 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("/values.star", "values", "kappNamespace")
+#@ load("@ytt:yaml", "yaml")
+
+#@ if values.kappController.createNamespace:
+#@overlay/match by=overlay.subset({"kind":"Namespace","metadata":{"name": "kapp-controller"}}),expects="1+"
+---
+metadata:
+  name: #@ kappNamespace
+#@ else:
+#@overlay/match by=overlay.subset({"kind":"Namespace","metadata":{"name": "kapp-controller"}}),expects="1+"
+#@overlay/remove
+---
+#@ end
+
+#@overlay/match by=overlay.subset({"kind": "ServiceAccount","metadata": {"name": "kapp-controller-sa"}}),expects="1+"
+---
+metadata:
+  namespace: #@ kappNamespace
+
+#@overlay/match by=overlay.subset({"kind": "ClusterRoleBinding","metadata": {"name": "kapp-controller-cluster-role-binding"}}),expects="1+"
+---
+subjects:
+#@overlay/match by=overlay.subset({"kind": "ServiceAccount"}),expects="1+"
+- namespace: #@ kappNamespace
+
+#@overlay/match by=overlay.subset({"kind": "ClusterRoleBinding","metadata": {"name": "pkg-apiserver:system:auth-delegator"}}),expects="1+"
+---
+subjects:
+#@overlay/match by=overlay.subset({"kind": "ServiceAccount"}),expects="1+"
+- namespace: #@ kappNamespace
+
+#@overlay/match by=overlay.subset({"kind": "RoleBinding","metadata": {"name": "pkgserver-auth-reader"}}),expects="1+"
+---
+subjects:
+#@overlay/match by=overlay.subset({"kind": "ServiceAccount"}),expects="1+"
+- namespace: #@ kappNamespace
+
+#@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name": "kapp-controller"}})
+---
+metadata:
+  namespace: #@ kappNamespace
+
+#@overlay/match by=overlay.subset({"kind":"Service","metadata":{"name": "packaging-api"}})
+---
+metadata:
+  namespace: #@ kappNamespace
+
+#@overlay/match by=overlay.subset({"kind":"APIService","metadata":{"name": "v1alpha1.data.packaging.carvel.dev"}})
+---
+spec:
+  service:
+    namespace: #@ kappNamespace
+
+#@overlay/match by=overlay.subset({"kind":"Namespace","metadata":{"name": "kapp-controller-packaging-global"}}),expects=1
+---
+metadata:
+  name: #@ values.kappController.globalNamespace

--- a/addons/packages/kapp-controller/0.28.0/bundle/config/overlays/update-configmap.yaml
+++ b/addons/packages/kapp-controller/0.28.0/bundle/config/overlays/update-configmap.yaml
@@ -1,0 +1,17 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("/values.star", "values", "kappNamespace")
+
+#@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name": "kapp-controller"}})
+#@overlay/insert before=True
+---
+#! This optional ConfigMap must be created before the kapp-controller pod launches in order to read it.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  #! Name must be `kapp-controller-config` for kapp controller to pick it up
+  name: kapp-controller-config
+  #! Namespace must match the namespace kapp-controller is deployed to
+  namespace: #@ kappNamespace
+  annotations:
+    kapp.k14s.io/change-group: "apps.kappctrl.k14s.io/kapp-controller-config"
+data: #@ values.kappController.config

--- a/addons/packages/kapp-controller/0.28.0/bundle/config/overlays/update-crds.yaml
+++ b/addons/packages/kapp-controller/0.28.0/bundle/config/overlays/update-crds.yaml
@@ -1,0 +1,9 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("/values.star", "values")
+
+#@overlay/match by=overlay.subset({"kind":"CustomResourceDefinition","metadata":{"name": "packagerepositories.packaging.carvel.dev"}})
+---
+metadata:
+  annotations:
+    #@overlay/match missing_ok=True
+    packaging.carvel.dev/global-namespace: #@ values.kappController.globalNamespace

--- a/addons/packages/kapp-controller/0.28.0/bundle/config/overlays/update-deployment.yaml
+++ b/addons/packages/kapp-controller/0.28.0/bundle/config/overlays/update-deployment.yaml
@@ -1,0 +1,36 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("/values.star", "values")
+#@ load("@ytt:yaml", "yaml")
+
+#@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name": "kapp-controller"}})
+---
+metadata:
+  annotations:
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/change-rule: "upsert after upserting apps.kappctrl.k14s.io/kapp-controller-config"
+spec:
+  template:
+    #@overlay/match-child-defaults missing_ok=True
+    spec:
+      containers:
+      #@overlay/match by=overlay.subset({"name":"kapp-controller"})
+      - args:
+        #@overlay/match by=overlay.subset("-packaging-global-namespace=kapp-controller-packaging-global")
+        - #@ "-packaging-global-namespace={}".format(values.kappController.globalNamespace)
+        #@overlay/append
+        - #@ "-concurrency={}".format(values.kappController.deployment.concurrency)
+        ports:
+          #@overlay/match by="name"
+          - name: api
+            containerPort: #@ values.kappController.deployment.apiPort
+        env:
+          #@overlay/match by="name"
+          - name: KAPPCTRL_API_PORT
+            value: #@ str(values.kappController.deployment.apiPort)
+      #@ if/end values.kappController.deployment.hostNetwork:
+      hostNetwork: #@ values.kappController.deployment.hostNetwork
+      #@ if/end values.kappController.deployment.priorityClassName:
+      priorityClassName: #@ values.kappController.deployment.priorityClassName
+      #@ if hasattr(values.kappController.deployment, 'tolerations') and values.kappController.deployment.tolerations:
+      tolerations: #@ values.kappController.deployment.tolerations
+      #@ end

--- a/addons/packages/kapp-controller/0.28.0/bundle/config/overlays/update-deployment.yaml
+++ b/addons/packages/kapp-controller/0.28.0/bundle/config/overlays/update-deployment.yaml
@@ -19,6 +19,8 @@ spec:
         - #@ "-packaging-global-namespace={}".format(values.kappController.globalNamespace)
         #@overlay/append
         - #@ "-concurrency={}".format(values.kappController.deployment.concurrency)
+        #@overlay/append
+        - #@ "-metrics-bind-address={}".format(values.kappController.deployment.metricsBindAddress)
         ports:
           #@overlay/match by="name"
           - name: api

--- a/addons/packages/kapp-controller/0.28.0/bundle/config/upstream/kapp-controller.yaml
+++ b/addons/packages/kapp-controller/0.28.0/bundle/config/upstream/kapp-controller.yaml
@@ -1,0 +1,1606 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kapp-controller
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kapp-controller-packaging-global
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.data.packaging.carvel.dev
+spec:
+  group: data.packaging.carvel.dev
+  groupPriorityMinimum: 100
+  service:
+    name: packaging-api
+    namespace: kapp-controller
+  version: v1alpha1
+  versionPriority: 100
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: packaging-api
+  namespace: kapp-controller
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: api
+  selector:
+    app: kapp-controller
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: internalpackagemetadatas.internal.packaging.carvel.dev
+spec:
+  group: internal.packaging.carvel.dev
+  names:
+    kind: InternalPackageMetadata
+    listKind: InternalPackageMetadataList
+    plural: internalpackagemetadatas
+    singular: internalpackagemetadata
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              categories:
+                items:
+                  type: string
+                type: array
+              displayName:
+                type: string
+              iconSVGBase64:
+                type: string
+              longDescription:
+                type: string
+              maintainers:
+                items:
+                  properties:
+                    name:
+                      type: string
+                  type: object
+                type: array
+              providerName:
+                type: string
+              shortDescription:
+                type: string
+              supportDescription:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: internalpackages.internal.packaging.carvel.dev
+spec:
+  group: internal.packaging.carvel.dev
+  names:
+    kind: InternalPackage
+    listKind: InternalPackageList
+    plural: internalpackages
+    singular: internalpackage
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              capacityRequirementsDescription:
+                type: string
+              licenses:
+                items:
+                  type: string
+                type: array
+              refName:
+                type: string
+              releaseNotes:
+                type: string
+              releasedAt:
+                format: date-time
+                nullable: true
+                type: string
+              template:
+                properties:
+                  spec:
+                    properties:
+                      canceled:
+                        description: Canceled when set to true will stop all active changes
+                        type: boolean
+                      cluster:
+                        properties:
+                          kubeconfigSecretRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            type: object
+                          namespace:
+                            type: string
+                        type: object
+                      deploy:
+                        items:
+                          properties:
+                            kapp:
+                              properties:
+                                delete:
+                                  properties:
+                                    rawOptions:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                inspect:
+                                  properties:
+                                    rawOptions:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                intoNs:
+                                  type: string
+                                mapNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                rawOptions:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      fetch:
+                        items:
+                          properties:
+                            git:
+                              description: TODO implement git
+                              properties:
+                                lfsSkipSmudge:
+                                  type: boolean
+                                ref:
+                                  type: string
+                                refSelection:
+                                  properties:
+                                    semver:
+                                      properties:
+                                        constraints:
+                                          type: string
+                                        prereleases:
+                                          properties:
+                                            identifiers:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                      type: object
+                                  type: object
+                                secretRef:
+                                  description: 'Secret may include one or more keys: ssh-privatekey, ssh-knownhosts'
+                                  properties:
+                                    name:
+                                      description: Object is expected to be within same namespace
+                                      type: string
+                                  type: object
+                                subPath:
+                                  type: string
+                                url:
+                                  type: string
+                              type: object
+                            helmChart:
+                              properties:
+                                name:
+                                  description: 'Example: stable/redis'
+                                  type: string
+                                repository:
+                                  properties:
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          description: Object is expected to be within same namespace
+                                          type: string
+                                      type: object
+                                    url:
+                                      type: string
+                                  type: object
+                                version:
+                                  type: string
+                              type: object
+                            http:
+                              properties:
+                                secretRef:
+                                  description: 'Secret may include one or more keys: username, password'
+                                  properties:
+                                    name:
+                                      description: Object is expected to be within same namespace
+                                      type: string
+                                  type: object
+                                sha256:
+                                  type: string
+                                subPath:
+                                  type: string
+                                url:
+                                  description: 'URL can point to one of following formats: text, tgz, zip'
+                                  type: string
+                              type: object
+                            image:
+                              properties:
+                                secretRef:
+                                  description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                                  properties:
+                                    name:
+                                      description: Object is expected to be within same namespace
+                                      type: string
+                                  type: object
+                                subPath:
+                                  type: string
+                                tagSelection:
+                                  properties:
+                                    semver:
+                                      properties:
+                                        constraints:
+                                          type: string
+                                        prereleases:
+                                          properties:
+                                            identifiers:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                      type: object
+                                  type: object
+                                url:
+                                  description: 'Example: username/app1-config:v0.1.0'
+                                  type: string
+                              type: object
+                            imgpkgBundle:
+                              properties:
+                                image:
+                                  type: string
+                                secretRef:
+                                  description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                                  properties:
+                                    name:
+                                      description: Object is expected to be within same namespace
+                                      type: string
+                                  type: object
+                                tagSelection:
+                                  properties:
+                                    semver:
+                                      properties:
+                                        constraints:
+                                          type: string
+                                        prereleases:
+                                          properties:
+                                            identifiers:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                            inline:
+                              properties:
+                                paths:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                pathsFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          directoryPath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        type: object
+                                      secretRef:
+                                        properties:
+                                          directoryPath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      noopDelete:
+                        description: When NoopDeletion set to true, App deletion should delete App CR but preserve App's associated resources
+                        type: boolean
+                      paused:
+                        description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                        type: boolean
+                      serviceAccountName:
+                        type: string
+                      syncPeriod:
+                        description: Controls frequency of app reconciliation
+                        type: string
+                      template:
+                        items:
+                          properties:
+                            helmTemplate:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                path:
+                                  type: string
+                                valuesFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      path:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            jsonnet:
+                              description: TODO implement jsonnet
+                              type: object
+                            kbld:
+                              properties:
+                                paths:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            kustomize:
+                              description: TODO implement kustomize
+                              type: object
+                            sops:
+                              properties:
+                                age:
+                                  properties:
+                                    privateKeysSecretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                paths:
+                                  items:
+                                    type: string
+                                  type: array
+                                pgp:
+                                  properties:
+                                    privateKeysSecretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            ytt:
+                              properties:
+                                fileMarks:
+                                  items:
+                                    type: string
+                                  type: array
+                                ignoreUnknownComments:
+                                  type: boolean
+                                inline:
+                                  properties:
+                                    paths:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    pathsFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              directoryPath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            type: object
+                                          secretRef:
+                                            properties:
+                                              directoryPath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                paths:
+                                  items:
+                                    type: string
+                                  type: array
+                                strict:
+                                  type: boolean
+                                valuesFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      path:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                required:
+                - spec
+                type: object
+              valuesSchema:
+                description: valuesSchema can be used to show template values that can be configured by users when a Package is installed in an OpenAPI schema format.
+                properties:
+                  openAPIv3:
+                    nullable: true
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              version:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: apps.kappctrl.k14s.io
+spec:
+  group: kappctrl.k14s.io
+  names:
+    kind: App
+    listKind: AppList
+    plural: apps
+    singular: app
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Friendly description
+      jsonPath: .status.friendlyDescription
+      name: Description
+      type: string
+    - description: Last time app started being deployed. Does not mean anything was changed.
+      jsonPath: .status.deploy.startedAt
+      name: Since-Deploy
+      type: date
+    - description: Time since creation
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              canceled:
+                description: Canceled when set to true will stop all active changes
+                type: boolean
+              cluster:
+                properties:
+                  kubeconfigSecretRef:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  namespace:
+                    type: string
+                type: object
+              deploy:
+                items:
+                  properties:
+                    kapp:
+                      properties:
+                        delete:
+                          properties:
+                            rawOptions:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        inspect:
+                          properties:
+                            rawOptions:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        intoNs:
+                          type: string
+                        mapNs:
+                          items:
+                            type: string
+                          type: array
+                        rawOptions:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                type: array
+              fetch:
+                items:
+                  properties:
+                    git:
+                      description: TODO implement git
+                      properties:
+                        lfsSkipSmudge:
+                          type: boolean
+                        ref:
+                          type: string
+                        refSelection:
+                          properties:
+                            semver:
+                              properties:
+                                constraints:
+                                  type: string
+                                prereleases:
+                                  properties:
+                                    identifiers:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              type: object
+                          type: object
+                        secretRef:
+                          description: 'Secret may include one or more keys: ssh-privatekey, ssh-knownhosts'
+                          properties:
+                            name:
+                              description: Object is expected to be within same namespace
+                              type: string
+                          type: object
+                        subPath:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    helmChart:
+                      properties:
+                        name:
+                          description: 'Example: stable/redis'
+                          type: string
+                        repository:
+                          properties:
+                            secretRef:
+                              properties:
+                                name:
+                                  description: Object is expected to be within same namespace
+                                  type: string
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        version:
+                          type: string
+                      type: object
+                    http:
+                      properties:
+                        secretRef:
+                          description: 'Secret may include one or more keys: username, password'
+                          properties:
+                            name:
+                              description: Object is expected to be within same namespace
+                              type: string
+                          type: object
+                        sha256:
+                          type: string
+                        subPath:
+                          type: string
+                        url:
+                          description: 'URL can point to one of following formats: text, tgz, zip'
+                          type: string
+                      type: object
+                    image:
+                      properties:
+                        secretRef:
+                          description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                          properties:
+                            name:
+                              description: Object is expected to be within same namespace
+                              type: string
+                          type: object
+                        subPath:
+                          type: string
+                        tagSelection:
+                          properties:
+                            semver:
+                              properties:
+                                constraints:
+                                  type: string
+                                prereleases:
+                                  properties:
+                                    identifiers:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              type: object
+                          type: object
+                        url:
+                          description: 'Example: username/app1-config:v0.1.0'
+                          type: string
+                      type: object
+                    imgpkgBundle:
+                      properties:
+                        image:
+                          type: string
+                        secretRef:
+                          description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                          properties:
+                            name:
+                              description: Object is expected to be within same namespace
+                              type: string
+                          type: object
+                        tagSelection:
+                          properties:
+                            semver:
+                              properties:
+                                constraints:
+                                  type: string
+                                prereleases:
+                                  properties:
+                                    identifiers:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    inline:
+                      properties:
+                        paths:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        pathsFrom:
+                          items:
+                            properties:
+                              configMapRef:
+                                properties:
+                                  directoryPath:
+                                    type: string
+                                  name:
+                                    type: string
+                                type: object
+                              secretRef:
+                                properties:
+                                  directoryPath:
+                                    type: string
+                                  name:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                type: array
+              noopDelete:
+                description: When NoopDeletion set to true, App deletion should delete App CR but preserve App's associated resources
+                type: boolean
+              paused:
+                description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                type: boolean
+              serviceAccountName:
+                type: string
+              syncPeriod:
+                description: Controls frequency of app reconciliation
+                type: string
+              template:
+                items:
+                  properties:
+                    helmTemplate:
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        path:
+                          type: string
+                        valuesFrom:
+                          items:
+                            properties:
+                              configMapRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              path:
+                                type: string
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                    jsonnet:
+                      description: TODO implement jsonnet
+                      type: object
+                    kbld:
+                      properties:
+                        paths:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    kustomize:
+                      description: TODO implement kustomize
+                      type: object
+                    sops:
+                      properties:
+                        age:
+                          properties:
+                            privateKeysSecretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        paths:
+                          items:
+                            type: string
+                          type: array
+                        pgp:
+                          properties:
+                            privateKeysSecretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
+                    ytt:
+                      properties:
+                        fileMarks:
+                          items:
+                            type: string
+                          type: array
+                        ignoreUnknownComments:
+                          type: boolean
+                        inline:
+                          properties:
+                            paths:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            pathsFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      directoryPath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                  secretRef:
+                                    properties:
+                                      directoryPath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        paths:
+                          items:
+                            type: string
+                          type: array
+                        strict:
+                          type: boolean
+                        valuesFrom:
+                          items:
+                            properties:
+                              configMapRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              path:
+                                type: string
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: TODO rename to Condition
+                  properties:
+                    message:
+                      description: Human-readable message indicating details about last transition.
+                      type: string
+                    reason:
+                      description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              consecutiveReconcileFailures:
+                type: integer
+              consecutiveReconcileSuccesses:
+                type: integer
+              deploy:
+                properties:
+                  error:
+                    type: string
+                  exitCode:
+                    type: integer
+                  finished:
+                    type: boolean
+                  startedAt:
+                    format: date-time
+                    type: string
+                  stderr:
+                    type: string
+                  stdout:
+                    type: string
+                  updatedAt:
+                    format: date-time
+                    type: string
+                type: object
+              fetch:
+                properties:
+                  error:
+                    type: string
+                  exitCode:
+                    type: integer
+                  startedAt:
+                    format: date-time
+                    type: string
+                  stderr:
+                    type: string
+                  stdout:
+                    type: string
+                  updatedAt:
+                    format: date-time
+                    type: string
+                type: object
+              friendlyDescription:
+                type: string
+              inspect:
+                properties:
+                  error:
+                    type: string
+                  exitCode:
+                    type: integer
+                  stderr:
+                    type: string
+                  stdout:
+                    type: string
+                  updatedAt:
+                    format: date-time
+                    type: string
+                type: object
+              managedAppName:
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              template:
+                properties:
+                  error:
+                    type: string
+                  exitCode:
+                    type: integer
+                  stderr:
+                    type: string
+                  updatedAt:
+                    format: date-time
+                    type: string
+                type: object
+              usefulErrorMessage:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: packageinstalls.packaging.carvel.dev
+spec:
+  group: packaging.carvel.dev
+  names:
+    kind: PackageInstall
+    listKind: PackageInstallList
+    plural: packageinstalls
+    shortNames:
+    - pkgi
+    singular: packageinstall
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: PackageMetadata name
+      jsonPath: .spec.packageRef.refName
+      name: Package name
+      type: string
+    - description: PackageMetadata version
+      jsonPath: .status.version
+      name: Package version
+      type: string
+    - description: Friendly description
+      jsonPath: .status.friendlyDescription
+      name: Description
+      type: string
+    - description: Time since creation
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              canceled:
+                description: Canceled when set to true will stop all active changes
+                type: boolean
+              cluster:
+                properties:
+                  kubeconfigSecretRef:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  namespace:
+                    type: string
+                type: object
+              noopDelete:
+                description: When NoopDelete set to true, PackageInstall deletion should delete PackageInstall/App CR but preserve App's associated resources.
+                type: boolean
+              packageRef:
+                properties:
+                  refName:
+                    type: string
+                  versionSelection:
+                    properties:
+                      constraints:
+                        type: string
+                      prereleases:
+                        properties:
+                          identifiers:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                type: object
+              paused:
+                description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                type: boolean
+              serviceAccountName:
+                type: string
+              syncPeriod:
+                description: Controls frequency of App reconciliation in time + unit format. Always >= 30s. If value below 30s is specified, 30s will be used.
+                type: string
+              values:
+                items:
+                  properties:
+                    secretRef:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: TODO rename to Condition
+                  properties:
+                    message:
+                      description: Human-readable message indicating details about last transition.
+                      type: string
+                    reason:
+                      description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              friendlyDescription:
+                type: string
+              lastAttemptedVersion:
+                description: LastAttemptedVersion specifies what version was last attempted to be installed. It does _not_ indicate it was successfully installed.
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              usefulErrorMessage:
+                type: string
+              version:
+                description: TODO this is desired resolved version (not actually deployed)
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    packaging.carvel.dev/global-namespace: kapp-controller-packaging-global
+  name: packagerepositories.packaging.carvel.dev
+spec:
+  group: packaging.carvel.dev
+  names:
+    kind: PackageRepository
+    listKind: PackageRepositoryList
+    plural: packagerepositories
+    shortNames:
+    - pkgr
+    singular: packagerepository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time since creation
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Friendly description
+      jsonPath: .status.friendlyDescription
+      name: Description
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              fetch:
+                properties:
+                  git:
+                    description: TODO implement git
+                    properties:
+                      lfsSkipSmudge:
+                        type: boolean
+                      ref:
+                        type: string
+                      refSelection:
+                        properties:
+                          semver:
+                            properties:
+                              constraints:
+                                type: string
+                              prereleases:
+                                properties:
+                                  identifiers:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
+                      secretRef:
+                        description: 'Secret may include one or more keys: ssh-privatekey, ssh-knownhosts'
+                        properties:
+                          name:
+                            description: Object is expected to be within same namespace
+                            type: string
+                        type: object
+                      subPath:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  http:
+                    properties:
+                      secretRef:
+                        description: 'Secret may include one or more keys: username, password'
+                        properties:
+                          name:
+                            description: Object is expected to be within same namespace
+                            type: string
+                        type: object
+                      sha256:
+                        type: string
+                      subPath:
+                        type: string
+                      url:
+                        description: 'URL can point to one of following formats: text, tgz, zip'
+                        type: string
+                    type: object
+                  image:
+                    properties:
+                      secretRef:
+                        description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                        properties:
+                          name:
+                            description: Object is expected to be within same namespace
+                            type: string
+                        type: object
+                      subPath:
+                        type: string
+                      tagSelection:
+                        properties:
+                          semver:
+                            properties:
+                              constraints:
+                                type: string
+                              prereleases:
+                                properties:
+                                  identifiers:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
+                      url:
+                        description: 'Example: username/app1-config:v0.1.0'
+                        type: string
+                    type: object
+                  imgpkgBundle:
+                    properties:
+                      image:
+                        type: string
+                      secretRef:
+                        description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                        properties:
+                          name:
+                            description: Object is expected to be within same namespace
+                            type: string
+                        type: object
+                      tagSelection:
+                        properties:
+                          semver:
+                            properties:
+                              constraints:
+                                type: string
+                              prereleases:
+                                properties:
+                                  identifiers:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              paused:
+                description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                type: boolean
+              syncPeriod:
+                description: Controls frequency of PackageRepository reconciliation
+                type: string
+            required:
+            - fetch
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: TODO rename to Condition
+                  properties:
+                    message:
+                      description: Human-readable message indicating details about last transition.
+                      type: string
+                    reason:
+                      description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              consecutiveReconcileFailures:
+                type: integer
+              consecutiveReconcileSuccesses:
+                type: integer
+              deploy:
+                properties:
+                  error:
+                    type: string
+                  exitCode:
+                    type: integer
+                  finished:
+                    type: boolean
+                  startedAt:
+                    format: date-time
+                    type: string
+                  stderr:
+                    type: string
+                  stdout:
+                    type: string
+                  updatedAt:
+                    format: date-time
+                    type: string
+                type: object
+              fetch:
+                properties:
+                  error:
+                    type: string
+                  exitCode:
+                    type: integer
+                  startedAt:
+                    format: date-time
+                    type: string
+                  stderr:
+                    type: string
+                  stdout:
+                    type: string
+                  updatedAt:
+                    format: date-time
+                    type: string
+                type: object
+              friendlyDescription:
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              template:
+                properties:
+                  error:
+                    type: string
+                  exitCode:
+                    type: integer
+                  stderr:
+                    type: string
+                  updatedAt:
+                    format: date-time
+                    type: string
+                type: object
+              usefulErrorMessage:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kapp-controller.carvel.dev/version: v0.28.0
+    kbld.k14s.io/images: |
+      - Metas:
+        - Path: /Users/dhelfand/go/src/github.com/vmware-tanzu/carvel-kapp-controller
+          Type: local
+        - Dirty: false
+          RemoteURL: https://github.com/vmware-tanzu/carvel-kapp-controller
+          SHA: e63bb7833133485bb2d0774ce9b75c68aab12e7e
+          Tags:
+          - v0.28.0
+          Type: git
+        URL: ghcr.io/vmware-tanzu/carvel-kapp-controller@sha256:083f0f526c4f9b5cb6e6506ad0a9c54a9b73209ab06906a6b6ae5872351048a0
+  name: kapp-controller
+  namespace: kapp-controller
+spec:
+  replicas: 1
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      app: kapp-controller
+  template:
+    metadata:
+      labels:
+        app: kapp-controller
+    spec:
+      containers:
+      - args:
+        - -packaging-global-namespace=kapp-controller-packaging-global
+        env:
+        - name: KAPPCTRL_MEM_TMP_DIR
+          value: /etc/kappctrl-mem-tmp
+        - name: KAPPCTRL_SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KAPPCTRL_API_PORT
+          value: "10350"
+        image: ghcr.io/vmware-tanzu/carvel-kapp-controller@sha256:083f0f526c4f9b5cb6e6506ad0a9c54a9b73209ab06906a6b6ae5872351048a0
+        name: kapp-controller
+        ports:
+        - containerPort: 10350
+          name: api
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 120m
+            memory: 100Mi
+        securityContext:
+          runAsGroup: 2000
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /etc/kappctrl-mem-tmp
+          name: template-fs
+      securityContext:
+        fsGroup: 3000
+      serviceAccount: kapp-controller-sa
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: template-fs
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kapp-controller-sa
+  namespace: kapp-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kapp-controller-cluster-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - kappctrl.k14s.io
+  resources:
+  - apps
+  - apps/status
+  verbs:
+  - '*'
+- apiGroups:
+  - packaging.carvel.dev
+  resources:
+  - packageinstalls
+  - packageinstalls/status
+  verbs:
+  - '*'
+- apiGroups:
+  - packaging.carvel.dev
+  resources:
+  - packagerepositories
+  - packagerepositories/status
+  verbs:
+  - '*'
+- apiGroups:
+  - internal.packaging.carvel.dev
+  resources:
+  - internalpackagemetadatas
+  verbs:
+  - '*'
+- apiGroups:
+  - data.packaging.carvel.dev
+  resources:
+  - packagemetadatas
+  - packagemetadatas/status
+  verbs:
+  - '*'
+- apiGroups:
+  - internal.packaging.carvel.dev
+  resources:
+  - internalpackages
+  verbs:
+  - '*'
+- apiGroups:
+  - data.packaging.carvel.dev
+  resources:
+  - packages
+  - packages/status
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - update
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kapp-controller-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kapp-controller-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: kapp-controller-sa
+  namespace: kapp-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pkg-apiserver:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: kapp-controller-sa
+  namespace: kapp-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pkgserver-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: kapp-controller-sa
+  namespace: kapp-controller

--- a/addons/packages/kapp-controller/0.28.0/bundle/config/values.star
+++ b/addons/packages/kapp-controller/0.28.0/bundle/config/values.star
@@ -1,5 +1,4 @@
 load("@ytt:data", "data")
-load("@ytt:assert", "assert")
 
 #export
 values = data.values

--- a/addons/packages/kapp-controller/0.28.0/bundle/config/values.star
+++ b/addons/packages/kapp-controller/0.28.0/bundle/config/values.star
@@ -1,0 +1,11 @@
+load("@ytt:data", "data")
+load("@ytt:assert", "assert")
+
+#export
+values = data.values
+kappNamespace = ""
+if hasattr(values.kappController, 'namespace') and values.kappController.namespace:
+    kappNamespace = values.kappController.namespace
+else:
+    kappNamespace = values.namespace
+end

--- a/addons/packages/kapp-controller/0.28.0/bundle/config/values.yaml
+++ b/addons/packages/kapp-controller/0.28.0/bundle/config/values.yaml
@@ -1,0 +1,20 @@
+#@data/values
+#@overlay/match-child-defaults missing_ok=True
+---
+namespace: kapp-controller
+kappController:
+  namespace: null
+  createNamespace: true
+  globalNamespace: tanzu-package-repo-global
+  deployment:
+    hostNetwork: null
+    priorityClassName: null
+    concurrency: 4
+    tolerations: []
+    apiPort: 10350
+  config:
+    caCerts: ""
+    httpProxy: ""
+    httpsProxy: ""
+    noProxy: ""
+    dangerousSkipTLSVerify: ""

--- a/addons/packages/kapp-controller/0.28.0/bundle/config/values.yaml
+++ b/addons/packages/kapp-controller/0.28.0/bundle/config/values.yaml
@@ -12,6 +12,7 @@ kappController:
     concurrency: 4
     tolerations: []
     apiPort: 10350
+    metricsBindAddress: ":8080"
   config:
     caCerts: ""
     httpProxy: ""

--- a/addons/packages/kapp-controller/0.28.0/bundle/vendir.lock.yml
+++ b/addons/packages/kapp-controller/0.28.0/bundle/vendir.lock.yml
@@ -1,0 +1,8 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/carvel-kapp-controller/releases/51824659
+    path: kapp-controller.yaml
+  path: config/upstream
+kind: LockConfig

--- a/addons/packages/kapp-controller/0.28.0/bundle/vendir.yml
+++ b/addons/packages/kapp-controller/0.28.0/bundle/vendir.yml
@@ -1,0 +1,14 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.12.0
+directories:
+- path: config/upstream
+  contents:
+    - path: kapp-controller.yaml
+      githubRelease:
+        slug: vmware-tanzu/carvel-kapp-controller
+        tag: v0.28.0
+        disableAutoChecksumValidation: true
+      includePaths:
+      - release.yml
+      newRootPath: release.yml

--- a/addons/packages/kapp-controller/0.28.0/package.yaml
+++ b/addons/packages/kapp-controller/0.28.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:ee2c6af40080c1e734e2d6fd4bab244c984ba15be29009c2319c18d7d77c7f1c
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:02618b6df32fb2da98409fa0ccb1eb080277fd26915597555d9ca4be6e50bc2d
       template:
         - ytt:
             paths:

--- a/addons/packages/kapp-controller/0.28.0/package.yaml
+++ b/addons/packages/kapp-controller/0.28.0/package.yaml
@@ -1,0 +1,26 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: kapp-controller.community.tanzu.vmware.com.0.28.0
+  namespace: kapp-controller
+spec:
+  refName: kapp-controller.community.tanzu.vmware.com
+  version: 0.28.0
+  releaseNotes: "kapp-controller 0.28.0 https://github.com/vmware-tanzu/carvel-kapp-controller"
+  licenses:
+    - "Apache 2.0"
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:ee2c6af40080c1e734e2d6fd4bab244c984ba15be29009c2319c18d7d77c7f1c
+      template:
+        - ytt:
+            paths:
+              - config/
+        - kbld:
+            paths:
+              - "-"
+              - .imgpkg/images.yml
+      deploy:
+        - kapp: {}

--- a/addons/packages/kapp-controller/0.28.0/package.yaml
+++ b/addons/packages/kapp-controller/0.28.0/package.yaml
@@ -2,7 +2,6 @@ apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: kapp-controller.community.tanzu.vmware.com.0.28.0
-  namespace: kapp-controller
 spec:
   refName: kapp-controller.community.tanzu.vmware.com
   version: 0.28.0


### PR DESCRIPTION
## What this PR does / why we need it
Changes for adding kapp controller in tce => release 0.28.0

## Details for the Release Notes 

```release-note
Bump kapp controller to released version 0.28.0
```

## Which issue(s) this PR fixes
Fixes: #2327 

## Describe testing done for PR
ytt --ignore-unknown-comments -f 0.28.0/bundle/config


