### PR TITLE
Fix incorrect image version in 1.6.1 for load-balancer-and-ingress-service.

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/.imgpkg/images.yml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/.imgpkg/images.yml
@@ -2,6 +2,6 @@
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
-    kbld.carvel.dev/id: projects-stg.registry.vmware.com/tkg/ako:v1.4.3_vmware.1
+    kbld.carvel.dev/id: projects-stg.registry.vmware.com/tkg/ako:v1.6.1_vmware.1
   image: projects-stg.registry.vmware.com/tkg/ako@sha256:483c22fb9b2f032ffbb08551dd502bc6bb72ef94076a76af5ced6edf4fe3316e
 kind: ImagesLock

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: ako
           securityContext: {}
-          image: projects-stg.registry.vmware.com/tkg/ako:v1.4.3_vmware.1
+          image: projects-stg.registry.vmware.com/tkg/ako:v1.6.1_vmware.1
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:


### PR DESCRIPTION
## What this PR does / why we need it
This PR fixes the incorrect image version (1.4.3) under the release bundle of version 1.6.1, so that the updated image can be used.


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: # None

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
