### PR TITLE
Updates standalone-overhaul readme with updated video

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/README.md
+++ b/cli/cmd/plugin/standalone-cluster/README.md
@@ -5,7 +5,7 @@ workstation or single-node deployments. It is not meant for production workloads
 and does not offer cluster lifecycle capabilities. For needs involving
 cluster lifecycle, use the `tanzu management-cluster` feature.
 
-https://user-images.githubusercontent.com/23109390/140801679-813a9f72-ded9-4453-b46b-75adb61e7ce2.mp4
+[standalone-video](https://user-images.githubusercontent.com/23109390/140801679-813a9f72-ded9-4453-b46b-75adb61e7ce2.mp4)
 
 This feature is currently
 [under proposal](https://github.com/vmware-tanzu/community-edition/issues/2266) and users should

--- a/cli/cmd/plugin/standalone-cluster/README.md
+++ b/cli/cmd/plugin/standalone-cluster/README.md
@@ -5,7 +5,7 @@ workstation or single-node deployments. It is not meant for production workloads
 and does not offer cluster lifecycle capabilities. For needs involving
 cluster lifecycle, use the `tanzu management-cluster` feature.
 
-[![asciicast](https://asciinema.org/a/adtGMmKYm2hniOtIPRQokGrzb.svg)](https://asciinema.org/a/adtGMmKYm2hniOtIPRQokGrzb?speed=4&autoplay=1&loop=1)
+https://user-images.githubusercontent.com/23109390/140801679-813a9f72-ded9-4453-b46b-75adb61e7ce2.mp4
 
 This feature is currently
 [under proposal](https://github.com/vmware-tanzu/community-edition/issues/2266) and users should

--- a/cli/cmd/plugin/standalone-cluster/README.md
+++ b/cli/cmd/plugin/standalone-cluster/README.md
@@ -5,7 +5,7 @@ workstation or single-node deployments. It is not meant for production workloads
 and does not offer cluster lifecycle capabilities. For needs involving
 cluster lifecycle, use the `tanzu management-cluster` feature.
 
-![standalone flow](../../../../docs/images/sa.gif)
+[![asciicast](https://asciinema.org/a/adtGMmKYm2hniOtIPRQokGrzb.svg)](https://asciinema.org/a/adtGMmKYm2hniOtIPRQokGrzb?speed=4&autoplay=1&loop=1)
 
 This feature is currently
 [under proposal](https://github.com/vmware-tanzu/community-edition/issues/2266) and users should
@@ -80,6 +80,19 @@ using `standalone`. This could be in the form of the docker daemon (Linux) or Do
     > `hello` is the cluster name.
     > The current version of antrea we ship cannot work on the standard WSL
     > kernel.
+
+### Bring your own cluster
+
+   ```sh
+   tanzu standalone create my-cluster --config=/path/to/config
+   ```
+
+   Within the config file, you can specify a path to an existing kubeconfig file.
+   This will not create a cluster but instead, will simply deploy the Tanzu bits
+   ontop of your existing cluster from your existing kubeconfig.
+
+   Warning: Providing a kubeconfig does not support setting a context.
+   It is best to provide a _single cluster_ kubeconfig.
 
 ### List clusters
 


### PR DESCRIPTION
## What this PR does / why we need it
Updates the standalone-overhaul readme with a mp4 uploaded directly to GitHub (and not hosted in our git repo). Also updates readme with mention of "bring your own cluster" with the config, kubeconfig option.

## Describe testing done for PR
[See here for a preview](https://github.com/jpmcb/community-edition/tree/update-sa-readme/cli/cmd/plugin/standalone-cluster)
