### PR TITLE
Standalone overhaul: Fixes 1 column emoji in delete command and fixes tty animating problem

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/cmd/delete.go
+++ b/cli/cmd/plugin/standalone-cluster/cmd/delete.go
@@ -46,7 +46,7 @@ func destroy(cmd *cobra.Command, args []string) error {
 	}
 	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
 
-	log.Eventf(logger.SawEmoji, "Deleting cluster: %s\n", clusterName)
+	log.Eventf(logger.TestTubeEmoji, "Deleting cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)
 	err := tClient.Delete(clusterName)
 	if err != nil {
@@ -54,7 +54,7 @@ func destroy(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	log.Eventf(logger.SawEmoji, "Deleted cluster: %s\n", clusterName)
+	log.Eventf(logger.TestTubeEmoji, "Deleted cluster: %s\n", clusterName)
 
 	return nil
 }

--- a/cli/cmd/plugin/standalone-cluster/log/log.go
+++ b/cli/cmd/plugin/standalone-cluster/log/log.go
@@ -35,7 +35,7 @@ const (
 	GlobeEmoji      = "\\U+1F310"
 	GreenCheckEmoji = "\\U+2705"
 	ControllerEmoji = "\\U+1F3AE"
-	SawEmoji        = "\\U+1FA9A"
+	TestTubeEmoji   = "\\U+1F9EA"
 )
 
 // CMDLogger is the logger implementation used for high-level command line logging.
@@ -269,6 +269,12 @@ func (l *CMDLogger) progressf(count int, message string, args ...interface{}) {
 	// we pad with extra space to ensure the line we overwrite (\r) is cleaned
 	// nolint
 	message += "             "
+
+	// when count is 0, a line break should be added at the end
+	// this support non-tty use cases
+	if count == 0 {
+		message += "\n"
+	}
 
 	fmt.Fprintf(l.output, message, args...)
 }


### PR DESCRIPTION
## What this PR does / why we need it
I noticed that the 🪚 emoji in the terminal wasn't 2 columns in the delete command leading to some odd spacing. The animate progress logging was also not working for `tty=false`:

- Replaces `SawEmoji` with `TestTubeEmoji` which is 2 columns
- Adds newline to count 0 for tty logging in animating progress

## Describe testing done for PR

---
Using the test tube emoji in the delete command:

![Screen Shot 2021-11-08 at 9 51 20 AM](https://user-images.githubusercontent.com/23109390/140783980-8ccffa24-edfc-4968-89dd-97fc9eb6ecb6.png)

---
Now, with `tty=false`, we get new lines after the logging events in animating events (instead of weird spacing between each line):

![Screen Shot 2021-11-08 at 9 51 42 AM](https://user-images.githubusercontent.com/23109390/140784038-10f54110-005f-4b3a-b946-2d588fa3dbe8.png)

