### PR TITLE
Introduce config directory per cluster

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/cluster/cluster.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/cluster.go
@@ -40,11 +40,11 @@ type ClusterManager interface {
 	// List gets a list of all local clusters.
 	List() ([]*KubernetesCluster, error)
 	// Delete will destroy a cluster or return an error indicating a problem.
-	Delete(clusterName string) error
+	Delete(c *config.LocalClusterConfig) error
 }
 
-// NewClusterManager gets a ClusterManager implementation.
-func NewClusterManager() ClusterManager {
+// NewKindClusterManager gets a ClusterManager implementation.
+func NewKindClusterManager() ClusterManager {
 	// For now, just hard coding to return our KindClusterManager.
 	return KindClusterManager{}
 }

--- a/cli/cmd/plugin/standalone-cluster/cluster/kind.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/kind.go
@@ -10,6 +10,8 @@ import (
 
 	kindCluster "sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/exec"
+
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/config"
 )
 
 const defaultKindConfig = `kind: Cluster
@@ -94,9 +96,9 @@ func (kcm KindClusterManager) List() ([]*KubernetesCluster, error) {
 }
 
 // Delete removes a kind cluster.
-func (kcm KindClusterManager) Delete(clusterName string) error {
+func (kcm KindClusterManager) Delete(c *config.LocalClusterConfig) error {
 	provider := kindCluster.NewProvider()
-	return provider.Delete(clusterName, "")
+	return provider.Delete(c.ClusterName, "")
 }
 
 // patchForAntrea modifies the node network settings to allow local routing.

--- a/cli/cmd/plugin/standalone-cluster/configure.go
+++ b/cli/cmd/plugin/standalone-cluster/configure.go
@@ -4,13 +4,9 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
-
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/config"
 	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/log"
 )
@@ -57,24 +53,17 @@ func configure(cmd *cobra.Command, args []string) error {
 		config.PodCIDR:           co.podcidr,
 		config.ServiceCIDR:       co.servicecidr,
 	}
+
 	lcConfig, err := config.InitializeConfiguration(configArgs)
 	if err != nil {
 		log.Errorf("Failed to initialize configuration. Error: %s\n", err.Error())
-	}
-
-	var rawConfig bytes.Buffer
-	yamlEncoder := yaml.NewEncoder(&rawConfig)
-	yamlEncoder.SetIndent(yamlIndent)
-	err = yamlEncoder.Encode(*lcConfig)
-	if err != nil {
-		log.Errorf("Failed to render rawConfig file. Error: %s\n", err.Error())
 		return nil
 	}
-
 	fileName := fmt.Sprintf("%s.yaml", clusterName)
-	err = os.WriteFile(fileName, rawConfig.Bytes(), 0644)
+
+	err = config.RenderConfigToFile(fileName, lcConfig)
 	if err != nil {
-		log.Errorf("Failed to write rawConfig file. Error: %s\n", err.Error())
+		log.Errorf("Failed to write configuration file: %s", err.Error())
 		return nil
 	}
 	log.Infof("Wrote configuration file to: %s\n", fileName)

--- a/cli/cmd/plugin/standalone-cluster/delete.go
+++ b/cli/cmd/plugin/standalone-cluster/delete.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/tanzu"
 
-	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/cluster"
 	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/log"
 )
 
@@ -38,14 +38,13 @@ func destroy(cmd *cobra.Command, args []string) error {
 	log := logger.NewLogger(true, 0)
 
 	log.Eventf("\\U+1F5D1", " Deleting cluster: %s\n", clusterName)
-	clusterManager := cluster.NewClusterManager()
-	err := clusterManager.Delete(clusterName)
-	// if failure, no need to bubble up error
-	// just log issue for user.
+	tClient := tanzu.New(log)
+	err := tClient.Delete(clusterName)
 	if err != nil {
-		log.Errorf("Failed to delete cluster. Error: %s", err.Error())
+		log.Errorf("Failed to delete cluster. Error: %s\n", err.Error())
 		return nil
 	}
+
 	log.Eventf("\\U+1F5D1", " Deleted cluster: %s\n", clusterName)
 
 	return nil

--- a/cli/cmd/plugin/standalone-cluster/list.go
+++ b/cli/cmd/plugin/standalone-cluster/list.go
@@ -27,7 +27,7 @@ var ListCmd = &cobra.Command{
 
 // list outputs a list of all local clusters on the system.
 func list(cmd *cobra.Command, args []string) error {
-	clusterManager := cluster.NewClusterManager()
+	clusterManager := cluster.NewKindClusterManager()
 	clusters, err := clusterManager.List()
 	if err != nil {
 		fmt.Printf("Unable to list clusters. Error: %s", err.Error())


### PR DESCRIPTION
This introduces a configuration directory per cluster at
`~/.config/tanzu/tkg/local/${CLUSTER_NAME}`. It stores the rendered
(flattened) configuration there.

This commit also re-wires the delete command to support multiple
provides and load the config.

Signed-off-by: joshrosso <rossoj@vmware.com>

