### PR TITLE
Use correct version in chocolately install command

### DIFF
--- a/docs/site/content/docs/assets/cli-install-windows.md
+++ b/docs/site/content/docs/assets/cli-install-windows.md
@@ -9,7 +9,7 @@
 1. Open PowerShell **as an administrator** and run the following:
 
     ```sh
-    choco install tanzu-community-edition --version={{<  release_latest >}}
+    choco install tanzu-community-edition --version={{< choco_release_latest  >}}
 
     ```
 

--- a/docs/site/layouts/shortcodes/choco_release_latest.html
+++ b/docs/site/layouts/shortcodes/choco_release_latest.html
@@ -1,0 +1,1 @@
+{{ trim .Site.Params.release_latest "v" }}


### PR DESCRIPTION


## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Chocolatey doesn't allow letters in their versions numbers, so we need
to strip out the prefix that is normally included in our versions. This
has to be done in a shortcode since functions don't appear to run in
partials/includes.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```


## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

`hugo server --disableFastRender` and navigate to the site locally.
