### PR TITLE
Implements reporting standalone cluster creation and deletion times

### DIFF
--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -59,19 +59,43 @@ jobs:
           ALLOW_INSTALL_AS_ROOT=true ./install.sh
   create-cluster:
     name: Create Cluster
+    outputs:
+      create-cluster-time: ${{ steps.check-create-cluster.outputs.create-cluster-time }}
     needs:
       - setup-runner # required to start the main job when the runner is ready
       - build-release
     runs-on: ${{ needs.setup-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Create Cluster
-        run: CLUSTER_PLAN=dev tanzu standalone-cluster create mytest -i docker -v 10
+        run: CLUSTER_PLAN=dev env time -f "%e" -o create-cluster-time.txt tanzu standalone-cluster create mytest -i docker -v 10
       - name: Check Create Cluster
+        id: check-create-cluster
         shell: bash
         run: |
           ./hack/runner/check-setup.sh
+          CREATE_TIME=$(cat ./create-cluster-time.txt)
+          echo "CREATE_TIME: ${CREATE_TIME}"
+          echo ::set-output name=create-cluster-time::${CREATE_TIME}
+  report-cluster-create-time:
+    name: Report Cluster Creation Time
+    needs:
+      - setup-runner # required to start the main job when the runner is ready
+      - create-cluster
+    runs-on: ${{ needs.setup-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
+    steps:
+      - name: Report cluster create time
+        shell: bash
+        run: |
+          GIT_SHA=$(git rev-parse HEAD)
+          TCE_VERSION=$(git describe --tags --abbrev=0)
+          echo "tce.pr.standalone-cluster.create-time ${{ needs.create-cluster.outputs.create-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
+            --header "Authorization: Bearer ${{ secrets.VMW_WAVEFRONT_API_TOKEN }}" \
+            --data @- \
+            https://vmware.wavefront.com/report
   delete-cluster:
     name: Delete Cluster
+    outputs:
+      delete-cluster-time: ${{ steps.check-delete-cluster.outputs.delete-cluster-time }}
     needs:
       - setup-runner # required to start the main job when the runner is ready
       - create-cluster
@@ -79,11 +103,31 @@ jobs:
     steps:
       - name: Delete Cluster
         shell: bash
-        run: tanzu standalone-cluster delete mytest --yes -v 10
+        run: env time -f "%e" -o delete-cluster-time.txt tanzu standalone-cluster delete mytest --yes -v 10
       - name: Check Delete Cluster
+        id: check-delete-cluster
         shell: bash
         run: |
           ./hack/runner/check-teardown.sh
+          DELETE_TIME=$(cat ./delete-cluster-time.txt)
+          echo "DELETE_TIME: ${DELETE_TIME}"
+          echo ::set-output name=delete-cluster-time::${DELETE_TIME}
+  report-cluster-delete-time:
+    name: Report Cluster Delete Time
+    needs:
+      - setup-runner # required to start the main job when the runner is ready
+      - delete-cluster
+    runs-on: ${{ needs.setup-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
+    steps:
+      - name: Report cluster deletion time
+        shell: bash
+        run: |
+          GIT_SHA=$(git rev-parse HEAD)
+          TCE_VERSION=$(git describe --tags --abbrev=0)
+          echo "tce.pr.standalone-cluster.delete-time ${{ needs.delete-cluster.outputs.delete-cluster-time }} source=<tce.github.${{ github.event.number }}> sha=${GIT_SHA} version=${TCE_VERSION}" | curl \
+            --header "Authorization: Bearer ${{ secrets.VMW_WAVEFRONT_API_TOKEN }}" \
+            --data @- \
+            https://vmware.wavefront.com/report
   teardown-runner:
     name: Stop self-hosted EC2 runner
     needs:

--- a/.github/workflows/check-pr-docker-management.yaml
+++ b/.github/workflows/check-pr-docker-management.yaml
@@ -60,8 +60,6 @@ jobs:
           ALLOW_INSTALL_AS_ROOT=true ./install.sh
   create-cluster:
     name: Create Cluster
-    outputs:
-      create-cluster-time: ${{ steps.check-create-cluster.outputs.create-cluster-time }}
     needs:
       - setup-runner # required to start the main job when the runner is ready
       - build-release
@@ -69,19 +67,13 @@ jobs:
     steps:
       - name: Create Cluster
         shell: bash
-        run: CLUSTER_PLAN=dev env time -f "%e" -o create-cluster-time.txt tanzu management-cluster create mytest -i docker -v 10
+        run: CLUSTER_PLAN=dev tanzu management-cluster create mytest -i docker -v 10
       - name: Check Create Cluster
-        id: check-create-cluster
         shell: bash
         run: |
           ./hack/runner/check-setup.sh
-          CREATE_TIME=$(cat ./create-cluster-time.txt)
-          echo "CREATE_TIME: ${CREATE_TIME}"
-          echo ::set-output name=create-cluster-time::${CREATE_TIME}
   delete-cluster:
     name: Delete Cluster
-    outputs:
-      delete-cluster-time: ${{ steps.check-delete-cluster.outputs.delete-cluster-time }}
     needs:
       - setup-runner # required to start the main job when the runner is ready
       - create-cluster
@@ -89,15 +81,11 @@ jobs:
     steps:
       - name: Delete Cluster
         shell: bash
-        run: env time -f "%e" -o delete-cluster-time.txt tanzu management-cluster delete mytest --yes -v 10
+        run: tanzu management-cluster delete mytest --yes -v 10
       - name: Check Delete Cluster
-        id: check-delete-cluster
         shell: bash
         run: |
           ./hack/runner/check-teardown.sh
-          DELETE_TIME=$(cat ./delete-cluster-time.txt)
-          echo "DELETE_TIME: ${DELETE_TIME}"
-          echo ::set-output name=delete-cluster-time::${DELETE_TIME}
   teardown-runner:
     name: Stop self-hosted EC2 runner
     needs:

--- a/.github/workflows/check-pr-docker-standalone.yaml
+++ b/.github/workflows/check-pr-docker-standalone.yaml
@@ -62,8 +62,6 @@ jobs:
           ALLOW_INSTALL_AS_ROOT=true ./install.sh
   create-cluster:
     name: Create Cluster
-    outputs:
-      create-cluster-time: ${{ steps.check-create-cluster.outputs.create-cluster-time }}
     needs:
       - setup-runner # required to start the main job when the runner is ready
       - build-release
@@ -71,19 +69,13 @@ jobs:
     steps:
       - name: Create Cluster
         shell: bash
-        run: CLUSTER_PLAN=dev env time -f "%e" -o create-cluster-time.txt tanzu standalone-cluster create mytest -i docker -v 10
+        run: CLUSTER_PLAN=dev tanzu standalone-cluster create mytest -i docker -v 10
       - name: Check Create Cluster
-        id: check-create-cluster
         shell: bash
         run: |
           ./hack/runner/check-setup.sh
-          CREATE_TIME=$(cat ./create-cluster-time.txt)
-          echo "CREATE_TIME: ${CREATE_TIME}"
-          echo ::set-output name=create-cluster-time::${CREATE_TIME}
   delete-cluster:
     name: Delete Cluster
-    outputs:
-      delete-cluster-time: ${{ steps.check-delete-cluster.outputs.delete-cluster-time }}
     needs:
       - setup-runner # required to start the main job when the runner is ready
       - create-cluster
@@ -91,15 +83,11 @@ jobs:
     steps:
       - name: Delete Cluster
         shell: bash
-        run: env time -f "%e" -o delete-cluster-time.txt tanzu standalone-cluster delete mytest --yes -v 10
+        run: tanzu standalone-cluster delete mytest --yes -v 10
       - name: Check Delete Cluster
-        id: check-delete-cluster
         shell: bash
         run: |
           ./hack/runner/check-teardown.sh
-          DELETE_TIME=$(cat ./delete-cluster-time.txt)
-          echo "DELETE_TIME: ${DELETE_TIME}"
-          echo ::set-output name=delete-cluster-time::${DELETE_TIME}
   teardown-runner:
     name: Stop self-hosted EC2 runner
     needs:


### PR DESCRIPTION
## What this PR does / why we need it
Implements reporting cluster creation and deletion times for standalone clusters to the vmware internal wavefront off the main branch check job.

Also removes unnecessary report steps in the existing PR jobs for standalone and management clusters.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
- Re-adds reporting cluster creation / deletion times for standalone clusters
```

## Which issue(s) this PR fixes
Followup to: https://github.com/vmware-tanzu/community-edition/pull/2300
and: https://github.com/vmware-tanzu/community-edition/issues/2361
which was intended to restore functionality to the PR branch checks. Since we can't expose the vmware to outside collaborators, we will run the checks on the main branch.

## Describe testing done for PR
N/a will check internal dashboards once merged

## Special notes for your reviewer
N/a
