### PR TITLE
Load local cluster config by order of precedent

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/tanzu/config.go
+++ b/cli/cmd/plugin/standalone-cluster/tanzu/config.go
@@ -4,9 +4,31 @@
 package tanzu
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
 )
+
+const (
+	TKRLocation string = "TkrLocation"
+	Provider    string = "Provider"
+	CNI         string = "Cni"
+	PodCIDR     string = "PodCidr"
+	ServiceCIDR string = "ServiceCidr"
+)
+
+var defaultConfigValues = map[string]string{
+	TKRLocation: "projects.registry.vmware.com/tkg/tkr-bom:v1.21.2_vmware.1-tkg.1",
+	Provider:    "kind",
+	CNI:         "antrea",
+	PodCIDR:     "10.244.0.0/16",
+	ServiceCIDR: "10.96.0.0/16",
+}
 
 // PortMap is the mapping between a host port and a container port.
 type PortMap struct {
@@ -25,12 +47,12 @@ type LocalClusterConfig struct {
 	Provider string `yaml:"Provider"`
 	// ProviderConfiguration offers optional provider-specific configuration.
 	// The exact keys and values accepted are determined by the provider.
-	ProviderConfiguration map[string]interface{}
+	ProviderConfiguration map[string]interface{} `yaml:"ProviderConfiguration"`
 	// CNI is the networking CNI to use in the cluster. Default is antrea.
-	CNI string `yaml:"CNI"`
+	CNI string `yaml:"Cni"`
 	// CNIConfiguration offers optional cni-plugin specific configuration.
 	// The exact keys and values accepted are determined by the CNI choice.
-	CNIConfiguration map[string]interface{}
+	CNIConfiguration map[string]interface{} `yaml:"CniConfiguration"`
 	// PodCidr is the Pod CIDR range to assign pod IP addresses.
 	PodCidr string `yaml:"PodCidr"`
 	// ServiceCidr is the Service CIDR range to assign service IP addresses.
@@ -45,4 +67,84 @@ type LocalClusterConfig struct {
 // KubeConfigPath gets the full path to the KubeConfig for this local cluster.
 func (lcc *LocalClusterConfig) KubeConfigPath() string {
 	return filepath.Join(os.Getenv("HOME"), configDir, tanzuConfigDir, lcc.ClusterName+".yaml")
+}
+
+// InitializeConfiguration determines the configuration to use for cluster creation.
+//
+// There are three places where configuration comes from:
+// - default settings
+// - configuration file
+// - environment variables
+// - command line arguments
+//
+// The effective configuration is determined by combining these sources, in ascending
+// order of preference listed. So env variables override values in the config file,
+// and explicit CLI arguments override config file and env variable values.
+func InitializeConfiguration(commandArgs map[string]string) (*LocalClusterConfig, error) {
+	config := &LocalClusterConfig{}
+
+	// First, populate values based on a supplied config file
+	if commandArgs["clusterconfigfile"] != "" {
+		configData, err := os.ReadFile(commandArgs["clusterconfigfile"])
+		if err != nil {
+			return nil, err
+		}
+
+		err = yaml.Unmarshal(configData, config)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Loop through and look up each field
+	element := reflect.ValueOf(config).Elem()
+	for i := 0; i < element.NumField(); i++ {
+		field := element.Type().Field(i)
+		if field.Type.Kind() != reflect.String {
+			// Not supporting more complex data types yet, will need to see if and
+			// how to do this.
+			continue
+		}
+
+		// Use the yaml name if provided so it matches what we serialize to file
+		fieldName := field.Tag.Get("yaml")
+		if fieldName == "" {
+			fieldName = field.Name
+		}
+
+		// Check if an explicit value was passed in
+		if value, ok := commandArgs[strings.ToLower(fieldName)]; ok {
+			element.FieldByName(field.Name).SetString(value)
+		} else if value := os.Getenv(fieldNameToEnvName(fieldName)); value != "" {
+			// See if there is an environment variable set for this field
+			element.FieldByName(field.Name).SetString(value)
+		}
+
+		// Only set to the default value if it hasn't been set already
+		if element.FieldByName(field.Name).String() == "" {
+			if value, ok := defaultConfigValues[fieldName]; ok {
+				element.FieldByName(field.Name).SetString(value)
+			}
+		}
+	}
+
+	// Make sure cluster name was either set on the command line or in the config
+	// file.
+	if config.ClusterName == "" {
+		return nil, fmt.Errorf("cluster name must be provided")
+	}
+
+	return config, nil
+}
+
+// fieldNameToEnvName converts the config values yaml name to its expected env
+// variable name.
+func fieldNameToEnvName(field string) string {
+	namedArray := []string{"TANZU"}
+	re := regexp.MustCompile(`[A-Z][^A-Z]*`)
+	allWords := re.FindAllString(field, -1)
+	for _, word := range allWords {
+		namedArray = append(namedArray, strings.ToUpper(word))
+	}
+	return strings.Join(namedArray, "_")
 }

--- a/cli/cmd/plugin/standalone-cluster/tanzu/config_test.go
+++ b/cli/cmd/plugin/standalone-cluster/tanzu/config_test.go
@@ -1,0 +1,186 @@
+// Copyright 2020-2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tanzu
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestInitializeConfigurationNoName(t *testing.T) {
+	_, err := InitializeConfiguration(make(map[string]string))
+	if err == nil {
+		t.Error("initialization should fail if no cluster name provided")
+	}
+}
+
+func TestInitializeConfigurationDefaults(t *testing.T) {
+	args := map[string]string{"clustername": "test"}
+	config, err := InitializeConfiguration(args)
+	if err != nil {
+		t.Error("initialization should pass")
+	}
+
+	if config.ClusterName != "test" {
+		t.Errorf("expected ClusterName to be 'test', was actually: %q", config.ClusterName)
+	}
+
+	if config.CNI != defaultConfigValues[CNI] {
+		t.Errorf("expected default CNI value, was: %q", config.CNI)
+	}
+
+	if config.TkrLocation != defaultConfigValues[TKRLocation] {
+		t.Errorf("expected default TkrLocation, was: %q", config.TkrLocation)
+	}
+
+	if config.Provider != defaultConfigValues[Provider] {
+		t.Errorf("expected default Provider, was: %q", config.Provider)
+	}
+
+	if config.PodCidr != defaultConfigValues[PodCIDR] {
+		t.Errorf("expected default PodCidr, was: %q", config.PodCidr)
+	}
+
+	if config.ServiceCidr != defaultConfigValues[ServiceCIDR] {
+		t.Errorf("expected default ServiceCidr, was: %q", config.ServiceCidr)
+	}
+}
+
+func TestInitializeConfigurationEnvVariables(t *testing.T) {
+	os.Setenv("TANZU_PROVIDER", "test_provider")
+	os.Setenv("TANZU_CLUSTER_NAME", "test2")
+	config, err := InitializeConfiguration(make(map[string]string))
+	if err != nil {
+		t.Error("initialization should pass")
+	}
+
+	if config.ClusterName != "test2" {
+		t.Errorf("expected ClusterName to be 'test2', was actually: %q", config.ClusterName)
+	}
+
+	if config.Provider != "test_provider" {
+		t.Errorf("expected Provider to be set to 'test_provider', was: %q", config.Provider)
+	}
+
+	if config.CNI != defaultConfigValues[CNI] {
+		t.Errorf("expected default CNI value, was: %q", config.CNI)
+	}
+
+	if config.TkrLocation != defaultConfigValues[TKRLocation] {
+		t.Errorf("expected default TkrLocation, was: %q", config.TkrLocation)
+	}
+
+	if config.PodCidr != defaultConfigValues[PodCIDR] {
+		t.Errorf("expected default PodCidr, was: %q", config.PodCidr)
+	}
+
+	if config.ServiceCidr != defaultConfigValues[ServiceCIDR] {
+		t.Errorf("expected default ServiceCidr, was: %q", config.ServiceCidr)
+	}
+}
+
+func TestInitializeConfigurationArgsTakePrecedent(t *testing.T) {
+	os.Setenv("TANZU_PROVIDER", "test_provider")
+	os.Setenv("TANZU_CLUSTER_NAME", "test2")
+	args := map[string]string{"clustername": "test"}
+	config, err := InitializeConfiguration(args)
+	if err != nil {
+		t.Error("initialization should pass")
+	}
+
+	if config.ClusterName != "test" {
+		t.Errorf("expected ClusterName to be 'test', was actually: %q", config.ClusterName)
+	}
+
+	if config.Provider != "test_provider" {
+		t.Errorf("expected Provider to be set to 'test_provider', was: %q", config.Provider)
+	}
+
+	if config.CNI != defaultConfigValues[CNI] {
+		t.Errorf("expected default CNI value, was: %q", config.CNI)
+	}
+
+	if config.TkrLocation != defaultConfigValues[TKRLocation] {
+		t.Errorf("expected default TkrLocation, was: %q", config.TkrLocation)
+	}
+
+	if config.PodCidr != defaultConfigValues[PodCIDR] {
+		t.Errorf("expected default PodCidr, was: %q", config.PodCidr)
+	}
+
+	if config.ServiceCidr != defaultConfigValues[ServiceCIDR] {
+		t.Errorf("expected default ServiceCidr, was: %q", config.ServiceCidr)
+	}
+}
+
+func TestInitializeConfigurationFromConfigFile(t *testing.T) {
+	os.Setenv("TANZU_PROVIDER", "")
+	os.Setenv("TANZU_CLUSTER_NAME", "")
+	var configData bytes.Buffer
+	yamlEncoder := yaml.NewEncoder(&configData)
+	yamlEncoder.SetIndent(2)
+
+	if err := yamlEncoder.Encode(LocalClusterConfig{
+		ClusterName: "test3",
+		Provider:    "courteous",
+		CNI:         "bongos",
+		PodCidr:     "8.8.8.0/24",
+		ServiceCidr: "9.9.9.0/24",
+		TkrLocation: "here",
+	}); err != nil {
+		t.Errorf("failed setting up test data")
+		return
+	}
+
+	f, err := os.CreateTemp("", "test*.yaml")
+	if err != nil {
+		t.Errorf("failed to create data config file. Error: %s", err.Error())
+		return
+	}
+	_, err = f.Write(configData.Bytes())
+	if err != nil {
+		t.Errorf("failed to write test data config file. Error: %s", err.Error())
+		return
+	}
+
+	args := map[string]string{"clusterconfigfile": f.Name()}
+	config, err := InitializeConfiguration(args)
+	if err != nil {
+		t.Error("initialization should pass")
+	}
+
+	if config.ClusterName != "test3" {
+		t.Errorf("expected ClusterName to be 'test', was actually: %q", config.ClusterName)
+	}
+
+	if config.Provider != "courteous" {
+		t.Errorf("expected Provider to be set to 'courteous', was: %q", config.Provider)
+	}
+
+	if config.CNI != "bongos" {
+		t.Errorf("expected CNI to be set to 'bongos', was: %q", config.CNI)
+	}
+
+	if config.TkrLocation != "here" {
+		t.Errorf("expected TkrLocation to be set to 'here', was: %q", config.TkrLocation)
+	}
+
+	if config.PodCidr != "8.8.8.0/24" {
+		t.Errorf("expected PodCidr to be set to '8.8.8.0/24', was: %q", config.PodCidr)
+	}
+
+	if config.ServiceCidr != "9.9.9.0/24" {
+		t.Errorf("expected ServiceCidr to be set to '9.9.9.0/24', was: %q", config.ServiceCidr)
+	}
+}
+
+func TestFieldNameToEnvName(t *testing.T) {
+	result := fieldNameToEnvName("SomeCamelCaseVar")
+	if result != "TANZU_SOME_CAMEL_CASE_VAR" {
+		t.Errorf("Conversion to env var failed, got %s", result)
+	}
+}

--- a/cli/cmd/plugin/standalone-cluster/tanzu/defaults.go
+++ b/cli/cmd/plugin/standalone-cluster/tanzu/defaults.go
@@ -1,9 +1,0 @@
-package tanzu
-
-const (
-	DefaultTkrLocation = "projects.registry.vmware.com/tkg/tkr-bom:v1.21.2_vmware.1-tkg.1"
-	DefaultProvider    = "kind"
-	DefaultCni         = "antrea"
-	DefaultPodCidr     = "10.244.0.0/16"
-	DefaultServiceCidr = "10.96.0.0/16"
-)


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This updates how we determine local cluster configuration by setting the
values based on:

1. explicit arguments
2. environment variables
3. configuration files
4. default values