### PR TITLE
Pre-Merge PR Checks for Diagnostics Plugin

### DIFF
--- a/.github/workflows/check-pr-diagnostics-plugin.yaml
+++ b/.github/workflows/check-pr-diagnostics-plugin.yaml
@@ -1,0 +1,95 @@
+name: Check - Diagnostics Plugin
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "cli/cmd/plugin/diagnostics/"
+      - "!cli/cmd/plugin/diagnostics/**.md"
+      - ".github/workflows/check-pr-diagnostics-plugin.yaml"
+      - ".github/workflows/e2e-diagnostics-plugin.yaml"
+    types:
+      - assigned
+      - opened
+      - synchronize
+      - reopened
+jobs:
+  setup-runner:
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    name: Start self-hosted EC2 runner
+    runs-on: ubuntu-latest
+    outputs:
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        shell: bash
+        run: |
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "INSTANCE_NAME: ${INSTANCE_NAME}"
+          echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
+  build-release:
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    name: Build Release based on PR
+    needs: setup-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.setup-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: Restore Go Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Get dependencies
+        shell: bash
+        run: |
+          make get-deps
+      - name: Build
+        shell: bash
+        run: |
+          make ensure-deps
+          make release
+      - name: Install
+        shell: bash
+        run: |
+          cd `find ./build -type d -name "tce-linux-amd64-*" | xargs -n1 echo -n`
+          ALLOW_INSTALL_AS_ROOT=true ./install.sh
+  test-diagnostics-plugin:
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    name: Test Diagnostics Plugin
+    needs:
+      - setup-runner # required to start the main job when the runner is ready
+      - build-release
+    runs-on: ${{ needs.setup-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
+    steps:
+      - name: Tests Diagnostics Plugin
+        run: |
+          cd cli/cmd/plugin/diagnostics/
+          make test-pr-check
+  teardown-runner:
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    name: Stop self-hosted EC2 runner
+    needs:
+      - setup-runner # required to get output from the setup-runner job
+      - test-diagnostics-plugin # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stop EC2 runner
+        id: stop-ec2-runner
+        shell: bash
+        run: |
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/.github/workflows/e2e-diagnostics-plugin.yaml
+++ b/.github/workflows/e2e-diagnostics-plugin.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - "cli/cmd/plugin/diagnostics/"
       - "!cli/cmd/plugin/diagnostics/**.md"
+      - ".github/workflows/check-pr-diagnostics-plugin.yaml"
       - ".github/workflows/e2e-diagnostics-plugin.yaml"
     tags-ignore:
       - "**"

--- a/cli/cmd/plugin/diagnostics/Makefile
+++ b/cli/cmd/plugin/diagnostics/Makefile
@@ -19,8 +19,13 @@ endif
 test: ## Run unit testing suite
 	echo "N/A: No unit tests for hack/packages"
 
+.PHONY: test-pr-check
+test-pr-check: ## Run e2e testing suite for PR check
+	./e2e-test/e2e-test.sh
+
 .PHONY: e2e-test
 e2e-test: ## Run e2e testing suite
+	./e2e-test/setup-e2e-test.sh
 	./e2e-test/e2e-test.sh
 
 build: ## Build the executable

--- a/cli/cmd/plugin/diagnostics/e2e-test/setup-e2e-test.sh
+++ b/cli/cmd/plugin/diagnostics/e2e-test/setup-e2e-test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+TCE_REPO_PATH=${MY_DIR}/../../../../..
+
+TCE_VERSION="v0.9.1"
+
+echo "Installing TCE ${TCE_VERSION}"
+
+BUILD_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+TCE_RELEASE_TAR_BALL="tce-${BUILD_OS}-amd64-${TCE_VERSION}.tar.gz"
+TCE_RELEASE_DIR="tce-${BUILD_OS}-amd64-${TCE_VERSION}"
+INSTALLATION_DIR="${MY_DIR}/tce-installation"
+
+"${TCE_REPO_PATH}"/hack/get-tce-release.sh ${TCE_VERSION} "${BUILD_OS}"-amd64
+
+mkdir -p "${INSTALLATION_DIR}"
+tar xzvf "${TCE_RELEASE_TAR_BALL}" --directory="${INSTALLATION_DIR}"
+
+"${INSTALLATION_DIR}"/"${TCE_RELEASE_DIR}"/install.sh || { error "Unexpected failure during TCE installation"; exit 1; }
+
+echo "TCE version: "
+tanzu standalone-cluster version || { error "Unexpected failure during TCE installation"; exit 1; }
+
+TANZU_DIAGNOSTICS_PLUGIN_DIR=${MY_DIR}/..
+TANZU_DIAGNOSTICS_BIN=${MY_DIR}/tanzu-diagnostics-e2e-bin
+
+echo "Entering ${TANZU_DIAGNOSTICS_PLUGIN_DIR} directory to build tanzu diagnostics plugin"
+pushd "${TANZU_DIAGNOSTICS_PLUGIN_DIR}"
+
+go build -o "${TANZU_DIAGNOSTICS_BIN}" -v
+
+echo "Finished building tanzu diagnostics plugin. Leaving ${TANZU_DIAGNOSTICS_PLUGIN_DIR}"
+popd

--- a/hack/ensure-dependencies.sh
+++ b/hack/ensure-dependencies.sh
@@ -274,4 +274,33 @@ case "${BUILD_OS}" in
 esac
 fi
 
+CMD="kind"
+if [[ -z "$(command -v ${CMD})" ]]; then
+echo "Attempting install of ${CMD}..."
+case "${BUILD_OS}" in
+  Linux)
+    curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64 -o kind
+    chmod +x ${CMD}
+    sudo install ./${CMD} /usr/local/bin
+    rm ./${CMD}
+    ;;
+  Darwin)
+    case "${BUILD_ARCH}" in
+      x86_64)
+        curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-darwin-amd64 -o kind
+        chmod +x ${CMD}
+        sudo install ./${CMD} /usr/local/bin
+        rm ./${CMD}
+        ;;
+      arm64)
+        curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-darwin-arm64 -o kind
+        chmod +x ${CMD}
+        sudo install ./${CMD} /usr/local/bin
+        rm ./${CMD}
+        ;;
+    esac
+    ;;
+esac
+fi
+
 echo "No missing dependencies!"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This does the same thing as the e2e test on main... except this checks to make sure that PRs submitted against the diagnostics plugin will pass the tests before getting merged into main. If the test fails, merging will be blocked until the issue is addressed.

The `e2e-test.sh` was broken out into: 
- `setup-e2e-test.sh` which handles setting things for the e2e test
- reworked the `e2e-test.sh` which now only performs the checks/tests without setup so we can run against latest TF

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Pre-Merge PR Checks for Diagnostics Plugin
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA
