### PR TITLE
improve package-release.sh by using ENVS variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ version:
 
 .PHONY: package-release
 package-release:
-	TCE_RELEASE_DIR=${TCE_RELEASE_DIR} FRAMEWORK_BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} BUILD_VERSION=${BUILD_VERSION} hack/release/package-release.sh
+	TCE_RELEASE_DIR=${TCE_RELEASE_DIR} FRAMEWORK_BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} BUILD_VERSION=${BUILD_VERSION} ENVS="${ENVS}" hack/release/package-release.sh
 
 # IMPORTANT: This should only ever be called CI/github-action
 .PHONY: cut-release

--- a/hack/release/package-release.sh
+++ b/hack/release/package-release.sh
@@ -45,10 +45,12 @@ ROOT_TCE_ARTIFACTS_DIR="${ROOT_REPO_DIR}/artifacts"
 
 # change settings
 chmod +x "${ROOT_REPO_DIR}/hack/install.sh"
+chmod +x "${ROOT_REPO_DIR}/hack/uninstall.sh"
 
 for env in ${ENVS}; do
     binaryname=${env//-/_}
     extension="" && [[ $binaryname = *windows* ]] && extension=".exe"
+    scriptextension=".sh" && [[ $binaryname = *windows* ]] && scriptextension=".bat"
     PACKAGE_DIR="${BUILD_ROOT_DIR}/tce-${env}-${BUILD_VERSION}"
     rm -rf "${PACKAGE_DIR}"
     mkdir -p "${PACKAGE_DIR}/bin"
@@ -67,8 +69,8 @@ for env in ${ENVS}; do
     cp -f "${ROOT_TCE_ARTIFACTS_DIR}/conformance/${TCE_BUILD_VERSION}/tanzu-conformance-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-conformance${extension}"
     cp -f "${ROOT_TCE_ARTIFACTS_DIR}/diagnostics/${TCE_BUILD_VERSION}/tanzu-diagnostics-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-diagnostics${extension}"
 
-    cp -f "${ROOT_REPO_DIR}/hack/install.sh" "${PACKAGE_DIR}"
-    cp -f "${ROOT_REPO_DIR}/hack/uninstall.sh" "${PACKAGE_DIR}"
+    cp -f "${ROOT_REPO_DIR}/hack/install.${scriptextension}" "${PACKAGE_DIR}"
+    cp -f "${ROOT_REPO_DIR}/hack/uninstall.${scriptextension}" "${PACKAGE_DIR}"
     chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_DIR}"
 
     # packaging

--- a/hack/release/package-release.sh
+++ b/hack/release/package-release.sh
@@ -72,7 +72,7 @@ for env in ${ENVS}; do
     chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_DIR}"
 
     # packaging
-    rm -f tce-${env}-*.tar.gz
+    rm -f "tce-${env}-*.tar.gz"
     pushd "${BUILD_ROOT_DIR}" || exit 1
         if [[ $env = *windows* ]]
         then

--- a/hack/release/package-release.sh
+++ b/hack/release/package-release.sh
@@ -8,6 +8,7 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+ENVS="${ENVS:-"linux-amd64 windows-amd64 darwin-amd64 darwin-arm64"}"
 # Change directories to the parent directory of the one in which this
 # script is located.
 ROOT_REPO_DIR="$(dirname "${BASH_SOURCE[0]}")/../.."
@@ -34,121 +35,50 @@ TCE_BUILD_VERSION="${BUILD_VERSION:-latest}"
 DEP_BUILD_DIR="${TCE_RELEASE_DIR}"
 ROOT_FRAMEWORK_DIR="${DEP_BUILD_DIR}/tanzu-framework"
 
-PACKAGE_LINUX_AMD64_DIR="${BUILD_ROOT_DIR}/tce-linux-amd64-${BUILD_VERSION}"
-PACKAGE_DARWIN_AMD64_DIR="${BUILD_ROOT_DIR}/tce-darwin-amd64-${BUILD_VERSION}"
-PACKAGE_DARWIN_ARM64_DIR="${BUILD_ROOT_DIR}/tce-darwin-arm64-${BUILD_VERSION}"
-PACKAGE_WINDOWS_AMD64_DIR="${BUILD_ROOT_DIR}/tce-windows-amd64-${BUILD_VERSION}"
-
-# delete and create everything
 rm -rf "${BUILD_ROOT_DIR}"
-rm -rf "${PACKAGE_LINUX_AMD64_DIR}"
-rm -rf "${PACKAGE_DARWIN_AMD64_DIR}"
-rm -rf "${PACKAGE_DARWIN_ARM64_DIR}"
-rm -rf "${PACKAGE_WINDOWS_AMD64_DIR}"
 mkdir -p "${BUILD_ROOT_DIR}"
-mkdir -p "${PACKAGE_LINUX_AMD64_DIR}/bin"
-mkdir -p "${PACKAGE_DARWIN_AMD64_DIR}/bin"
-mkdir -p "${PACKAGE_DARWIN_ARM64_DIR}/bin"
-mkdir -p "${PACKAGE_WINDOWS_AMD64_DIR}/bin"
 
 # Common directories
 ROOT_FRAMEWORK_ARTFACTS_DIR="${ROOT_FRAMEWORK_DIR}/artifacts"
 ROOT_FRAMEWORK_ARTFACTS_ADMIN_DIR="${ROOT_FRAMEWORK_DIR}/artifacts-admin"
 ROOT_TCE_ARTIFACTS_DIR="${ROOT_REPO_DIR}/artifacts"
 
-# copy tanzu cli bits Linux AMD64
-# Tanzu bits
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/core/${FRAMEWORK_BUILD_VERSION}/tanzu-core-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/cluster/${FRAMEWORK_BUILD_VERSION}/tanzu-cluster-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu-plugin-cluster"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/kubernetes-release/${FRAMEWORK_BUILD_VERSION}/tanzu-kubernetes-release-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu-plugin-kubernetes-release"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/login/${FRAMEWORK_BUILD_VERSION}/tanzu-login-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu-plugin-login"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/package/${FRAMEWORK_BUILD_VERSION}/tanzu-package-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu-plugin-package"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/pinniped-auth/${FRAMEWORK_BUILD_VERSION}/tanzu-pinniped-auth-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu-plugin-pinniped-auth"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/management-cluster/${FRAMEWORK_BUILD_VERSION}/tanzu-management-cluster-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu-plugin-management-cluster"
-
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_ADMIN_DIR}/builder/${FRAMEWORK_BUILD_VERSION}/tanzu-builder-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu-plugin-builder"
-
-# TCE bits (New folder structure using tanzu-framework main)
-cp -f "${ROOT_TCE_ARTIFACTS_DIR}/standalone-cluster/${TCE_BUILD_VERSION}/tanzu-standalone-cluster-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu-plugin-standalone-cluster"
-cp -f "${ROOT_TCE_ARTIFACTS_DIR}/conformance/${TCE_BUILD_VERSION}/tanzu-conformance-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu-plugin-conformance"
-cp -f "${ROOT_TCE_ARTIFACTS_DIR}/diagnostics/${TCE_BUILD_VERSION}/tanzu-diagnostics-linux_amd64" "${PACKAGE_LINUX_AMD64_DIR}/bin/tanzu-plugin-diagnostics"
-
-
-# copy tanzu cli bits Darwin AMD64
-# Tanzu bits
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/core/${FRAMEWORK_BUILD_VERSION}/tanzu-core-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/cluster/${FRAMEWORK_BUILD_VERSION}/tanzu-cluster-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-cluster"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/kubernetes-release/${FRAMEWORK_BUILD_VERSION}/tanzu-kubernetes-release-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-kubernetes-release"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/login/${FRAMEWORK_BUILD_VERSION}/tanzu-login-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-login"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/package/${FRAMEWORK_BUILD_VERSION}/tanzu-package-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-package"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/pinniped-auth/${FRAMEWORK_BUILD_VERSION}/tanzu-pinniped-auth-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-pinniped-auth"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/management-cluster/${FRAMEWORK_BUILD_VERSION}/tanzu-management-cluster-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-management-cluster"
-
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_ADMIN_DIR}/builder/${FRAMEWORK_BUILD_VERSION}/tanzu-builder-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-builder"
-
-# TCE bits (New folder structure using tanzu-framwork main)
-cp -f "${ROOT_TCE_ARTIFACTS_DIR}/standalone-cluster/${TCE_BUILD_VERSION}/tanzu-standalone-cluster-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-standalone-cluster"
-cp -f "${ROOT_TCE_ARTIFACTS_DIR}/conformance/${TCE_BUILD_VERSION}/tanzu-conformance-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-conformance"
-cp -f "${ROOT_TCE_ARTIFACTS_DIR}/diagnostics/${TCE_BUILD_VERSION}/tanzu-diagnostics-darwin_amd64" "${PACKAGE_DARWIN_AMD64_DIR}/bin/tanzu-plugin-diagnostics"
-
-# copy tanzu cli bits Darwin ARM64
-# Tanzu bits
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/core/${FRAMEWORK_BUILD_VERSION}/tanzu-core-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/cluster/${FRAMEWORK_BUILD_VERSION}/tanzu-cluster-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-cluster"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/kubernetes-release/${FRAMEWORK_BUILD_VERSION}/tanzu-kubernetes-release-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-kubernetes-release"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/login/${FRAMEWORK_BUILD_VERSION}/tanzu-login-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-login"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/package/${FRAMEWORK_BUILD_VERSION}/tanzu-package-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-package"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/pinniped-auth/${FRAMEWORK_BUILD_VERSION}/tanzu-pinniped-auth-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-pinniped-auth"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/management-cluster/${FRAMEWORK_BUILD_VERSION}/tanzu-management-cluster-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-management-cluster"
-
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_ADMIN_DIR}/builder/${FRAMEWORK_BUILD_VERSION}/tanzu-builder-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-builder"
-
-# TCE bits (New folder structure using tanzu-framwork main)
-cp -f "${ROOT_TCE_ARTIFACTS_DIR}/standalone-cluster/${TCE_BUILD_VERSION}/tanzu-standalone-cluster-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-standalone-cluster"
-cp -f "${ROOT_TCE_ARTIFACTS_DIR}/conformance/${TCE_BUILD_VERSION}/tanzu-conformance-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-conformance"
-cp -f "${ROOT_TCE_ARTIFACTS_DIR}/diagnostics/${TCE_BUILD_VERSION}/tanzu-diagnostics-darwin_arm64" "${PACKAGE_DARWIN_ARM64_DIR}/bin/tanzu-plugin-diagnostics"
-
-
-# copy tanzu cli bits Windows AMD64
-# Tanzu bits
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/core/${FRAMEWORK_BUILD_VERSION}/tanzu-core-windows_amd64.exe" "${PACKAGE_WINDOWS_AMD64_DIR}/bin/tanzu.exe"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/cluster/${FRAMEWORK_BUILD_VERSION}/tanzu-cluster-windows_amd64.exe" "${PACKAGE_WINDOWS_AMD64_DIR}/bin/tanzu-plugin-cluster.exe"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/kubernetes-release/${FRAMEWORK_BUILD_VERSION}/tanzu-kubernetes-release-windows_amd64.exe" "${PACKAGE_WINDOWS_AMD64_DIR}/bin/tanzu-plugin-kubernetes-release.exe"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/login/${FRAMEWORK_BUILD_VERSION}/tanzu-login-windows_amd64.exe" "${PACKAGE_WINDOWS_AMD64_DIR}/bin/tanzu-plugin-login.exe"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/package/${FRAMEWORK_BUILD_VERSION}/tanzu-package-windows_amd64.exe" "${PACKAGE_WINDOWS_AMD64_DIR}/bin/tanzu-plugin-package.exe"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/pinniped-auth/${FRAMEWORK_BUILD_VERSION}/tanzu-pinniped-auth-windows_amd64.exe" "${PACKAGE_WINDOWS_AMD64_DIR}/bin/tanzu-plugin-pinniped-auth.exe"
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/management-cluster/${FRAMEWORK_BUILD_VERSION}/tanzu-management-cluster-windows_amd64.exe" "${PACKAGE_WINDOWS_AMD64_DIR}/bin/tanzu-plugin-management-cluster.exe"
-
-cp -f "${ROOT_FRAMEWORK_ARTFACTS_ADMIN_DIR}/builder/${FRAMEWORK_BUILD_VERSION}/tanzu-builder-windows_amd64.exe" "${PACKAGE_WINDOWS_AMD64_DIR}/bin/tanzu-plugin-builder.exe"
-
-# TCE bits (New folder structure using tanzu-framwork main)
-cp -f "${ROOT_TCE_ARTIFACTS_DIR}/standalone-cluster/${TCE_BUILD_VERSION}/tanzu-standalone-cluster-windows_amd64.exe" "${PACKAGE_WINDOWS_AMD64_DIR}/bin/tanzu-plugin-standalone-cluster.exe"
-cp -f "${ROOT_TCE_ARTIFACTS_DIR}/conformance/${TCE_BUILD_VERSION}/tanzu-conformance-windows_amd64.exe" "${PACKAGE_WINDOWS_AMD64_DIR}/bin/tanzu-plugin-conformance.exe"
-cp -f "${ROOT_TCE_ARTIFACTS_DIR}/diagnostics/${TCE_BUILD_VERSION}/tanzu-diagnostics-windows_amd64.exe" "${PACKAGE_WINDOWS_AMD64_DIR}/bin/tanzu-plugin-diagnostics.exe"
-
 # change settings
 chmod +x "${ROOT_REPO_DIR}/hack/install.sh"
-cp -f "${ROOT_REPO_DIR}/hack/install.sh" "${PACKAGE_LINUX_AMD64_DIR}"
-cp -f "${ROOT_REPO_DIR}/hack/uninstall.sh" "${PACKAGE_LINUX_AMD64_DIR}"
-cp -f "${ROOT_REPO_DIR}/hack/install.sh" "${PACKAGE_DARWIN_AMD64_DIR}"
-cp -f "${ROOT_REPO_DIR}/hack/uninstall.sh" "${PACKAGE_DARWIN_AMD64_DIR}"
-cp -f "${ROOT_REPO_DIR}/hack/install.sh" "${PACKAGE_DARWIN_ARM64_DIR}"
-cp -f "${ROOT_REPO_DIR}/hack/uninstall.sh" "${PACKAGE_DARWIN_ARM64_DIR}"
-cp -f "${ROOT_REPO_DIR}/hack/install.bat" "${PACKAGE_WINDOWS_AMD64_DIR}"
-cp -f "${ROOT_REPO_DIR}/hack/uninstall.bat" "${PACKAGE_WINDOWS_AMD64_DIR}"
-chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_LINUX_AMD64_DIR}"
-chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_DARWIN_AMD64_DIR}"
-chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_DARWIN_ARM64_DIR}"
-chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_WINDOWS_AMD64_DIR}"
 
-# packaging
-rm -f tce-linux-amd64-*.tar.gz
-rm -f tce-darwin-amd64-*.tar.gz
-rm -f tce-darwin-arm64-*.tar.gz
-rm -f tce-windows-amd64-*.tar.gz
-pushd "${BUILD_ROOT_DIR}" || exit 1
-tar -czvf "tce-linux-amd64-${TCE_BUILD_VERSION}.tar.gz" "tce-linux-amd64-${BUILD_VERSION}"
-tar -czvf "tce-darwin-amd64-${TCE_BUILD_VERSION}.tar.gz" "tce-darwin-amd64-${BUILD_VERSION}"
-tar -czvf "tce-darwin-arm64-${TCE_BUILD_VERSION}.tar.gz" "tce-darwin-arm64-${BUILD_VERSION}"
-zip -r "tce-windows-amd64-${TCE_BUILD_VERSION}.zip" "tce-windows-amd64-${BUILD_VERSION}"
-popd || exit 1
+for env in ${ENVS}; do
+    binaryname=${env//-/_}
+    extension="" && [[ $binaryname = *windows* ]] && extension=".exe"
+    PACKAGE_DIR="${BUILD_ROOT_DIR}/tce-${env}-${BUILD_VERSION}"
+    rm -rf "${PACKAGE_DIR}"
+    mkdir -p "${PACKAGE_DIR}/bin"
+    # Tanzu bits
+    cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/core/${FRAMEWORK_BUILD_VERSION}/tanzu-core-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu${extension}"
+    cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/cluster/${FRAMEWORK_BUILD_VERSION}/tanzu-cluster-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-cluster${extension}"
+    cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/kubernetes-release/${FRAMEWORK_BUILD_VERSION}/tanzu-kubernetes-release-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-kubernetes-release${extension}"
+    cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/login/${FRAMEWORK_BUILD_VERSION}/tanzu-login-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-login${extension}"
+    cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/package/${FRAMEWORK_BUILD_VERSION}/tanzu-package-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-package${extension}"
+    cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/pinniped-auth/${FRAMEWORK_BUILD_VERSION}/tanzu-pinniped-auth-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-pinniped-auth${extension}"
+    cp -f "${ROOT_FRAMEWORK_ARTFACTS_DIR}/management-cluster/${FRAMEWORK_BUILD_VERSION}/tanzu-management-cluster-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-management-cluster${extension}"
+    cp -f "${ROOT_FRAMEWORK_ARTFACTS_ADMIN_DIR}/builder/${FRAMEWORK_BUILD_VERSION}/tanzu-builder-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-builder${extension}"
+
+    # TCE bits (New folder structure using tanzu-framework main)
+    cp -f "${ROOT_TCE_ARTIFACTS_DIR}/standalone-cluster/${TCE_BUILD_VERSION}/tanzu-standalone-cluster-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-standalone-cluster${extension}"
+    cp -f "${ROOT_TCE_ARTIFACTS_DIR}/conformance/${TCE_BUILD_VERSION}/tanzu-conformance-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-conformance${extension}"
+    cp -f "${ROOT_TCE_ARTIFACTS_DIR}/diagnostics/${TCE_BUILD_VERSION}/tanzu-diagnostics-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-diagnostics${extension}"
+
+    cp -f "${ROOT_REPO_DIR}/hack/install.sh" "${PACKAGE_DIR}"
+    cp -f "${ROOT_REPO_DIR}/hack/uninstall.sh" "${PACKAGE_DIR}"
+    chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_DIR}"
+
+    # packaging
+    rm -f tce-${env}-*.tar.gz
+    pushd "${BUILD_ROOT_DIR}" || exit 1
+        if [[ $env = *windows* ]]
+        then
+            zip -r "tce-${env}-${TCE_BUILD_VERSION}.zip" "tce-${env}-${BUILD_VERSION}"
+        else
+            tar -czvf "tce-${env}-${TCE_BUILD_VERSION}.tar.gz" "tce-${env}-${BUILD_VERSION}"
+        fi
+    popd || exit 1
+done

--- a/hack/release/package-release.sh
+++ b/hack/release/package-release.sh
@@ -69,8 +69,8 @@ for env in ${ENVS}; do
     cp -f "${ROOT_TCE_ARTIFACTS_DIR}/conformance/${TCE_BUILD_VERSION}/tanzu-conformance-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-conformance${extension}"
     cp -f "${ROOT_TCE_ARTIFACTS_DIR}/diagnostics/${TCE_BUILD_VERSION}/tanzu-diagnostics-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-diagnostics${extension}"
 
-    cp -f "${ROOT_REPO_DIR}/hack/install.${scriptextension}" "${PACKAGE_DIR}"
-    cp -f "${ROOT_REPO_DIR}/hack/uninstall.${scriptextension}" "${PACKAGE_DIR}"
+    cp -f "${ROOT_REPO_DIR}/hack/install${scriptextension}" "${PACKAGE_DIR}"
+    cp -f "${ROOT_REPO_DIR}/hack/uninstall${scriptextension}" "${PACKAGE_DIR}"
     chown -R "$(id -u -n)":"$(id -g -n)" "${PACKAGE_DIR}"
 
     # packaging


### PR DESCRIPTION
Signed-off-by: Joe Fitzgerald <jfitzgerald@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR improves the build script to remove duplication in `package-release.sh` by leveraging the ENVS variable set in the `Makefile`.

- pass ENVS to `package-release.sh`
- remove duplicate instructions for each architecture, and instead loop through each element in ENVS

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
improve package-release.sh by leveraging the ENVS variable during builds
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
`$ make release`

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
N/A