### PR TITLE
Update `get-deps` Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,6 @@ verify-modules: get-deps
 		echo "-- Verifying modules for $$i --"; \
 		working_dir=`pwd`; \
 		cd $${i}; \
-		go mod tidy; \
 		if [ "`git diff --name-only HEAD -- go.sum go.mod`" != "" ]; then \
 			echo "go module files in $$i directory are out of date, run 'go mod tidy' and commit the changes"; exit 1; \
 		fi; \

--- a/addons/packages/calico/3.11.3/test/Makefile
+++ b/addons/packages/calico/3.11.3/test/Makefile
@@ -16,7 +16,7 @@ else
 endif
 
 get-deps: ## Get all dependencies
-	go mod download
+	go mod tidy
 
 test: ## Run unit testing suite
 	ginkgo -v .

--- a/addons/packages/calico/3.19.1/test/Makefile
+++ b/addons/packages/calico/3.19.1/test/Makefile
@@ -16,7 +16,7 @@ else
 endif
 
 get-deps: ## Get all dependencies
-	go mod download
+	go mod tidy
 
 test: ## Run unit testing suite
 	ginkgo -v .

--- a/addons/packages/external-dns/0.10.0/test/Makefile
+++ b/addons/packages/external-dns/0.10.0/test/Makefile
@@ -16,7 +16,7 @@ else
 endif
 
 get-deps: ## Get all dependencies
-	go mod download
+	go mod tidy
 
 test: ## Run unit testing suite
 	@echo "TODO: implement unit tests"

--- a/addons/packages/external-dns/0.8.0/test/Makefile
+++ b/addons/packages/external-dns/0.8.0/test/Makefile
@@ -19,7 +19,7 @@ else
 endif
 
 get-deps: ## Get all dependencies
-	go mod download
+	go mod tidy
 
 test: ## Run unit testing suite
 	@echo "TODO: implement unit tests"

--- a/addons/packages/harbor/2.2.3/test/Makefile
+++ b/addons/packages/harbor/2.2.3/test/Makefile
@@ -16,7 +16,7 @@ else
 endif
 
 get-deps: ## Get all dependencies
-	go mod download
+	go mod tidy
 
 test: ## Run unit testing suite
 	CGO_ENABLED=0 go run github.com/onsi/ginkgo/ginkgo -v unittest

--- a/addons/packages/harbor/2.3.3/test/Makefile
+++ b/addons/packages/harbor/2.3.3/test/Makefile
@@ -16,7 +16,7 @@ else
 endif
 
 get-deps: ## Get all dependencies
-	go mod download
+	go mod tidy
 
 test: ## Run unit testing suite
 	CGO_ENABLED=0 go run github.com/onsi/ginkgo/ginkgo -v unittest

--- a/addons/packages/multus-cni/3.7.1/test/Makefile
+++ b/addons/packages/multus-cni/3.7.1/test/Makefile
@@ -28,7 +28,7 @@ lint: ## lint check for tests files
 
 get-deps: ## get go sources dependencies.
 	@printf "\nget go sources dependencies\n\n"; \
-	go mod download
+	go mod tidy
 
 build: ## build
 	@echo "TODO: No build steps now"

--- a/addons/packages/pinniped/hack/Makefile
+++ b/addons/packages/pinniped/hack/Makefile
@@ -14,7 +14,7 @@ else
 endif
 
 get-deps: ## Get all dependencies
-	go mod download
+	go mod tidy
 
 test: ## Run unit testing suite
 	echo "N/A: No unit tests for addons/packages/pinniped/hack"

--- a/addons/packages/test/pkg/Makefile
+++ b/addons/packages/test/pkg/Makefile
@@ -16,7 +16,7 @@ else
 endif
 
 get-deps: ## Get all dependencies
-	go mod download
+	go mod tidy
 
 test: ## Run unit testing suite
 	@echo "TODO: implement unit tests"

--- a/cli/cmd/plugin/conformance/Makefile
+++ b/cli/cmd/plugin/conformance/Makefile
@@ -7,7 +7,7 @@ help: ## Display this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 get-deps: ## Download the necessary dependencies from go mod
-	go mod download && go mod tidy
+	go mod tidy
 
 lint: ## Run Go code linting
 ifeq ($(origin GOLANGCI_LINT),undefined)

--- a/cli/cmd/plugin/diagnostics/Makefile
+++ b/cli/cmd/plugin/diagnostics/Makefile
@@ -7,7 +7,7 @@ help: ## Display this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 get-deps: ## Download the necessary dependencies from go mod
-	go mod download && go mod tidy
+	go mod tidy
 
 lint: ## Run Go code linting
 ifeq ($(origin GOLANGCI_LINT),undefined)

--- a/cli/cmd/plugin/standalone-cluster/Makefile
+++ b/cli/cmd/plugin/standalone-cluster/Makefile
@@ -7,7 +7,7 @@ help: ## Display this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 get-deps: ## Download the necessary dependencies from go mod
-	go mod download && go mod tidy
+	go mod tidy
 
 lint: ## Run Go code linting
 ifeq ($(origin GOLANGCI_LINT),undefined)

--- a/docs/site/content/docs/latest/contribute/contributing.md
+++ b/docs/site/content/docs/latest/contribute/contributing.md
@@ -164,7 +164,7 @@ it _is_ expected that each Makefile provide the following targets:
 - `make test`: invokes unit tests
 - `make e2e-test`: invokes an E2E testing suite
 - `make lint`: invokes linting protocols for the individual module. For example, in a Go project, it should call Golangci-lint.
-- `make get-deps`: gets the necessary dependencies for running, testing, and building.  Typically is `go mod download` in Go modules
+- `make get-deps`: gets the necessary dependencies for running, testing, and building.  Typically is `go mod tidy` in Go modules
 - `make build`: builds the individual piece of software
 
 Some of these targets may be irrelevant to you and your project.

--- a/hack/asset/Makefile
+++ b/hack/asset/Makefile
@@ -14,7 +14,7 @@ else
 endif
 
 get-deps: ## Get all go dependencies
-	go mod download
+	go mod tidy
 
 test:
 	@echo "N/A: No unit tests for hack/packages"

--- a/hack/builder/Makefile
+++ b/hack/builder/Makefile
@@ -69,7 +69,7 @@ build:
 	echo "N/A: No binary output for hack/builder"
 
 get-deps: ## Download the necessary dependencies for the builder
-	go mod download
+	go mod tidy
 
 check-go:
 ifeq ($(origin GO),undefined)

--- a/hack/imagelinter/Makefile
+++ b/hack/imagelinter/Makefile
@@ -14,7 +14,7 @@ else
 endif
 
 get-deps: ## Get all go dependencies
-	go mod download
+	go mod tidy
 
 test:
 	@echo "N/A: No unit tests for hack/packages"

--- a/hack/makefile-template
+++ b/hack/makefile-template
@@ -13,7 +13,7 @@ else
 endif
 
 get-deps: ## Get all dependencies
-	go mod download
+	go mod tidy
 
 test: ## Run unit testing suite
 	@echo "TODO: implement unit tests"

--- a/hack/packages/Makefile
+++ b/hack/packages/Makefile
@@ -14,7 +14,7 @@ else
 endif
 
 get-deps: ## Get all dependencies
-	go mod download
+	go mod tidy
 
 test: ## Run unit testing suite
 	echo "N/A: No unit tests for hack/packages"

--- a/hack/release/release/Makefile
+++ b/hack/release/release/Makefile
@@ -14,7 +14,7 @@ else
 endif
 
 get-deps: ## Get all go dependencies
-	go mod download
+	go mod tidy
 
 test:
 	@echo "N/A: No unit tests for hack/packages"

--- a/hack/runner/webhook/Makefile
+++ b/hack/runner/webhook/Makefile
@@ -14,7 +14,7 @@ else
 endif
 
 get-deps: ## Get all go dependencies
-	go mod download
+	go mod tidy
 
 test:
 	@echo "N/A: No unit tests for hack/packages"

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -33,7 +33,7 @@ lint:
 	echo "N/A: Skipping tools linting"
 
 get-deps: ## Get all dependencies
-	go mod download
+	go mod tidy
 
 test:
 	echo "N/A: No unit tests for hack/tools"

--- a/hack/workflows/packages/Makefile
+++ b/hack/workflows/packages/Makefile
@@ -14,7 +14,7 @@ else
 endif
 
 get-deps: ## Get all dependencies
-	go mod download
+	go mod tidy
 
 test: ## Run unit testing suite
 	echo "N/A: No unit tests for hack/packages"

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 get-deps: ## Download the necessary dependencies from go mod
-	go mod download
+	go mod tidy
 
 lint: ## Run Go code linting
 ifeq ($(origin GOLANGCI_LINT),undefined)


### PR DESCRIPTION
## What this PR does / why we need it

_Note: This is a follow up of #2470 PR_

Most get-deps targets were using "go mod download", which isn't as
accurate as "go mod tidy" for evaluating dependencies. From one of the
go maintainers:

```
go mod download is downloading all of the modules in the dependency
graph, which it can determine from reading only the go.mod files. It
doesn't know which of those modules are actually needed to satisfy a
build, so it doesn't pull in the checksums for those modules (because
they may not be relevant).

On the other hand, go mod tidy has to walk the package graph in order
to ensure that all imports are satisfied. So it knows, for a fact,
without doing any extra work, that the modules it walks through are
needed for a go build in some configuration.
```

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

--

## Describe testing done for PR

--

## Special notes for your reviewer

This is a follow up of #2470 based on the conversation [here](https://github.com/vmware-tanzu/community-edition/pull/2470#discussion_r746874456). This is based on the commit from #2498 by @stmcginnis 