### PR TITLE
Contour package: use cert-manager v1 API

### DIFF
--- a/addons/packages/contour/1.17.1/bundle/config/certificates.lib.yaml
+++ b/addons/packages/contour/1.17.1/bundle/config/certificates.lib.yaml
@@ -3,7 +3,7 @@
 #@ load("@ytt:yaml", "yaml")
 
 #@ def get_issuer():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: "issuer"
@@ -47,7 +47,7 @@ spec:
 #@ end
 
 #@ def get_certificate():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "certificate"
@@ -56,12 +56,14 @@ spec:
   secretName: "ca-key-pair"
   duration: 8760h
   renewBefore: 360h
-  organization: []
+  subject:
+    organizations: []
   commonName: "certificate"
   isCA: false
-  keySize: 2048
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    size: 2048
+    algorithm: RSA
+    encoding: PKCS1
   usages:
     - server auth
     - client auth
@@ -133,8 +135,9 @@ spec:
 spec:
   duration: #@ duration
   renewBefore: #@ renew_before
-  #@overlay/replace
-  organization: #@ organizations
+  subject:
+    #@overlay/replace
+    organizations: #@ organizations
   commonName: #@ common_name
   #@overlay/replace
   dnsNames: #@ dns_names

--- a/addons/packages/contour/1.17.1/bundle/config/overlays/change-namespace.yaml
+++ b/addons/packages/contour/1.17.1/bundle/config/overlays/change-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
   name: #@ data.values.namespace
 
 #! ignore cert-manager objects, since the code for generating them is already setting the namespace correctly.
-#@overlay/match by=overlay.and_op(overlay.subset({"metadata": {"namespace": "projectcontour"}}), overlay.not_op(overlay.subset({"apiVersion": "cert-manager.io/v1alpha2"}))), expects=11
+#@overlay/match by=overlay.and_op(overlay.subset({"metadata": {"namespace": "projectcontour"}}), overlay.not_op(overlay.subset({"apiVersion": "cert-manager.io/v1"}))), expects=11
 ---
 metadata:
   namespace: #@ data.values.namespace

--- a/addons/packages/contour/1.17.1/package.yaml
+++ b/addons/packages/contour/1.17.1/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/contour@sha256:0c3d0f33c171e437268e57bdbe0d83feb1606362d8235f1b656556da8c944e18
+            image: projects.registry.vmware.com/tce/contour@sha256:df21fcabacaf247a01ae4ae75ee227d181060a7e981962224467d2222f765054
       template:
         - ytt:
             paths:

--- a/addons/packages/contour/1.17.2/bundle/config/certificates.lib.yaml
+++ b/addons/packages/contour/1.17.2/bundle/config/certificates.lib.yaml
@@ -3,7 +3,7 @@
 #@ load("@ytt:yaml", "yaml")
 
 #@ def get_issuer():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: "issuer"
@@ -47,7 +47,7 @@ spec:
 #@ end
 
 #@ def get_certificate():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "certificate"
@@ -56,12 +56,14 @@ spec:
   secretName: "ca-key-pair"
   duration: 8760h
   renewBefore: 360h
-  organization: []
+  subject:
+    organizations: []
   commonName: "certificate"
   isCA: false
-  keySize: 2048
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    size: 2048
+    algorithm: RSA
+    encoding: PKCS1
   usages:
     - server auth
     - client auth
@@ -133,8 +135,9 @@ spec:
 spec:
   duration: #@ duration
   renewBefore: #@ renew_before
-  #@overlay/replace
-  organization: #@ organizations
+  subject:
+    #@overlay/replace
+    organizations: #@ organizations
   commonName: #@ common_name
   #@overlay/replace
   dnsNames: #@ dns_names

--- a/addons/packages/contour/1.17.2/bundle/config/overlays/change-namespace.yaml
+++ b/addons/packages/contour/1.17.2/bundle/config/overlays/change-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
   name: #@ data.values.namespace
 
 #! ignore cert-manager objects, since the code for generating them is already setting the namespace correctly.
-#@overlay/match by=overlay.and_op(overlay.subset({"metadata": {"namespace": "projectcontour"}}), overlay.not_op(overlay.subset({"apiVersion": "cert-manager.io/v1alpha2"}))), expects=11
+#@overlay/match by=overlay.and_op(overlay.subset({"metadata": {"namespace": "projectcontour"}}), overlay.not_op(overlay.subset({"apiVersion": "cert-manager.io/v1"}))), expects=11
 ---
 metadata:
   namespace: #@ data.values.namespace

--- a/addons/packages/contour/1.17.2/package.yaml
+++ b/addons/packages/contour/1.17.2/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/contour@sha256:e485ed740ad65c6831ce821d09f419fe92b13f00e1abac40f20f19f5bde9696a
+            image: projects.registry.vmware.com/tce/contour@sha256:73cea143220db395b5bc17f6b7f72f206eea206b29eb31f800f31ec2b23f352b
       template:
         - ytt:
             paths:

--- a/addons/packages/contour/1.18.1/bundle/config/certificates.lib.yaml
+++ b/addons/packages/contour/1.18.1/bundle/config/certificates.lib.yaml
@@ -3,7 +3,7 @@
 #@ load("@ytt:yaml", "yaml")
 
 #@ def get_issuer():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: "issuer"
@@ -47,7 +47,7 @@ spec:
 #@ end
 
 #@ def get_certificate():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "certificate"
@@ -56,12 +56,14 @@ spec:
   secretName: "ca-key-pair"
   duration: 8760h
   renewBefore: 360h
-  organization: []
+  subject:
+    organizations: []
   commonName: "certificate"
   isCA: false
-  keySize: 2048
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    size: 2048
+    algorithm: RSA
+    encoding: PKCS1
   usages:
     - server auth
     - client auth
@@ -133,8 +135,9 @@ spec:
 spec:
   duration: #@ duration
   renewBefore: #@ renew_before
-  #@overlay/replace
-  organization: #@ organizations
+  subject:
+    #@overlay/replace
+    organizations: #@ organizations
   commonName: #@ common_name
   #@overlay/replace
   dnsNames: #@ dns_names

--- a/addons/packages/contour/1.18.1/bundle/config/overlays/change-namespace.yaml
+++ b/addons/packages/contour/1.18.1/bundle/config/overlays/change-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
   name: #@ data.values.namespace
 
 #! ignore cert-manager objects, since the code for generating them is already setting the namespace correctly.
-#@overlay/match by=overlay.and_op(overlay.subset({"metadata": {"namespace": "projectcontour"}}), overlay.not_op(overlay.subset({"apiVersion": "cert-manager.io/v1alpha2"}))), expects=11
+#@overlay/match by=overlay.and_op(overlay.subset({"metadata": {"namespace": "projectcontour"}}), overlay.not_op(overlay.subset({"apiVersion": "cert-manager.io/v1"}))), expects=11
 ---
 metadata:
   namespace: #@ data.values.namespace

--- a/addons/packages/contour/1.18.1/package.yaml
+++ b/addons/packages/contour/1.18.1/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/contour@sha256:7f031ada007ab3ba53a8a71b55a7f2123343a7f180263de13ac72d7de97a16b0
+            image: projects.registry.vmware.com/tce/contour@sha256:630f7a1a73b1c4912a983a08aceadb35cc6af118ef0b35e01ee5f26cd884a4da
       template:
         - ytt:
             paths:

--- a/addons/packages/contour/1.18.2/bundle/config/certificates.lib.yaml
+++ b/addons/packages/contour/1.18.2/bundle/config/certificates.lib.yaml
@@ -3,7 +3,7 @@
 #@ load("@ytt:yaml", "yaml")
 
 #@ def get_issuer():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: "issuer"
@@ -47,7 +47,7 @@ spec:
 #@ end
 
 #@ def get_certificate():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "certificate"
@@ -56,12 +56,14 @@ spec:
   secretName: "ca-key-pair"
   duration: 8760h
   renewBefore: 360h
-  organization: []
+  subject:
+    organizations: []
   commonName: "certificate"
   isCA: false
-  keySize: 2048
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    size: 2048
+    algorithm: RSA
+    encoding: PKCS1
   usages:
     - server auth
     - client auth
@@ -133,8 +135,9 @@ spec:
 spec:
   duration: #@ duration
   renewBefore: #@ renew_before
-  #@overlay/replace
-  organization: #@ organizations
+  subject:
+    #@overlay/replace
+    organizations: #@ organizations
   commonName: #@ common_name
   #@overlay/replace
   dnsNames: #@ dns_names

--- a/addons/packages/contour/1.18.2/bundle/config/overlays/change-namespace.yaml
+++ b/addons/packages/contour/1.18.2/bundle/config/overlays/change-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
   name: #@ data.values.namespace
 
 #! ignore cert-manager objects, since the code for generating them is already setting the namespace correctly.
-#@overlay/match by=overlay.and_op(overlay.subset({"metadata": {"namespace": "projectcontour"}}), overlay.not_op(overlay.subset({"apiVersion": "cert-manager.io/v1alpha2"}))), expects=11
+#@overlay/match by=overlay.and_op(overlay.subset({"metadata": {"namespace": "projectcontour"}}), overlay.not_op(overlay.subset({"apiVersion": "cert-manager.io/v1"}))), expects=11
 ---
 metadata:
   namespace: #@ data.values.namespace

--- a/addons/packages/contour/1.18.2/package.yaml
+++ b/addons/packages/contour/1.18.2/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/contour@sha256:11968655e5612120d3c0745a6b39e45e3432cdd0eae57f5cd7b9429d74c25cbc
+            image: projects.registry.vmware.com/tce/contour@sha256:4be75e9f7ac4e07a4da6f9f8c061899d43e48f5bcd7f18eafbc264a24ad0d528
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Updates Contour overlays to use the
cert-manager v1 API for forward
compatibility.

Signed-off-by: Steve Kriss <krisss@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Updates Contour overlays to use the
cert-manager v1 API for forward
compatibility.


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Updates Contour packages to use cert-manager v1 API.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2194 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
For each affected version, generated YAML via `ytt`, installed it in a standalone AWS TCE cluster, verified install succeeded, deployed a test workload & HTTPProxy, verified traffic was routed properly.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
This PR backports the cert-manager changes that were made in https://github.com/vmware-tanzu/community-edition/pull/2362 for 1.19.1 to older versions of the Contour package.

