### PR TITLE
harbor package update issue with ReadWriteOnce pvc mode

### DIFF
--- a/addons/packages/harbor/2.2.3/bundle/config/overlay/harbor/update-jobservice.yaml
+++ b/addons/packages/harbor/2.2.3/bundle/config/overlay/harbor/update-jobservice.yaml
@@ -11,6 +11,14 @@
 
 #@ jobservice = values.persistence.persistentVolumeClaim.jobservice
 
+#@ def getStrategyType():
+#@   if jobservice.accessMode == "ReadWriteOnce":
+#@     return "Recreate"
+#@   else:
+#@     return "RollingUpdate"
+#@   end
+#@ end
+
 #@overlay/match by=overlay.and_op(overlay.and_op(kind.persistent_volume_claim, jobservice_metadata), overlay.not_op(use_existing_claim(jobservice))),expects="0+"
 ---
 spec:
@@ -44,6 +52,8 @@ spec:
 ---
 spec:
   replicas: #@ values.jobservice.replicas
+  strategy:
+    type: #@ getStrategyType()
   template:
     spec:
       containers:

--- a/addons/packages/harbor/2.2.3/bundle/config/overlay/harbor/update-registry.yaml
+++ b/addons/packages/harbor/2.2.3/bundle/config/overlay/harbor/update-registry.yaml
@@ -40,6 +40,14 @@ keyfile: /etc/registry/gcs-key.json
 #@   end
 #@ end
 
+#@ def getStrategyType():
+#@   if registry.accessMode == "ReadWriteOnce" and storage.type == "filesystem":
+#@     return "Recreate"
+#@   else:
+#@     return "RollingUpdate"
+#@   end
+#@ end
+
 #@ def registry_config():
 #@overlay/match-child-defaults missing_ok=True
 log:
@@ -140,6 +148,8 @@ spec:
 ---
 spec:
   replicas: #@ values.registry.replicas
+  strategy:
+    type: #@ getStrategyType()
   template:
     spec:
       containers:

--- a/addons/packages/harbor/2.2.3/package.yaml
+++ b/addons/packages/harbor/2.2.3/package.yaml
@@ -645,7 +645,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/harbor@sha256:51c9728301e64763ff872378e86b17d4cedc9cb64305519faa4e90c1ce257e9a
+            image: projects.registry.vmware.com/tce/harbor@sha256:4622adcfbef012ffab6a02ff9d88129ca10fdbe2c83cdb4c1372c5e25642b6ce
       template:
         - ytt:
             paths:

--- a/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/default.yaml
+++ b/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/default.yaml
@@ -529,7 +529,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app: harbor
@@ -1058,7 +1058,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app: harbor

--- a/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-azure-storage.yaml
+++ b/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-azure-storage.yaml
@@ -529,7 +529,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app: harbor

--- a/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-existing-pvc.yaml
+++ b/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-existing-pvc.yaml
@@ -529,7 +529,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app: harbor
@@ -1058,7 +1058,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app: harbor

--- a/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-s3-storage.yaml
+++ b/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-s3-storage.yaml
@@ -529,7 +529,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app: harbor


### PR DESCRIPTION
## What this PR does / why we need it

Fix the update issue with the ReadWriteOnce pvc in harbor package


## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
Fixes: #2320

## Describe testing done for PR

1. Update package repository on VSphere with multiple work nodes
```
tanzu package repository add <repo-name> --namespace default --url <repository url>
```
2. install harbor package 
```
tanzu package install harbor --package-name harbor.community.tanzu.vmware.com --version 2.2.3 -f harbor-data-values.yaml
```
3. update harbor-values-data.yaml file
```
trivy:
  enabled: true
  replicas: 2
```
```
proxy:
  httpProxy: <edit to a random proxy>
  httpsProxy: 
  noProxy: 127.0.0.1,localhost,.local,.internal
```
4. update harbor package 
```
tanzu package installed update harbor --version 2.2.3 -f harbor-data-values.yaml
```
5. observe all the pods under harbor is running and harbor package reconcile succeeded
```
kubectl get pods -n harbor
tanzu package installed list
```
