### PR TITLE
Bump vsphere-cpi version to 1.22.3.

### DIFF
--- a/addons/packages/vsphere-cpi/1.22.3/README.md
+++ b/addons/packages/vsphere-cpi/1.22.3/README.md
@@ -1,0 +1,47 @@
+# vSphere CPI
+
+> This package provides cloud provider interface using vsphere-cpi.
+
+For more information, see the [GitHub page](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere) of vSphere CPI.
+
+## Configuration
+
+The following configuration values can be set to customize the vsphere CPI installation.
+
+### Global
+
+None
+
+### vSphere CPI Configuration
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `vsphereCPI.server` | Required | The IP address or FQDN of the vSphere endpoint. Default value is `null`. |
+| `vsphereCPI.datacenter` | Required | The datacenter in which VMs are created/located. Default value is `null`. |
+| `vsphereCPI.username` | Required | Username used to access a vSphere endpoint. Default value is `null`. |
+| `vsphereCPI.password` | Required | Password used to access a vSphere endpoint. Default value is `null`. |
+| `vsphereCPI.tlsThumbprint` | Optional | The cryptographic thumbprint of the vSphere endpoint's certificate. Default value is `""`. |
+| `vsphereCPI.insecureFlag` | Optional | The flag that disables TLS peer verification. Default value is `False`. |
+| `vsphereCPI.ipFamily` | Optional | IP family. Default value is `null`. |
+| `vsphereCPI.vmInternalNetwork` | Optional | Internal VM network name. Default value is `null`. |
+| `vsphereCPI.vmExternalNetwork` | Optional | External VM network name. Default value is `null`. |
+| `vsphereCPI.cloudProviderExtraArgs.tls-cipher-suites` | Optional | External arguments for cloud provider. Default: `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384` |
+| `vsphereCPI.nsxt.podRoutingEnabled` | Optional | A flag that enables pod routing. Default: `false`. |
+| `vsphereCPI.nsxt.routes.routerPath` | Optional | NSX-T T0/T1 logical router path. Default: `""`. |
+| `vsphereCPI.nsxt.routes.clusterCidr` | Optional | Cluster CIDR. Default: `""` . |
+| `vsphereCPI.nsxt.username` | Optional | The username used to access NSX-T. Default: `""`. |
+| `vsphereCPI.nsxt.password` | Optional | The password used to access NSX-T. Default: `""`. |
+| `vsphereCPI.nsxt.host`| Optional | The NSX-T server. Default: `null`. |
+| `vsphereCPI.nsxt.insecureFlag` | Optional | InsecureFlag is to be set to true if NSX-T uses self-signed cert. Default: `false`. |
+| `vsphereCPI.nsxt.remoteAuth` | Optional | RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM). Default: `false`. |
+| `vsphereCPI.nsxt.vmcAccessToken`| Optional | VMCAccessToken is VMC access token for token based authentification. Default: `""`. |
+| `vsphereCPI.nsxt.vmcAuthHost` | Optional | VMCAuthHost is VMC verification host for token based authentification. Default: `""`. |
+| `vsphereCPI.nsxt.clientCertKeyData` | Optional | Client certificate key. Default: `""`. |
+| `vsphereCPI.nsxt.clientCertData`| Optional | Client certificate data. Default: `""`. |
+|`vsphereCPI.nsxt.rootCAData` | Optional | The certificate authority for the server certificate for locally signed certificates. Default: `""`. |
+| `vsphereCPI.nsxt.secretName` | Optional | The name of secret that stores CPI configuration. Default: `cloud-provider-vsphere-nsxt-credentials`. |
+| `vsphereCPI.nsxt.secretNamespace`| Optional | The namespace of secret that stores CPI configuration. Default: `True`. |
+
+## Usage Example
+
+To learn more about how to use vSphere CPI refer to [vSphere CPI website](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere)

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/.imgpkg/bundle.yml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/.imgpkg/bundle.yml
@@ -1,0 +1,9 @@
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: Bundle
+metadata:
+  name: vsphere-cpi
+authors:
+- name: Lucheng Bao
+  email: luchengb@vmware.com
+websites:
+- url: https://github.com/kubernetes/cloud-provider-vsphere

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/.imgpkg/images.yml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/.imgpkg/images.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- annotations:
+    kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.22.3
+  image: gcr.io/cloud-provider-vsphere/cpi/release/manager@sha256:8b39430b93b5da65e377fafcae12e3ae8b2d7f07a7e633599ac1c62f6b4a9eb4
+kind: ImagesLock

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/overlays/add-secret.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/overlays/add-secret.yaml
@@ -1,0 +1,29 @@
+#@ load("/values.star", "values")
+#@ if values.vsphereCPI.nsxt.podRoutingEnabled and values.vsphereCPI.nsxt.secretName != "" and values.vsphereCPI.nsxt.secretNamespace != "" and values.vsphereCPI.nsxt.username != "" and values.vsphereCPI.nsxt.password != "" :
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ values.vsphereCPI.nsxt.secretName
+  namespace: #@ values.vsphereCPI.nsxt.secretNamespace
+stringData:
+  username: #@ values.vsphereCPI.nsxt.username
+  password: #@ values.vsphereCPI.nsxt.password
+type: Opaque
+#@ end
+
+#@ if values.vsphereCPI.nsxt.podRoutingEnabled and values.vsphereCPI.nsxt.clientCertData != "" and values.vsphereCPI.nsxt.clientCertKeyData != "" :
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nsxt-tls-certificates
+  namespace: kube-system
+type: kubernetes.io/tls
+data:
+  tls.crt: #@ values.vsphereCPI.nsxt.clientCertData
+  tls.key: #@ values.vsphereCPI.nsxt.clientCertKeyData
+  #@ if values.vsphereCPI.nsxt.rootCAData != "" :
+  tls.ca: #@ values.vsphereCPI.nsxt.rootCAData
+  #@ end
+#@ end

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/overlays/update-config.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/overlays/update-config.yaml
@@ -1,0 +1,9 @@
+#@ load("/values.star", "values")
+#@ load("@ytt:overlay", "overlay")
+#@ load("/vsphereconf.lib.txt", "vsphere_conf")
+
+#@overlay/match by=overlay.subset({"kind": "ConfigMap", "metadata": {"name": "vsphere-cloud-config"}})
+---
+#@overlay/replace
+data:
+  vsphere.conf: #@ vsphere_conf(values)

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/overlays/update-daemonset.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/overlays/update-daemonset.yaml
@@ -1,0 +1,65 @@
+#@ load("/values.star", "values")
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:struct", "struct")
+#@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:sha256", "sha256")
+
+#@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "vsphere-cloud-controller-manager"}})
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
+    kapp.k14s.io/update-strategy: fallback-on-replace
+
+spec:
+  template:
+    metadata:
+      labels:
+        #@overlay/match missing_ok=True
+        vsphere-cpi/data-values-hash: #@ sha256.sum(yaml.encode(values))
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      containers:
+      #@overlay/match by=overlay.subset({"name": "vsphere-cloud-controller-manager"})
+      - args:
+          #@ if values.vsphereCPI.nsxt.podRoutingEnabled:
+          #@overlay/append
+          - --configure-cloud-routes=true
+          #@overlay/append
+          - --allocate-node-cidrs=true
+          #@overlay/append
+          - #@ "--cluster-cidr=" + values.vsphereCPI.nsxt.routes.clusterCidr
+          #@ end
+          #@overlay/append
+          #@yaml/text-templated-strings
+          #@ for arg in struct.decode(values.vsphereCPI.cloudProviderExtraArgs):
+          - --(@=arg @)=(@=struct.decode(values.vsphereCPI.cloudProviderExtraArgs)[arg]@)
+          #@ end
+      #@ if values.vsphereCPI.http_proxy != "" :
+      #@overlay/match by=overlay.subset({"name": "vsphere-cloud-controller-manager"})
+      #@overlay/match-child-defaults missing_ok=True
+      - env:
+        - name: "HTTP_PROXY"
+          value: #@ values.vsphereCPI.http_proxy
+        - name: "HTTPS_PROXY"
+          value: #@ values.vsphereCPI.https_proxy
+        - name: "NO_PROXY"
+          value: #@ values.vsphereCPI.no_proxy
+      #@ end
+      #@ if values.vsphereCPI.nsxt.podRoutingEnabled and values.vsphereCPI.nsxt.clientCertData != "" and values.vsphereCPI.nsxt.clientCertKeyData != "" :
+      #@overlay/match by=overlay.subset({"name": "vsphere-cloud-controller-manager"})
+      - volumeMounts:
+        #@overlay/append
+        - mountPath: /etc/cloud/nsxt
+          name: nsxt-certificates-volume
+          readOnly: true
+      volumes:
+      #@overlay/match by=overlay.subset({"name": "vsphere-cloud-controller-manager"})
+        #@overlay/append
+        - secret:
+            secretName: nsxt-tls-certificates
+          name: nsxt-certificates-volume
+      #@ end

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/overlays/update-secret.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/overlays/update-secret.yaml
@@ -1,0 +1,10 @@
+#@ load("/values.star", "values")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind": "Secret", "metadata": {"name": "cloud-provider-vsphere-credentials"}})
+#@yaml/text-templated-strings
+---
+#@overlay/replace
+stringData:
+  (@=values.vsphereCPI.server@).username: (@=values.vsphereCPI.username@)
+  (@=values.vsphereCPI.server@).password: (@=values.vsphereCPI.password@)

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/01-rbac.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/01-rbac.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+  - kind: User
+    name: cloud-controller-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: servicecatalog.k8s.io:apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+  - kind: User
+    name: cloud-controller-manager

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/02-config.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/02-config.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vsphere-cloud-config
+  namespace: kube-system
+data:
+  vsphere.conf: |+
+    [Global]
+    secret-name = "cloud-provider-vsphere-credentials"
+    secret-namespace = "kube-system"
+    thumbprint = "${VSPHERE_TLS_THUMBPRINT}"
+    [VirtualCenter "${VSPHERE_SERVER}"]
+    datacenters = "${VSPHERE_DATACENTER}"
+    thumbprint = "${VSPHERE_TLS_THUMBPRINT}"
+    [Network]
+    public-network = "${VSPHERE_NETWORK}"
+    [Workspace]
+    server = "${VSPHERE_SERVER}"
+    datacenter = "${VSPHERE_DATACENTER}"
+    folder = "${VSPHERE_FOLDER}"
+    default-datastore = "${VSPHERE_DATASTORE}"
+    resourcepool-path = "${VSPHERE_RESOURCE_POOL}"

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/03-secret.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/03-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-provider-vsphere-credentials
+  namespace: kube-system
+stringData:
+  ${VSPHERE_SERVER}.password: ${VSPHERE_PASSWORD}
+  ${VSPHERE_SERVER}.username: ${VSPHERE_USERNAME}
+type: Opaque

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/04-service.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/04-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: cloud-controller-manager
+  name: cloud-controller-manager
+  namespace: kube-system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 43001
+  selector:
+    component: cloud-controller-manager
+  type: NodePort

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: vsphere-cloud-controller-manager
+  name: vsphere-cloud-controller-manager
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: vsphere-cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        k8s-app: vsphere-cloud-controller-manager
+    spec:
+      containers:
+        - args:
+            - --v=2
+            - --cloud-provider=vsphere
+            - --cloud-config=/etc/cloud/vsphere.conf
+          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.22.3
+          imagePullPolicy: IfNotPresent
+          name: vsphere-cloud-controller-manager
+          resources:
+            requests:
+              cpu: 200m
+          volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+      hostNetwork: true
+      serviceAccountName: cloud-controller-manager
+      tolerations:
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+      volumes:
+        - configMap:
+            name: vsphere-cloud-config
+          name: vsphere-config-volume
+  updateStrategy:
+    type: RollingUpdate

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/values.star
@@ -1,0 +1,60 @@
+load("@ytt:data", "data")
+load("@ytt:assert", "assert")
+
+def validate_vsphereCPI():
+   data.values.vsphereCPI.server or assert.fail("vsphereCPI server should be provided")
+   data.values.vsphereCPI.datacenter or assert.fail("vsphereCPI datacenter should be provided")
+   data.values.vsphereCPI.username or assert.fail("vsphereCPI username should be provided")
+   data.values.vsphereCPI.password or assert.fail("vsphereCPI password should be provided")
+   if not data.values.vsphereCPI.insecureFlag:
+     data.values.vsphereCPI.tlsThumbprint or assert.fail("vsphereCPI tlsThumbprint should be provided when insecureFlag is False")
+   end
+   if data.values.vsphereCPI.ipFamily and (data.values.vsphereCPI.ipFamily not in ["ipv4", "ipv6"]):
+     assert.fail("vsphereCPI ipFamily should be either ipv4 or ipv6 if provided")
+   end
+end
+
+def validate_nsxt_config():
+   if validate_nsxt_username_password() == False and validate_nsxt_secret() == False and validate_nsxt_token() == False and validate_nsxt_cert() == False:
+     assert.fail("Invalid NSX-T credentials: username/password or vmc access token or client certificates must be set")
+   end
+   data.values.vsphereCPI.nsxt.host or assert.fail("vsphereCPI nsxtHost should be provided")
+   data.values.vsphereCPI.nsxt.routes.clusterCidr or assert.fail("vsphereCPI nsxt routes clusterCidr should be provided")
+end
+
+def validate_nsxt_token():
+   if data.values.vsphereCPI.nsxt.vmcAccessToken == "" or data.values.vsphereCPI.nsxt.vmcAuthHost == "":
+     return False
+   end
+   return True
+end
+
+def validate_nsxt_cert():
+   if data.values.vsphereCPI.nsxt.clientCertKeyData == "" or data.values.vsphereCPI.nsxt.clientCertData == "":
+     return False
+   end
+   return True
+end
+
+def validate_nsxt_secret():
+   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "" or validate_nsxt_username_password() == False:
+     return False
+   end
+   return True
+end
+
+def validate_nsxt_username_password():
+   if data.values.vsphereCPI.nsxt.username == "" or data.values.vsphereCPI.nsxt.password == "":
+     return False
+   end
+   return True
+end
+
+# export
+values = data.values
+
+# validate
+validate_vsphereCPI()
+if data.values.vsphereCPI.nsxt.podRoutingEnabled:
+validate_nsxt_config()
+end

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/values.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/values.yaml
@@ -1,0 +1,38 @@
+#@data/values
+#@overlay/match-child-defaults missing_ok=True
+
+---
+vsphereCPI:
+  tlsThumbprint: ""
+  server: null
+  datacenter: null
+  username: null
+  password: null
+  region: null
+  zone: null
+  insecureFlag: False
+  ipFamily: null
+  vmInternalNetwork: null
+  vmExternalNetwork: null
+  cloudProviderExtraArgs:
+    tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+  nsxt:
+    podRoutingEnabled: false
+    routes:
+      routerPath: ""
+      clusterCidr: ""
+    username: ""
+    password: ""
+    host: null
+    insecureFlag: "false"
+    remoteAuth: "false"
+    vmcAccessToken: ""
+    vmcAuthHost: ""
+    clientCertKeyData: ""
+    clientCertData: ""
+    rootCAData: ""
+    secretName: "cloud-provider-vsphere-nsxt-credentials"
+    secretNamespace: "kube-system"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/vsphereconf.lib.txt
@@ -1,0 +1,68 @@
+
+(@ def vsphere_conf(values): -@)
+[Global]
+secret-name = "cloud-provider-vsphere-credentials"
+secret-namespace = "kube-system"
+(@ if values.vsphereCPI.insecureFlag: -@)
+insecure-flag = "1"
+(@ else: -@)
+thumbprint = "(@=values.vsphereCPI.tlsThumbprint @)"
+(@ end -@)
+[VirtualCenter "(@=values.vsphereCPI.server @)"]
+datacenters = "(@=values.vsphereCPI.datacenter @)"
+(@ if values.vsphereCPI.ipFamily: -@)
+ip-family = "(@=values.vsphereCPI.ipFamily @)"
+(@ end -@)
+(@ if values.vsphereCPI.insecureFlag: -@)
+insecure-flag = "1"
+(@ else: -@)
+thumbprint = "(@=values.vsphereCPI.tlsThumbprint @)"
+(@ end -@)
+(@ if values.vsphereCPI.region or values.vsphereCPI.zone: -@)
+[Labels]
+(@ if values.vsphereCPI.region: -@)
+region = "(@=values.vsphereCPI.region @)"
+(@ end -@)
+(@ if values.vsphereCPI.zone: -@)
+zone = "(@=values.vsphereCPI.zone @)"
+(@ end -@)
+(@ end -@)
+(@ if values.vsphereCPI.vmInternalNetwork or values.vsphereCPI.vmExternalNetwork: -@)
+[Nodes]
+(@ if values.vsphereCPI.vmInternalNetwork: -@)
+internal-vm-network-name = "(@=values.vsphereCPI.vmInternalNetwork @)"
+(@ end -@)
+(@ if values.vsphereCPI.vmExternalNetwork: -@)
+external-vm-network-name = "(@=values.vsphereCPI.vmExternalNetwork @)"
+(@ end -@)
+(@ end -@)
+(@ if values.vsphereCPI.nsxt.podRoutingEnabled : -@)
+[Route]
+router-path = "(@=values.vsphereCPI.nsxt.routes.routerPath @)"
+[NSXT]
+host = "(@=values.vsphereCPI.nsxt.host @)"
+insecure-flag = "(@=str(values.vsphereCPI.nsxt.insecureFlag).lower() @)"
+remote-auth = "(@=str(values.vsphereCPI.nsxt.remoteAuth).lower() @)"
+(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace and values.vsphereCPI.nsxt.username and values.vsphereCPI.nsxt.password  : -@)
+secret-name = "(@=values.vsphereCPI.nsxt.secretName @)"
+secret-namespace = "(@=values.vsphereCPI.nsxt.secretNamespace @)"
+(@ end -@)
+(@ if values.vsphereCPI.nsxt.clientCertData and values.vsphereCPI.nsxt.clientCertKeyData : -@)
+client-auth-cert-file = "/etc/cloud/nsxt/tls.crt"
+client-auth-key-file = "/etc/cloud/nsxt/tls.key"
+(@ if values.vsphereCPI.nsxt.rootCAData : -@)
+ca-file = "/etc/cloud/nsxt/tls.ca"
+(@ end -@)
+(@ end -@)
+(@ if values.vsphereCPI.nsxt.vmcAccessToken and values.vsphereCPI.nsxt.vmcAuthHost : -@)
+vmc-access-token = "(@=values.vsphereCPI.nsxt.vmcAccessToken @)"
+vmc-auth-host = "(@=values.vsphereCPI.nsxt.vmcAuthHost @)"
+(@ end -@)
+(@ if values.vsphereCPI.nsxt.secretName == '' or values.vsphereCPI.nsxt.secretNamespace == '' : -@)
+(@ if values.vsphereCPI.nsxt.username and values.vsphereCPI.nsxt.password : -@)
+user = "(@=values.vsphereCPI.nsxt.username @)"
+password = "(@=values.vsphereCPI.nsxt.password @)"
+(@ end -@)
+(@ end -@)
+(@ end -@)
+(@ end -@)

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/vendir.lock.yml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/vendir.lock.yml
@@ -1,0 +1,7 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - manual: {}
+    path: vsphere-cpi
+  path: config/upstream
+kind: LockConfig

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/vendir.yml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/vendir.yml
@@ -1,0 +1,8 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.12.0
+directories:
+- path: config/upstream
+  contents:
+  - path: vsphere-cpi
+    manual: {}

--- a/addons/packages/vsphere-cpi/1.22.3/package.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/package.yaml
@@ -1,0 +1,25 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: vsphere-cpi.community.tanzu.vmware.com.1.22.3
+spec:
+  refName: vsphere-cpi.community.tanzu.vmware.com
+  version: 1.22.3
+  releaseNotes: "vsphere-cpi 1.22.3 https://github.com/kubernetes/cloud-provider-vsphere"
+  licenses:
+    - "Apache 2.0"
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:a132e8b4eef8c5df5c816b9a8fa41a2e418f1de7fde5b22b32e1d9896ed74d01
+      template:
+        - ytt:
+            paths:
+              - config/
+        - kbld:
+            paths:
+              - "-"
+              - .imgpkg/images.yml
+      deploy:
+        - kapp: {}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This PR bumps vsphere-cpi version from 1.22.1 to 1.22.3.

For E release, it will be using Kuberentes 1.22. CPI need to be bumped to 1.22.3 to be compatible with that version

Note that 1.22.3 contains the dual-stack feature.

DONE: change image SHA after vsphere-cpi publishes image for version 1.22.3.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
vSphere CPI has been bumped to version 1.22.3.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: # JIRA TKG-7861

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
