### PR TITLE
Disable label scopping rules for calico-kube-controllers

### DIFF
--- a/addons/packages/calico/3.11.3/bundle/config/overlay/calico_overlay.yaml
+++ b/addons/packages/calico/3.11.3/bundle/config/overlay/calico_overlay.yaml
@@ -6,6 +6,15 @@
 #@  return left.startswith(right)
 #@ end
 
+#@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name": "calico-kube-controllers"}})
+---
+kind: Deployment
+metadata:
+  name: calico-kube-controllers
+  #@overlay/match missing_ok=True
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
+
 #@overlay/match by=overlay.subset({"kind":"DaemonSet", "metadata": {"name": "calico-node"}})
 ---
 kind: DaemonSet

--- a/addons/packages/calico/3.11.3/package.yaml
+++ b/addons/packages/calico/3.11.3/package.yaml
@@ -13,7 +13,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/calico@sha256:67263d940d05af0ec3de35666e639117cb33cfda88822f549b933456e254f99a
+            image: projects.registry.vmware.com/tce/calico@sha256:136b5b12aef94910a082988998dd8cd2e84ecc42598b0fb248da93d99dd41edd
       template:
         - ytt:
             paths:

--- a/addons/packages/calico/3.11.3/test/calico_test.go
+++ b/addons/packages/calico/3.11.3/test/calico_test.go
@@ -33,6 +33,10 @@ var _ = Describe("Calico Ytt Templates", func() {
 		fileValuesStar        = filepath.Join(configDir, "values.star")
 	)
 
+	desiredAnnotations := map[string]string{
+		"kapp.k14s.io/disable-default-label-scoping-rules": "",
+	}
+
 	BeforeEach(func() {
 		values = ""
 	})
@@ -100,6 +104,14 @@ data:
 			Expect(envVarNames(containerEnvVars)).NotTo(ContainElement("CALICO_ROUTER_ID"))
 			Expect(envVarNames(containerEnvVars)).NotTo(ContainElement("CALICO_IPV6POOL_NAT_OUTGOING"))
 		})
+
+		It("renders the DaemonSet and Deployment with desired annotations", func() {
+			Expect(err).NotTo(HaveOccurred())
+			daemonSet := parseDaemonSet(output)
+			deployment := parseDeployment(output)
+			Expect(daemonSet.Annotations).To(Equal(desiredAnnotations))
+			Expect(deployment.Annotations).To(Equal(desiredAnnotations))
+		})
 	})
 
 	Context("IPv6 configuration", func() {
@@ -146,6 +158,7 @@ data:
 			Expect(envVarNames(containerEnvVars)).NotTo(ContainElement("CALICO_IPV4POOL_IPIP"))
 			Expect(envVarNames(containerEnvVars)).NotTo(ContainElement("CALICO_IPV4POOL_CIDR"))
 		})
+
 	})
 
 	Context("IPv4,IPv6 dualstack configuration", func() {
@@ -267,4 +280,13 @@ func parseDaemonSet(output string) appsv1.DaemonSet {
 	err := yaml.Unmarshal([]byte(daemonSetDoc), &daemonSet)
 	Expect(err).NotTo(HaveOccurred())
 	return daemonSet
+}
+
+func parseDeployment(output string) appsv1.Deployment {
+	deploymentDocIndex := 21
+	deploymentDoc := strings.Split(output, "---")[deploymentDocIndex]
+	var deployment appsv1.Deployment
+	err := yaml.Unmarshal([]byte(deploymentDoc), &deployment)
+	Expect(err).NotTo(HaveOccurred())
+	return deployment
 }

--- a/addons/packages/calico/3.19.1/bundle/config/overlay/calico_overlay.yaml
+++ b/addons/packages/calico/3.19.1/bundle/config/overlay/calico_overlay.yaml
@@ -6,6 +6,15 @@
 #@  return left.startswith(right)
 #@ end
 
+#@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name": "calico-kube-controllers"}})
+---
+kind: Deployment
+metadata:
+  name: calico-kube-controllers
+  #@overlay/match missing_ok=True
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
+
 #@overlay/match by=overlay.subset({"kind":"DaemonSet", "metadata": {"name": "calico-node"}})
 ---
 kind: DaemonSet

--- a/addons/packages/calico/3.19.1/package.yaml
+++ b/addons/packages/calico/3.19.1/package.yaml
@@ -14,7 +14,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/calico@sha256:b62252f00a9bb083245688c218c2365af05b9bd327fdce107689ea3ded55b2cd
+            image: projects.registry.vmware.com/tce/calico@sha256:2c970371ba25215ce0c70388fb91bfd82db5da983508d8868a039dd80ba0b4f2
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
The annotation `kapp.k14s.io/disable-default-label-scoping-rules: ""` is missing in the deployment calico-kube-controllers

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2387 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Added test cases and ran make test for Calico 3.11.3 and 3.19.1 package.
Using this package to adopt installed calico and reconciliation succeeded


## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
For DaemonSet calico-node, this annotation `kapp.k14s.io/disable-default-label-scoping-rules: ""` is already added before.