### PR TITLE
installation: install builder plugin too in windows as part of install script

### DIFF
--- a/hack/install.bat
+++ b/hack/install.bat
@@ -23,6 +23,7 @@ mkdir %TCE_DIR%
 rmdir /Q /S %TANZU_CACHE_DIR%
 
 :: core
+copy /B /Y bin\tanzu-plugin-builder.exe %PLUGIN_DIR%
 copy /B /Y bin\tanzu-plugin-cluster.exe %PLUGIN_DIR%
 copy /B /Y bin\tanzu-plugin-kubernetes-release.exe %PLUGIN_DIR%
 copy /B /Y bin\tanzu-plugin-login.exe %PLUGIN_DIR%


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #2397

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
installation: install builder plugin too in windows as part of install script
```

## Which issue(s) this PR fixes

Fixes #2397

## Describe testing done for PR

--

## Special notes for your reviewer

We could add some tests in the future to test `install.bat` in some way every time there's a change in it. Let me know if you think we should add that as part of this PR and how that would look like - because we need some binaries to install when invoking `install.bat` and I think it would be nice to use pre-built binaries, for example the latest TCE release binaries. But yeah, using an older release binaries may not test the script properly if it includes some new features, also will give false results when there are breaking changes in which case the test also has to be updated to use some other set of binaries instead of latest release binaries