### PR TITLE
make avi controller version configurable

### DIFF
--- a/addons/packages/ako-operator/1.5.0/README.md
+++ b/addons/packages/ako-operator/1.5.0/README.md
@@ -25,6 +25,7 @@ The following configuration values can be set to customize the ako-operator inst
 | `avi_admin_credential_name` | Required | the name of a Secret resource which includes the username and password to access and configure the Avi Controller. |
 | `avi_ca_name` | Required | Avi controller credential name. |
 | `avi_controller` | Required | Avi controller ip. |
+| `avi_controller_version` | optional | The version of the Avi controller you want AKO Operator and AKO talk to. |
 | `avi_username` | Required | Avi controller username. |
 | `avi_password` | Required | Avi controller password. |
 | `avi_cloud_name` | Required | the configured cloud name on the Avi controller. |

--- a/addons/packages/ako-operator/1.5.0/bundle/config/kapp-config.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/kapp-config.yaml
@@ -10,6 +10,12 @@ data:
     kind: Config
     rebaseRules:
     - paths:
+      - [spec, cloudName]
+      - [spec, controller]
+      - [spec, adminCredentialRef]
+      - [spec, certificateAuthorityRef]
+      - [spec, dataNetwork]
+      - [spec, controllerVersion]
       - [spec, extraConfigs]
       - [spec, dataNetwork]
       - [spec, serviceEngineGroup]

--- a/addons/packages/ako-operator/1.5.0/bundle/config/overlays/overlay-akodeploymentconfig.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/overlays/overlay-akodeploymentconfig.yaml
@@ -15,6 +15,10 @@ spec:
     clusterSelector:
         matchLabels: #@ json.decode(values.akoOperator.config.avi_labels)
 #@ end
+#@ if values.akoOperator.config.avi_controller_version != "":
+    #@overlay/match missing_ok=True
+    controllerVersion: #@ values.akoOperator.config.avi_controller_version
+#@ end
     cloudName: #@ values.akoOperator.config.avi_cloud_name
     serviceEngineGroup: #@ values.akoOperator.config.avi_service_engine_group
     controller: #@ values.akoOperator.config.avi_controller
@@ -83,6 +87,10 @@ spec:
     clusterSelector:
         matchLabels:
             cluster-role.tkg.tanzu.vmware.com/management: ""
+#@ if values.akoOperator.config.avi_controller_version != "":
+    #@overlay/match missing_ok=True
+    controllerVersion: #@ values.akoOperator.config.avi_controller_version
+#@ end
     dataNetwork:
         name: #@ values.akoOperator.config.avi_management_cluster_vip_network_name
         cidr: #@ values.akoOperator.config.avi_management_cluster_vip_network_cidr

--- a/addons/packages/ako-operator/1.5.0/bundle/config/overlays/overlay-deployment.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/overlays/overlay-deployment.yaml
@@ -51,6 +51,8 @@ spec:
               value: #@ values.akoOperator.cluster_name
             - name: control_plane_endpoint_port
               value: #@ "{}".format(values.akoOperator.config.avi_control_plane_endpoint_port)
+            - name: avi_controller_version
+              value: #@ "{}".format(values.akoOperator.config.avi_controller_version)
           resources:
             limits:
               cpu: 100m

--- a/addons/packages/ako-operator/1.5.0/bundle/config/upstream/akooperator/static.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/upstream/akooperator/static.yaml
@@ -95,6 +95,9 @@ spec:
               controller:
                 description: Controller is the AVI Controller endpoint to which AKO talks to provision Load Balancer resources The format is [scheme://]address[:port] * scheme                     http or https, defaults to https if not                              specified * address                    IP address of the AVI Controller                              specified * port                       if not specified, use default port for                              the corresponding scheme
                 type: string
+              controllerVersion:
+                description: ControllerVersion is the AVI Controller version which AKO Operator and AKO talks to. If not set, default version is 20.1.3
+                type: string
               dataNetwork:
                 description: DataNetworks describes the Data Networks the AKO will be deployed with. This field is immutable.
                 properties:

--- a/addons/packages/ako-operator/1.5.0/bundle/config/values.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/values.yaml
@@ -6,6 +6,7 @@ akoOperator:
   namespace: tkg-system-networking
   cluster_name: ""
   config:
+    avi_controller_version: ""
     avi_disable_ingress_class: true
     avi_ingress_default_ingress_controller: false
     avi_ingress_shard_vs_size: ""


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

- Since `AKO Operator` and `AKO` both support multi AVI Controller versions, this PR makes AVI Controller Version configurable, so users can set the controller version to be the one they actually deployed.

- Allow user to change default `AKODeploymentConfig(adc)` 's controller setting.


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
This PR allows users to set AVI controller version and change the default adc's AVI controller configurations, so users now can switch AVI controllers.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
