### PR TITLE
add overlay to modify secure port for metrics server

### DIFF
--- a/addons/packages/metrics-server/0.5.1/README.md
+++ b/addons/packages/metrics-server/0.5.1/README.md
@@ -22,6 +22,7 @@ The following configuration values can be set to customize the Metrics Server in
 |-------|-------------------|-------------|
 | `metricsServer.createNamespace` | Optional | A boolean that indicates whether to create the namespace specified. Default value is `true`. |
 | `metricsServer.namespace` | Optional | The namespace value used by older templates, will overwrite will top level namespace of present, keep for backward compatibility. Default value is `null`. |
+| `metricsServer.config.securePort` | Optional | The port that Metrics Server binds to. Default: `4443`. |
 | `metricsServer.config.updateStrategy` | Optional | The update strategy of the deployment. Default: `RollingUpdate` |
 | `metricsServer.config.probe.failureThreshold` | Optional | Probe failure threshold. Default: `3`. |
 | `metricsServer.config.probe.periodSeconds` | Optional | Probe period. Default: `10` . |

--- a/addons/packages/metrics-server/0.5.1/bundle/config/overlays/overlay-deployment.yaml
+++ b/addons/packages/metrics-server/0.5.1/bundle/config/overlays/overlay-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       containers:
       #@overlay/match by=overlay.subset({"name": "metrics-server"})
       - args:
+        #@overlay/match by=overlay.subset("--secure-port=443")
+        - #@ "--secure-port=" + str(data.values.metricsServer.config.securePort)
         #@overlay/append
         - --kubelet-insecure-tls
         #@ for arg in data.values.metricsServer.config.args:
@@ -22,6 +24,10 @@ spec:
         - #@ arg
         #@ end
         name: metrics-server
+        ports:
+          #@overlay/match by="name"
+          - name: https
+            containerPort: #@ data.values.metricsServer.config.securePort
         livenessProbe:
           failureThreshold: #@ data.values.metricsServer.config.probe.failureThreshold
           periodSeconds: #@ data.values.metricsServer.config.probe.periodSeconds

--- a/addons/packages/metrics-server/0.5.1/bundle/config/values.yaml
+++ b/addons/packages/metrics-server/0.5.1/bundle/config/values.yaml
@@ -6,6 +6,7 @@ metricsServer:
   namespace: null
   createNamespace: true
   config:
+    securePort: 4443
     updateStrategy: RollingUpdate
     args: [] #! Add any command args here
     probe:


### PR DESCRIPTION
## What this PR does / why we need it
add overlay to modify secure port for metrics server
in order to fix this issue happens on cluster: https://github.com/kubernetes-sigs/metrics-server/issues/814
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
add overlay to modify secure port for metrics server
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #
https://github.com/kubernetes-sigs/metrics-server/issues/814
## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
