### PR TITLE
Enhance the e2e of the harbor package

### DIFF
--- a/addons/packages/harbor/2.2.3/test/e2e/fixtures/contour.yaml
+++ b/addons/packages/harbor/2.2.3/test/e2e/fixtures/contour.yaml
@@ -1,3 +1,5 @@
+namespace: projectcontour
+
 envoy:
   hostPorts:
     enable: true


### PR DESCRIPTION
1. Install the contour components to a fixed namespace.
2. Install the harbor package with available version contains '2.2.3'.
3. Clean up the package in AfterSuite stage only it's installed in BeforeSuite stage.
4. Use the host ip when the load balancer ip is empty for contour.

Signed-off-by: He Weiwei <hweiwei@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Enhance the e2e of the harbor package to make it run in the tkg env.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
