### PR TITLE
Fix housekeeping after token change error due to spacing

### DIFF
--- a/.github/workflows/label-pull-requests.yaml
+++ b/.github/workflows/label-pull-requests.yaml
@@ -12,8 +12,8 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-     - name: Label pull requests based on the paths
-       uses: actions/labeler@v3
-       with:
-        repo-token: "${{ secrets.GH_HOUSEKEEPING_ACCESS_TOKEN }}"
-        configuration-path: .github/labels.yml
+      - name: Label pull requests based on the paths
+        uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GH_HOUSEKEEPING_ACCESS_TOKEN }}"
+          configuration-path: .github/labels.yml


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
The spacing originally was not correct, but when we switched from using the default token (which was being consumed by default) the spacing really came into play which is why the workflow now thinks we aren't supplying a token.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA