### PR TITLE
Collect diagnostics data from E2E pipelines for vSphere, Azure and AWS

### DIFF
--- a/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
@@ -49,3 +49,13 @@ jobs:
 
           go env -w GOFLAGS=-mod=mod
           make aws-management-and-workload-cluster-e2e-test
+
+      - name: Collect tanzu diagnostics data
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: diagnostics-data
+          path: |
+            bootstrap.*.diagnostics.tar.gz
+            management-cluster.*.diagnostics.tar.gz
+            workload-cluster.*.diagnostics.tar.gz

--- a/.github/workflows/e2e-aws-standalone-cluster.yaml
+++ b/.github/workflows/e2e-aws-standalone-cluster.yaml
@@ -49,3 +49,13 @@ jobs:
 
           go env -w GOFLAGS=-mod=mod
           make aws-standalone-cluster-e2e-test
+
+      - name: Collect tanzu diagnostics data
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: diagnostics-data
+          path: |
+            bootstrap.*.diagnostics.tar.gz
+            management-cluster.*.diagnostics.tar.gz
+            workload-cluster.*.diagnostics.tar.gz

--- a/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
@@ -48,3 +48,13 @@ jobs:
           sudo sysctl net/netfilter/nf_conntrack_max=131072
 
           make azure-management-and-workload-cluster-e2e-test
+
+      - name: Collect tanzu diagnostics data
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: diagnostics-data
+          path: |
+            bootstrap.*.diagnostics.tar.gz
+            management-cluster.*.diagnostics.tar.gz
+            workload-cluster.*.diagnostics.tar.gz

--- a/.github/workflows/e2e-azure-standalone-cluster.yaml
+++ b/.github/workflows/e2e-azure-standalone-cluster.yaml
@@ -48,3 +48,13 @@ jobs:
           sudo sysctl net/netfilter/nf_conntrack_max=131072
 
           make azure-standalone-cluster-e2e-test
+
+      - name: Collect tanzu diagnostics data
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: diagnostics-data
+          path: |
+            bootstrap.*.diagnostics.tar.gz
+            management-cluster.*.diagnostics.tar.gz
+            workload-cluster.*.diagnostics.tar.gz

--- a/.github/workflows/e2e-vsphere-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-vsphere-management-and-workload-cluster.yaml
@@ -38,3 +38,13 @@ jobs:
           sudo sysctl net/netfilter/nf_conntrack_max=131072
 
           make vsphere-management-and-workload-cluster-e2e-test
+
+      - name: Collect tanzu diagnostics data
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: diagnostics-data
+          path: |
+            bootstrap.*.diagnostics.tar.gz
+            management-cluster.*.diagnostics.tar.gz
+            workload-cluster.*.diagnostics.tar.gz

--- a/.github/workflows/e2e-vsphere-standalone-cluster.yaml
+++ b/.github/workflows/e2e-vsphere-standalone-cluster.yaml
@@ -37,3 +37,13 @@ jobs:
           sudo sysctl net/netfilter/nf_conntrack_max=131072
 
           make vsphere-standalone-cluster-e2e-test
+
+      - name: Collect tanzu diagnostics data
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: diagnostics-data
+          path: |
+            bootstrap.*.diagnostics.tar.gz
+            management-cluster.*.diagnostics.tar.gz
+            workload-cluster.*.diagnostics.tar.gz

--- a/test/aws/deploy-tce-managed.sh
+++ b/test/aws/deploy-tce-managed.sh
@@ -31,7 +31,12 @@ function delete_management_cluster {
     echo "$@"
     export AWS_REGION="us-east-2"
     export CLUSTER_NAME="${MGMT_CLUSTER_NAME}"
-    tanzu management-cluster delete "${CLUSTER_NAME}" -y || { delete_kind_cluster; kubeconfig_cleanup "${CLUSTER_NAME}"; aws-nuke-tear-down "MANAGEMENT CLUSTER DELETION FAILED! Deleting the cluster using AWS-NUKE..." "${CLUSTER_NAME}"; }
+    tanzu management-cluster delete "${CLUSTER_NAME}" -y || {
+        collect_management_cluster_diagnostics "${CLUSTER_NAME}"
+        delete_kind_cluster
+        kubeconfig_cleanup "${CLUSTER_NAME}"
+        aws-nuke-tear-down "MANAGEMENT CLUSTER DELETION FAILED! Deleting the cluster using AWS-NUKE..." "${CLUSTER_NAME}"
+    }
 }
 
 function nuke_management_and_workload_clusters {
@@ -40,12 +45,16 @@ function nuke_management_and_workload_clusters {
     aws-nuke-tear-down "Deleting the MANAGEMENT CLUSTER using AWS-NUKE..." "${CLUSTER_NAME}"
     export CLUSTER_NAME="${WLD_CLUSTER_NAME}"
     kubeconfig_cleanup "${CLUSTER_NAME}"
-    aws-nuke-tear-down "Deleting the WORKLOAD CLUSTER using AWS-NUKE..." "${CLUSTER_NAME}";
+    aws-nuke-tear-down "Deleting the WORKLOAD CLUSTER using AWS-NUKE..." "${CLUSTER_NAME}"
 }
 
 function delete_workload_cluster {
     echo "$@"
-    tanzu cluster delete "${WLD_CLUSTER_NAME}" --yes || { nuke_management_and_workload_clusters; exit 1; }
+    tanzu cluster delete "${WLD_CLUSTER_NAME}" --yes || {
+        collect_management_and_workload_cluster_diagnostics aws "${MGMT_CLUSTER_NAME}" "${WLD_CLUSTER_NAME}"
+        nuke_management_and_workload_clusters
+        exit 1
+    }
     for (( i = 1 ; i <= 120 ; i++))
     do
         echo "Waiting for workload cluster to get deleted..."
@@ -57,6 +66,7 @@ function delete_workload_cluster {
         if [[ "$i" == 120 ]]; then
             echo "Timed out waiting for workload cluster ${WLD_CLUSTER_NAME} to get deleted"
             echo "Using AWS NUKE to delete management and workload clusters"
+            collect_management_and_workload_cluster_diagnostics aws "${MGMT_CLUSTER_NAME}" "${WLD_CLUSTER_NAME}"
             nuke_management_and_workload_clusters
             exit 1
         fi
@@ -74,10 +84,30 @@ function create_management_cluster {
     export MGMT_CLUSTER_NAME="test-mc-${CLUSTER_NAME_SUFFIX}"
     echo "Setting MANAGEMENT CLUSTER NAME to ${MGMT_CLUSTER_NAME}..."
     export CLUSTER_NAME="${MGMT_CLUSTER_NAME}"
-    tanzu management-cluster create "${CLUSTER_NAME}" -f "${TCE_REPO_PATH}"/test/aws/cluster-config.yaml || { error "MANAGEMENT CLUSTER CREATION FAILED!"; delete_kind_cluster; kubeconfig_cleanup ${CLUSTER_NAME}; aws-nuke-tear-down "Deleting management cluster" "${MGMT_CLUSTER_NAME}"; exit 1; }
-    kubectl config use-context "${MGMT_CLUSTER_NAME}"-admin@"${MGMT_CLUSTER_NAME}" || { error "CONTEXT SWITCH TO MANAGEMENT CLUSTER FAILED!"; delete_management_cluster "Deleting management cluster"; exit 1; }
-    kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s || { error "TIMED OUT WAITING FOR ALL PODS TO BE UP!"; delete_management_cluster "Deleting management cluster"; exit 1; }
-    tanzu management-cluster get | grep "${MGMT_CLUSTER_NAME}" | grep running || { error "MANAGEMENT CLUSTER NOT RUNNING!"; delete_management_cluster "Deleting management cluster"; exit 1; }
+    tanzu management-cluster create "${CLUSTER_NAME}" -f "${TCE_REPO_PATH}"/test/aws/cluster-config.yaml || {
+        error "MANAGEMENT CLUSTER CREATION FAILED!"
+        collect_management_cluster_diagnostics ${MGMT_CLUSTER_NAME}
+        delete_kind_cluster
+        kubeconfig_cleanup ${CLUSTER_NAME}
+        aws-nuke-tear-down "Deleting management cluster" "${MGMT_CLUSTER_NAME}"
+        exit 1
+    }
+    kubectl config use-context "${MGMT_CLUSTER_NAME}"-admin@"${MGMT_CLUSTER_NAME}" || {
+        error "CONTEXT SWITCH TO MANAGEMENT CLUSTER FAILED!"
+        delete_management_cluster "Deleting management cluster"
+        exit 1
+    }
+    kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s || {
+        error "TIMED OUT WAITING FOR ALL PODS TO BE UP!"
+        collect_management_cluster_diagnostics ${MGMT_CLUSTER_NAME}
+        delete_management_cluster "Deleting management cluster"
+        exit 1
+    }
+    tanzu management-cluster get | grep "${MGMT_CLUSTER_NAME}" | grep running || {
+        error "MANAGEMENT CLUSTER NOT RUNNING!"
+        delete_management_cluster "Deleting management cluster"
+        exit 1
+    }
 }
 
 function create_workload_cluster {
@@ -86,10 +116,26 @@ function create_workload_cluster {
     export WLD_CLUSTER_NAME="test-wld-${CLUSTER_NAME_SUFFIX}"
     echo "Setting WORKLOAD CLUSTER NAME to ${WLD_CLUSTER_NAME}..."
     export CLUSTER_NAME="${WLD_CLUSTER_NAME}"
-    tanzu cluster create "${CLUSTER_NAME}" -f "${TCE_REPO_PATH}"/test/aws/cluster-config.yaml || { error "WORKLOAD CLUSTER CREATION FAILED!"; nuke_management_and_workload_clusters; exit 1; }
+    tanzu cluster create "${CLUSTER_NAME}" -f "${TCE_REPO_PATH}"/test/aws/cluster-config.yaml || {
+        error "WORKLOAD CLUSTER CREATION FAILED!"
+        collect_management_and_workload_cluster_diagnostics aws ${MGMT_CLUSTER_NAME} ${WLD_CLUSTER_NAME}
+        nuke_management_and_workload_clusters
+        exit 1
+    }
     tanzu cluster kubeconfig get "${WLD_CLUSTER_NAME}" --admin
-    kubectl config use-context "${WLD_CLUSTER_NAME}"-admin@"${WLD_CLUSTER_NAME}" || { error "CONTEXT SWITCH TO MANAGEMENT CLUSTER FAILED!"; delete_workload_cluster "Deleting workload cluster"; delete_management_cluster "Deleting management cluster"; exit 1; }
-    kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s || { error "TIMED OUT WAITING FOR ALL PODS TO BE UP!"; delete_workload_cluster "Deleting workload cluster"; delete_management_cluster "Deleting management cluster"; exit 1; }
+    kubectl config use-context "${WLD_CLUSTER_NAME}"-admin@"${WLD_CLUSTER_NAME}" || {
+        error "CONTEXT SWITCH TO MANAGEMENT CLUSTER FAILED!"
+        delete_workload_cluster "Deleting workload cluster"
+        delete_management_cluster "Deleting management cluster"
+        exit 1
+    }
+    kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s || {
+        error "TIMED OUT WAITING FOR ALL PODS TO BE UP!"
+        collect_management_and_workload_cluster_diagnostics aws ${MGMT_CLUSTER_NAME} ${WLD_CLUSTER_NAME}
+        delete_workload_cluster "Deleting workload cluster"
+        delete_management_cluster "Deleting management cluster"
+        exit 1
+    }
 }
 
 # Create management and workload clusters
@@ -98,12 +144,31 @@ create_workload_cluster || exit 1
 
 # Install packages
 echo "Installing packages on TCE..."
-"${TCE_REPO_PATH}"/test/add-tce-package-repo.sh || { error "PACKAGE REPOSITORY INSTALLATION FAILED!"; delete_workload_cluster "Deleting workload cluster"; delete_management_cluster "Deleting management cluster"; exit 1; }
-tanzu package available list || { error "UNEXPECTED FAILURE OCCURRED!"; delete_workload_cluster "Deleting workload cluster"; delete_management_cluster "Deleting management cluster"; exit 1; }
+"${TCE_REPO_PATH}"/test/add-tce-package-repo.sh || {
+    error "PACKAGE REPOSITORY INSTALLATION FAILED!"
+    collect_management_and_workload_cluster_diagnostics aws ${MGMT_CLUSTER_NAME} ${WLD_CLUSTER_NAME}
+    delete_workload_cluster "Deleting workload cluster"
+    delete_management_cluster "Deleting management cluster"
+    exit 1
+}
+
+tanzu package available list || {
+    error "UNEXPECTED FAILURE OCCURRED!"
+    collect_management_and_workload_cluster_diagnostics aws ${MGMT_CLUSTER_NAME} ${WLD_CLUSTER_NAME}
+    delete_workload_cluster "Deleting workload cluster"
+    delete_management_cluster "Deleting management cluster"
+    exit 1
+}
 
 # Run e2e test
 echo "Starting Gatekeeper test..."
-"${TCE_REPO_PATH}"/test/gatekeeper/e2e-test.sh || { error "TEST FAILED!"; delete_workload_cluster "Deleting workload cluster"; delete_management_cluster "Deleting management cluster"; exit 1; }
+"${TCE_REPO_PATH}"/test/gatekeeper/e2e-test.sh || {
+    error "TEST FAILED!"
+    collect_management_and_workload_cluster_diagnostics aws ${MGMT_CLUSTER_NAME} ${WLD_CLUSTER_NAME}
+    delete_workload_cluster "Deleting workload cluster"
+    delete_management_cluster "Deleting management cluster"
+    exit 1
+}
 
 # Clean up
 echo "Cleaning up..."

--- a/test/aws/deploy-tce-standalone.sh
+++ b/test/aws/deploy-tce-standalone.sh
@@ -34,14 +34,34 @@ echo "Setting CLUSTER_NAME to ${CLUSTER_NAME}..."
 # Cleanup function
 function delete_cluster {
     echo "$@"
-    tanzu standalone-cluster delete ${CLUSTER_NAME} -y || { delete_kind_cluster; kubeconfig_cleanup ${CLUSTER_NAME}; aws-nuke-tear-down "STANDALONE CLUSTER DELETION FAILED! Deleting the cluster using AWS-NUKE..."; }
+    tanzu standalone-cluster delete ${CLUSTER_NAME} -y || {
+        collect_standalone_cluster_diagnostics aws ${CLUSTER_NAME}
+        delete_kind_cluster
+        kubeconfig_cleanup ${CLUSTER_NAME}
+        aws-nuke-tear-down "STANDALONE CLUSTER DELETION FAILED! Deleting the cluster using AWS-NUKE..."
+    }
 }
 
 function create_standalone_cluster {
     echo "Bootstrapping TCE standalone cluster on AWS..."
-    tanzu standalone-cluster create "${CLUSTER_NAME}" -f "${TCE_REPO_PATH}"/test/aws/cluster-config.yaml || { error "STANDALONE CLUSTER CREATION FAILED!"; delete_kind_cluster; kubeconfig_cleanup ${CLUSTER_NAME}; aws-nuke-tear-down "Deleting standalone cluster" "${CLUSTER_NAME}"; exit 1; }
-    kubectl config use-context "${CLUSTER_NAME}"-admin@"${CLUSTER_NAME}" || { error "CONTEXT SWITCH TO STANDALONE CLUSTER FAILED!"; delete_cluster "Deleting standalone cluster"; exit 1; }
-    kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s || { error "TIMED OUT WAITING FOR ALL PODS TO BE UP!"; delete_cluster "Deleting standalone cluster"; exit 1; }
+    tanzu standalone-cluster create "${CLUSTER_NAME}" -f "${TCE_REPO_PATH}"/test/aws/cluster-config.yaml || {
+        error "STANDALONE CLUSTER CREATION FAILED!"
+        collect_standalone_cluster_diagnostics aws ${CLUSTER_NAME}
+        delete_kind_cluster kubeconfig_cleanup ${CLUSTER_NAME}
+        aws-nuke-tear-down "Deleting standalone cluster" "${CLUSTER_NAME}"
+        exit 1
+    }
+    kubectl config use-context "${CLUSTER_NAME}"-admin@"${CLUSTER_NAME}" || {
+        error "CONTEXT SWITCH TO STANDALONE CLUSTER FAILED!"
+        delete_cluster "Deleting standalone cluster"
+        exit 1
+    }
+    kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s || {
+        error "TIMED OUT WAITING FOR ALL PODS TO BE UP!"
+        collect_standalone_cluster_diagnostics aws ${CLUSTER_NAME}
+        delete_cluster "Deleting standalone cluster"
+        exit 1
+    }
 }
 
 # Create standalone cluster
@@ -49,12 +69,27 @@ create_standalone_cluster
 
 # Install packages
 echo "Installing packages on TCE..."
-"${TCE_REPO_PATH}"/test/add-tce-package-repo.sh || { error "PACKAGE REPOSITORY INSTALLATION FAILED!"; delete_cluster "Deleting standalone cluster"; exit 1; }
-tanzu package available list || { error "UNEXPECTED FAILURE OCCURRED!"; delete_cluster "Deleting standalone cluster"; exit 1; }
+"${TCE_REPO_PATH}"/test/add-tce-package-repo.sh || {
+    error "PACKAGE REPOSITORY INSTALLATION FAILED!"
+    collect_standalone_cluster_diagnostics aws ${CLUSTER_NAME}
+    delete_cluster "Deleting standalone cluster"
+    exit 1
+}
+tanzu package available list || {
+    error "UNEXPECTED FAILURE OCCURRED!"
+    collect_standalone_cluster_diagnostics aws ${CLUSTER_NAME}
+    delete_cluster "Deleting standalone cluster"
+    exit 1
+}
 
 # Run e2e-test
 echo "Starting Gatekeeper test..."
-"${TCE_REPO_PATH}"/test/gatekeeper/e2e-test.sh || { error "TEST FAILED!"; delete_cluster "Deleting standalone cluster"; exit 1; }
+"${TCE_REPO_PATH}"/test/gatekeeper/e2e-test.sh || {
+    error "TEST FAILED!"
+    collect_standalone_cluster_diagnostics aws ${CLUSTER_NAME}
+    delete_cluster "Deleting standalone cluster"
+    exit 1
+}
 
 # Clean up
 delete_cluster "Cleaning up..."

--- a/test/azure/deploy-management-and-workload-cluster.sh
+++ b/test/azure/deploy-management-and-workload-cluster.sh
@@ -226,37 +226,44 @@ function wait_for_workload_cluster_deletion {
 accept_vm_image_terms || exit 1
 
 create_management_cluster || {
+    collect_management_cluster_diagnostics ${MANAGEMENT_CLUSTER_NAME}
     delete_kind_cluster
     cleanup_management_cluster
     exit 1
 }
 
 check_management_cluster_creation || {
+    collect_management_cluster_diagnostics ${MANAGEMENT_CLUSTER_NAME}
     cleanup_management_cluster
     exit 1
 }
 
 create_workload_cluster || {
+    collect_management_and_workload_cluster_diagnostics azure ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
 
 check_workload_cluster_creation || {
+    collect_management_and_workload_cluster_diagnostics azure ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
 
 add_package_repo || {
+    collect_management_and_workload_cluster_diagnostics azure ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
 
 list_packages || {
+    collect_management_and_workload_cluster_diagnostics azure ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
 
 test_gate_keeper_package || {
+    collect_management_and_workload_cluster_diagnostics azure ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
@@ -264,11 +271,13 @@ test_gate_keeper_package || {
 echo "Cleaning up"
 
 delete_workload_cluster || {
+    collect_management_and_workload_cluster_diagnostics azure ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
 
 wait_for_workload_cluster_deletion || {
+    collect_management_and_workload_cluster_diagnostics azure ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
@@ -277,6 +286,7 @@ wait_for_workload_cluster_deletion || {
 kubeconfig_cleanup ${WORKLOAD_CLUSTER_NAME}
 
 delete_management_cluster || {
+    collect_management_cluster_diagnostics ${MANAGEMENT_CLUSTER_NAME}
     cleanup_management_cluster
     exit 1
 }

--- a/test/azure/deploy-standalone-cluster.sh
+++ b/test/azure/deploy-standalone-cluster.sh
@@ -63,7 +63,8 @@ function cleanup_standalone_cluster {
 function delete_cluster_or_cleanup {
     echo "Deleting standalone cluster"
     time tanzu standalone-cluster delete ${CLUSTER_NAME} -y || {
-        error "STANDALONE CLUSTER DELETION FAILED!"
+        error "STANDALONE CLUSTER DELETION FAILED!";
+        collect_standalone_cluster_diagnostics azure ${CLUSTER_NAME}
         delete_kind_cluster
         cleanup_standalone_cluster
         return 1
@@ -115,28 +116,32 @@ function test_gate_keeper_package {
 accept_vm_image_terms || exit 1
 
 create_standalone_cluster || {
+    collect_standalone_cluster_diagnostics azure ${CLUSTER_NAME}
     delete_kind_cluster
     cleanup_standalone_cluster
     exit 1
 }
 
 wait_for_pods || {
+    collect_standalone_cluster_diagnostics azure ${CLUSTER_NAME}
     delete_cluster_or_cleanup
     exit 1
 }
 
-
 add_package_repo || {
+    collect_standalone_cluster_diagnostics azure ${CLUSTER_NAME}
     delete_cluster_or_cleanup
     exit 1
 }
 
 list_packages || {
+    collect_standalone_cluster_diagnostics azure ${CLUSTER_NAME}
     delete_cluster_or_cleanup
     exit 1
 }
 
 test_gate_keeper_package || {
+    collect_standalone_cluster_diagnostics azure ${CLUSTER_NAME}
     delete_cluster_or_cleanup
     exit 1
 }

--- a/test/util/utils.sh
+++ b/test/util/utils.sh
@@ -27,3 +27,64 @@ function kubeconfig_cleanup {
     kubectl config delete-user "${cluster_name}-admin" || true
     kubectl config delete-cluster "${cluster_name}" || true
 }
+
+function collect_standalone_cluster_diagnostics {
+    cluster_infra=$1
+    cluster_name=$2
+
+    if [[ -z "${cluster_infra}" ]]; then
+        error "Cluster infra (vsphere, azure, aws, docker) not passed to collect_standalone_cluster_diagnostics function. Ignoring error. Usage example: collect_standalone_cluster_diagnostics vsphere test-cluster-1234"
+    fi
+
+    if [[ -z "${cluster_name}" ]]; then
+        error "Cluster name not passed to collect_standalone_cluster_diagnostics function. Ignoring error. Usage example: collect_standalone_cluster_diagnostics vsphere test-cluster-1234"
+    fi
+
+    echo "Collecting ${cluster_name} standalone cluster diagnostics data"
+
+    tanzu diagnostics collect --workload-cluster-infra "${cluster_infra}" \
+        --workload-cluster-name "${cluster_name}" || {
+        error "There was an error collecting tanzu diagnostics data. Ignoring the error"
+    }
+}
+
+function collect_management_cluster_diagnostics {
+    cluster_name=$1
+
+    if [[ -z "${cluster_name}" ]]; then
+        error "Cluster name not passed to collect_management_cluster_diagnostics function. Ignoring error. Usage example: collect_management_cluster_diagnostics management-cluster-1234"
+    fi
+
+    echo "Collecting ${cluster_name} management cluster diagnostics data"
+
+    tanzu diagnostics collect --management-cluster-name "${cluster_name}" || {
+        error "There was an error collecting tanzu diagnostics data. Ignoring the error"
+    }
+}
+
+function collect_management_and_workload_cluster_diagnostics {
+    cluster_infra=$1
+    management_cluster_name=$2
+    workload_cluster_name=$3
+
+    if [[ -z "${cluster_infra}" ]]; then
+        error "Workload cluster infra (vsphere, azure, aws, docker) not passed to collect_management_and_workload_cluster_diagnostics function. Ignoring error. Usage example: collect_management_and_workload_cluster_diagnostics vsphere management-cluster-1234 workload-cluster-1234"
+    fi
+
+    if [[ -z "${management_cluster_name}" ]]; then
+        error "Management cluster name not passed to collect_management_and_workload_cluster_diagnostics function. Ignoring error. Usage example: collect_management_and_workload_cluster_diagnostics vsphere management-cluster-1234 workload-cluster-1234"
+    fi
+
+    if [[ -z "${workload_cluster_name}" ]]; then
+        error "Management cluster name not passed to collect_management_and_workload_cluster_diagnostics function. Ignoring error. Usage example: collect_management_and_workload_cluster_diagnostics vsphere management-cluster-1234 workload-cluster-1234"
+    fi
+
+    echo "Collecting ${management_cluster_name} management cluster and ${workload_cluster_name} workload cluster diagnostics data"
+
+    tanzu diagnostics collect --bootstrap-cluster-skip \
+        --management-cluster-name "${management_cluster_name}" \
+        --workload-cluster-infra "${cluster_infra}" \
+        --workload-cluster-name "${workload_cluster_name}" || {
+        error "There was an error collecting tanzu diagnostics data. Ignoring the error"
+    }    
+}

--- a/test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
+++ b/test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
@@ -198,37 +198,44 @@ function wait_for_workload_cluster_deletion {
 }
 
 create_management_cluster || {
+    collect_management_cluster_diagnostics ${MANAGEMENT_CLUSTER_NAME}
     delete_kind_cluster
     cleanup_management_cluster
     exit 1
 }
 
 check_management_cluster_creation || {
+    collect_management_cluster_diagnostics ${MANAGEMENT_CLUSTER_NAME}
     cleanup_management_cluster
     exit 1
 }
 
 create_workload_cluster || {
+    collect_management_and_workload_cluster_diagnostics vsphere ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
 
 check_workload_cluster_creation || {
+    collect_management_and_workload_cluster_diagnostics vsphere ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
 
 add_package_repo || {
+    collect_management_and_workload_cluster_diagnostics vsphere ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
 
 list_packages || {
+    collect_management_and_workload_cluster_diagnostics vsphere ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
 
 test_gate_keeper_package || {
+    collect_management_and_workload_cluster_diagnostics vsphere ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
@@ -236,11 +243,13 @@ test_gate_keeper_package || {
 echo "Cleaning up"
 
 delete_workload_cluster || {
+    collect_management_and_workload_cluster_diagnostics vsphere ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
 
 wait_for_workload_cluster_deletion || {
+    collect_management_and_workload_cluster_diagnostics vsphere ${MANAGEMENT_CLUSTER_NAME} ${WORKLOAD_CLUSTER_NAME}
     cleanup_management_and_workload_cluster
     exit 1
 }
@@ -249,6 +258,7 @@ wait_for_workload_cluster_deletion || {
 kubeconfig_cleanup ${WORKLOAD_CLUSTER_NAME}
 
 delete_management_cluster || {
+    collect_management_cluster_diagnostics ${MANAGEMENT_CLUSTER_NAME}
     cleanup_management_cluster
     exit 1
 }

--- a/test/vsphere/run-tce-vsphere-standalone-cluster.sh
+++ b/test/vsphere/run-tce-vsphere-standalone-cluster.sh
@@ -55,6 +55,7 @@ function cleanup {
 
 time tanzu standalone-cluster create ${CLUSTER_NAME} --file "${cluster_config_file}" -v 10 || {
     error "STANDALONE CLUSTER CREATION FAILED!"
+    collect_standalone_cluster_diagnostics vsphere ${CLUSTER_NAME}
     delete_kind_cluster
     cleanup
     exit 1
@@ -62,6 +63,7 @@ time tanzu standalone-cluster create ${CLUSTER_NAME} --file "${cluster_config_fi
 
 "${TCE_REPO_PATH}/test/check-tce-cluster-creation.sh" ${CLUSTER_NAME}-admin@${CLUSTER_NAME} || {
     error "STANDALONE CLUSTER CREATION CHECK FAILED!"
+    collect_standalone_cluster_diagnostics vsphere ${CLUSTER_NAME}
     cleanup
     exit 1
 }
@@ -71,6 +73,7 @@ echo "Deleting standalone cluster"
 
 time tanzu standalone-cluster delete ${CLUSTER_NAME} -y || {
     error "STANDALONE CLUSTER DELETION FAILED!"
+    collect_standalone_cluster_diagnostics vsphere ${CLUSTER_NAME}
     delete_kind_cluster
     cleanup
     exit 1


### PR DESCRIPTION
## What this PR does / why we need it

Collects diagnostics data from E2E pipelines for vSphere, Azure and AWS

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Collect diagnostics data from E2E pipelines for vSphere, Azure and AWS
```

## Which issue(s) this PR fixes

Fixes: #1443 

## Describe testing done for PR

E2E Azure Standalone Cluster Test failure collecting diagnostics and uploading it to GitHub Actions - https://github.com/karuppiah7890/community-edition/runs/4190341648?check_suite_focus=true . The tar ball can be seen at `diagnostics-data` in https://github.com/karuppiah7890/community-edition/actions/runs/1453280816

E2E Azure Management and Workload Cluster Test  failure collecting diagnostics and uploading it to GitHub Actions - https://github.com/karuppiah7890/community-edition/runs/4190341651?check_suite_focus=true. The tar ball can be seen at `diagnostics-data` in https://github.com/karuppiah7890/community-edition/actions/runs/1453280810

## Special notes for your reviewer

One tricky thing is, there is a problem in one scenario

- Create management cluster
- It's created. Now run tests on the management cluster
- One of the tests fail, for example a test verifying TCE package installation. Automatically collect diagnostics data about the management cluster and store it in `management-cluster.<cluster-name>.diagnostics.tar.gz`. This data will help in understanding the test failure in TCE package installation
- Delete the cluster using `tanzu`
- Cluster deletion fails. Automatically collect diagnostics data about the management cluster and store it in `management-cluster.<cluster-name>.diagnostics.tar.gz`. This data will help in understanding the failure in deleting the management cluster - it could be some issue in the kind bootstrap cluster - some CAPI controller didn't work, or maybe some credentials issue - for example the token used to interact with the cloud APIs expired, for example Azure credentials

Note that - in such a scenario, we will end up with collecting diagnostics twice but the second tar ball will overwrite the first tar ball, as they both use the same name for the tar ball. Also, such a situation could happen to standalone clusters too