### PR TITLE
Fix cleanup of kubeconfig entry for vSphere, AWS and Azure E2E tests

### DIFF
--- a/test/aws/deploy-tce-standalone.sh
+++ b/test/aws/deploy-tce-standalone.sh
@@ -34,12 +34,12 @@ echo "Setting CLUSTER_NAME to ${CLUSTER_NAME}..."
 # Cleanup function
 function delete_cluster {
     echo "$@"
-    tanzu standalone-cluster delete ${CLUSTER_NAME} -y || { aws-nuke-tear-down "STANDALONE CLUSTER DELETION FAILED! Deleting the cluster using AWS-NUKE..."; }
+    tanzu standalone-cluster delete ${CLUSTER_NAME} -y || { kubeconfig_cleanup ${CLUSTER_NAME}; aws-nuke-tear-down "STANDALONE CLUSTER DELETION FAILED! Deleting the cluster using AWS-NUKE..."; }
 }
 
 function create_standalone_cluster {
     echo "Bootstrapping TCE standalone cluster on AWS..."
-    tanzu standalone-cluster create "${CLUSTER_NAME}" -f "${TCE_REPO_PATH}"/test/aws/cluster-config.yaml || { error "STANDALONE CLUSTER CREATION FAILED!"; delete_kind_cluster; aws-nuke-tear-down "Deleting standalone cluster" "${CLUSTER_NAME}"; exit 1; }
+    tanzu standalone-cluster create "${CLUSTER_NAME}" -f "${TCE_REPO_PATH}"/test/aws/cluster-config.yaml || { error "STANDALONE CLUSTER CREATION FAILED!"; delete_kind_cluster; kubeconfig_cleanup ${CLUSTER_NAME}; aws-nuke-tear-down "Deleting standalone cluster" "${CLUSTER_NAME}"; exit 1; }
     kubectl config use-context "${CLUSTER_NAME}"-admin@"${CLUSTER_NAME}" || { error "CONTEXT SWITCH TO STANDALONE CLUSTER FAILED!"; delete_cluster "Deleting standalone cluster"; exit 1; }
     kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s || { error "TIMED OUT WAITING FOR ALL PODS TO BE UP!"; delete_cluster "Deleting standalone cluster"; exit 1; }
 }

--- a/test/azure/deploy-management-and-workload-cluster.sh
+++ b/test/azure/deploy-management-and-workload-cluster.sh
@@ -58,6 +58,7 @@ function cleanup_management_cluster {
     echo "Using azure CLI to cleanup ${MANAGEMENT_CLUSTER_NAME} management cluster resources"
     export CLUSTER_NAME="${MANAGEMENT_CLUSTER_NAME}"
     set_azure_env_vars
+    kubeconfig_cleanup ${CLUSTER_NAME}
     azure_cluster_cleanup || error "MANAGEMENT CLUSTER CLEANUP USING azure CLI FAILED! Please manually delete any ${MANAGEMENT_CLUSTER_NAME} management cluster resources using Azure Web UI"
     unset_azure_env_vars
     unset CLUSTER_NAME
@@ -67,6 +68,7 @@ function cleanup_workload_cluster {
     echo "Using azure CLI to cleanup ${WORKLOAD_CLUSTER_NAME} workload cluster resources"
     export CLUSTER_NAME="${WORKLOAD_CLUSTER_NAME}"
     set_azure_env_vars
+    kubeconfig_cleanup ${CLUSTER_NAME}
     azure_cluster_cleanup || error "WORKLOAD CLUSTER CLEANUP USING azure CLI FAILED! Please manually delete any ${WORKLOAD_CLUSTER_NAME} workload cluster resources using Azure Web UI"
     unset_azure_env_vars
     unset CLUSTER_NAME
@@ -269,6 +271,9 @@ wait_for_workload_cluster_deletion || {
     cleanup_management_and_workload_cluster
     exit 1
 }
+
+# since tanzu cluster delete does not delete workload cluster kubeconfig entry
+kubeconfig_cleanup ${WORKLOAD_CLUSTER_NAME}
 
 delete_management_cluster || {
     cleanup_management_cluster

--- a/test/azure/deploy-standalone-cluster.sh
+++ b/test/azure/deploy-standalone-cluster.sh
@@ -53,6 +53,7 @@ export VM_IMAGE_BILLING_PLAN_SKU="k8s-1dot21dot2-ubuntu-2004"
 export VM_IMAGE_OFFER="tkg-capi"
 
 function cleanup_standalone_cluster {
+    kubeconfig_cleanup ${CLUSTER_NAME}
     azure_cluster_cleanup || {
         error "STANDLONE CLUSTER CLEANUP USING azure CLI FAILED! Please manually delete any ${CLUSTER_NAME} standalone cluster resources using Azure Web UI"
         return 1

--- a/test/util/utils.sh
+++ b/test/util/utils.sh
@@ -11,3 +11,19 @@ function delete_kind_cluster {
 	echo "Deleting local kind bootstrap cluster(s) running in Docker container(s)"
     docker ps --all --format "{{ .Names }}" | grep tkg-kind | xargs -r docker rm --force
 }
+
+function kubeconfig_cleanup {
+    cluster_name=$1
+
+    if [[ -z "${cluster_name}" ]]; then
+        echo "Cluster name not passed to kubeconfig_cleanup function. Usage example: kubeconfig_cleanup management-cluster-1234"
+        return 1
+    fi
+
+    echo "Removing cluster context, cluster user and cluster entry from kubeconfig for ${cluster_name} cluster"
+
+    # ignore errors assuming the error happens only when the values are already deleted
+    kubectl config delete-context "${cluster_name}-admin@${cluster_name}" || true
+    kubectl config delete-user "${cluster_name}-admin" || true
+    kubectl config delete-cluster "${cluster_name}" || true
+}

--- a/test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
+++ b/test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
@@ -53,11 +53,13 @@ export MANAGEMENT_CLUSTER_NAME="test-management-cluster-${random_id}"
 export WORKLOAD_CLUSTER_NAME="test-workload-cluster-${random_id}"
 
 function cleanup_management_cluster {
+    kubeconfig_cleanup ${MANAGEMENT_CLUSTER_NAME}
     echo "Using govc to cleanup ${MANAGEMENT_CLUSTER_NAME} management cluster resources"
     govc_cleanup ${MANAGEMENT_CLUSTER_NAME} || error "MANAGEMENT CLUSTER CLEANUP USING GOVC FAILED! Please manually delete any ${MANAGEMENT_CLUSTER_NAME} management cluster resources using vCenter Web UI"
 }
 
 function cleanup_workload_cluster {
+    kubeconfig_cleanup ${WORKLOAD_CLUSTER_NAME}
     error "Using govc to cleanup ${WORKLOAD_CLUSTER_NAME} workload cluster resources"
     govc_cleanup ${WORKLOAD_CLUSTER_NAME} || error "WORKLOAD CLUSTER CLEANUP USING GOVC FAILED! Please manually delete any ${WORKLOAD_CLUSTER_NAME} workload cluster resources using vCenter Web UI"
 }
@@ -241,6 +243,9 @@ wait_for_workload_cluster_deletion || {
     cleanup_management_and_workload_cluster
     exit 1
 }
+
+# since tanzu cluster delete does not delete workload cluster kubeconfig entry
+kubeconfig_cleanup ${WORKLOAD_CLUSTER_NAME}
 
 delete_management_cluster || {
     cleanup_management_cluster

--- a/test/vsphere/run-tce-vsphere-standalone-cluster.sh
+++ b/test/vsphere/run-tce-vsphere-standalone-cluster.sh
@@ -48,17 +48,22 @@ export CLUSTER_NAME="test-standalone-cluster-${RANDOM}"
 
 cluster_config_file="${TCE_REPO_PATH}/test/vsphere/cluster-config.yaml"
 
+function cleanup {
+    kubeconfig_cleanup ${CLUSTER_NAME}
+    govc_cleanup ${CLUSTER_NAME}
+}
+
 time tanzu standalone-cluster create ${CLUSTER_NAME} --file "${cluster_config_file}" -v 10 || {
     error "STANDALONE CLUSTER CREATION FAILED!"
     delete_kind_cluster
-    govc_cleanup ${CLUSTER_NAME}
+    cleanup
     exit 1
 }
 
 "${TCE_REPO_PATH}/test/check-tce-cluster-creation.sh" ${CLUSTER_NAME}-admin@${CLUSTER_NAME} || {
     error "STANDALONE CLUSTER CREATION CHECK FAILED!"
     delete_kind_cluster
-    govc_cleanup ${CLUSTER_NAME}
+    cleanup
     exit 1
 }
 
@@ -67,6 +72,6 @@ echo "Deleting standalone cluster"
 
 time tanzu standalone-cluster delete ${CLUSTER_NAME} -y || {
     error "STANDALONE CLUSTER DELETION FAILED!"
-    govc_cleanup ${CLUSTER_NAME}
+    cleanup
     exit 1
 }


### PR DESCRIPTION
## What this PR does / why we need it

Fixes cleanup of kubeconfig entry for vSphere, AWS and Azure E2E tests

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #2481 

## Describe testing done for PR

--

## Special notes for your reviewer

In terms of implementation, I had two ideas -
- One was to individually use `kubconfig_cleanup` function in all places where it was needed. This caused a bit of repetition at times. This is the current implemenation
- Another was to use `kubeconfig_cleanup` inside existing cleanup functions like `govc_cleanup`, `aws-nuke-tear-down`, `azure_cluster_cleanup`. This causes very low repetition and favors DRY. I didn't do this though, as the name `govc_cleanup` or `aws-nuke-tear-down` suggested some implementation details that it uses `govc` or `aws-nuke` and if I add `kubeconfig_cleanup` function usage to that, it didn't make sense. `azure_cluster_cleanup` does make a generic name to say it's a cleanup of an Azure cluster, but I was still thinking it should contain only `az` (Azure CLI) related code. If we want to choose this way, I could go ahead and change the code accordingly and also maybe rename `govc_cleanup` to `vsphere_cluster_cleanup` or similar and `aws-nuke-tear-down` to `aws_cluster_cleanup` or similar and put `kubeconfig_cleanup` code in it