### PR TITLE
Fix CPI daemonset overlay for v1.22.3

### DIFF
--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/overlays/update-daemonset.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/overlays/update-daemonset.yaml
@@ -15,9 +15,9 @@ metadata:
 spec:
   template:
     metadata:
-      labels:
-        #@overlay/match missing_ok=True
-        vsphere-cpi/data-values-hash: #@ sha256.sum(yaml.encode(values))
+      #@overlay/match missing_ok=True
+      annotations:
+        vsphere-cpi/data-values-hash: #@ "{}".format(sha256.sum(yaml.encode(values))[:7])
     spec:
       #@overlay/match missing_ok=True
       nodeSelector:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Move vsphere-cpi/data-values-hash from labels to annotations, contexts: https://github.com/vmware-tanzu/tanzu-framework/pull/1118/files#r746755284

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix cpi daemonset overlay for v1.22.3
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
```
$ ytt -f addons/packages/vsphere-cpi/1.22.3/bundle/config/

apiVersion: v1
kind: ServiceAccount
metadata:
  name: cloud-controller-manager
  namespace: kube-system
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: system:cloud-controller-manager
rules:
- apiGroups:
  - ""
  resources:
  - events
  verbs:
  - create
  - patch
  - update
- apiGroups:
  - ""
  resources:
  - nodes
  verbs:
  - '*'
- apiGroups:
  - ""
  resources:
  - nodes/status
  verbs:
  - patch
- apiGroups:
  - ""
  resources:
  - services
  verbs:
  - list
  - patch
  - update
  - watch
- apiGroups:
  - ""
  resources:
  - services/status
  verbs:
  - patch
- apiGroups:
  - ""
  resources:
  - serviceaccounts
  verbs:
  - create
  - get
  - list
  - watch
  - update
- apiGroups:
  - ""
  resources:
  - persistentvolumes
  verbs:
  - get
  - list
  - update
  - watch
- apiGroups:
  - ""
  resources:
  - endpoints
  verbs:
  - create
  - get
  - list
  - watch
  - update
- apiGroups:
  - ""
  resources:
  - secrets
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - coordination.k8s.io
  resources:
  - leases
  verbs:
  - get
  - list
  - watch
  - create
  - update
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: system:cloud-controller-manager
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system:cloud-controller-manager
subjects:
- kind: ServiceAccount
  name: cloud-controller-manager
  namespace: kube-system
- kind: User
  name: cloud-controller-manager
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: servicecatalog.k8s.io:apiserver-authentication-reader
  namespace: kube-system
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: extension-apiserver-authentication-reader
subjects:
- kind: ServiceAccount
  name: cloud-controller-manager
  namespace: kube-system
- kind: User
  name: cloud-controller-manager
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: vsphere-cloud-config
  namespace: kube-system
data:
  vsphere.conf: |
    [Global]
    secret-name = "cloud-provider-vsphere-credentials"
    secret-namespace = "kube-system"
    thumbprint = "sdasdasdasd"
    [VirtualCenter "balabasdassdasd"]
    datacenters = "dasdsddasdasda"
    thumbprint = "sdasdasdasd"
    [Labels]
    region = "asdasdsdsdas"
    zone = "dasdasd"
---
apiVersion: v1
kind: Secret
metadata:
  name: cloud-provider-vsphere-credentials
  namespace: kube-system
stringData:
  balabasdassdasd.username: sadsdsasd
  balabasdassdasd.password: asdasda
type: Opaque
---
apiVersion: v1
kind: Service
metadata:
  labels:
    component: cloud-controller-manager
  name: cloud-controller-manager
  namespace: kube-system
spec:
  ports:
  - port: 443
    protocol: TCP
    targetPort: 43001
  selector:
    component: cloud-controller-manager
  type: NodePort
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  labels:
    k8s-app: vsphere-cloud-controller-manager
  name: vsphere-cloud-controller-manager
  namespace: kube-system
  annotations:
    kapp.k14s.io/disable-default-label-scoping-rules: ""
    kapp.k14s.io/update-strategy: fallback-on-replace
spec:
  selector:
    matchLabels:
      k8s-app: vsphere-cloud-controller-manager
  template:
    metadata:
      annotations:
        vsphere-cpi/data-values-hash: 8f7b537
      labels:
        k8s-app: vsphere-cloud-controller-manager
    spec:
      containers:
      - args:
        - --v=2
        - --cloud-provider=vsphere
        - --cloud-config=/etc/cloud/vsphere.conf
        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.22.3
        imagePullPolicy: IfNotPresent
        name: vsphere-cloud-controller-manager
        resources:
          requests:
            cpu: 200m
        volumeMounts:
        - mountPath: /etc/cloud
          name: vsphere-config-volume
          readOnly: true
      hostNetwork: true
      serviceAccountName: cloud-controller-manager
      tolerations:
      - effect: NoSchedule
        key: node.cloudprovider.kubernetes.io/uninitialized
        value: "true"
      - effect: NoSchedule
        key: node-role.kubernetes.io/master
      - effect: NoSchedule
        key: node.kubernetes.io/not-ready
      volumes:
      - configMap:
          name: vsphere-cloud-config
        name: vsphere-config-volume
      nodeSelector:
        node-role.kubernetes.io/master: ""
  updateStrategy:
    type: RollingUpdate
```

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
