### PR TITLE
Fix ec2 instance leak when tagging fails

### DIFF
--- a/hack/runner/webhook/server.go
+++ b/hack/runner/webhook/server.go
@@ -137,6 +137,7 @@ func deleteRunner(uniqueID string) error {
 	err = deleteGitHubRunnerByName(ghClient, uniqueID)
 	if err != nil {
 		// Just a warning because of the new self host ephemeral
+		// Do not error this function out because we need to delete the instance
 		klog.Infof("deleteGitHubRunnerByName failed. Err: %v\n", err)
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This fixes a small ec2 instance leak when using self-hosted runners. This doesn't happen often (like once every day), but it does happen which leads to manual clean up for orphaned ec2 instances. If the tagging fails, delete the instance. Then (like normal) let the outer loop start the create-tag loop all over again.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix ec2 instance leak when tagging fails
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA