### PR TITLE
Force data value hash to string in csi daemonset

### DIFF
--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/overlays/update-csi-driver.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/overlays/update-csi-driver.yaml
@@ -74,7 +74,7 @@ spec:
     metadata:
       labels:
         #@overlay/match missing_ok=True
-        vsphere-csi/data-values-hash: #@ sha256.sum(yaml.encode(values))[:7]
+        vsphere-csi/data-values-hash: #@ "{}".format(sha256.sum(yaml.encode(values))[:7])
     spec:
       containers:
         #@overlay/match by=overlay.subset({"name": "vsphere-csi-node"})

--- a/addons/packages/vsphere-csi/2.3.0/package.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:ac8e916b88755b67058515b5eafff8d29afdea7d92c7c74195833718ee6d7f89
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:a2814538e00b6a875ead5cbc3bfd43335b5fa981c2d6c5ead42058eab79edf4e
       template:
         - ytt:
             paths:


### PR DESCRIPTION

## What this PR does / why we need it
Fix vsphere-csi 2.3.0 daemonset rollout when first 7 characters of data values hash is numeric

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix vsphere-csi 2.3.0 daemonset rollout when first 7 characters of data values hash is numeric
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2406 

## Describe testing done for PR
1. ytt render with data values
2. verify with sample values that yields numeric characters for first 7 tokens

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
