### PR TITLE
Set default tty mode based on runtime

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/configure.go
+++ b/cli/cmd/plugin/standalone-cluster/configure.go
@@ -27,7 +27,7 @@ func init() {
 	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'antrea'")
 	ConfigureCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR to use for Pod IP addresses. Default and format is '10.244.0.0/16'")
 	ConfigureCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR to use for Service IP addresses. Default and format is '10.96.0.0/16'")
-	ConfigureCmd.Flags().BoolVar(&co.tty, "tty", true, "Specify whether terminal is tty. Set to false to disable styled output; default: true")
+	ConfigureCmd.Flags().BoolVar(&co.tty, "tty", true, "Specify whether terminal is tty. Set to false to disable styled output.")
 }
 
 func configure(cmd *cobra.Command, args []string) error {
@@ -40,7 +40,7 @@ func configure(cmd *cobra.Command, args []string) error {
 		clusterName = args[0]
 	}
 
-	log := logger.NewLogger(co.tty, 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
 
 	// Determine our configuration to use
 	configArgs := map[string]string{

--- a/cli/cmd/plugin/standalone-cluster/create.go
+++ b/cli/cmd/plugin/standalone-cluster/create.go
@@ -40,7 +40,7 @@ func init() {
 	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'antrea'")
 	CreateCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR to use for Pod IP addresses. Default and format is '10.244.0.0/16'")
 	CreateCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR to use for Service IP addresses. Default and format is '10.96.0.0/16'")
-	CreateCmd.Flags().BoolVar(&co.tty, "tty", true, "Specify whether terminal is tty. Set to false to disable styled output; default: true")
+	CreateCmd.Flags().BoolVar(&co.tty, "tty", true, "Specify whether terminal is tty. Set to false to disable styled output.")
 }
 
 func create(cmd *cobra.Command, args []string) error {
@@ -52,8 +52,9 @@ func create(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
+
 	// initial logger, needed for logging if something goes wrong
-	log := logger.NewLogger(co.tty, 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
 
 	// Determine our configuration to use
 	configArgs := map[string]string{

--- a/cli/cmd/plugin/standalone-cluster/delete.go
+++ b/cli/cmd/plugin/standalone-cluster/delete.go
@@ -26,6 +26,10 @@ var DeleteCmd = &cobra.Command{
 	},
 }
 
+func init() {
+	DeleteCmd.Flags().BoolVar(&co.tty, "tty", true, "Specify whether terminal is tty. Set to false to disable styled output.")
+}
+
 func destroy(cmd *cobra.Command, args []string) error {
 	var clusterName string
 
@@ -35,7 +39,7 @@ func destroy(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(true, 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
 
 	log.Eventf("\\U+1F5D1", " Deleting cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/standalone-cluster/go.mod
+++ b/cli/cmd/plugin/standalone-cluster/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/k14s/imgpkg v0.6.0
 	github.com/k14s/ytt v0.37.0
 	github.com/spf13/cobra v1.2.1
+	github.com/spf13/pflag v1.0.5
 	github.com/vmware-tanzu/carvel-kapp-controller v0.28.0
 	github.com/vmware-tanzu/carvel-vendir v0.23.0
 	github.com/vmware-tanzu/tanzu-framework v1.4.0-pre-alpha-2.0.20210915174701-14fe0fdf4f0b

--- a/cli/cmd/plugin/standalone-cluster/list.go
+++ b/cli/cmd/plugin/standalone-cluster/list.go
@@ -4,11 +4,10 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/cluster"
+	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/log"
 )
 
 // ListCmd returns a list of existing clusters.
@@ -25,18 +24,25 @@ var ListCmd = &cobra.Command{
 	},
 }
 
+func init() {
+	ListCmd.Flags().BoolVar(&co.tty, "tty", true, "Specify whether terminal is tty. Set to false to disable styled output.")
+}
+
 // list outputs a list of all local clusters on the system.
 func list(cmd *cobra.Command, args []string) error {
+	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+
 	clusterManager := cluster.NewKindClusterManager()
 	clusters, err := clusterManager.List()
 	if err != nil {
-		fmt.Printf("Unable to list clusters. Error: %s", err.Error())
+		log.Errorf("Unable to list clusters. Error: %s", err.Error())
 	}
 
 	// TODO(stmcginnis): Pull in table output formatting from tanzu-framework
 	// and determine what else should be shown in addition to the name.
+	log.Info("NAME\n")
 	for _, c := range clusters {
-		fmt.Println(c.Name)
+		log.Infof("%s\n", c.Name)
 	}
 
 	return nil

--- a/cli/cmd/plugin/standalone-cluster/main.go
+++ b/cli/cmd/plugin/standalone-cluster/main.go
@@ -5,6 +5,9 @@ package main
 
 import (
 	"os"
+	"strconv"
+
+	"github.com/spf13/pflag"
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
@@ -46,4 +49,27 @@ func main() {
 	if err := p.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+// TtySetting gets the setting to use for formatted TTY output based on whether
+// the user explicitly set it with a command line argument, or if not, whether
+// there is an environment variable set. If neither of these things, it will
+// default to whether or not we detect we are running in a terminal that allows
+// tty formatting.
+func TtySetting(flags *pflag.FlagSet) bool {
+	// See if we are running in a tty enabled terminal
+	fileInfo, _ := os.Stdout.Stat()
+	result := (fileInfo.Mode() & os.ModeCharDevice) != 0
+
+	if flags.Changed("tty") {
+		// User has explicitly set the flag, use that value
+		result, _ = flags.GetBool("tty")
+	} else if tty := os.Getenv("TANZU_TTY"); tty != "" {
+		// Not explicitly provided, but there is an env setting
+		val, err := strconv.ParseBool(tty)
+		if err == nil {
+			result = val
+		}
+	}
+	return result
 }


### PR DESCRIPTION
This sets the default value for the `--tty` CLI setting for local
cluster create and configure to match what the current runtime supports.
This makes it so the user shouldn't need to specify the `--tty` flag in
most cases unless they have a specific reason for changing it.