### PR TITLE
standalone-cluster/create: expose -t timeout flags

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/create.go
+++ b/cli/cmd/plugin/standalone-cluster/create.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -24,6 +25,7 @@ type initStandaloneOptions struct {
 	ui                     bool
 	bind                   string
 	browser                string
+	timeout                time.Duration
 }
 
 // CreateCmd creates a standalone workload cluster.
@@ -43,6 +45,7 @@ func init() {
 	CreateCmd.Flags().StringVarP(&iso.infrastructureProvider, "infrastructure", "i", "", "Infrastructure to deploy the standalone cluster on. Only needed when using -i docker.")
 	CreateCmd.Flags().StringVarP(&iso.bind, "bind", "b", "127.0.0.1:8080", "Specify the IP and port to bind the Kickstart UI against (e.g. 127.0.0.1:8080).")
 	CreateCmd.Flags().StringVarP(&iso.browser, "browser", "", "", "Specify the browser to open the Kickstart UI on. Use 'none' for no browser. Defaults to OS default browser. Supported: ['chrome', 'firefox', 'safari', 'ie', 'edge', 'none']")
+	CreateCmd.Flags().DurationVarP(&iso.timeout, "timeout", "t", constants.DefaultLongRunningOperationTimeout, "Time duration to wait for an operation before timeout. Timeout duration in hours(h)/minutes(m)/seconds(s) units or as some combination of them (e.g. 2h, 30m, 2h30m10s)")
 }
 
 func create(cmd *cobra.Command, args []string) error {
@@ -70,6 +73,7 @@ func create(cmd *cobra.Command, args []string) error {
 		Bind:              iso.bind,
 		Browser:           iso.browser,
 		Edition:           BuildEdition,
+		Timeout:           iso.timeout,
 		// all tce-based clusters should opt out of CEIP
 		// since standalone-clusters are specific to TCE, we'll
 		// always set this to "false"


### PR DESCRIPTION
Signed-off-by: Mritunjay Sharma <mritunjaysharma394@gmail.com>

## What this PR does / why we need it
To expose add the timeout flag to standalone-clusters just like we have for the management-clusters.
With this PR, now whenever we use `tanzu standalone-cluster create -h`, we get below:
```
create a standalone workload cluster

Usage:
  tanzu standalone-cluster create <cluster name> -f <configuration location> [flags]

Flags:
  -b, --bind string             Specify the IP and port to bind the Kickstart UI against (e.g. 127.0.0.1:8080). (default "127.0.0.1:8080")
      --browser string          Specify the browser to open the Kickstart UI on. Use 'none' for no browser. Defaults to OS default browser. Supported: ['chrome', 'firefox', 'safari', 'ie', 'edge', 'none']
  -f, --file string             Configuration file from which to create a standalone cluster
  -h, --help                    help for create
  -i, --infrastructure string   Infrastructure to deploy the standalone cluster on. Only needed when using -i docker.
  -t, --timeout duration        Time duration to wait for an operation before timeout. Timeout duration in hours(h)/minutes(m)/seconds(s) units or as some combination of them (e.g. 2h, 30m, 2h30m10s) (default 30m0s)
  -u, --ui                      Launch interactive standalone cluster provisioning UI

Global Flags:
      --log-file string   Log file path
  -v, --verbose int32     Number for the log level verbosity(0-9)
```

<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Exposes `-t`, `--timeout` flags in standalone clusters
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1470

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested it locally by building the tanzu binary using `make`
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
