### PR TITLE
Lint check for outdated `go.mod` and `go.sum` files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,19 @@ get-deps:
 		cd $$working_dir; \
 	done
 
-lint: tools get-deps
+# Verify if go.mod and go.sum Go module files are out of sync
+verify-modules: get-deps
+	@for i in $(GO_MODULES); do \
+		echo "-- Verifying modules for $$i --"; \
+		working_dir=`pwd`; \
+		cd $${i}; \
+		if [ "`git diff --name-only HEAD -- go.sum go.mod`" != "" ]; then \
+			echo "go module files are out of date"; exit 1; \
+		fi; \
+		cd $$working_dir; \
+	done
+
+lint: tools verify-modules
 	@for i in $(GO_MODULES); do \
 		echo "-- Linting $$i --"; \
 		working_dir=`pwd`; \

--- a/hack/tagger/go.mod
+++ b/hack/tagger/go.mod
@@ -4,18 +4,4 @@ go 1.16
 
 require github.com/google/go-containerregistry v0.6.0
 
-require (
-	github.com/containerd/stargz-snapshotter/estargz v0.7.0 // indirect
-	github.com/docker/cli v20.10.7+incompatible // indirect
-	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/docker/docker v20.10.7+incompatible // indirect
-	github.com/docker/docker-credential-helpers v0.6.3 // indirect
-	github.com/golang/snappy v0.0.3 // indirect
-	github.com/klauspost/compress v1.13.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20210603125802-9665404d3644 // indirect
-)
+require github.com/sirupsen/logrus v1.8.1


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #2453 

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Add lint check for outdated `go.mod` and `go.sum` files
```

## Which issue(s) this PR fixes

Fixes: #2453 

## Describe testing done for PR

```
make verify-modules
make lint
```

## Special notes for your reviewer

I have also updated the `go.mod` file as part of this PR to fix linting issues