### PR TITLE
fix: change rbac.authorization.k8s.io/v1beta1 of RoleBinding to v1

### DIFF
--- a/addons/packages/harbor/2.2.3/bundle/config/upstream/harbor/00-common.yaml
+++ b/addons/packages/harbor/2.2.3/bundle/config/upstream/harbor/00-common.yaml
@@ -21,7 +21,7 @@ rules:
     verbs:
       - use
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: harbor

--- a/addons/packages/harbor/2.2.3/package.yaml
+++ b/addons/packages/harbor/2.2.3/package.yaml
@@ -645,7 +645,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/harbor@sha256:4622adcfbef012ffab6a02ff9d88129ca10fdbe2c83cdb4c1372c5e25642b6ce
+            image: projects.registry.vmware.com/tce/harbor@sha256:05945a64cf1ddb897893b0558bedbd8badcf766daa7c6a6fd98f6f7eeccc88ca
       template:
         - ytt:
             paths:

--- a/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/default.yaml
+++ b/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/default.yaml
@@ -23,7 +23,7 @@ rules:
   - use
   resourceNames: []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: harbor

--- a/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-azure-storage.yaml
+++ b/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-azure-storage.yaml
@@ -23,7 +23,7 @@ rules:
   - use
   resourceNames: []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: harbor

--- a/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-existing-pvc.yaml
+++ b/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-existing-pvc.yaml
@@ -23,7 +23,7 @@ rules:
   - use
   resourceNames: []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: harbor

--- a/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-s3-storage.yaml
+++ b/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-s3-storage.yaml
@@ -23,7 +23,7 @@ rules:
   - use
   resourceNames: []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: harbor


### PR DESCRIPTION
Signed-off-by: Shengwen Yu <yshengwen@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Because the apiVersion rbac.authorization.k8s.io/v1beta1 of RoleBinding has been deprecated in k8s 1.22, Harbor package changes it to rbac.authorization.k8s.io/v1 to support k8s 1.22 in the PR

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2353 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
run unit test:
`cd addons/packages/harbor/2.2.3/test`
`make test`

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
