### PR TITLE
fix: change cert-manager.io/v1alpha2 to cert-manager.io/v1

### DIFF
--- a/addons/packages/harbor/2.2.3/bundle/config/certificates.lib.yaml
+++ b/addons/packages/harbor/2.2.3/bundle/config/certificates.lib.yaml
@@ -3,7 +3,7 @@
 #@ load("@ytt:yaml", "yaml")
 
 #@ def get_issuer():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: "issuer"
@@ -47,7 +47,7 @@ spec:
 #@ end
 
 #@ def get_certificate():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "certificate"

--- a/addons/packages/harbor/2.2.3/package.yaml
+++ b/addons/packages/harbor/2.2.3/package.yaml
@@ -645,7 +645,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/harbor@sha256:05945a64cf1ddb897893b0558bedbd8badcf766daa7c6a6fd98f6f7eeccc88ca
+            image: projects.registry.vmware.com/tce/harbor@sha256:9ad722a66269e306a27ed110e2b957bf82573125b88a918048c1d40ded7e6fba
       template:
         - ytt:
             paths:

--- a/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/default.yaml
+++ b/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/default.yaml
@@ -1405,7 +1405,7 @@ spec:
     app: harbor
     component: trivy
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: harbor-self-signed-ca-issuer
@@ -1413,7 +1413,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-ca
@@ -1440,7 +1440,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: harbor-ca-issuer
@@ -1449,7 +1449,7 @@ spec:
   ca:
     secretName: harbor-ca-key-pair
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-core-internal-cert
@@ -1479,7 +1479,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-jobservice-internal-cert
@@ -1509,7 +1509,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-portal-internal-cert
@@ -1539,7 +1539,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-registry-internal-cert
@@ -1569,7 +1569,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-trivy-internal-cert
@@ -1599,7 +1599,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-token-service-cert
@@ -1629,7 +1629,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-notary-signer-cert
@@ -1659,7 +1659,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-tls-cert

--- a/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-azure-storage.yaml
+++ b/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-azure-storage.yaml
@@ -1385,7 +1385,7 @@ spec:
     app: harbor
     component: trivy
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: harbor-self-signed-ca-issuer
@@ -1393,7 +1393,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-ca
@@ -1420,7 +1420,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: harbor-ca-issuer
@@ -1429,7 +1429,7 @@ spec:
   ca:
     secretName: harbor-ca-key-pair
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-core-internal-cert
@@ -1459,7 +1459,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-jobservice-internal-cert
@@ -1489,7 +1489,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-portal-internal-cert
@@ -1519,7 +1519,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-registry-internal-cert
@@ -1549,7 +1549,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-trivy-internal-cert
@@ -1579,7 +1579,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-token-service-cert
@@ -1609,7 +1609,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-notary-signer-cert
@@ -1639,7 +1639,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-tls-cert

--- a/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-existing-pvc.yaml
+++ b/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-existing-pvc.yaml
@@ -1390,7 +1390,7 @@ spec:
     app: harbor
     component: trivy
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: harbor-self-signed-ca-issuer
@@ -1398,7 +1398,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-ca
@@ -1425,7 +1425,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: harbor-ca-issuer
@@ -1434,7 +1434,7 @@ spec:
   ca:
     secretName: harbor-ca-key-pair
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-core-internal-cert
@@ -1464,7 +1464,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-jobservice-internal-cert
@@ -1494,7 +1494,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-portal-internal-cert
@@ -1524,7 +1524,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-registry-internal-cert
@@ -1554,7 +1554,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-trivy-internal-cert
@@ -1584,7 +1584,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-token-service-cert
@@ -1614,7 +1614,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-notary-signer-cert
@@ -1644,7 +1644,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-tls-cert

--- a/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-s3-storage.yaml
+++ b/addons/packages/harbor/2.2.3/test/unittest/fixtures/expected/registry-s3-storage.yaml
@@ -1394,7 +1394,7 @@ spec:
     app: harbor
     component: trivy
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: harbor-self-signed-ca-issuer
@@ -1402,7 +1402,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-ca
@@ -1429,7 +1429,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: harbor-ca-issuer
@@ -1438,7 +1438,7 @@ spec:
   ca:
     secretName: harbor-ca-key-pair
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-core-internal-cert
@@ -1468,7 +1468,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-jobservice-internal-cert
@@ -1498,7 +1498,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-portal-internal-cert
@@ -1528,7 +1528,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-registry-internal-cert
@@ -1558,7 +1558,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-trivy-internal-cert
@@ -1588,7 +1588,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-token-service-cert
@@ -1618,7 +1618,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-notary-signer-cert
@@ -1648,7 +1648,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-tls-cert


### PR DESCRIPTION
Signed-off-by: Shengwen Yu <yshengwen@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
In Harbor package change cert-manager.io/v1alpha2 to cert-manager.io/v1 for k8s 1.22

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2393 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
run unit test
`cd addons/packages/harbor/2.2.3/test`
`make test`

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
