### PR TITLE
Update Chocolatey Workflow Name for Consistency

### DIFF
--- a/.github/workflows/check-chocolatey-package.yaml
+++ b/.github/workflows/check-chocolatey-package.yaml
@@ -1,4 +1,4 @@
-name: E2E Test - Chocolatey package
+name: Check - Chocolatey Package
 
 on:
   pull_request:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Updating the Chocolatey Workflow Name for Consistency reasons. PR check type workflows should have the name prefixed with `Check -` to help users consume what the nature of the workflow is. `Check -` is currently being used by checks against PRs submitted by users and `E2E Test -` are for longer running tests that are only periodically run say for like integration purposes. It's could be that there is a `Check` and `E2E` that are completely identical in what they test and that's ok.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
 Update Chocolatey Workflow Name for Consistency
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA