### PR TITLE
Doc - add link to triage process issue in doc

### DIFF
--- a/docs/site/content/docs/latest/triage-process.md
+++ b/docs/site/content/docs/latest/triage-process.md
@@ -1,8 +1,13 @@
 # Triage Process
 
+## Issues
+
+Issues are regularly triaged (weekly), the triage process is described in this
+[github issue](https://github.com/vmware-tanzu/community-edition/issues/1829).
+
 ## Office Hours
 
-Issues filed are regularly (weekly) triaged and we encourage attending office hours for in person discussions. Twice a month, Tanzu Community Edition maintainers are available at Office Hour meetings as described in the Meet with Us section [here](https://tanzucommunityedition.io/community/#). This is an open forum where community members can discuss issues in person with maintainers.
+We encourage attending Office Hours meetings for in person discussions. Twice a month, Tanzu Community Edition maintainers are available at Office Hour meetings as described in the Meet with Us section [here](https://tanzucommunityedition.io/community/#). This is an open forum where community members can discuss issues in person with maintainers.
 
 ## Tracking issues
 


### PR DESCRIPTION
## What this PR does / why we need it
Adds link to triage process/issue in this topic: https://tanzucommunityedition.io/docs/latest/triage-process/

## Details for the Release Notes (PLEASE PROVIDE)

```NONE

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2432

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
