### PR TITLE
Adds deprecation notices to all `standalone-cluster` commands

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/create.go
+++ b/cli/cmd/plugin/standalone-cluster/create.go
@@ -49,6 +49,13 @@ func init() {
 }
 
 func create(cmd *cobra.Command, args []string) error {
+	fmt.Print("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+	fmt.Print("Warning - Standalone clusters will be deprecated in a future release of Tanzu Community Edition\n")
+	fmt.Print("                                   Use at your own Risk\n")
+	fmt.Print("           Checkout the proposal for the standalone cluster replacement:\n")
+	fmt.Print("           https://github.com/vmware-tanzu/community-edition/issues/2266\n")
+	fmt.Print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n\n")
+
 	var clusterName string
 
 	// validate a cluster name was passed when not using the kickstart UI

--- a/cli/cmd/plugin/standalone-cluster/delete.go
+++ b/cli/cmd/plugin/standalone-cluster/delete.go
@@ -43,6 +43,13 @@ func init() {
 }
 
 func teardown(cmd *cobra.Command, args []string) error {
+	fmt.Print("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+	fmt.Print("Warning - Standalone clusters will be deprecated in a future release of Tanzu Community Edition\n")
+	fmt.Print("                                   Use at your own Risk\n")
+	fmt.Print("           Checkout the proposal for the standalone cluster replacement:\n")
+	fmt.Print("           https://github.com/vmware-tanzu/community-edition/issues/2266\n")
+	fmt.Print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n\n")
+
 	// validate a cluster name was passed
 	if len(args) < 1 {
 		return fmt.Errorf("no cluster name specified")

--- a/cli/cmd/plugin/standalone-cluster/main.go
+++ b/cli/cmd/plugin/standalone-cluster/main.go
@@ -12,9 +12,17 @@ import (
 )
 
 var descriptor = cliv1alpha1.PluginDescriptor{
-	Name:        "standalone-cluster",
-	Description: "Create clusters without a dedicated management cluster",
-	Group:       cliv1alpha1.RunCmdGroup,
+	Name: "standalone-cluster",
+	Description: `
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Warning - Standalone clusters will be deprecated in a future release of Tanzu Community Edition
+                                  Use at your own Risk
+	           Checkout the proposal for the standalone cluster replacement:
+	           https://github.com/vmware-tanzu/community-edition/issues/2266
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+Create clusters without a dedicated management cluster`,
+	Group: cliv1alpha1.RunCmdGroup,
 }
 
 var (


### PR DESCRIPTION
## What this PR does / why we need it
This adds a few deprecation notices to the standalone cluster. Now, a user in future releases will see the deprecation notice on the command line.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Adds deprecation notice to standalone-cluster commands
```

## Which issue(s) this PR fixes
Related to: https://github.com/vmware-tanzu/community-edition/issues/2266

## Describe testing done for PR
Ran `make build-cli-plugins-local` and see the deprecation notice in the `--help` output, `create` output, and `delete` output.

![Screen Shot 2021-11-10 at 3 49 52 PM](https://user-images.githubusercontent.com/23109390/141206378-bdb99038-ddfb-4b6c-b88c-43940e714e1d.png)

## Special notes for your reviewer
N/a
