### PR TITLE
Separate image pull from cluster creation

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/cluster/cluster.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/cluster.go
@@ -33,6 +33,9 @@ type ClusterManager interface {
 	Get(clusterName string) (*KubernetesCluster, error)
 	// Delete will destroy a cluster or return an error indicating a problem.
 	Delete(c *config.StandaloneClusterConfig) error
+	// Prepare will fetch an image or perform any pre-steps that can be done
+	// prior to actually creating the cluster.
+	Prepare(c *config.StandaloneClusterConfig) error
 }
 
 // NewClusterManager provides a way to dynamically get a cluster manager based on the standalone cluster config provider

--- a/cli/cmd/plugin/standalone-cluster/cluster/kind.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/kind.go
@@ -88,6 +88,16 @@ func (kcm KindClusterManager) Delete(c *config.StandaloneClusterConfig) error {
 	return provider.Delete(c.ClusterName, "")
 }
 
+// Prepare will fetch a container image to the cluster host.
+func (kcm KindClusterManager) Prepare(c *config.StandaloneClusterConfig) error {
+	cmd := exec.Command("docker", "pull", c.NodeImage)
+	_, err := exec.Output(cmd)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // patchForAntrea modifies the node network settings to allow local routing.
 // this needs to happen for antrea running on kind or else you'll lose network connectivity
 // see: https://github.com/antrea-io/antrea/blob/main/hack/kind-fix-networking.sh

--- a/cli/cmd/plugin/standalone-cluster/cluster/noop.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/noop.go
@@ -36,3 +36,8 @@ func (ncm NoopClusterManager) Get(clusterName string) (*KubernetesCluster, error
 func (ncm NoopClusterManager) Delete(c *config.StandaloneClusterConfig) error {
 	return nil
 }
+
+// Prepare doesn't perform any preparation steps before cluster creation.
+func (ncm NoopClusterManager) Prepare(c *config.StandaloneClusterConfig) error {
+	return nil
+}

--- a/cli/cmd/plugin/standalone-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/standalone-cluster/tanzu/tanzu.go
@@ -546,6 +546,14 @@ func runClusterCreate(scConfig *config.StandaloneClusterConfig) (*cluster.Kubern
 	}
 
 	clusterManager := cluster.NewClusterManager(scConfig)
+
+	log.Style(outputIndent, logger.ColorLightGrey).Info("Pulling base image...\n")
+	err := clusterManager.Prepare(scConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Style(outputIndent, logger.ColorLightGrey).Info("Creating cluster...\n")
 	kc, err := clusterManager.Create(scConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In regions where the cluster image hasn't been cached yet, it can take
some time to pull down the image. Right now this just happens during
cluster creation, so the CLI prints out "Creating cluster", then appears
to hang for a very long time.

We can't do too much to speed up the image pull, but we can at least
break it out into its own step so it's more obvious to the user what is
happening. This adds a separate step for getting the image first before
continuing on to the cluster creation.

Also cleans up some log handling while we're at it.