### PR TITLE
Add CLI args for local cluster create and configure

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/config/config.go
+++ b/cli/cmd/plugin/standalone-cluster/config/config.go
@@ -15,14 +15,16 @@ import (
 )
 
 const (
-	TKRLocation    = "TkrLocation"
-	Provider       = "Provider"
-	Cni            = "Cni"
-	Tty            = "Tty"
-	PodCIDR        = "PodCidr"
-	ServiceCIDR    = "ServiceCidr"
-	configDir      = ".config"
-	tanzuConfigDir = "tanzu"
+	ClusterConfigFile = "ClusterConfigFile"
+	ClusterName       = "ClusterName"
+	Tty               = "Tty"
+	TKRLocation       = "TkrLocation"
+	Provider          = "Provider"
+	Cni               = "Cni"
+	PodCIDR           = "PodCidr"
+	ServiceCIDR       = "ServiceCidr"
+	configDir         = ".config"
+	tanzuConfigDir    = "tanzu"
 )
 
 var defaultConfigValues = map[string]string{
@@ -90,8 +92,8 @@ func InitializeConfiguration(commandArgs map[string]string) (*LocalClusterConfig
 	config := &LocalClusterConfig{}
 
 	// First, populate values based on a supplied config file
-	if commandArgs["clusterconfigfile"] != "" {
-		configData, err := os.ReadFile(commandArgs["clusterconfigfile"])
+	if commandArgs[ClusterConfigFile] != "" {
+		configData, err := os.ReadFile(commandArgs[ClusterConfigFile])
 		if err != nil {
 			return nil, err
 		}
@@ -119,7 +121,7 @@ func InitializeConfiguration(commandArgs map[string]string) (*LocalClusterConfig
 		}
 
 		// Check if an explicit value was passed in
-		if value, ok := commandArgs[strings.ToLower(fieldName)]; ok {
+		if value, ok := commandArgs[fieldName]; ok {
 			element.FieldByName(field.Name).SetString(value)
 		} else if value := os.Getenv(fieldNameToEnvName(fieldName)); value != "" {
 			// See if there is an environment variable set for this field

--- a/cli/cmd/plugin/standalone-cluster/config/config_test.go
+++ b/cli/cmd/plugin/standalone-cluster/config/config_test.go
@@ -20,7 +20,7 @@ func TestInitializeConfigurationNoName(t *testing.T) {
 }
 
 func TestInitializeConfigurationDefaults(t *testing.T) {
-	args := map[string]string{"clustername": "test"}
+	args := map[string]string{ClusterName: "test"}
 	config, err := InitializeConfiguration(args)
 	if err != nil {
 		t.Error("initialization should pass")
@@ -87,7 +87,7 @@ func TestInitializeConfigurationEnvVariables(t *testing.T) {
 func TestInitializeConfigurationArgsTakePrecedent(t *testing.T) {
 	os.Setenv("TANZU_PROVIDER", "test_provider")
 	os.Setenv("TANZU_CLUSTER_NAME", "test2")
-	args := map[string]string{"clustername": "test"}
+	args := map[string]string{ClusterName: "test"}
 	config, err := InitializeConfiguration(args)
 	if err != nil {
 		t.Error("initialization should pass")
@@ -148,7 +148,7 @@ func TestInitializeConfigurationFromConfigFile(t *testing.T) {
 		return
 	}
 
-	args := map[string]string{"clusterconfigfile": f.Name()}
+	args := map[string]string{ClusterConfigFile: f.Name()}
 	config, err := InitializeConfiguration(args)
 	if err != nil {
 		t.Error("initialization should pass")

--- a/cli/cmd/plugin/standalone-cluster/create.go
+++ b/cli/cmd/plugin/standalone-cluster/create.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -17,7 +16,10 @@ import (
 type createLocalOpts struct {
 	clusterConfigFile      string
 	infrastructureProvider string
-	ui                     bool
+	tkrLocation            string
+	cni                    string
+	podcidr                string
+	servicecidr            string
 	tty                    bool
 }
 
@@ -30,41 +32,44 @@ var CreateCmd = &cobra.Command{
 
 var co = createLocalOpts{}
 
+//nolint:dupl
 func init() {
 	CreateCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "Configuration file for local cluster creation")
 	CreateCmd.Flags().StringVarP(&co.infrastructureProvider, "provider", "p", "", "The infrastructure provider to use for cluster creation. Default is 'kind'")
+	CreateCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The Tanzu Kubernetes Release location.")
+	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'antrea'")
+	CreateCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR to use for Pod IP addresses. Default and format is '10.244.0.0/16'")
+	CreateCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR to use for Service IP addresses. Default and format is '10.96.0.0/16'")
 	CreateCmd.Flags().BoolVar(&co.tty, "tty", true, "Specify whether terminal is tty. Set to false to disable styled output; default: true")
 }
 
 func create(cmd *cobra.Command, args []string) error {
 	var clusterName string
 
-	// validate a cluster name was passed when not using the kickstart UI
-	if len(args) < 1 && !co.ui {
+	// validate a cluster name was passed
+	if len(args) < 1 {
 		return fmt.Errorf("cluster name not specified")
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
 	// initial logger, needed for logging if something goes wrong
-	log := logger.NewLogger(false, 0)
+	log := logger.NewLogger(co.tty, 0)
 
 	// Determine our configuration to use
 	configArgs := map[string]string{
-		"clusterconfigfile": co.clusterConfigFile,
-		"clustername":       clusterName,
+		config.ClusterConfigFile: co.clusterConfigFile,
+		config.ClusterName:       clusterName,
+		config.Provider:          co.infrastructureProvider,
+		config.TKRLocation:       co.tkrLocation,
+		config.Cni:               co.cni,
+		config.PodCIDR:           co.podcidr,
+		config.ServiceCIDR:       co.servicecidr,
 	}
 	clusterConfig, err := config.InitializeConfiguration(configArgs)
 	if err != nil {
 		log.Errorf("Failed to initialize configuration. Error %s\n", clusterConfig)
 		return nil
 	}
-	ttySetting, err := strconv.ParseBool(clusterConfig.Tty)
-	if err != nil {
-		log.Errorf("TTY setting was invalid. Error: %s", err.Error())
-		return nil
-	}
-	// reset logger here based on parsed configuration
-	log = logger.NewLogger(ttySetting, 0)
 
 	tm := tanzu.New(log)
 	err = tm.Deploy(clusterConfig)

--- a/cli/cmd/plugin/standalone-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/standalone-cluster/tanzu/tanzu.go
@@ -529,7 +529,7 @@ func resolveCNI(mgr packages.PackageManager, cniName string) (*CNIPackage, error
 		return nil, err
 	}
 	if cniPkg.fqPkgName == "" {
-		return nil, fmt.Errorf("No package was resolved for CNI choice %s", cniName)
+		return nil, fmt.Errorf("no package was resolved for CNI choice %s", cniName)
 	}
 
 	return cniPkg, nil


### PR DESCRIPTION
This adds the remaining CLI arguments to the local cluster create and
configure commands to be able to provide the most of the configuration
to use as part of the command line.