### PR TITLE
Add port mapping to sa cluster creation

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/cluster/kind.go
+++ b/cli/cmd/plugin/standalone-cluster/cluster/kind.go
@@ -102,6 +102,23 @@ func kindConfigFromClusterConfig(c *config.StandaloneClusterConfig) ([]byte, err
 	}
 	for i := range kindConfig.Nodes {
 		kindConfig.Nodes[i].Image = c.NodeImage
+
+		// We do the port mapping for all nodes. Need to see if there is a way
+		// to change this if we support scaling worker nodes.
+		for j := range c.PortsToForward {
+			portMapping := kindconfig.PortMapping{}
+			if c.PortsToForward[j].ContainerPort != 0 {
+				portMapping.ContainerPort = int32(c.PortsToForward[j].ContainerPort)
+			}
+			if c.PortsToForward[j].HostPort != 0 {
+				portMapping.HostPort = int32(c.PortsToForward[j].HostPort)
+			}
+			if c.PortsToForward[j].Protocol != "" {
+				portMapping.Protocol = kindconfig.PortMappingProtocol(c.PortsToForward[j].Protocol)
+			}
+
+			kindConfig.Nodes[i].ExtraPortMappings = append(kindConfig.Nodes[i].ExtraPortMappings, portMapping)
+		}
 	}
 
 	// Marshal it into the raw bytes we need for creation

--- a/cli/cmd/plugin/standalone-cluster/config/config_test.go
+++ b/cli/cmd/plugin/standalone-cluster/config/config_test.go
@@ -209,3 +209,67 @@ func TestSanatizeKubeconfigPath(t *testing.T) {
 		t.Errorf("Sanatizing kubeconfig path failed, got %s", result)
 	}
 }
+
+func TestParsePortMapFullString(t *testing.T) {
+	portMap, err := ParsePortMap("80:8080/tcp")
+	if err != nil {
+		t.Error("Parsing should pass")
+	}
+
+	if portMap.ContainerPort != 80 {
+		t.Errorf("Container port should be 80, was %d", portMap.ContainerPort)
+	}
+
+	if portMap.HostPort != 8080 {
+		t.Errorf("Host port should be 8080, was %d", portMap.HostPort)
+	}
+
+	if portMap.Protocol != "tcp" {
+		t.Errorf("Protocol should be tcp, was %s", portMap.Protocol)
+	}
+}
+
+func TestParsePortMapContainerPort(t *testing.T) {
+	portMap, err := ParsePortMap("80")
+	if err != nil {
+		t.Error("Parsing should pass")
+	}
+
+	if portMap.ContainerPort != 80 {
+		t.Errorf("Container port should be 80, was %d", portMap.ContainerPort)
+	}
+
+	if portMap.HostPort != 0 {
+		t.Errorf("Host port should be 0, was %d", portMap.HostPort)
+	}
+
+	if portMap.Protocol != "" {
+		t.Errorf("Protocol should be empty, was %s", portMap.Protocol)
+	}
+}
+
+func TestParsePortMapContainerPortProtocol(t *testing.T) {
+	portMap, err := ParsePortMap("80/UDP")
+	if err != nil {
+		t.Error("Parsing should pass")
+	}
+
+	if portMap.ContainerPort != 80 {
+		t.Errorf("Container port should be 80, was %d", portMap.ContainerPort)
+	}
+
+	if portMap.HostPort != 0 {
+		t.Errorf("Host port should be 0, was %d", portMap.HostPort)
+	}
+
+	if portMap.Protocol != "udp" {
+		t.Errorf("Protocol should be udp, was %s", portMap.Protocol)
+	}
+}
+
+func TestParsePortMapInvalid(t *testing.T) {
+	_, err := ParsePortMap("http")
+	if err == nil {
+		t.Error("Parsing should fail")
+	}
+}

--- a/cli/cmd/plugin/standalone-cluster/configure.go
+++ b/cli/cmd/plugin/standalone-cluster/configure.go
@@ -19,10 +19,9 @@ var ConfigureCmd = &cobra.Command{
 	RunE:  configure,
 }
 
-//nolint:dupl
 func init() {
 	ConfigureCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "Configuration file for standalone cluster creation")
-	ConfigureCmd.Flags().StringVarP(&co.infrastructureProvider, "provider", "p", "", "The infrastructure provider to use for cluster creation. Default is 'kind'")
+	ConfigureCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider to use for cluster creation. Default is 'kind'")
 	ConfigureCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The Tanzu Kubernetes Release location.")
 	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'antrea'")
 	ConfigureCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR to use for Pod IP addresses. Default and format is '10.244.0.0/16'")


### PR DESCRIPTION
This adds the ability to provide a list of ports to map from container
to host when creating a new standalone cluster. Multiple port mappings
can be provided by specifying the --port-map or -p switch and giving it
in the Docker format of container:host/protocol.

Note: the -p switch had previously been used as the short form for
--provider. This removes that and makes -p the short form for --port-map
since that is more consistent with how tools like the docker CLI handle
mapping or publishing ports.