### PR TITLE
Update Velero readme #2373

### DIFF
--- a/addons/packages/velero/1.6.3/README.md
+++ b/addons/packages/velero/1.6.3/README.md
@@ -255,6 +255,7 @@ the first option in those instructions.
       name: cloud-credentials
       secretContents:
         cloud: |
+          [default]
           aws_access_key_id=${AWS_ACCESS_KEY}
           aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
     backupStorageLocation:

--- a/addons/packages/velero/1.6.3/bundle/config/values.yaml
+++ b/addons/packages/velero/1.6.3/bundle/config/values.yaml
@@ -20,6 +20,7 @@ credential:
   #! Note that the format will be different for different providers, please check their documentation. Required if `useDefaultSecret` is true.
   secretContents:
   #!  cloud: |
+  #!    [default]
   #!    aws_access_key_id=<redacted>
   #!    aws_secret_access_key=<redacted>
   #! additional key/value pairs to be used as environment variables such as "DIGITALOCEAN_TOKEN: <your-key>". Values will be stored in the secret.


### PR DESCRIPTION
## What this PR does / why we need it

The Velero documentation needs to reference `[default]` when declaring AWS credentials in the values.yaml file.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
The Velero documentation needs to reference `[default]` when declaring AWS credentials in the values.yaml file.
```

## Which issue(s) this PR fixes
Fixes: #2373

## Describe testing done for PR
Installed the Velero package on an AWS cluster
Performed a backup

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
