### PR TITLE
[E2E][diagnostics-plugin] Use git rev-parse for finding the root of the repo

### DIFF
--- a/cli/cmd/plugin/diagnostics/e2e-test/setup-e2e-test.sh
+++ b/cli/cmd/plugin/diagnostics/e2e-test/setup-e2e-test.sh
@@ -6,7 +6,7 @@
 set -e
 
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-TCE_REPO_PATH=${MY_DIR}/../../../../..
+TCE_REPO_PATH="$(git rev-parse --show-toplevel)"
 
 TCE_VERSION="v0.9.1"
 


### PR DESCRIPTION
## What this PR does / why we need it

Following #2341 , uses `git rev-parse` for finding the root of the repo

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

--

## Describe testing done for PR

--

## Special notes for your reviewer

--
