### PR TITLE
Restore missing images #2390

### DIFF
--- a/addons/packages/ako-operator/1.5.0/bundle/.imgpkg/images.yml
+++ b/addons/packages/ako-operator/1.5.0/bundle/.imgpkg/images.yml
@@ -3,8 +3,14 @@ apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
     kbld.carvel.dev/id: projects-stg.registry.vmware.com/tkg/ako-operator:v1.5.0_vmware.1
+    kbld.carvel.dev/origins: |
+      - preresolved:
+          url: projects-stg.registry.vmware.com/tkg/ako-operator@sha256:53926b85c969126fb9893c45e6d8fee29bb1d1b082b27946a72c2dd8b2d26442
   image: projects-stg.registry.vmware.com/tkg/ako-operator@sha256:53926b85c969126fb9893c45e6d8fee29bb1d1b082b27946a72c2dd8b2d26442
 - annotations:
     kbld.carvel.dev/id: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2
+    kbld.carvel.dev/origins: |
+      - preresolved:
+          url: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy@sha256:6b83d791388546ce66372f621435d55bea57d892675c3180d85a4d9dc7bb818f
   image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy@sha256:6b83d791388546ce66372f621435d55bea57d892675c3180d85a4d9dc7bb818f
 kind: ImagesLock

--- a/addons/packages/ako-operator/1.5.0/package.yaml
+++ b/addons/packages/ako-operator/1.5.0/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/ako-operator@sha256:c21d1af3909cc1b679acb3c2db8f384fa478784f4fec7f7d58b3b087922db023
+            image: projects.registry.vmware.com/tce/ako-operator@sha256:e723cae7924b7caec70771a92e3d0aea7c14df4829e8cbaba19e4b0e5315cba2
       template:
         - ytt:
             paths:

--- a/addons/packages/antrea/0.13.3/bundle/.imgpkg/images.yml
+++ b/addons/packages/antrea/0.13.3/bundle/.imgpkg/images.yml
@@ -3,5 +3,9 @@ apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
     kbld.carvel.dev/id: antrea/antrea-ubuntu:v0.13.3
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v0.13.3
+          url: antrea/antrea-ubuntu:v0.13.3
   image: index.docker.io/antrea/antrea-ubuntu@sha256:f9529d7225ffc52683c596f83f329a38d1dd425a2c174f079d9966ab540ffe30
 kind: ImagesLock

--- a/addons/packages/antrea/0.13.3/package.yaml
+++ b/addons/packages/antrea/0.13.3/package.yaml
@@ -13,7 +13,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/antrea@sha256:bf80a1114ac0dda12753ac4d7d34e1ff34052f9228636df823a5852480bf0be2
+            image: projects.registry.vmware.com/tce/antrea@sha256:aa8e1850170ac8e6b3838a3d1ed0ad3df3fcbdfab89ce1f3f7df3f12b4f5ec90
       template:
         - ytt:
             paths:

--- a/addons/packages/calico/3.11.3/package.yaml
+++ b/addons/packages/calico/3.11.3/package.yaml
@@ -13,7 +13,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/calico@sha256:3b6ed6cabbb75781add947799b3c6c87008f700fbdcb1fbbfa56860e0bc1abb0
+            image: projects.registry.vmware.com/tce/calico@sha256:67263d940d05af0ec3de35666e639117cb33cfda88822f549b933456e254f99a
       template:
         - ytt:
             paths:

--- a/addons/packages/calico/3.19.1/package.yaml
+++ b/addons/packages/calico/3.19.1/package.yaml
@@ -14,7 +14,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/calico@sha256:dac539d2ae4477bbbd570008cdc34e3a580b58a60e36ae60a1d55b434faf5bf6
+            image: projects.registry.vmware.com/tce/calico@sha256:b62252f00a9bb083245688c218c2365af05b9bd327fdce107689ea3ded55b2cd
       template:
         - ytt:
             paths:

--- a/addons/packages/kapp-controller/0.20.0/package.yaml
+++ b/addons/packages/kapp-controller/0.20.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:9f2f28a0ee26ca485f4c36fa9cc5a806cfbc873beb5b1a2ed8d8d53795396424
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:8a829f245c9b0a0b8763d470ca658f54af6700a51d99cc5c723db2c3ea9a60b5
       template:
         - ytt:
             paths:

--- a/addons/packages/kapp-controller/0.21.0/package.yaml
+++ b/addons/packages/kapp-controller/0.21.0/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:9f2f28a0ee26ca485f4c36fa9cc5a806cfbc873beb5b1a2ed8d8d53795396424
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:ef02c13cacf1f98c9ec43f03f71c882778539862de7cce85b0c02eb75c8ea374
       template:
         - ytt:
             paths:

--- a/addons/packages/metrics-server/0.5.1/package.yaml
+++ b/addons/packages/metrics-server/0.5.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/metrics-server@sha256:393e7aa6c89f55229e9559f82165c3a51fe408c4c7dd4b72409844513b8caf83
+            image: projects.registry.vmware.com/tce/metrics-server@sha256:b2d2407d230d770e216f3ae83ea2f392d7e2099f39f64244083fbcfdb7e2acad
       template:
         - ytt:
             paths:

--- a/addons/packages/vsphere-csi/2.3.0/bundle/.imgpkg/images.yml
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/.imgpkg/images.yml
@@ -3,23 +3,44 @@ apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
     kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.3.0
+    kbld.carvel.dev/origins: |
+      - preresolved:
+          url: gcr.io/cloud-provider-vsphere/csi/release/driver@sha256:6d9de8e546aa55beec14019238260393287a5637df9e6ab0b77f015dd8bf797c
   image: gcr.io/cloud-provider-vsphere/csi/release/driver@sha256:6d9de8e546aa55beec14019238260393287a5637df9e6ab0b77f015dd8bf797c
 - annotations:
     kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.3.0
+    kbld.carvel.dev/origins: |
+      - preresolved:
+          url: gcr.io/cloud-provider-vsphere/csi/release/syncer@sha256:3f362d35e4723ee7921c696b09c2597844142124815d6163b09aeb26af0cf133
   image: gcr.io/cloud-provider-vsphere/csi/release/syncer@sha256:3f362d35e4723ee7921c696b09c2597844142124815d6163b09aeb26af0cf133
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-attacher:v3.2.0
+    kbld.carvel.dev/origins: |
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-attacher@sha256:c5be65d6679efabb969d9b019300d187437ae876f992c40911fd2892bbef3b36
   image: k8s.gcr.io/sig-storage/csi-attacher@sha256:c5be65d6679efabb969d9b019300d187437ae876f992c40911fd2892bbef3b36
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
+    kbld.carvel.dev/origins: |
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-provisioner@sha256:c8e03f60afa90a28e4bb6ec9a8d0fc36d89de4b7475cf2d613afa793ec969fe0
   image: k8s.gcr.io/sig-storage/csi-provisioner@sha256:c8e03f60afa90a28e4bb6ec9a8d0fc36d89de4b7475cf2d613afa793ec969fe0
 - annotations:
     kbld.carvel.dev/id: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
+    kbld.carvel.dev/origins: |
+      - preresolved:
+          url: quay.io/k8scsi/csi-node-driver-registrar@sha256:fb4f139b51ae5b449a132949d7f3d839fa9ea5c57df1c1cd61f781389fdacefb
   image: quay.io/k8scsi/csi-node-driver-registrar@sha256:fb4f139b51ae5b449a132949d7f3d839fa9ea5c57df1c1cd61f781389fdacefb
 - annotations:
     kbld.carvel.dev/id: quay.io/k8scsi/csi-resizer:v1.1.0
+    kbld.carvel.dev/origins: |
+      - preresolved:
+          url: quay.io/k8scsi/csi-resizer@sha256:9a4130836e6eead0bfd1d6cca3e569a2ca27b82ce542927fd3da7e7eeff5fe22
   image: quay.io/k8scsi/csi-resizer@sha256:9a4130836e6eead0bfd1d6cca3e569a2ca27b82ce542927fd3da7e7eeff5fe22
 - annotations:
     kbld.carvel.dev/id: quay.io/k8scsi/livenessprobe:v2.2.0
+    kbld.carvel.dev/origins: |
+      - preresolved:
+          url: quay.io/k8scsi/livenessprobe@sha256:d657c5644aefe12d4bbdffb900602df65c67dbaea99b26b2005465b88b1bc96e
   image: quay.io/k8scsi/livenessprobe@sha256:d657c5644aefe12d4bbdffb900602df65c67dbaea99b26b2005465b88b1bc96e
 kind: ImagesLock

--- a/addons/packages/vsphere-csi/2.3.0/package.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:ac8e916b88755b67058515b5eafff8d29afdea7d92c7c74195833718ee6d7f89
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:8bc29eb85b7bd5cba9257dbdb051ba816fb82a868d0d5a1efeffeb947429cd81
       template:
         - ytt:
             paths:

--- a/addons/packages/vsphere-csi/2.4.0-rc.1/bundle/.imgpkg/images.yml
+++ b/addons/packages/vsphere-csi/2.4.0-rc.1/bundle/.imgpkg/images.yml
@@ -3,23 +3,51 @@ apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
     kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.0-rc.1
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v2.4.0-rc.1
+          url: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.0-rc.1
   image: gcr.io/cloud-provider-vsphere/csi/release/driver@sha256:7c06626e5688d84798c9d6c4ab1b54ebe5cf69cf2a74526b908d8441fa4726f0
 - annotations:
     kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.0-rc.1
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v2.4.0-rc.1
+          url: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.0-rc.1
   image: gcr.io/cloud-provider-vsphere/csi/release/syncer@sha256:4a19f71fbc32cf8ff6bb763a65e1925dbd0455598c4b84cbe8008bff72651e76
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v3.3.0
+          url: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
   image: k8s.gcr.io/sig-storage/csi-attacher@sha256:80dec81b679a733fda448be92a2331150d99095947d04003ecff3dbd7f2a476a
 - annotations:
+    kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v2.3.0
+          url: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
+  image: k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:f9bcee63734b7b01555ee8fc8fb01ac2922478b2c8934bf8d468dd2916edc405
+- annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v3.0.0
+          url: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
   image: k8s.gcr.io/sig-storage/csi-provisioner@sha256:6477988532358148d2e98f7c747db4e9250bbc7ad2664bf666348abf9ee1f5aa
 - annotations:
-    kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
-  image: quay.io/k8scsi/csi-node-driver-registrar@sha256:f9bcee63734b7b01555ee8fc8fb01ac2922478b2c8934bf8d468dd2916edc405
-- annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
-  image: quay.io/k8scsi/csi-resizer@sha256:6e0546563b18872b0aa0cad7255a26bb9a87cb879b7fc3e2383c867ef4f706fb
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v1.3.0
+          url: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+  image: k8s.gcr.io/sig-storage/csi-resizer@sha256:6e0546563b18872b0aa0cad7255a26bb9a87cb879b7fc3e2383c867ef4f706fb
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
-  image: quay.io/k8scsi/livenessprobe@sha256:529be2c9770add0cdd0c989115222ea9fc1be430c11095eb9f6dafcf98a36e2b
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v2.4.0
+          url: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
+  image: k8s.gcr.io/sig-storage/livenessprobe@sha256:529be2c9770add0cdd0c989115222ea9fc1be430c11095eb9f6dafcf98a36e2b
 kind: ImagesLock

--- a/addons/packages/vsphere-csi/2.4.0-rc.1/bundle/vendir.lock.yml
+++ b/addons/packages/vsphere-csi/2.4.0-rc.1/bundle/vendir.lock.yml
@@ -2,7 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Update release script to use correct release version for csi driver images
+      commitTitle: Update release script to use correct release version for csi driver
+        images (#1356)
       sha: b56e4cecf627d17d94353ac554cf9de54a5c9078
       tags:
       - v2.4.0-rc.1

--- a/addons/packages/vsphere-csi/2.4.0-rc.1/package.yaml
+++ b/addons/packages/vsphere-csi/2.4.0-rc.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:7283ca78598ed51e8b0853e90d983ca45fd1b7d8f1dd4ca3a8d584b245f9befb
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:1f85817c27af93854363503e70926b7f82fe8f5dafec7733b8071b5203e87444
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it

The `make imagelint` task reported a number of missing images.
This updates the package image lock files.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Restore images reported missing by `make imagelint`
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2390 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer

For package owners reviewing this PR:
- Some of these changes are due to `kbld` annotating the images.yaml lock file. There is no functional change. However, since that file is part of the package, the package's digest changed when I re-pushed it. So you'll see a change in the digest.
- Some of the package digest changes are due to other changes in the package that were never pushed. With a freshly pushed packagw, there's a new digest, hence an update.
- I know that not all of these packages are consumed from their OCI Registry images, I'm just trying to keep things updated and current in the registry.
