### PR TITLE
Standalone overhaul: Renames `local` to `standalone` within codebase

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/README.md
+++ b/cli/cmd/plugin/standalone-cluster/README.md
@@ -183,7 +183,7 @@ Tanzu bits to be installed atop. To get started, try:
         tm := tanzu.New(log)
 
         // settings for how to create the cluster
-        clusterConfig := config.LocalClusterConfig{}
+        clusterConfig := config.StandaloneClusterConfig{}
 
         // deploy the cluster, by default using kind
         err = tm.Deploy(clusterConfig)
@@ -294,7 +294,7 @@ This provides a great toolset for users looking to:
 * Run single-node experiments with Tanzu
 * Author packages
 * Author TKRs
-* Integrate a local-Tanzu environment into their CI/CD
+* Integrate a standalone-Tanzu environment into their CI/CD
 
 ### Cluster Infrastructure
 

--- a/cli/cmd/plugin/standalone-cluster/cluster/cluster.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/cluster.go
@@ -28,15 +28,15 @@ type KubernetesCluster struct {
 type ClusterManager interface {
 	// Create will create a new cluster or return an error indicating a problem
 	// during creation.
-	Create(c *config.LocalClusterConfig) (*KubernetesCluster, error)
+	Create(c *config.StandaloneClusterConfig) (*KubernetesCluster, error)
 	// Get retrieves cluster information or return an error indicating a problem.
 	Get(clusterName string) (*KubernetesCluster, error)
 	// Delete will destroy a cluster or return an error indicating a problem.
-	Delete(c *config.LocalClusterConfig) error
+	Delete(c *config.StandaloneClusterConfig) error
 }
 
-// NewClusterManager provides a way to dynamically get a cluster manager based on the local cluster config provider
-func NewClusterManager(c *config.LocalClusterConfig) ClusterManager {
+// NewClusterManager provides a way to dynamically get a cluster manager based on the standalone cluster config provider
+func NewClusterManager(c *config.StandaloneClusterConfig) ClusterManager {
 	switch c.Provider {
 	case KindClusterManagerProvider:
 		return NewKindClusterManager()

--- a/cli/cmd/plugin/standalone-cluster/cluster/kind.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/kind.go
@@ -38,7 +38,7 @@ type KindClusterManager struct {
 }
 
 // Create will create a new kind cluster or return an error.
-func (kcm KindClusterManager) Create(c *config.LocalClusterConfig) (*KubernetesCluster, error) {
+func (kcm KindClusterManager) Create(c *config.StandaloneClusterConfig) (*KubernetesCluster, error) {
 	kindProvider := kindCluster.NewProvider()
 	clusterConfig := kindCluster.CreateWithKubeconfigPath(c.KubeconfigPath)
 	nodeConfig := kindCluster.CreateWithNodeImage(c.NodeImage)
@@ -83,7 +83,7 @@ func (kcm KindClusterManager) Get(clusterName string) (*KubernetesCluster, error
 }
 
 // Delete removes a kind cluster.
-func (kcm KindClusterManager) Delete(c *config.LocalClusterConfig) error {
+func (kcm KindClusterManager) Delete(c *config.StandaloneClusterConfig) error {
 	provider := kindCluster.NewProvider()
 	return provider.Delete(c.ClusterName, "")
 }

--- a/cli/cmd/plugin/standalone-cluster/cluster/noop.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/noop.go
@@ -12,7 +12,7 @@ import (
 type NoopClusterManager struct{}
 
 // Create will create a new KubernetesCluster that points to the default
-func (ncm NoopClusterManager) Create(c *config.LocalClusterConfig) (*KubernetesCluster, error) {
+func (ncm NoopClusterManager) Create(c *config.StandaloneClusterConfig) (*KubernetesCluster, error) {
 	// readkubeconfig in bytes
 	kcBytes, err := os.ReadFile(c.KubeconfigPath)
 	if err != nil {
@@ -33,6 +33,6 @@ func (ncm NoopClusterManager) Get(clusterName string) (*KubernetesCluster, error
 }
 
 // Delete for noop does nothing since these clusters have no provider and are not lifecycled
-func (ncm NoopClusterManager) Delete(c *config.LocalClusterConfig) error {
+func (ncm NoopClusterManager) Delete(c *config.StandaloneClusterConfig) error {
 	return nil
 }

--- a/cli/cmd/plugin/standalone-cluster/config/config.go
+++ b/cli/cmd/plugin/standalone-cluster/config/config.go
@@ -47,9 +47,9 @@ type PortMap struct {
 	ContainerPort int `yaml:"ContainerPort"`
 }
 
-// LocalClusterConfig contains all the configuration settings for creating a
-// local Tanzu cluster.
-type LocalClusterConfig struct {
+// StandaloneClusterConfig contains all the configuration settings for creating a
+// standalone Tanzu cluster.
+type StandaloneClusterConfig struct {
 	// ClusterName is the name of the cluster.
 	ClusterName string `yaml:"ClusterName"`
 	// KubeconfigPath is the serialized path to the kubeconfig to use.
@@ -58,7 +58,7 @@ type LocalClusterConfig struct {
 	// It is typically resolved, automatically, in the Taznu Kubernetes Release (TKR) BOM,
 	// but also can be overridden in configuration.
 	NodeImage string `yaml:"NodeImage"`
-	// Provider is the local infrastructure provider to use (e.g. kind).
+	// Provider is the standalone infrastructure provider to use (e.g. kind).
 	Provider string `yaml:"Provider"`
 	// ProviderConfiguration offers optional provider-specific configuration.
 	// The exact keys and values accepted are determined by the provider.
@@ -81,9 +81,9 @@ type LocalClusterConfig struct {
 	Tty string `yaml:"Tty"`
 }
 
-// KubeConfigPath gets the full path to the KubeConfig for this local cluster.
-func (lcc *LocalClusterConfig) KubeConfigPath() string {
-	return filepath.Join(os.Getenv("HOME"), configDir, tanzuConfigDir, lcc.ClusterName+".yaml")
+// KubeConfigPath gets the full path to the KubeConfig for this standalone cluster.
+func (scc *StandaloneClusterConfig) KubeConfigPath() string {
+	return filepath.Join(os.Getenv("HOME"), configDir, tanzuConfigDir, scc.ClusterName+".yaml")
 }
 
 // InitializeConfiguration determines the configuration to use for cluster creation.
@@ -97,8 +97,8 @@ func (lcc *LocalClusterConfig) KubeConfigPath() string {
 // The effective configuration is determined by combining these sources, in ascending
 // order of preference listed. So env variables override values in the config file,
 // and explicit CLI arguments override config file and env variable values.
-func InitializeConfiguration(commandArgs map[string]string) (*LocalClusterConfig, error) {
-	config := &LocalClusterConfig{}
+func InitializeConfiguration(commandArgs map[string]string) (*StandaloneClusterConfig, error) {
+	config := &StandaloneClusterConfig{}
 
 	// First, populate values based on a supplied config file
 	if commandArgs[ClusterConfigFile] != "" {
@@ -214,18 +214,18 @@ func RenderConfigToFile(filePath string, config interface{}) error {
 }
 
 // RenderFileToConfig reads in configuration from a file and returns the
-// LocalClusterConfig structure based on it. If the file does not exist or there
+// StandaloneClusterConfig structure based on it. If the file does not exist or there
 // is a problem reading the configuration from it an error is returned.
-func RenderFileToConfig(filePath string) (*LocalClusterConfig, error) {
+func RenderFileToConfig(filePath string) (*StandaloneClusterConfig, error) {
 	d, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed reading config file. Error: %s", err.Error())
 	}
-	lcc := &LocalClusterConfig{}
-	err = yaml.Unmarshal(d, lcc)
+	scc := &StandaloneClusterConfig{}
+	err = yaml.Unmarshal(d, scc)
 	if err != nil {
 		return nil, fmt.Errorf("configuration at %s was invalid. Error: %s", filePath, err.Error())
 	}
 
-	return lcc, nil
+	return scc, nil
 }

--- a/cli/cmd/plugin/standalone-cluster/config/config_test.go
+++ b/cli/cmd/plugin/standalone-cluster/config/config_test.go
@@ -136,7 +136,7 @@ func TestInitializeConfigurationFromConfigFile(t *testing.T) {
 	yamlEncoder := yaml.NewEncoder(&configData)
 	yamlEncoder.SetIndent(2)
 
-	if err := yamlEncoder.Encode(LocalClusterConfig{
+	if err := yamlEncoder.Encode(StandaloneClusterConfig{
 		ClusterName: "test3",
 		Provider:    "courteous",
 		Cni:         "bongos",

--- a/cli/cmd/plugin/standalone-cluster/configure.go
+++ b/cli/cmd/plugin/standalone-cluster/configure.go
@@ -21,7 +21,7 @@ var ConfigureCmd = &cobra.Command{
 
 //nolint:dupl
 func init() {
-	ConfigureCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "Configuration file for local cluster creation")
+	ConfigureCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "Configuration file for standalone cluster creation")
 	ConfigureCmd.Flags().StringVarP(&co.infrastructureProvider, "provider", "p", "", "The infrastructure provider to use for cluster creation. Default is 'kind'")
 	ConfigureCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The Tanzu Kubernetes Release location.")
 	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'antrea'")
@@ -53,14 +53,14 @@ func configure(cmd *cobra.Command, args []string) error {
 		config.ServiceCIDR:       co.servicecidr,
 	}
 
-	lcConfig, err := config.InitializeConfiguration(configArgs)
+	scConfig, err := config.InitializeConfiguration(configArgs)
 	if err != nil {
 		log.Errorf("Failed to initialize configuration. Error: %s\n", err.Error())
 		return nil
 	}
 	fileName := fmt.Sprintf("%s.yaml", clusterName)
 
-	err = config.RenderConfigToFile(fileName, lcConfig)
+	err = config.RenderConfigToFile(fileName, scConfig)
 	if err != nil {
 		log.Errorf("Failed to write configuration file: %s", err.Error())
 		return nil

--- a/cli/cmd/plugin/standalone-cluster/create.go
+++ b/cli/cmd/plugin/standalone-cluster/create.go
@@ -13,7 +13,7 @@ import (
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/tanzu"
 )
 
-type createLocalOpts struct {
+type createStandaloneOpts struct {
 	clusterConfigFile      string
 	infrastructureProvider string
 	tkrLocation            string
@@ -26,15 +26,15 @@ type createLocalOpts struct {
 // CreateCmd creates a standalone workload cluster.
 var CreateCmd = &cobra.Command{
 	Use:   "create <cluster name> -f <configuration location>",
-	Short: "create a local tanzu cluster",
+	Short: "create a standalone tanzu cluster",
 	RunE:  create,
 }
 
-var co = createLocalOpts{}
+var co = createStandaloneOpts{}
 
 //nolint:dupl
 func init() {
-	CreateCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "Configuration file for local cluster creation")
+	CreateCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "Configuration file for standalone cluster creation")
 	CreateCmd.Flags().StringVarP(&co.infrastructureProvider, "provider", "p", "", "The infrastructure provider to use for cluster creation. Default is 'kind'")
 	CreateCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The Tanzu Kubernetes Release location.")
 	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'antrea'")

--- a/cli/cmd/plugin/standalone-cluster/delete.go
+++ b/cli/cmd/plugin/standalone-cluster/delete.go
@@ -15,7 +15,7 @@ import (
 // DeleteCmd deletes a standalone workload cluster.
 var DeleteCmd = &cobra.Command{
 	Use:   "delete <cluster name>",
-	Short: "delete a local tanzu cluster",
+	Short: "delete a standalone tanzu cluster",
 	PreRunE: func(cmd *cobra.Command, args []string) (err error) {
 		return nil
 	},

--- a/cli/cmd/plugin/standalone-cluster/list.go
+++ b/cli/cmd/plugin/standalone-cluster/list.go
@@ -30,7 +30,7 @@ func init() {
 	ListCmd.Flags().BoolVar(&co.tty, "tty", true, "Specify whether terminal is tty. Set to false to disable styled output.")
 }
 
-// list outputs a list of all local clusters on the system.
+// list outputs a list of all standalone clusters on the system.
 func list(cmd *cobra.Command, args []string) error {
 	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
 	log.Eventf("\\U+1F440", " Listing clusters found in config dir\n\n")

--- a/cli/cmd/plugin/standalone-cluster/log/log.go
+++ b/cli/cmd/plugin/standalone-cluster/log/log.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package log provides logging mechanisms for the tanzu local CLI plugin. It offers logging functionality that
+// Package log provides logging mechanisms for the tanzu standalone CLI plugin. It offers logging functionality that
 // can include stylized logs, updating progress dots (...), and emojis. It also respects a TTY parameter. When set to
 // false, all stylization is removed.
 package log

--- a/cli/cmd/plugin/standalone-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/standalone-cluster/tanzu/tanzu.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package tanzu is responsible for orchestrating the various components that result in
-// a local tanzu cluster creation.
+// a standalone tanzu cluster creation.
 package tanzu
 
 import (
@@ -32,7 +32,7 @@ const (
 	configFileName        = "config.yaml"
 	tanzuConfigDir        = "tanzu"
 	tkgConfigDir          = "tkg"
-	localConfigDir        = "local"
+	standaloneConfigDir   = "standalone"
 	bomDir                = "bom"
 	tkgSysNamespace       = "tkg-system"
 	tkgSvcAcctName        = "core-pkgs"
@@ -53,15 +53,15 @@ type TanzuCluster struct {
 	Name string
 }
 
-// TanzuLocal contains information about a local Tanzu cluster.
+// TanzuStandalone contains information about a standalone Tanzu cluster.
 //nolint:golint
-type TanzuLocal struct {
+type TanzuStandalone struct {
 	// kcPath               string
-	// config               *LocalClusterConfig
+	// config               *StandaloneClusterConfig
 	bom                  *tkr.TKRBom
 	kappControllerBundle tkr.TkrImageReader
 	selectedCNIPkg       *CNIPackage
-	config               *config.LocalClusterConfig
+	config               *config.StandaloneClusterConfig
 	clusterDirectory     string
 }
 
@@ -72,11 +72,11 @@ type CNIPackage struct {
 
 //nolint:golint
 type TanzuMgr interface {
-	// Deploy orchestrates all the required steps in order to create a local Tanzu cluster. This can involve
+	// Deploy orchestrates all the required steps in order to create a standalone Tanzu cluster. This can involve
 	// cluster creation, kapp-controller installation, CNI installation, and more. The steps that are taken
 	// depend on the configuration passed into Deploy. If something goes wrong during deploy, an error is
 	// returned.
-	Deploy(lcConfig *config.LocalClusterConfig) error
+	Deploy(scConfig *config.StandaloneClusterConfig) error
 	// List retrieves all known tanzu clusters are returns a list of them. If it's unable to interact with the
 	// underlying cluster provider, it returns an error.
 	List() ([]TanzuCluster, error)
@@ -85,26 +85,26 @@ type TanzuMgr interface {
 	Delete(name string) error
 }
 
-// New returns a TanzuMgr for interacting with local clusters. It is implemented by TanzuLocal.
+// New returns a TanzuMgr for interacting with standalone clusters. It is implemented by TanzuStandalone.
 func New(parentLogger logger.Logger) TanzuMgr {
 	log = parentLogger
-	return &TanzuLocal{}
+	return &TanzuStandalone{}
 }
 
 // validateConfiguration makes sure the configuration is valid, returning an
 // error if there is an issue.
-func validateConfiguration(lcConfig *config.LocalClusterConfig) error {
-	if lcConfig.TkrLocation == "" {
+func validateConfiguration(scConfig *config.StandaloneClusterConfig) error {
+	if scConfig.TkrLocation == "" {
 		return fmt.Errorf("Tanzu Kubernetes Release (TKR) not specified.") //nolint:golint,stylecheck
 	}
-	if lcConfig.ClusterName == "" {
+	if scConfig.ClusterName == "" {
 		return fmt.Errorf("cluster name is required")
 	}
 
-	if lcConfig.Provider == "" {
+	if scConfig.Provider == "" {
 		// Should have been validated earlier, but not an error. We can just
 		// default it to kind.
-		lcConfig.Provider = cluster.KindClusterManagerProvider
+		scConfig.Provider = cluster.KindClusterManagerProvider
 	}
 
 	return nil
@@ -112,17 +112,17 @@ func validateConfiguration(lcConfig *config.LocalClusterConfig) error {
 
 // Deploy deploys a new cluster.
 //nolint:funlen,gocyclo
-func (t *TanzuLocal) Deploy(lcConfig *config.LocalClusterConfig) error {
+func (t *TanzuStandalone) Deploy(scConfig *config.StandaloneClusterConfig) error {
 	var err error
 	// 1. Validate the configuration
-	if err := validateConfiguration(lcConfig); err != nil {
+	if err := validateConfiguration(scConfig); err != nil {
 		return err
 	}
-	t.config = lcConfig
+	t.config = scConfig
 
 	// 2. Download and Read the TKR
 	log.Event("\\U+2692", " Resolving Tanzu Kubernetes Release (TKR)\n")
-	bomFileName, err := getTkrBom(lcConfig.TkrLocation)
+	bomFileName, err := getTkrBom(scConfig.TkrLocation)
 	if err != nil {
 		return fmt.Errorf("failed getting TKR BOM. Error: %s", err.Error())
 	}
@@ -153,7 +153,7 @@ func (t *TanzuLocal) Deploy(lcConfig *config.LocalClusterConfig) error {
 	// base image
 	log.Event("\\U+1F5BC", " Selected base image\n")
 	log.Style(outputIndent, logger.ColorLightGrey).Infof("%s\n", t.bom.GetTKRNodeImage())
-	lcConfig.NodeImage = t.bom.GetTKRNodeImage()
+	scConfig.NodeImage = t.bom.GetTKRNodeImage()
 
 	// core package repository
 	log.Event("\\U+1F4E6", "Selected core package repository\n")
@@ -172,15 +172,15 @@ func (t *TanzuLocal) Deploy(lcConfig *config.LocalClusterConfig) error {
 	log.Style(outputIndent, logger.ColorLightGrey).Infof("%s\n", t.kappControllerBundle.GetRegistryURL())
 
 	// 4. Create the cluster
-	log.Eventf("\\U+1F6F0", " Creating cluster %s\n", lcConfig.ClusterName)
-	createdCluster, err := runClusterCreate(lcConfig)
+	log.Eventf("\\U+1F6F0", " Creating cluster %s\n", scConfig.ClusterName)
+	createdCluster, err := runClusterCreate(scConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create cluster, Error: %s", err.Error())
 	}
 
 	kcBytes := createdCluster.Kubeconfig
 	log.Style(outputIndent, logger.ColorLightGrey).Info("To troubleshoot, use:\n")
-	log.Style(outputIndent, logger.ColorLightGrey).Infof("kubectl ${COMMAND} --kubeconfig %s\n", lcConfig.KubeconfigPath)
+	log.Style(outputIndent, logger.ColorLightGrey).Infof("kubectl ${COMMAND} --kubeconfig %s\n", scConfig.KubeconfigPath)
 
 	// 5. Install kapp-controller
 	kc, err := kapp.New(kcBytes)
@@ -224,29 +224,29 @@ func (t *TanzuLocal) Deploy(lcConfig *config.LocalClusterConfig) error {
 
 	// 8. Update kubeconfig and context
 	kubeConfigMgr := kubeconfig.NewManager()
-	err = mergeKubeconfigAndSetContext(kubeConfigMgr, lcConfig.KubeconfigPath, lcConfig.ClusterName)
+	err = mergeKubeconfigAndSetContext(kubeConfigMgr, scConfig.KubeconfigPath, scConfig.ClusterName)
 	if err != nil {
 		log.Warnf("Failed to merge kubeconfig and set your context. Cluster should still work! Error: %s", err)
 	}
 
 	// 8. Return
 	log.Event("\\U+2705", "Cluster created\n")
-	log.Eventf("\\U+1F3AE", "kubectl context set to %s\n\n", lcConfig.ClusterName)
+	log.Eventf("\\U+1F3AE", "kubectl context set to %s\n\n", scConfig.ClusterName)
 	// provide user example commands to run
 	log.Style(0, logger.ColorLightGrey).Infof("View available packages:\n")
 	log.Style(outputIndent, logger.ColorLightGreen).Infof("tanzu package available list\n")
 	log.Style(0, logger.ColorLightGrey).Infof("View running pods:\n")
 	log.Style(outputIndent, logger.ColorLightGreen).Infof("kubectl get po -A\n")
 	log.Style(0, logger.ColorLightGrey).Infof("Delete this cluster:\n")
-	log.Style(outputIndent, logger.ColorLightGreen).Infof("tanzu local delete %s\n", lcConfig.ClusterName)
+	log.Style(outputIndent, logger.ColorLightGreen).Infof("tanzu standalone delete %s\n", scConfig.ClusterName)
 	return nil
 }
 
-// List lists the local clusters.
-func (t *TanzuLocal) List() ([]TanzuCluster, error) {
+// List lists the standalone clusters.
+func (t *TanzuStandalone) List() ([]TanzuCluster, error) {
 	var clusters []TanzuCluster
 
-	configDir, err := getTkgLocalConfigDir()
+	configDir, err := getTkgStandaloneConfigDir()
 	if err != nil {
 		return nil, err
 	}
@@ -271,21 +271,21 @@ func (t *TanzuLocal) List() ([]TanzuCluster, error) {
 			continue
 		}
 
-		lc, err := config.RenderFileToConfig(configFilePath)
+		scc, err := config.RenderFileToConfig(configFilePath)
 		if err != nil {
 			return nil, err
 		}
 
 		clusters = append(clusters, TanzuCluster{
-			Name: lc.ClusterName,
+			Name: scc.ClusterName,
 		})
 	}
 
 	return clusters, nil
 }
 
-// Delete deletes a local cluster.
-func (t *TanzuLocal) Delete(name string) error {
+// Delete deletes a standalone cluster.
+func (t *TanzuStandalone) Delete(name string) error {
 	var err error
 	t.clusterDirectory, err = resolveClusterDir(name)
 	if err != nil {
@@ -325,22 +325,22 @@ func getTkgConfigDir() (path string, err error) {
 	return path, nil
 }
 
-func getTkgLocalConfigDir() (path string, err error) {
+func getTkgStandaloneConfigDir() (path string, err error) {
 	tkgConfigDir, err := getTkgConfigDir()
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(tkgConfigDir, localConfigDir), nil
+	return filepath.Join(tkgConfigDir, standaloneConfigDir), nil
 }
 
-func getLocalBomPath() (path string, err error) {
-	tkgLocalConfigDir, err := getTkgLocalConfigDir()
+func getStandaloneBomPath() (path string, err error) {
+	tkgStandaloneConfigDir, err := getTkgStandaloneConfigDir()
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(tkgLocalConfigDir, bomDir), nil
+	return filepath.Join(tkgStandaloneConfigDir, bomDir), nil
 }
 
 func buildFilesystemSafeBomName(bomFileName string) (path string) {
@@ -371,13 +371,13 @@ func buildFilesystemSafeBomName(bomFileName string) (path string) {
 }
 
 func resolveClusterDir(clusterName string) (string, error) {
-	lcd, err := getTkgLocalConfigDir()
+	scd, err := getTkgStandaloneConfigDir()
 	if err != nil {
 		return "", err
 	}
 
 	// determine if directory pre-exists
-	fp := filepath.Join(lcd, clusterName)
+	fp := filepath.Join(scd, clusterName)
 	_, err = os.ReadDir(fp)
 
 	if os.IsNotExist(err) {
@@ -387,13 +387,13 @@ func resolveClusterDir(clusterName string) (string, error) {
 }
 
 func resolveClusterConfig(clusterName string) (string, error) {
-	lcd, err := getTkgLocalConfigDir()
+	scd, err := getTkgStandaloneConfigDir()
 	if err != nil {
 		return "", err
 	}
 
 	// determine if directory pre-exists
-	fp := filepath.Join(lcd, clusterName)
+	fp := filepath.Join(scd, clusterName)
 	files, err := os.ReadDir(fp)
 
 	if os.IsNotExist(err) {
@@ -416,12 +416,12 @@ func resolveClusterConfig(clusterName string) (string, error) {
 }
 
 func createClusterDirectory(clusterName string) (string, error) {
-	lcd, err := getTkgLocalConfigDir()
+	scd, err := getTkgStandaloneConfigDir()
 	if err != nil {
 		return "", err
 	}
 	// determine if directory pre-exists
-	fp := filepath.Join(lcd, clusterName)
+	fp := filepath.Join(scd, clusterName)
 	_, err = os.ReadDir(fp)
 
 	// if it does not exist, which is expected, create it
@@ -441,22 +441,22 @@ func getTkrBom(registry string) (string, error) {
 	log.Style(outputIndent, logger.ColorLightGrey).Infof("%s\n", registry)
 	expectedBomName := buildFilesystemSafeBomName(registry)
 
-	bomPath, err := getLocalBomPath()
+	bomPath, err := getStandaloneBomPath()
 	if err != nil {
-		return "", fmt.Errorf("failed to get tanzu local bom path: %s", err)
+		return "", fmt.Errorf("failed to get tanzu stanadlone bom path: %s", err)
 	}
 
 	_, err = os.Stat(bomPath)
 	if os.IsNotExist(err) {
 		err := os.MkdirAll(bomPath, 0755)
 		if err != nil {
-			return "", fmt.Errorf("failed to make new tanzu local bom config directories %s", err)
+			return "", fmt.Errorf("failed to make new tanzu standalone bom config directories %s", err)
 		}
 	}
 
 	items, err := os.ReadDir(bomPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to read tanzu local bom directories: %s", err)
+		return "", fmt.Errorf("failed to read tanzu standalone bom directories: %s", err)
 	}
 
 	// if the expected bom is already in the config directory, don't download it again. return early
@@ -497,7 +497,7 @@ func getTkrBom(registry string) (string, error) {
 
 	newBomFile, err := os.Create(filepath.Join(bomPath, expectedBomName))
 	if err != nil {
-		return "", fmt.Errorf("could not create tanzu local bom tkr file: %s", err)
+		return "", fmt.Errorf("could not create tanzu standalone bom tkr file: %s", err)
 	}
 	defer newBomFile.Close()
 
@@ -510,7 +510,7 @@ func getTkrBom(registry string) (string, error) {
 }
 
 func parseTKRBom(fileName string) (*tkr.TKRBom, error) {
-	tkgBomPath, err := getLocalBomPath()
+	tkgBomPath, err := getStandaloneBomPath()
 	if err != nil {
 		return nil, err
 	}
@@ -524,7 +524,7 @@ func parseTKRBom(fileName string) (*tkr.TKRBom, error) {
 	return bom, nil
 }
 
-func resolveKappBundle(t *TanzuLocal) error {
+func resolveKappBundle(t *TanzuStandalone) error {
 	var err error
 	t.kappControllerBundle, err = t.bom.GetTKRKappImage()
 	if err != nil {
@@ -533,24 +533,24 @@ func resolveKappBundle(t *TanzuLocal) error {
 	return nil
 }
 
-func runClusterCreate(lcConfig *config.LocalClusterConfig) (*cluster.KubernetesCluster, error) {
-	if lcConfig.KubeconfigPath == "" {
-		clusterDir, err := resolveClusterDir(lcConfig.ClusterName)
+func runClusterCreate(scConfig *config.StandaloneClusterConfig) (*cluster.KubernetesCluster, error) {
+	if scConfig.KubeconfigPath == "" {
+		clusterDir, err := resolveClusterDir(scConfig.ClusterName)
 		if err != nil {
 			return nil, err
 		}
-		lcConfig.KubeconfigPath = filepath.Join(clusterDir, "kube.conf")
+		scConfig.KubeconfigPath = filepath.Join(clusterDir, "kube.conf")
 	}
 
-	clusterManager := cluster.NewClusterManager(lcConfig)
-	kc, err := clusterManager.Create(lcConfig)
+	clusterManager := cluster.NewClusterManager(scConfig)
+	kc, err := clusterManager.Create(scConfig)
 	if err != nil {
 		return nil, err
 	}
 	return kc, nil
 }
 
-func installKappController(t *TanzuLocal, kc kapp.KappManager) (*v1.Deployment, error) {
+func installKappController(t *TanzuStandalone, kc kapp.KappManager) (*v1.Deployment, error) {
 	err := t.kappControllerBundle.DownloadBundleImage()
 	if err != nil {
 		return nil, err
@@ -618,7 +618,7 @@ func blockForRepoStatus(repo *v1alpha1.PackageRepository, pkgClient packages.Pac
 }
 
 // TODO(joshrosso) this function is a mess, but waiting on some stuff to happen in other packages
-func installCNI(pkgClient packages.PackageManager, t *TanzuLocal) error {
+func installCNI(pkgClient packages.PackageManager, t *TanzuStandalone) error {
 	// install CNI (TODO(joshrosso): needs to support multiple CNIs
 	rootSvcAcct, err := pkgClient.CreateRootServiceAccount(tkgSysNamespace, tkgSvcAcctName)
 	if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it
This PR renames instances of `local` (and any variables derived from that) to `standalone`

This will be beneficial to any external programmer "users" who will be implementing their own providers to plug into the standalone model
