### PR TITLE
Pinniped Package: remove namespace from JWTauthenticator

### DIFF
--- a/addons/packages/pinniped/0.12.0/bundle/config/libs/constants.lib.yaml
+++ b/addons/packages/pinniped/0.12.0/bundle/config/libs/constants.lib.yaml
@@ -32,10 +32,6 @@
 #@   return "upstream-oidc-identity-provider"
 #@ end
 
-#@ def pinniped_concierge_namespace():
-#@   return "pinniped-concierge"
-#@ end
-
 #@ def pinniped_cert_name():
 #@   return pinniped_name() + "-cert"
 #@ end

--- a/addons/packages/pinniped/0.12.0/bundle/config/overlay/kapp-config.yaml
+++ b/addons/packages/pinniped/0.12.0/bundle/config/overlay/kapp-config.yaml
@@ -1,7 +1,7 @@
 #@ load("/values.star", "values")
 #@ load("@ytt:template", "template")
 #@ load("@ytt:overlay", "overlay")
-#@ load("/libs/constants.lib.yaml", "pinniped_supervisor_namespace", "pinniped_cert_name", "pinniped_concierge_namespace", "pinniped_upstream_idp_secret_name")
+#@ load("/libs/constants.lib.yaml", "pinniped_supervisor_namespace", "pinniped_cert_name", "pinniped_upstream_idp_secret_name")
 
 ---
 apiVersion: v1

--- a/addons/packages/pinniped/0.12.0/bundle/config/overlay/pinniped-jwtauthenticator.yaml
+++ b/addons/packages/pinniped/0.12.0/bundle/config/overlay/pinniped-jwtauthenticator.yaml
@@ -1,12 +1,10 @@
 #@ load("@ytt:data", "data")
-#@ load("/libs/constants.lib.yaml", "pinniped_concierge_namespace")
 
 ---
 apiVersion: authentication.concierge.pinniped.dev/v1alpha1
 kind: JWTAuthenticator
 metadata:
   name: tkg-jwt-authenticator
-  namespace: #@ pinniped_concierge_namespace()
 spec:
   audience: #@ data.values.pinniped.supervisor_svc_endpoint
   issuer: #@ data.values.pinniped.supervisor_svc_endpoint

--- a/addons/packages/pinniped/0.12.0/bundle/config/overlay/post-deploy-overlay.yaml
+++ b/addons/packages/pinniped/0.12.0/bundle/config/overlay/post-deploy-overlay.yaml
@@ -2,7 +2,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:yaml", "yaml")
 #@ load("@ytt:sha256", "sha256")
-#@ load("/libs/constants.lib.yaml", "pinniped_supervisor_namespace", "pinniped_concierge_namespace", "jwt_authenticator_name", "federation_domain_name", "pinniped_supervisor_svc_name", "pinniped_cert_name", "post_deploy_job_name", "is_dex_required")
+#@ load("/libs/constants.lib.yaml", "pinniped_supervisor_namespace", "jwt_authenticator_name", "federation_domain_name", "pinniped_supervisor_svc_name", "pinniped_cert_name", "post_deploy_job_name", "is_dex_required")
 #@ load("/globals.star", "get_image_location", "globals")
 #@ load("/kinds.lib.yaml", "kind_overlays")
 
@@ -27,7 +27,6 @@
 #@ commands = ["/tkg-pinniped-post-deploy"]
 #@ if data.values.tkg_cluster_role == "management":
 #@   commands.append("--supervisor-namespace={}".format(pinniped_supervisor_namespace()))
-#@   commands.append("--concierge-namespace={}".format(pinniped_concierge_namespace()))
 #@   commands.append("--supervisor-svc-name={}".format(pinniped_supervisor_svc_name()))
 #@   commands.append("--federationdomain-name={}".format(federation_domain_name()))
 #@   commands.append("--jwtauthenticator-name={}".format(jwt_authenticator_name()))
@@ -41,7 +40,6 @@
 #@   end
 #@ else:
 #@   commands.append("--jwtauthenticator-name={}".format(jwt_authenticator_name()))
-#@   commands.append("--concierge-namespace={}".format(pinniped_concierge_namespace()))
 #@   commands.append("--supervisor-svc-endpoint={}".format(data.values.pinniped.supervisor_svc_endpoint))
 #@   commands.append("--supervisor-ca-bundle-data={}".format(data.values.pinniped.supervisor_ca_bundle_data))
 #@ end

--- a/addons/packages/pinniped/0.12.0/bundle/config/upstream/02-pinniped-concierge.yaml
+++ b/addons/packages/pinniped/0.12.0/bundle/config/upstream/02-pinniped-concierge.yaml
@@ -2,14 +2,12 @@
 #@ load("@ytt:library", "library")
 #@ load("@ytt:template", "template")
 #@ load("@ytt:data", "data")
-#@ load("/libs/constants.lib.yaml", "pinniped_concierge_namespace")
 
 #! export vendored contour bundle as a var
 #@ pinniped_concierge_lib = library.get("concierge")
 
 #! define a map for values to be passed to vendored contour lib
 #@ def pinniped_concierge_values():
-namespace: #@ pinniped_concierge_namespace()
 
 image_repo: docker.io/getpinniped/pinniped-server
 image_tag: v0.12.0


### PR DESCRIPTION
Signed-off-by: Benjamin A. Petersen <ben@benjaminapetersen.me>

## What this PR does / why we need it

JWTAuthenticator is a Concierge resource, as of the 0.12.0 package update these are now cluster scoped, there should not be a namespace printed for this resource.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
