### PR TITLE
Implements the `noop` cluster manager and implements `List` in tanzu package

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/cluster/cluster.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/cluster.go
@@ -19,7 +19,7 @@ type KubernetesCluster struct {
 	// Name is the name of the cluster.
 	Name string
 	// KubeConfig contains the Kubeconfig data for the cluster.
-	Kubeconfig string
+	Kubeconfig []byte
 }
 
 // ClusterManager provides methods for creating and managing Kubernetes
@@ -31,13 +31,29 @@ type ClusterManager interface {
 	Create(c *config.LocalClusterConfig) (*KubernetesCluster, error)
 	// Get retrieves cluster information or return an error indicating a problem.
 	Get(clusterName string) (*KubernetesCluster, error)
-	// List gets a list of all local clusters.
-	List() ([]*KubernetesCluster, error)
 	// Delete will destroy a cluster or return an error indicating a problem.
 	Delete(c *config.LocalClusterConfig) error
 }
 
-// NewKindClusterManager gets a ClusterManager implementation.
+// NewClusterManager provides a way to dynamically get a cluster manager based on the local cluster config provider
+func NewClusterManager(c *config.LocalClusterConfig) ClusterManager {
+	switch c.Provider {
+	case KindClusterManagerProvider:
+		return NewKindClusterManager()
+	case NoneClusterManagerProvider:
+		return NewNoopClusterManager()
+	}
+
+	// By default, return a noop cluster manager in cases we can't parse what provider the users gave
+	return NewNoopClusterManager()
+}
+
+// NewNoopClusterManager creates a new noop cluster manager - intended for use with "none" provider
+func NewNoopClusterManager() ClusterManager {
+	return NoopClusterManager{}
+}
+
+// NewKindClusterManager gets a ClusterManager implementation for the kind provider.
 func NewKindClusterManager() ClusterManager {
 	// For now, just hard coding to return our KindClusterManager.
 	return KindClusterManager{}

--- a/cli/cmd/plugin/standalone-cluster/cluster/kind.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/kind.go
@@ -5,6 +5,7 @@ package cluster
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -50,9 +51,15 @@ func (kcm KindClusterManager) Create(c *config.LocalClusterConfig) (*KubernetesC
 		return nil, err
 	}
 
+	// readkubeconfig in bytes
+	kcBytes, err := os.ReadFile(c.KubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+
 	kc := &KubernetesCluster{
 		Name:       c.ClusterName,
-		Kubeconfig: c.KubeconfigPath,
+		Kubeconfig: kcBytes,
 	}
 
 	if strings.Contains(c.Cni, "antrea") {
@@ -73,27 +80,6 @@ func (kcm KindClusterManager) Create(c *config.LocalClusterConfig) (*KubernetesC
 // Get retrieves cluster information or return an error indicating a problem.
 func (kcm KindClusterManager) Get(clusterName string) (*KubernetesCluster, error) {
 	return nil, nil
-}
-
-// List gets all kind clusters.
-func (kcm KindClusterManager) List() ([]*KubernetesCluster, error) {
-	provider := kindCluster.NewProvider()
-	clusters, err := provider.List()
-	if err != nil {
-		return nil, err
-	}
-
-	var result []*KubernetesCluster
-
-	// TODO(stmcginnis): Need to figure out a way to filter out only tanzu clusters
-	// in case there are other kind clusters present.
-	for _, cl := range clusters {
-		result = append(result, &KubernetesCluster{
-			Name: cl,
-		})
-	}
-
-	return result, nil
 }
 
 // Delete removes a kind cluster.

--- a/cli/cmd/plugin/standalone-cluster/cluster/noop.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/noop.go
@@ -1,0 +1,38 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"os"
+
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/config"
+)
+
+type NoopClusterManager struct{}
+
+// Create will create a new KubernetesCluster that points to the default
+func (ncm NoopClusterManager) Create(c *config.LocalClusterConfig) (*KubernetesCluster, error) {
+	// readkubeconfig in bytes
+	kcBytes, err := os.ReadFile(c.KubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	kc := &KubernetesCluster{
+		Name:       c.ClusterName,
+		Kubeconfig: kcBytes,
+	}
+
+	return kc, nil
+}
+
+// Get retrieves cluster information or return an error indicating a problem.
+func (ncm NoopClusterManager) Get(clusterName string) (*KubernetesCluster, error) {
+	return nil, nil
+}
+
+// Delete for noop does nothing since these clusters have no provider and are not lifecycled
+func (ncm NoopClusterManager) Delete(c *config.LocalClusterConfig) error {
+	return nil
+}

--- a/cli/cmd/plugin/standalone-cluster/config/config_test.go
+++ b/cli/cmd/plugin/standalone-cluster/config/config_test.go
@@ -196,3 +196,16 @@ func TestFieldNameToEnvName(t *testing.T) {
 		t.Errorf("Conversion to env var failed, got %s", result)
 	}
 }
+
+func TestSanatizeKubeconfigPath(t *testing.T) {
+	result := sanatizeKubeconfigPath("/path/to/file/kubeconfig.yaml")
+	if result != "/path/to/file/kubeconfig.yaml" {
+		t.Errorf("Sanatizing kubeconfig path failed, got %s", result)
+	}
+
+	result = sanatizeKubeconfigPath("~/path/with/tilda/kubeconfig.yaml")
+	home, _ := os.UserHomeDir()
+	if result != home+"/path/with/tilda/kubeconfig.yaml" {
+		t.Errorf("Sanatizing kubeconfig path failed, got %s", result)
+	}
+}

--- a/cli/cmd/plugin/standalone-cluster/list.go
+++ b/cli/cmd/plugin/standalone-cluster/list.go
@@ -4,10 +4,12 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
-	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/cluster"
 	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/log"
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/tanzu"
 )
 
 // ListCmd returns a list of existing clusters.
@@ -31,18 +33,18 @@ func init() {
 // list outputs a list of all local clusters on the system.
 func list(cmd *cobra.Command, args []string) error {
 	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
-
-	clusterManager := cluster.NewKindClusterManager()
-	clusters, err := clusterManager.List()
+	log.Eventf("\\U+1F440", " Listing clusters found in config dir\n\n")
+	tClient := tanzu.New(log)
+	clusters, err := tClient.List()
 	if err != nil {
-		log.Errorf("Unable to list clusters. Error: %s", err.Error())
+		return fmt.Errorf("unable to list clusters. Error: %s", err.Error())
 	}
 
 	// TODO(stmcginnis): Pull in table output formatting from tanzu-framework
 	// and determine what else should be shown in addition to the name.
 	log.Info("NAME\n")
 	for _, c := range clusters {
-		log.Infof("%s\n", c.Name)
+		log.Style(0, logger.ColorLightGrey).Infof("%s\n", c.Name)
 	}
 
 	return nil

--- a/cli/cmd/plugin/standalone-cluster/packages/packages.go
+++ b/cli/cmd/plugin/standalone-cluster/packages/packages.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 const (
@@ -98,8 +99,11 @@ type PackageManager interface {
 // by passing a kubeconfig targeting the cluster. It also sets up both a restClient
 // for CRD interaction (Package APIs) and a clientSet for Kubernetes API interaction.
 // For the restClient, it registers the packaging APIs to the scheme.
-func NewClient(kubeconfig string) PackageManager {
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+func NewClient(kubeconfigBytes []byte) PackageManager {
+	config, err := clientcmd.BuildConfigFromKubeconfigGetter("", func() (*clientcmdapi.Config, error) {
+		return clientcmd.Load(kubeconfigBytes)
+	})
+
 	if err != nil {
 		// TODO(joshrosso): do something here
 		panic(err.Error())


### PR DESCRIPTION
## What this PR does / why we need it

All changes related to the standalone cluster overhaul

- Enables users to bring their own cluster with their own kubeconfig
- Removes listing as part of the cluster package and moves it's functionality to the tanzu package. Now, users can list all clusters under the config dir (wheather they were created by our provider or were `provider: none`)
- Adds error logging in kapp controller manager
- Updates calls to NewKindClusterManager to be generic
