### PR TITLE
Implements `repository` field on all TKR components

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/tkr/tkr.go
+++ b/cli/cmd/plugin/standalone-cluster/tkr/tkr.go
@@ -26,8 +26,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				AkoOperatorImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"akoOperatorImage"`
 			} `yaml:"images"`
 		} `yaml:"ako-operator"`
@@ -35,8 +36,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				AntreaImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"antreaImage"`
 			} `yaml:"images"`
 		} `yaml:"antrea"`
@@ -44,20 +46,24 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				CalicoCniImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"calicoCniImage"`
 				CalicoKubecontrollerImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"calicoKubecontrollerImage"`
 				CalicoNodeImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"calicoNodeImage"`
 				CalicoPodDaemonImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"calicoPodDaemonImage"`
 			} `yaml:"images"`
 		} `yaml:"calico_all"`
@@ -65,8 +71,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				CcmControllerImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"ccmControllerImage"`
 			} `yaml:"images"`
 		} `yaml:"cloud_provider_vsphere"`
@@ -80,8 +87,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				Coredns struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"coredns"`
 			} `yaml:"images"`
 		} `yaml:"coredns"`
@@ -92,8 +100,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				CsiAttacherImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"csiAttacherImage"`
 			} `yaml:"images"`
 		} `yaml:"csi_attacher"`
@@ -101,8 +110,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				CsiLivenessProbeImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"csiLivenessProbeImage"`
 			} `yaml:"images"`
 		} `yaml:"csi_livenessprobe"`
@@ -110,8 +120,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				CsiNodeDriverRegistrarImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"csiNodeDriverRegistrarImage"`
 			} `yaml:"images"`
 		} `yaml:"csi_node_driver_registrar"`
@@ -119,8 +130,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				CsiProvisonerImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"csiProvisonerImage"`
 			} `yaml:"images"`
 		} `yaml:"csi_provisioner"`
@@ -128,8 +140,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				DexImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"dexImage"`
 			} `yaml:"images"`
 		} `yaml:"dex"`
@@ -137,8 +150,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				Etcd struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"etcd"`
 			} `yaml:"images"`
 		} `yaml:"etcd"`
@@ -146,8 +160,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				KappControllerImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"kappControllerImage"`
 			} `yaml:"images"`
 		} `yaml:"kapp-controller"`
@@ -155,44 +170,54 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				KubeAPIServer struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"kubeAPIServer"`
 				KubeControllerManager struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"kubeControllerManager"`
 				KubeE2E struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"kubeE2e"`
 				KubeProxy struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"kubeProxy"`
 				KubeScheduler struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"kubeScheduler"`
 				Pause struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"pause"`
 				PauseWindows1809 struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"pause_windows_1809"`
 				PauseWindows1903 struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"pause_windows_1903"`
 				PauseWindows1909 struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"pause_windows_1909"`
 				PauseWindows2004 struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"pause_windows_2004"`
 			} `yaml:"images"`
 		} `yaml:"kubernetes"`
@@ -200,8 +225,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				CsiExternalResizer struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"csiExternalResizer"`
 			} `yaml:"images"`
 		} `yaml:"kubernetes-csi_external-resizer"`
@@ -209,8 +235,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				KindNodeImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"kindNodeImage"`
 			} `yaml:"images"`
 		} `yaml:"kubernetes-sigs_kind"`
@@ -218,8 +245,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				LoadBalancerAndIngressServiceImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"loadBalancerAndIngressServiceImage"`
 			} `yaml:"images"`
 		} `yaml:"load-balancer-and-ingress-service"`
@@ -227,8 +255,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				MetricsServerImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"metricsServerImage"`
 			} `yaml:"images"`
 		} `yaml:"metrics-server"`
@@ -236,8 +265,9 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				PinnipedImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"pinnipedImage"`
 			} `yaml:"images"`
 		} `yaml:"pinniped"`
@@ -245,12 +275,14 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				TanzuAddonsManagerImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"tanzuAddonsManagerImage"`
 				TkgPinnipedPostDeployImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"tkgPinnipedPostDeployImage"`
 			} `yaml:"images"`
 		} `yaml:"tanzu-framework-addons"`
@@ -258,48 +290,59 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				AddonsManagerTanzuVmwareCom struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"addons-manager.tanzu.vmware.com"`
 				AkoOperatorTanzuVmwareCom struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"ako-operator.tanzu.vmware.com"`
 				AntreaTanzuVmwareCom struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"antrea.tanzu.vmware.com"`
 				CalicoTanzuVmwareCom struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"calico.tanzu.vmware.com"`
 				KappControllerTanzuVmwareCom struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"kapp-controller.tanzu.vmware.com"`
 				LoadBalancerAndIngressServiceTanzuVmwareCom struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"load-balancer-and-ingress-service.tanzu.vmware.com"`
 				MetricsServerTanzuVmwareCom struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"metrics-server.tanzu.vmware.com"`
 				PinnipedTanzuVmwareCom struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"pinniped.tanzu.vmware.com"`
 				TanzuCorePackageRepositoryImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"tanzuCorePackageRepositoryImage"`
 				VsphereCpiTanzuVmwareCom struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"vsphere-cpi.tanzu.vmware.com"`
 				VsphereCsiTanzuVmwareCom struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"vsphere-csi.tanzu.vmware.com"`
 			} `yaml:"images"`
 		} `yaml:"tkg-core-packages"`
@@ -486,51 +529,61 @@ type TKRBom struct {
 			Category     string   `yaml:"category"`
 			ClusterTypes []string `yaml:"clusterTypes"`
 			PackageName  string   `yaml:"packageName"`
+			Reposoitory  string   `yaml:"repository"`
 		} `yaml:"ako-operator"`
 		Antrea struct {
 			Category     string   `yaml:"category"`
 			ClusterTypes []string `yaml:"clusterTypes"`
 			PackageName  string   `yaml:"packageName"`
+			Reposoitory  string   `yaml:"repository"`
 		} `yaml:"antrea"`
 		Calico struct {
 			Category     string   `yaml:"category"`
 			ClusterTypes []string `yaml:"clusterTypes"`
 			PackageName  string   `yaml:"packageName"`
+			Reposoitory  string   `yaml:"repository"`
 		} `yaml:"calico"`
 		KappController struct {
 			Category     string   `yaml:"category"`
 			ClusterTypes []string `yaml:"clusterTypes"`
 			PackageName  string   `yaml:"packageName"`
+			Reposoitory  string   `yaml:"repository"`
 		} `yaml:"kapp-controller"`
 		LoadBalancerAndIngressService struct {
 			Category     string   `yaml:"category"`
 			ClusterTypes []string `yaml:"clusterTypes"`
 			PackageName  string   `yaml:"packageName"`
+			Reposoitory  string   `yaml:"repository"`
 		} `yaml:"load-balancer-and-ingress-service"`
 		MetricsServer struct {
 			Category     string   `yaml:"category"`
 			ClusterTypes []string `yaml:"clusterTypes"`
 			PackageName  string   `yaml:"packageName"`
+			Reposoitory  string   `yaml:"repository"`
 		} `yaml:"metrics-server"`
 		Pinniped struct {
 			Category     string   `yaml:"category"`
 			ClusterTypes []string `yaml:"clusterTypes"`
 			PackageName  string   `yaml:"packageName"`
+			Reposoitory  string   `yaml:"repository"`
 		} `yaml:"pinniped"`
 		TanzuAddonsManager struct {
 			Category     string   `yaml:"category"`
 			ClusterTypes []string `yaml:"clusterTypes"`
 			PackageName  string   `yaml:"packageName"`
+			Reposoitory  string   `yaml:"repository"`
 		} `yaml:"tanzu-addons-manager"`
 		VsphereCpi struct {
 			Category     string   `yaml:"category"`
 			ClusterTypes []string `yaml:"clusterTypes"`
 			PackageName  string   `yaml:"packageName"`
+			Reposoitory  string   `yaml:"repository"`
 		} `yaml:"vsphere-cpi"`
 		VsphereCsi struct {
 			Category     string   `yaml:"category"`
 			ClusterTypes []string `yaml:"clusterTypes"`
 			PackageName  string   `yaml:"packageName"`
+			Reposoitory  string   `yaml:"repository"`
 		} `yaml:"vsphere-csi"`
 	} `yaml:"addons"`
 }
@@ -554,31 +607,11 @@ func (tkr *TKRBom) getTKRRegistry() string {
 }
 
 func (tkr *TKRBom) GetTKRNodeImage() string {
-	path := tkr.getTKRNodeImagePath()
-	tag := tkr.getTKRNodeImageTag()
+	repo := tkr.getTKRNodeRepository()
+	path := tkr.Components.KubernetesSigsKind[0].Images.KindNodeImage.ImagePath
+	tag := tkr.Components.KubernetesSigsKind[0].Images.KindNodeImage.Tag
 
-	return fmt.Sprintf("projects.registry.vmware.com/tce/%s:%s", path, tag)
-}
-
-func (tkr *TKRBom) getTKRNodeImagePath() string {
-	return tkr.Components.KubernetesSigsKind[0].Images.KindNodeImage.ImagePath
-}
-
-func (tkr *TKRBom) getTKRNodeImageTag() string {
-	return tkr.Components.KubernetesSigsKind[0].Images.KindNodeImage.Tag
-}
-
-func (tkr *TKRBom) GetTKRKappImage() (TkrImageReader, error) {
-	registry := tkr.getTKRRegistry()
-	path := tkr.getTKRKappImagePath()
-	tag := tkr.getTKRKappImageTag()
-
-	t, err := NewTkrImageReader(fmt.Sprintf("%s/%s:%s", registry, path, tag))
-	if err != nil {
-		return nil, err
-	}
-
-	return t, nil
+	return fmt.Sprintf("%s/%s:%s", repo, path, tag)
 }
 
 func (tkr *TKRBom) GetTKRCoreRepoBundlePath() string {
@@ -595,10 +628,31 @@ func (tkr *TKRBom) GetAdditionalRepoBundlesPaths() []string {
 	return []string{tceRepoURL}
 }
 
-func (tkr *TKRBom) getTKRKappImagePath() string {
-	return tkr.Components.TkgCorePackages[0].Images.KappControllerTanzuVmwareCom.ImagePath
+func (tkr *TKRBom) GetTKRKappImage() (TkrImageReader, error) {
+	registry := tkr.getTKRKappRepository()
+	path := tkr.Components.TkgCorePackages[0].Images.KappControllerTanzuVmwareCom.ImagePath
+	tag := tkr.Components.TkgCorePackages[0].Images.KappControllerTanzuVmwareCom.Tag
+
+	t, err := NewTkrImageReader(fmt.Sprintf("%s/%s:%s", registry, path, tag))
+	if err != nil {
+		return nil, err
+	}
+
+	return t, nil
 }
 
-func (tkr *TKRBom) getTKRKappImageTag() string {
-	return tkr.Components.TkgCorePackages[0].Images.KappControllerTanzuVmwareCom.Tag
+func (tkr *TKRBom) getTKRNodeRepository() string {
+	if tkr.Components.KubernetesSigsKind[0].Images.KindNodeImage.Reposoitory == "" {
+		return tkr.getTKRRegistry()
+	}
+
+	return tkr.Components.KubernetesSigsKind[0].Images.KindNodeImage.Reposoitory
+}
+
+func (tkr *TKRBom) getTKRKappRepository() string {
+	if tkr.Components.TkgCorePackages[0].Images.KappControllerTanzuVmwareCom.Reposoitory == "" {
+		return tkr.getTKRRegistry()
+	}
+
+	return tkr.Components.TkgCorePackages[0].Images.KappControllerTanzuVmwareCom.Reposoitory
 }


### PR DESCRIPTION
- Adds get methods for `node` and `kapp` images to get their custom repository. Otherwise, uses the TKR repository by default if non is used 
- Refactors the `tkr.go` file to have fewer functions (I can be convinced we need these if necessary

## What this PR does / why we need it
Enables using custom repository for individual components in the TKR. Otherwise, default behavior remains the same

## Details for the Release Notes (PLEASE PROVIDE)
N/a

## Describe testing done for PR
- build binary and still able to create cluster. Correct images are selected for

## Special notes for your reviewer
N/a
