### PR TITLE
Table format standalone cluster list

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/config/config.go
+++ b/cli/cmd/plugin/standalone-cluster/config/config.go
@@ -77,8 +77,6 @@ type StandaloneClusterConfig struct {
 	// PortsToForward contains a mapping of host to container ports that should
 	// be exposed.
 	PortsToForward []PortMap `yaml:"PortsToForward"`
-	// TTY specifies whether the output of commands can be stylized and/or interactive.
-	Tty string `yaml:"Tty"`
 }
 
 // KubeConfigPath gets the full path to the KubeConfig for this standalone cluster.

--- a/cli/cmd/plugin/standalone-cluster/list.go
+++ b/cli/cmd/plugin/standalone-cluster/list.go
@@ -10,6 +10,7 @@ import (
 
 	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/log"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/standalone-cluster/tanzu"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
 )
 
 // ListCmd returns a list of existing clusters.
@@ -33,19 +34,17 @@ func init() {
 // list outputs a list of all standalone clusters on the system.
 func list(cmd *cobra.Command, args []string) error {
 	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
-	log.Eventf("\\U+1F440", " Listing clusters found in config dir\n\n")
 	tClient := tanzu.New(log)
 	clusters, err := tClient.List()
 	if err != nil {
 		return fmt.Errorf("unable to list clusters. Error: %s", err.Error())
 	}
 
-	// TODO(stmcginnis): Pull in table output formatting from tanzu-framework
-	// and determine what else should be shown in addition to the name.
-	log.Info("NAME\n")
+	t := component.NewOutputWriter(cmd.OutOrStdout(), "table", "NAME", "PROVIDER")
 	for _, c := range clusters {
-		log.Style(0, logger.ColorLightGrey).Infof("%s\n", c.Name)
+		t.AddRow(c.Name, c.Provider)
 	}
+	t.Render()
 
 	return nil
 }

--- a/cli/cmd/plugin/standalone-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/standalone-cluster/tanzu/tanzu.go
@@ -51,14 +51,13 @@ var log logger.Logger
 // TanzuCluster contains information about a cluster.
 //nolint:golint
 type TanzuCluster struct {
-	Name string
+	Name     string
+	Provider string
 }
 
 // TanzuStandalone contains information about a standalone Tanzu cluster.
 //nolint:golint
 type TanzuStandalone struct {
-	// kcPath               string
-	// config               *StandaloneClusterConfig
 	bom                  *tkr.TKRBom
 	kappControllerBundle tkr.TkrImageReader
 	selectedCNIPkg       *CNIPackage
@@ -280,7 +279,8 @@ func (t *TanzuStandalone) List() ([]TanzuCluster, error) {
 		}
 
 		clusters = append(clusters, TanzuCluster{
-			Name: scc.ClusterName,
+			Name:     scc.ClusterName,
+			Provider: scc.Provider,
 		})
 	}
 


### PR DESCRIPTION
This updates the list output for standalone clusters to show the name
and provider in a table format.