### PR TITLE
Fix path of check-tce-cluster-creation.sh script

### DIFF
--- a/test/azure/deploy-management-and-workload-cluster.sh
+++ b/test/azure/deploy-management-and-workload-cluster.sh
@@ -122,7 +122,7 @@ function check_management_cluster_creation {
         return 1
     }
 
-    "${TCE_REPO_PATH}"/test/docker/check-tce-cluster-creation.sh ${MANAGEMENT_CLUSTER_NAME}-admin@${MANAGEMENT_CLUSTER_NAME} || {
+    "${TCE_REPO_PATH}"/test/check-tce-cluster-creation.sh ${MANAGEMENT_CLUSTER_NAME}-admin@${MANAGEMENT_CLUSTER_NAME} || {
         error "MANAGEMENT CLUSTER CREATION CHECK FAILED!"
         return 1
     }


### PR DESCRIPTION
## What this PR does / why we need it

Fixes the path of `check-tce-cluster-creation.sh` script to fix the issue in CI -

https://github.com/vmware-tanzu/community-edition/runs/3966514622?check_suite_focus=true#step:5:1530

```
test/azure/deploy-management-and-workload-cluster.sh: line 125: /home/runner/work/community-edition/community-edition/test/azure/../../test/docker/check-tce-cluster-creation.sh: No such file or directory
```

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

-

## Describe testing done for PR

-

## Special notes for your reviewer

-