### PR TITLE
set priorityClassName: system-cluster-critical in CPI daemonset

### DIFF
--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         k8s-app: vsphere-cloud-controller-manager
     spec:
+      priorityClassName: system-cluster-critical
       containers:
         - args:
             - --v=2


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
vsphere-cloud-controller-manager does not have a priority set
need to set priorityClassName: system-cluster-critical in vsphere-cloud-controller-manager daemonset in order to avoid getting evicted when coredns pods that are scaled to 500 as part of the Autoscaler BYOT consistent test trying to take up as much resources available in control plane nodes

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
set priorityClassName: system-cluster-critical in vsphere-cloud-controller-manager daemonset
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
