### PR TITLE
doc- Change doc layout for TCE install

### DIFF
--- a/docs/site/content/docs/latest/installation-planning.md
+++ b/docs/site/content/docs/latest/installation-planning.md
@@ -7,24 +7,23 @@ There are four main steps involved in deploying Tanzu Community Edition. The fol
    You will download this from GitHub and install it on your desktop machine. This installs the Tanzu CLI. For information about the supported operating systems and prerequisites for your desktop machine, see the[Support Matrix](support-matrix/#local-client-bootstrap-machine-prerequisites). For information about the Tanzu Community Edition architecture, see [Architecture](architecture).
 
 1. **Prepare to deploy clusters.**
-   Choose the [target platform](installation-planning/#target-platform-infrastructure-provider) where you want to deploy clusters and ensure that the prerequisites are met for this platform.
-   {{% include "/docs/assets/support-matrix.md" %}}
+   Choose the target platform where you want to deploy clusters and ensure that the prerequisites are met for this platform. See Target Platforms below.
 
 1. **Deploy a cluster to your target platform.**
 
    There are two ways to approach this:
 
-   * Use the Tanzu CLI to launch the Tanzu Community Edition installer, deploy a [management cluster](installation-planning/#managed-clusters), and then deploy a [workload cluster](installation-planning/#workload-cluster).
+   * Use the Tanzu CLI to launch the Tanzu Community Edition installer, deploy a [management cluster](glossary/#management-cluster), and then deploy a [workload cluster](glossary/#workload-cluster).
 
      **or**
 
-   * Use the Tanzu CLI to launch the installer and deploy a [standalone cluster](installation-planning/#standalone-clusters).
+   * Use the Tanzu CLI to launch the installer and deploy a [standalone cluster](glossary/#standalone-cluster).
 
    **Note**: the installer is a web based interface, if you need to perform an installation on a machine that does not have a desktop environment, see [Headless Installation](headless-install).
 
 1. **Install and configure packages.**
 
-   Use the Tanzu CLI to install and configure [Packages](installation-planning/#package).
+   Use the Tanzu CLI to install and configure [Packages](glossary/#package).
 
 1. **Start here:**
    ||
@@ -33,3 +32,7 @@ There are four main steps involved in deploying Tanzu Community Edition. The fol
    |**If your target platform is Microsoft Azure start [here](azure-intro).**|
    |**If your target platform is Docker start [here](docker-intro).**|
    |**If your target platform is vSphere start [here](vsphere-intro).**|
+
+## Target Platforms
+
+{{% include "/docs/assets/support-matrix.md" %}}

--- a/docs/site/data/docs/latest-toc.yml
+++ b/docs/site/data/docs/latest-toc.yml
@@ -17,11 +17,11 @@ toc:
       subfolderitems:
         - page: Plan Your Installation
           url: /installation-planning
+        - page: Install Tanzu Community Edition
+          url: /cli-installation
         - page: AWS
           url: /aws-intro
           subitems:
-            - subpage: Install Tanzu Community Edition
-              suburl: /cli-installation
             - subpage: Prepare to Deploy a Cluster to AWS
               suburl: /aws
             - subpage: Deploy a Management Cluster to AWS
@@ -35,8 +35,6 @@ toc:
         - page: Microsoft Azure
           url: /azure-intro
           subitems:
-            - subpage: Install Tanzu Community Edition
-              suburl: /cli-installation
             - subpage: Prepare to Deploy a Cluster to Azure
               suburl: /azure-mgmt
             - subpage: Deploy a Management Cluster to Azure
@@ -50,8 +48,6 @@ toc:
         - page: Docker
           url: /docker-intro
           subitems:
-            - subpage: Install Tanzu Community Edition
-              suburl: /cli-installation
             - subpage: Deploy a Management and Workload Cluster to Docker
               suburl: /docker-install-mgmt
             - subpage: Deploy a Standalone Cluster to Docker
@@ -61,8 +57,6 @@ toc:
         - page: vSphere
           url: /vsphere-intro
           subitems:
-            - subpage: Install Tanzu Community Edition
-              suburl: /cli-installation
             - subpage: Prepare to Deploy a Cluster to vSphere
               suburl: /vsphere
             - subpage: Deploy a Management Cluster to vSphere


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
-Move the TCE install topic to the same level as, "Plan Your Installation."
-Remove repetition of TCE install topic at target platform level
-moved Target Platform include to bottom of "Plan Your Installation" as it was breaking the numbering
-fixed some broken glossary items in  "Plan Your Installation"  (regression on #2491)


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```NONE

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2487 

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
