### PR TITLE
removing two lines from the harbor values.yaml

### DIFF
--- a/addons/packages/harbor/2.2.3/bundle/config/values.yaml
+++ b/addons/packages/harbor/2.2.3/bundle/config/values.yaml
@@ -1,6 +1,3 @@
-#@data/values
-#@overlay/match-child-defaults missing_ok=True
-
 ---
 #! The namespace to install Harbor
 namespace: harbor


### PR DESCRIPTION
## What this PR does / why we need it
Carvel fails to install Harbor because Error: package reconciliation failed: ytt: Error: Extracting data value from file based on the top two lines of #@. After removing #@ the install worked.

```
Error: package reconciliation failed: ytt: Error: Extracting data value from file:
  Checking data values file '/etc/kappctrl-mem-tmp/kapp-controller-template-values263829594/values.yaml':
    Expected to not find annotations inside data values file (hint: remove comments starting with '#@')
```

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Update of values.yaml template for harbor to install correctly according to the documentation.
```

## Which issue(s) this PR fixes
m/a

## Describe testing done for PR
Installed it on a cluster running in AWS.

## Special notes for your reviewer
n/a
