### PR TITLE
Remove mention of version flag in choco install command in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ After install, homebrew will prompt you with a configure script, run it.
 ### Windows via chocolatey
 
 ```sh
-choco install tanzu-community-edition --version=0.9.1
+choco install tanzu-community-edition
 ```
 
 

--- a/docs/site/content/docs/assets/cli-install-windows.md
+++ b/docs/site/content/docs/assets/cli-install-windows.md
@@ -9,8 +9,7 @@
 1. Open PowerShell **as an administrator** and run the following:
 
     ```sh
-    choco install tanzu-community-edition --version={{< choco_release_latest  >}}
-
+    choco install tanzu-community-edition
     ```
 
     > Both `docker` and `kubectl` are required to be present on the system, but are not explicit Chocolatey dependencies.

--- a/docs/site/layouts/shortcodes/choco_release_latest.html
+++ b/docs/site/layouts/shortcodes/choco_release_latest.html
@@ -1,1 +1,0 @@
-{{ trim .Site.Params.release_latest "v" }}


### PR DESCRIPTION
## What this PR does / why we need it

Removes mention of `version` flag in choco install command in docs

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #2478 

## Describe testing done for PR

`choco install tanzu-community-edition` - https://github.com/karuppiah7890/community-edition/runs/4149321647?check_suite_focus=true

## Special notes for your reviewer

--