### PR TITLE
Add missing `Repository` struct field for CSI elements in TKR

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/tkr/tkr.go
+++ b/cli/cmd/plugin/standalone-cluster/tkr/tkr.go
@@ -350,12 +350,14 @@ type TKRBom struct {
 			Version string `yaml:"version"`
 			Images  struct {
 				CsiControllerImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"csiControllerImage"`
 				CsiMetaDataSyncerImage struct {
-					ImagePath string `yaml:"imagePath"`
-					Tag       string `yaml:"tag"`
+					ImagePath   string `yaml:"imagePath"`
+					Tag         string `yaml:"tag"`
+					Reposoitory string `yaml:"repository"`
 				} `yaml:"csiMetaDataSyncerImage"`
 			} `yaml:"images"`
 		} `yaml:"vsphere_csi_driver"`


### PR DESCRIPTION
## What this PR does / why we need it
Adds missing `repository` field for `CsiControllerImage` and `CsiMetaDataSyncerImage` in TKR struct

## Details for the Release Notes (PLEASE PROVIDE)
N/a

## Describe testing done for PR
Build binary, created cluster 👍 
