### PR TITLE
Remove namespace creation yaml from ako template

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/overlays/overlay-statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/overlays/overlay-statefulset.yaml
@@ -1,13 +1,14 @@
 #@ load("/values.star", "values")
 #@ load("@ytt:overlay", "overlay")
 
-#@overlay/match by=overlay.subset({"kind": "Namespace"})
+#@ if not values.loadBalancerAndIngressService.is_management_cluster:
 ---
-#@overlay/replace
+#@overlay/match missing_ok=True
 apiVersion: v1
 kind: Namespace
 metadata:
   name: #@ values.loadBalancerAndIngressService.namespace
+#@ end
 
 #@overlay/match by=overlay.subset({"kind": "StatefulSet", "metadata": {"name": "ako"}})
 ---

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: avi-system
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/values.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/values.yaml
@@ -3,7 +3,8 @@
 ---
 loadBalancerAndIngressService:
   name: ako-default-wc-1
-  namespace: avi-system
+  namespace: tkg-system-networking
+  is_management_cluster: true
   config:
     is_cluster_service: false
     replica_count: 1


### PR DESCRIPTION
## What this PR does / why we need it
<!--
If both ako-operator and ako are deployed in the same namespace, kapp controller will throw ownership error. Therefore, we remove namespace creation from ako template.
-->
