### PR TITLE
Switch to the TCE TKR-BOM

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/config/config.go
+++ b/cli/cmd/plugin/standalone-cluster/config/config.go
@@ -30,7 +30,7 @@ const (
 )
 
 var defaultConfigValues = map[string]string{
-	TKRLocation: "projects.registry.vmware.com/tkg/tkr-bom:v1.21.2_vmware.1-tkg.1",
+	TKRLocation: "projects.registry.vmware.com/tce/tkr:v1.21.5",
 	Provider:    "kind",
 	Cni:         "antrea",
 	PodCIDR:     "10.244.0.0/16",


### PR DESCRIPTION
This introduces our own custom TKR-BOM as the default. The primary
changes is this uses our kind image, compatible with the newest version
of kind and newest version of k8s 1.21.x.

Signed-off-by: joshrosso <rossoj@vmware.com>