### PR TITLE
Check for forks before running vsphere e2e job

### DIFF
--- a/.github/workflows/e2e-vsphere-management-cluster.yaml
+++ b/.github/workflows/e2e-vsphere-management-cluster.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   e2e-vsphere-management-cluster-test:
     name: E2E vSphere Management Cluster Test
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
     runs-on: vsphere-e2e-runner
     steps:
       - name: Set up Go 1.x


### PR DESCRIPTION
## What this PR does / why we need it

Checks for forks before running vsphere e2e job. Similar to PR #2292 

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

Related: #2291 

## Describe testing done for PR

-

## Special notes for your reviewer

-