### PR TITLE
Removing `kind` command dependency for Diagnostics

### DIFF
--- a/cli/cmd/plugin/diagnostics/go.mod
+++ b/cli/cmd/plugin/diagnostics/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/vmware-tanzu/crash-diagnostics v0.3.4
 	github.com/vmware-tanzu/tanzu-framework v0.2.1
 	sigs.k8s.io/controller-runtime v0.9.0 // indirect
+	sigs.k8s.io/kind v0.11.1
 )

--- a/cli/cmd/plugin/diagnostics/go.sum
+++ b/cli/cmd/plugin/diagnostics/go.sum
@@ -114,6 +114,7 @@ github.com/Azure/go-autorest/tracing v0.1.0/go.mod h1:ROEEAFwXycQw7Sn3DXNtEedEvd
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/sketches-go v0.0.1/go.mod h1:Q5DbzQ+3AkgGwymQO7aZFNP7ns2lZKGtvRBzRXfdi60=
@@ -158,6 +159,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053/go.mod h1:xW8sBma2LE3QxFSzCnH9qe6gAE2yO9GvQaWwX89HxbE=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
@@ -332,6 +334,7 @@ github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible h1:glyUF9yIYtMHzn8xaKw5rMhdWcwsYV8dZHIq5567/xs=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch/v5 v5.2.0 h1:8ozOH5xxoMYDt5/u+yMTsVXydVCbTORFnOOoq2lumco=
 github.com/evanphx/json-patch/v5 v5.2.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
@@ -916,6 +919,7 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
+github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.0-beta.3/go.mod h1:aNseLYu/uKskg0zpr/kbr2z8yGuWtotWf/0BpGIAL2Y=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
@@ -1929,6 +1933,7 @@ sigs.k8s.io/controller-runtime v0.9.0 h1:ZIZ/dtpboPSbZYY7uUz2OzrkaBTOThx2yekLtpG
 sigs.k8s.io/controller-runtime v0.9.0/go.mod h1:TgkfvrhhEw3PlI0BRL/5xM+89y3/yc0ZDfdbTl84si8=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
 sigs.k8s.io/kind v0.7.1-0.20200303021537-981bd80d3802/go.mod h1:HIZ3PWUezpklcjkqpFbnYOqaqsAE1JeCTEwkgvPLXjk=
+sigs.k8s.io/kind v0.11.1 h1:pVzOkhUwMBrCB0Q/WllQDO3v14Y+o2V0tFgjTqIUjwA=
 sigs.k8s.io/kind v0.11.1/go.mod h1:fRpgVhtqAWrtLB9ED7zQahUimpUXuG/iHT88xYqEGIA=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190426204423-ea680f03cc65/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/cli/cmd/plugin/diagnostics/scripts/bootstrap_cluster.star
+++ b/cli/cmd/plugin/diagnostics/scripts/bootstrap_cluster.star
@@ -2,11 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # extract diagnostic info from local kind boostrap cluster
-def diagnose_bootstrap_clusters(workdir, clusters, outputdir):
-    if len(clusters) == 0:
-        log(prefix="Warn", msg="Bootstrap cluster: no cluster found: nothing will be collected")
-        return
-
+def diagnose_bootstrap_clusters(kubeconfig, cluster, workdir, outputdir):
     nspaces=[
         "capi-kubeadm-bootstrap-system",
         "capi-kubeadm-control-plane-system",
@@ -19,54 +15,109 @@ def diagnose_bootstrap_clusters(workdir, clusters, outputdir):
     ]
 
     # for each tkg-kind cluster:
-    #  - capture kind logs, export kubecfg, and api objects
-    for kind_cluster in clusters:
-        wd = "{}/{}".format(workdir, kind_cluster)
-        log(prefix="Info", msg="Bootstrap cluster: {}: capturing node logs".format(kind_cluster))
-        run_local("kind export logs --name {} {}/kind-logs".format(kind_cluster, wd))
+    wd = "{}/{}".format(workdir, cluster)
+    log(prefix="Info", msg="Bootstrap cluster: {}: capturing node logs".format(cluster))
 
-        # extract kubeconfig file for cluster
-        kind_cfg = capture_local(
-            cmd="kind get kubeconfig --name {0}".format(kind_cluster),
-            workdir=wd,
-            file_name="{}.kubecfg".format(kind_cluster)
-        )
+    # collect node logs and info
+    nodes = get_kind_nodes(cluster)
+    for node in nodes:
+        log(prefix="Debug", msg="Capturing logs for node {}".format(node))
+        capture_kind_logs(node, wd)
 
-        conf = crashd_config(workdir=wd)
-        k8sconf = kube_config(path=kind_cfg)
+    # extract kubeconfig file for cluster
+    control_planes = get_control_plane_nodes(cluster)
+    if len(control_planes) == 0:
+        log(prefix="Warn", msg="Cluster {}: has no control plane node:".format(cluster))
 
-        capture_k8s_objects(k8sconf, kind_cluster, nspaces)
+    conf = crashd_config(workdir=wd)
+    k8sconf = kube_config(path=kubeconfig)
 
-        # remove kubeconfig before archiving
-        run_local("rm {}".format(kind_cfg))
+    capture_k8s_objects(k8sconf, cluster, nspaces)
 
-        arc_file = "{}/bootstrap.{}.diagnostics.tar.gz".format(outputdir, kind_cluster)
-        log(prefix="Info", msg="Archiving: {}".format(arc_file))
-        archive(output_file=arc_file, source_paths=[conf.workdir])
+    arc_file = "{}/bootstrap.{}.diagnostics.tar.gz".format(outputdir, cluster)
+    log(prefix="Info", msg="Archiving: {}".format(arc_file))
+    archive(output_file=arc_file, source_paths=[conf.workdir])
 
-# return all bootstrap clusters in kind (tkg-kind-xxxx) or
-# returns the cluster that matches name
-def get_bootstrap_clusters(name):
-    clusters = run_local("kind get clusters").split('\n')
-    result = []
 
-    for cluster in clusters:
-        if name == cluster:
-            result.append(cluster)
-            break
+# returns a priviledged command string to launch a contained process
+# docker exec --privileged <container> <command>
+def docker_exec_cmd(container, cmd):
+    return "docker exec --privileged {} {}".format(container, cmd)
 
-        if cluster.startswith("tkg-kind"):
-            result.append(cluster)
+# simulates command `kind export log`
+# to collect logs from cluster_node
+def capture_kind_logs(cluster_node, dir):
+    # docker exec --privileged <node_name> cat /kind/version >> kubernetes-version.txt
+    command = docker_exec_cmd(cluster_node, "cat /kind/version")
+    capture_local(
+        cmd=docker_exec_cmd(cluster_node, "cat /kind/version"),
+        workdir=dir,
+        file_name="kubernetes-version.txt"
+    )
 
-    if len(result) > 0:
-        log(prefix="Info", msg="Found bootstrap cluster(s): {}".format(result))
-    return result
+    # journalctl --no-pager >> journal.log
+    capture_local(
+        cmd=docker_exec_cmd(cluster_node,"journalctl --no-pager"),
+        workdir=dir,
+        file_name="journal.log"
+    )
+
+    # journalctl --no-pager -u kubelet.service >> kubelet.log
+    capture_local(
+        cmd=docker_exec_cmd(cluster_node, "journalctl --no-pager -u kubelet.service"),
+        workdir=dir,
+        file_name="kubelet.log"
+    )
+
+    # journalctl --no-pager -u containerd.service >> container.log
+    capture_local(
+        cmd=docker_exec_cmd(cluster_node, "journalctl --no-pager -u containerd.service"),
+        workdir=dir,
+        file_name="container.log"
+    )
+
+    # docker logs <node-name> >> serial.log
+    capture_local(cmd="docker logs {}".format(cluster_node), workdir=dir, file_name="serial.log")
+
+    # capture docker info `docker inspect >> inspect.json`
+    capture_local(cmd="docker inspect {}".format(cluster_node), workdir=dir, file_name="inspect.log")
+
+# returns a list of kind clusters in Docker
+def get_kind_clusters():
+    return run_local("""docker ps -a --filter 'label=io.x-k8s.kind.cluster' --format '{{.Label "io.x-k8s.kind.cluster"}}'""").split('\n')
+
+# Returns all nodes in kind cluster
+def get_kind_nodes(cluster_name):
+    return run_local("""docker ps -a --filter 'label=io.x-k8s.kind.cluster={}' --format '{{{{.Names}}}}'""".format(cluster_name)).split('\n')
+
+# Returns a list of control plane nodes for specified cluster
+def get_control_plane_nodes(cluster_name):
+    return run_local("""docker ps -a --filter 'label=io.x-k8s.kind.cluster={}' --filter 'label=io.x-k8s.kind.role=control-plane' --format '{{{{.Names}}}}'""".format(cluster_name)).split('\n')
+
 
 def diagnose():
     # program pre-checks
     if not prog_checks():
         log(prefix="Error", msg="One or more required program(s) missing")
         return
+
+    # argument validation
+    name = None
+    if not hasattr(args, "bootstrap_cluster_name") or len(args.bootstrap_cluster_name) == 0:
+        log(prefix="Error", msg="No valid bootstrap cluster provided")
+        return
+
+    name = args.bootstrap_cluster_name
+
+    if name != None and not name.startswith("tkg-kind"):
+        log(prefix="Warn", msg="Bootstrap cluster: may not be a valid tanzu bootstrap cluster: {}".format(name))
+
+    kubecfg = None
+    if not hasattr(args, "bootstrap_kubeconfig") or len(args.bootstrap_kubeconfig) == 0:
+        log(prefix="Error", msg="No valid bootstrap cluster kubeconfig provided")
+        return
+
+    kubecfg = args.bootstrap_kubeconfig
 
     workdir = "./diagnostics"
     if hasattr(args, "workdir") and len(args.workdir) > 0:
@@ -76,21 +127,14 @@ def diagnose():
     if hasattr(args, "outputdir") and len(args.outputdir) > 0:
         outputdir = args.outputdir
 
-    # argument validation
-    name = None
-    if hasattr(args, "bootstrap_cluster_name") and len(args.bootstrap_cluster_name) > 0:
-        log(prefix="Info", msg="Bootstrap cluster: name={}".format(args.bootstrap_cluster_name))
-        name = args.bootstrap_cluster_name
 
-    if name != None and not name.startswith("tkg-kind"):
-        log(prefix="Warn", msg="Bootstrap cluster: specified name may not be valid: {}".format(name))
-
-    clusters=get_bootstrap_clusters(name)
+    # clusters=get_bootstrap_clusters(name)
 
     # diagnose boostrap cluster
     diagnose_bootstrap_clusters(
+        kubeconfig=kubecfg,
+        cluster=name,
         workdir=workdir,
-        clusters=clusters,
         outputdir=outputdir,
     )
 

--- a/cli/cmd/plugin/diagnostics/scripts/lib.star
+++ b/cli/cmd/plugin/diagnostics/scripts/lib.star
@@ -2,10 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 def prog_checks():
-    if prog_avail_local("kind") == "":
-        log(prefix="Error", msg="kind program binary not found")
-        return False
-
     if prog_avail_local("tanzu") == "":
         log(prefix="Error", msg="tanzu program binary not found")
         return False
@@ -25,7 +21,7 @@ def capture_node_diagnostics(nodes):
 
 # extracts kubernetes object from cluster
 def capture_k8s_objects(k8sconf,cluster_name,nspaces):
-    log(prefix="Info", msg="Capturing pod logs: cluster={}".format(cluster_name))
+    log(prefix="Info", msg="Capturing pod logs: cluster={}; kubeconf={}".format(cluster_name, k8sconf))
     kube_capture(what="logs", namespaces=nspaces, kube_config=k8sconf)
     log(prefix="Info", msg="Capturing API objects: cluster={}".format(cluster_name))
     kube_capture(what="objects", kinds=["pods", "services"], namespaces=nspaces, kube_config=k8sconf)


### PR DESCRIPTION
## What this PR does / why we need it
This PR remove the dependency on the kind command by replacing exec kind commands with equivalent docker command in scripts.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Removed the need to have kind install in order to collect diagnostics
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1950 

## Describe testing done for PR
Create stand-alone and managed Docker-backed clusters to test `tanzu diagnostics collect`