### PR TITLE
introduce config pkg and plumb config

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/cluster/cluster.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/cluster.go
@@ -5,6 +5,10 @@
 // perform CRUD and other operations.
 package cluster
 
+import (
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/config"
+)
+
 // KubernetesCluster represents a defines k8s cluster.
 type KubernetesCluster struct {
 	// Name is the name of the cluster.
@@ -19,8 +23,9 @@ type CreateOpts struct {
 	Name string
 	// KubeconfigPath is the path to the kubeconfig to use.
 	KubeconfigPath string
-	// Config contains the raw configuration data to use when creating the cluster.
-	Config []byte
+	// Config contains the full cluster creation details passed in from the user when calling
+	// create.
+	Config config.LocalClusterConfig
 }
 
 // ClusterManager provides methods for creating and managing Kubernetes

--- a/cli/cmd/plugin/standalone-cluster/cluster/kind.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/kind.go
@@ -6,6 +6,7 @@ package cluster
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	kindCluster "sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/exec"
@@ -51,10 +52,11 @@ func (kcm KindClusterManager) Create(opts *CreateOpts) (*KubernetesCluster, erro
 		Kubeconfig: opts.KubeconfigPath,
 	}
 
-	// TODO(stmcginnis): This should be conditional based on the CNI chosen.
-	nodes, _ := kindProvider.ListNodes(opts.Name)
-	for _, n := range nodes {
-		patchForAntrea(n.String())
+	if strings.Contains(opts.Config.Cni, "antrea") {
+		nodes, _ := kindProvider.ListNodes(opts.Name)
+		for _, n := range nodes {
+			patchForAntrea(n.String())
+		}
 	}
 
 	return kc, nil

--- a/cli/cmd/plugin/standalone-cluster/config/config.go
+++ b/cli/cmd/plugin/standalone-cluster/config/config.go
@@ -1,7 +1,4 @@
-// Copyright 2020-2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-package tanzu
+package config
 
 import (
 	"fmt"
@@ -15,19 +12,23 @@ import (
 )
 
 const (
-	TKRLocation string = "TkrLocation"
-	Provider    string = "Provider"
-	CNI         string = "Cni"
-	PodCIDR     string = "PodCidr"
-	ServiceCIDR string = "ServiceCidr"
+	TKRLocation    = "TkrLocation"
+	Provider       = "Provider"
+	Cni            = "Cni"
+	Tty            = "Tty"
+	PodCIDR        = "PodCidr"
+	ServiceCIDR    = "ServiceCidr"
+	configDir      = ".config"
+	tanzuConfigDir = "tanzu"
 )
 
 var defaultConfigValues = map[string]string{
 	TKRLocation: "projects.registry.vmware.com/tkg/tkr-bom:v1.21.2_vmware.1-tkg.1",
 	Provider:    "kind",
-	CNI:         "antrea",
+	Cni:         "antrea",
 	PodCIDR:     "10.244.0.0/16",
 	ServiceCIDR: "10.96.0.0/16",
+	Tty:         "true",
 }
 
 // PortMap is the mapping between a host port and a container port.
@@ -49,7 +50,7 @@ type LocalClusterConfig struct {
 	// The exact keys and values accepted are determined by the provider.
 	ProviderConfiguration map[string]interface{} `yaml:"ProviderConfiguration"`
 	// CNI is the networking CNI to use in the cluster. Default is antrea.
-	CNI string `yaml:"Cni"`
+	Cni string `yaml:"Cni"`
 	// CNIConfiguration offers optional cni-plugin specific configuration.
 	// The exact keys and values accepted are determined by the CNI choice.
 	CNIConfiguration map[string]interface{} `yaml:"CniConfiguration"`
@@ -62,6 +63,8 @@ type LocalClusterConfig struct {
 	// PortsToForward contains a mapping of host to container ports that should
 	// be exposed.
 	PortsToForward []PortMap `yaml:"PortsToForward"`
+	// TTY specifies whether the output of commands can be stylized and/or interactive.
+	Tty string `yaml:"Tty"`
 }
 
 // KubeConfigPath gets the full path to the KubeConfig for this local cluster.

--- a/cli/cmd/plugin/standalone-cluster/config/config_test.go
+++ b/cli/cmd/plugin/standalone-cluster/config/config_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package tanzu
+package config
 
 import (
 	"bytes"

--- a/cli/cmd/plugin/standalone-cluster/configure.go
+++ b/cli/cmd/plugin/standalone-cluster/configure.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/spf13/cobra"
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/config"
 	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/log"
-	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/tanzu"
 )
 
 // ConfigureCmd creates a standalone workload cluster.
@@ -30,7 +30,7 @@ func configure(cmd *cobra.Command, args []string) error {
 	var clusterName string
 
 	// validate a cluster name was passed when not using the kickstart UI
-	if len(args) < 1 && !iso.ui {
+	if len(args) < 1 && !co.ui {
 		return fmt.Errorf("cluster name not specified.")
 	} else if len(args) == 1 {
 		clusterName = args[0]
@@ -38,24 +38,24 @@ func configure(cmd *cobra.Command, args []string) error {
 
 	log := logger.NewLogger(true, 0)
 
-	var config bytes.Buffer
-	yamlEncoder := yaml.NewEncoder(&config)
+	var rawConfig bytes.Buffer
+	yamlEncoder := yaml.NewEncoder(&rawConfig)
 	yamlEncoder.SetIndent(2)
 
-	lcConfig, err := tanzu.InitializeConfiguration(map[string]string{"clustername": clusterName})
+	lcConfig, err := config.InitializeConfiguration(map[string]string{"clustername": clusterName})
 	if err != nil {
 		log.Errorf("Failed to initialize configuration. Error: %s\n", err.Error())
 	}
 	err = yamlEncoder.Encode(*lcConfig)
 	if err != nil {
-		log.Errorf("Failed to render config file. Error: %s\n", err.Error())
+		log.Errorf("Failed to render rawConfig file. Error: %s\n", err.Error())
 		return nil
 	}
 
 	fileName := fmt.Sprintf("%s.yaml", clusterName)
-	err = os.WriteFile(fileName, config.Bytes(), 0644)
+	err = os.WriteFile(fileName, rawConfig.Bytes(), 0644)
 	if err != nil {
-		log.Errorf("Failed to write config file. Error: %s\n", err.Error())
+		log.Errorf("Failed to write rawConfig file. Error: %s\n", err.Error())
 		return nil
 	}
 	log.Infof("Wrote configuration file to: %s\n", fileName)

--- a/cli/cmd/plugin/standalone-cluster/delete.go
+++ b/cli/cmd/plugin/standalone-cluster/delete.go
@@ -29,7 +29,7 @@ func destroy(cmd *cobra.Command, args []string) error {
 	var clusterName string
 
 	// validate a cluster name was passed when not using the kickstart UI
-	if len(args) < 1 && !iso.ui {
+	if len(args) < 1 && !co.ui {
 		return fmt.Errorf("Must specify cluster name to delete")
 	} else if len(args) == 1 {
 		clusterName = args[0]


### PR DESCRIPTION
With configuration now flowing through local, this commit forwards the
configuration from the tanzu package to the various packages it
interacts with.

Signed-off-by: joshrosso <rossoj@vmware.com>

![image](https://user-images.githubusercontent.com/6200057/138597909-42bef3b2-fd9b-4e24-a890-3b720271c8c3.png)
