### PR TITLE
Standalone overhaul: Implements a set of standard 2 column width emojis for logging

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/delete.go
+++ b/cli/cmd/plugin/standalone-cluster/delete.go
@@ -41,7 +41,7 @@ func destroy(cmd *cobra.Command, args []string) error {
 	}
 	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
 
-	log.Eventf("\\U+1F5D1", " Deleting cluster: %s\n", clusterName)
+	log.Eventf(logger.SawEmoji, "Deleting cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)
 	err := tClient.Delete(clusterName)
 	if err != nil {
@@ -49,7 +49,7 @@ func destroy(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	log.Eventf("\\U+1F5D1", " Deleted cluster: %s\n", clusterName)
+	log.Eventf(logger.SawEmoji, "Deleted cluster: %s\n", clusterName)
 
 	return nil
 }

--- a/cli/cmd/plugin/standalone-cluster/list.go
+++ b/cli/cmd/plugin/standalone-cluster/list.go
@@ -33,7 +33,6 @@ func init() {
 // list outputs a list of all standalone clusters on the system.
 func list(cmd *cobra.Command, args []string) error {
 	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
-	log.Eventf("\\U+1F440", " Listing clusters found in config dir\n\n")
 	tClient := tanzu.New(log)
 	clusters, err := tClient.List()
 	if err != nil {

--- a/cli/cmd/plugin/standalone-cluster/log/log.go
+++ b/cli/cmd/plugin/standalone-cluster/log/log.go
@@ -20,6 +20,21 @@ const (
 	ColorLightGreen = "\033[32m"
 	ColorLightGrey  = "\033[37m"
 	colorReset      = "\033[0m"
+
+	// The following are a set of emoji codes that can be used
+	// with the Event and Eventf logging methods in this package.
+	// They should all take up 2 terminal columns.
+	// https://www.unicode.org/emoji/charts/full-emoji-list.html
+	WrenchEmoji     = "\\U+1F527"
+	FolderEmoji     = "\\U+1F4C1"
+	PictureEmoji    = "\\U+1F3A8"
+	PackageEmoji    = "\\U+1F4E6"
+	RocketEmoji     = "\\U+1F680"
+	EnvelopeEmoji   = "\\U+1F4E7"
+	GlobeEmoji      = "\\U+1F310"
+	GreenCheckEmoji = "\\U+2705"
+	ControllerEmoji = "\\U+1F3AE"
+	SawEmoji        = "\\U+1FA9A"
 )
 
 // CMDLogger is the logger implementation used for high-level command line logging.
@@ -41,11 +56,15 @@ type CMDLogger struct {
 // Logger provides the logging interaction for the application.
 type Logger interface {
 	// Event takes an emoji codepoint (e.g. "\\U+1F609") and presents a log message.
-	// Emojis may have variable width, so no space is automatically placed between the emoji and the message.
+	// This package provides several standard emoji codepoints as string constants. I.e: logger.HammerEmoji
+	// Warning: Emojis may have variable width and this method assumes 2 width emojis, adding a space between the emoji and message.
+	// Emojis provided in this package as string consts have 2 width and work with this method.
 	// If you wish for additional space, add it at the beginning of the message (string) argument.
 	Event(emoji, message string)
 	// Eventf takes an emoji codepoint (e.g. "\\U+1F609"), a format string, arguments for the format string.
-	// Emojis may have variable width, so no space is automatically placed between the emoji and the message.
+	// This package provides several standard emoji codepoints as string constants. I.e: logger.HammerEmoji
+	// Warning: Emojis may have variable width and this method assumes 2 width emojis, adding a space between the emoji and message.
+	// Emojis provided in this package as string consts have 2 width and work with this method.
 	// If you wish for additional space, add it at the beginning of the message (string) argument.
 	Eventf(emoji, message string, args ...interface{})
 	// Info prints a standard log message.
@@ -118,8 +137,12 @@ func (l *CMDLogger) Event(emoji, message string) {
 		emoji = unquoteCodePoint(emoji)
 	}
 
-	// process indentation
-	message = "%s" + message
+	// Print a new line before the event is logged
+	// so that each event is within it's own "block"
+	fmt.Print("\n")
+
+	// process indentation and ensure a space after the emoji
+	message = "%s " + message
 	message = processStyle(l, message)
 	fmt.Fprintf(l.output, message, emoji)
 }
@@ -137,7 +160,13 @@ func (l *CMDLogger) Eventf(emoji, message string, args ...interface{}) {
 	} else {
 		emoji = unquoteCodePoint(emoji)
 	}
-	message = emoji + message
+
+	// Print a new line before the event is logged
+	// so that each event is within it's own "block"
+	fmt.Print("\n")
+
+	// ensure a space between the emoji and the message
+	message = emoji + " " + message
 	message = processStyle(l, message)
 	fmt.Fprintf(l.output, message, args...)
 }


### PR DESCRIPTION
All changes related to the standalone cluster overhaul

## What this PR does / why we need it
- Implements a set of standard 2 column width emojis that can be used with the `Event` and `Eventf` logger methods.
- Adds breaks to each "event" as it's logged
- Removes logging for the list operation (which is more in line with what `kubectl get pods` might do)

## Describe testing done for PR
Take a look!

![Screen Shot 2021-11-01 at 4 25 06 PM](https://user-images.githubusercontent.com/23109390/139750117-50cdae2b-5eb6-41ea-a1c0-a1459fa4aca9.png)

