### PR TITLE
pinniped: update dex config to issue refresh tokens

### DIFF
--- a/addons/packages/pinniped/0.12.0/bundle/config/overlay/dex-cm.yaml
+++ b/addons/packages/pinniped/0.12.0/bundle/config/overlay/dex-cm.yaml
@@ -19,7 +19,15 @@ expiry:
   #@ if/end values.dex.config.expiry.signingKeys:
   signingKeys: #@ values.dex.config.expiry.signingKeys
   #@ if/end values.dex.config.expiry.idTokens:
-  idTokens:  #@ values.dex.config.expiry.idTokens
+  idTokens: #@ values.dex.config.expiry.idTokens
+  #@ if/end values.dex.config.expiry.authRequests:
+  authRequests: #@ values.dex.config.expiry.authRequests
+  #@ if/end values.dex.config.expiry.deviceRequests:
+  deviceRequests: #@ values.dex.config.expiry.deviceRequests
+  #@ if values.dex.config.expiry.refreshTokens.absoluteLifetime:
+  refreshTokens:
+    absoluteLifetime: #@ values.dex.config.expiry.refreshTokens.absoluteLifetime
+  #@ end
 logger: #@ values.dex.config.logger
 staticClients: #@ values.dex.config.staticClients
 connectors:

--- a/addons/packages/pinniped/0.12.0/bundle/config/overlay/pinniped-idp.yaml
+++ b/addons/packages/pinniped/0.12.0/bundle/config/overlay/pinniped-idp.yaml
@@ -42,6 +42,7 @@ spec:
   issuer: #@ data.values.pinniped.upstream_oidc_issuer_url
   authorizationConfig:
     additionalScopes: #@ additionalScopes()
+    allowPasswordGrant: #@ data.values.pinniped.upstream_oidc_allow_password_grant
   claims: #@ claims()
   client:
     secretName: #@ pinniped_upstream_idp_secret_name()

--- a/addons/packages/pinniped/0.12.0/bundle/config/values.yaml
+++ b/addons/packages/pinniped/0.12.0/bundle/config/values.yaml
@@ -37,6 +37,7 @@ pinniped:
     username: "" #! Leaving this as the empty string will force Pinniped's default to take effect
     groups: "" #! Leaving this as the empty string will force Pinniped's default to take effect
   upstream_oidc_additional_scopes: [ ]
+  upstream_oidc_allow_password_grant: false
   upstream_oidc_provider_name: DEPRECATED #! This data value is now hardcoded to be "dex"
   image: #! Container image information is taken from the TKR BOM now
     name: DEPRECATED
@@ -67,10 +68,12 @@ dex:
       tlsCert: /etc/dex/tls/tls.crt
       tlsKey: /etc/dex/tls/tls.key
     expiry:  #! these will need to be adjusted with future updated to Pinniped
-      signingKeys: 90m
+      signingKeys: 9h #! needs to match the longest duration in this object
       idTokens: 5m
       authRequests: 90m
       deviceRequests: 5m
+      refreshTokens:
+        absoluteLifetime: 9h #! matches Pinniped's hard coded refresh token lifetime
     logger:
       level: info
       format: json
@@ -124,6 +127,7 @@ dex:
         scope: sub
         userMatchers: []
     oauth2:
+      passwordConnector: ldap
       skipApprovalScreen: true
       responseTypes: []
     storage:


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

@ankeesler @sabbey37 @benjaminapetersen this is untested and meant as a example for how to handle upcoming changes in Pinniped 0.13+

xref: https://github.com/vmware-tanzu/tanzu-framework/pull/1145