### PR TITLE
Handle empty CLI default config values

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/config/config.go
+++ b/cli/cmd/plugin/standalone-cluster/config/config.go
@@ -122,7 +122,7 @@ func InitializeConfiguration(commandArgs map[string]string) (*LocalClusterConfig
 		}
 
 		// Check if an explicit value was passed in
-		if value, ok := commandArgs[fieldName]; ok {
+		if value, ok := commandArgs[fieldName]; ok && value != "" {
 			element.FieldByName(field.Name).SetString(value)
 		} else if value := os.Getenv(fieldNameToEnvName(fieldName)); value != "" {
 			// See if there is an environment variable set for this field

--- a/cli/cmd/plugin/standalone-cluster/config/config_test.go
+++ b/cli/cmd/plugin/standalone-cluster/config/config_test.go
@@ -12,8 +12,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var emptyConfig = map[string]string{
+	ClusterConfigFile: "",
+	ClusterName:       "",
+	Tty:               "",
+	TKRLocation:       "",
+	Provider:          "",
+	Cni:               "",
+	PodCIDR:           "",
+	ServiceCIDR:       "",
+}
+
 func TestInitializeConfigurationNoName(t *testing.T) {
-	_, err := InitializeConfiguration(make(map[string]string))
+	_, err := InitializeConfiguration(emptyConfig)
 	if err == nil {
 		t.Error("initialization should fail if no cluster name provided")
 	}
@@ -54,7 +65,7 @@ func TestInitializeConfigurationDefaults(t *testing.T) {
 func TestInitializeConfigurationEnvVariables(t *testing.T) {
 	os.Setenv("TANZU_PROVIDER", "test_provider")
 	os.Setenv("TANZU_CLUSTER_NAME", "test2")
-	config, err := InitializeConfiguration(make(map[string]string))
+	config, err := InitializeConfiguration(emptyConfig)
 	if err != nil {
 		t.Error("initialization should pass")
 	}


### PR DESCRIPTION
Initializing the local cluster configuration was checking for the
presence of config settings, but not whether they actually contained a
value. This is a problem with the real CLI processing since the default
values set on all options ends up being "", resulting in default values
being used unless passed in as a command line argument.