### PR TITLE
patch priorityClassName: system-node-critical in CPI daemonset for all versions

### DIFF
--- a/addons/packages/vsphere-cpi/1.18.1/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
+++ b/addons/packages/vsphere-cpi/1.18.1/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         k8s-app: vsphere-cloud-controller-manager
     spec:
+      priorityClassName: system-node-critical
       containers:
         - args:
             - --v=2

--- a/addons/packages/vsphere-cpi/1.19.1/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
+++ b/addons/packages/vsphere-cpi/1.19.1/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         k8s-app: vsphere-cloud-controller-manager
     spec:
+      priorityClassName: system-node-critical
       containers:
         - args:
             - --v=2

--- a/addons/packages/vsphere-cpi/1.20.0/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
+++ b/addons/packages/vsphere-cpi/1.20.0/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         k8s-app: vsphere-cloud-controller-manager
     spec:
+      priorityClassName: system-node-critical
       containers:
         - args:
             - --v=2

--- a/addons/packages/vsphere-cpi/1.21.0/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
+++ b/addons/packages/vsphere-cpi/1.21.0/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         k8s-app: vsphere-cloud-controller-manager
     spec:
+      priorityClassName: system-node-critical
       containers:
         - args:
             - --v=2

--- a/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
+++ b/addons/packages/vsphere-cpi/1.22.3/bundle/config/upstream/vsphere-cpi/05-daemonset.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         k8s-app: vsphere-cloud-controller-manager
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: system-node-critical
       containers:
         - args:
             - --v=2


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
patch `priorityClassName: system-node-critical` in CPI daemonset for all versions

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
patch `priorityClassName: system-node-critical` in CPI daemonset for all versions. 1.18 -> 1.22
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
```
$ ytt -f addons/packages/vsphere-cpi/1.21.0/bundle/config/

apiVersion: v1
kind: ServiceAccount
metadata:
  name: cloud-controller-manager
  namespace: kube-system
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: system:cloud-controller-manager
rules:
- apiGroups:
  - ""
  resources:
  - events
  verbs:
  - create
  - patch
  - update
- apiGroups:
  - ""
  resources:
  - nodes
  verbs:
  - '*'
- apiGroups:
  - ""
  resources:
  - nodes/status
  verbs:
  - patch
- apiGroups:
  - ""
  resources:
  - services
  verbs:
  - list
  - patch
  - update
  - watch
- apiGroups:
  - ""
  resources:
  - services/status
  verbs:
  - patch
- apiGroups:
  - ""
  resources:
  - serviceaccounts
  verbs:
  - create
  - get
  - list
  - watch
  - update
- apiGroups:
  - ""
  resources:
  - persistentvolumes
  verbs:
  - get
  - list
  - update
  - watch
- apiGroups:
  - ""
  resources:
  - endpoints
  verbs:
  - create
  - get
  - list
  - watch
  - update
- apiGroups:
  - ""
  resources:
  - secrets
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - coordination.k8s.io
  resources:
  - leases
  verbs:
  - get
  - list
  - watch
  - create
  - update
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: system:cloud-controller-manager
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system:cloud-controller-manager
subjects:
- kind: ServiceAccount
  name: cloud-controller-manager
  namespace: kube-system
- kind: User
  name: cloud-controller-manager
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: servicecatalog.k8s.io:apiserver-authentication-reader
  namespace: kube-system
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: extension-apiserver-authentication-reader
subjects:
- kind: ServiceAccount
  name: cloud-controller-manager
  namespace: kube-system
- kind: User
  name: cloud-controller-manager
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: vsphere-cloud-config
  namespace: kube-system
data:
  vsphere.conf: |
    [Global]
    secret-name = "cloud-provider-vsphere-credentials"
    secret-namespace = "kube-system"
    thumbprint = "sdasdasdasd"
    [VirtualCenter "balabasdassdasd"]
    datacenters = "dasdsddasdasda"
    thumbprint = "sdasdasdasd"
    [Labels]
    region = "asdasdsdsdas"
    zone = "dasdasd"
---
apiVersion: v1
kind: Secret
metadata:
  name: cloud-provider-vsphere-credentials
  namespace: kube-system
stringData:
  balabasdassdasd.username: sadsdsasd
  balabasdassdasd.password: asdasda
type: Opaque
---
apiVersion: v1
kind: Service
metadata:
  labels:
    component: cloud-controller-manager
  name: cloud-controller-manager
  namespace: kube-system
spec:
  ports:
  - port: 443
    protocol: TCP
    targetPort: 43001
  selector:
    component: cloud-controller-manager
  type: NodePort
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  labels:
    k8s-app: vsphere-cloud-controller-manager
  name: vsphere-cloud-controller-manager
  namespace: kube-system
  annotations:
    kapp.k14s.io/disable-default-label-scoping-rules: ""
spec:
  selector:
    matchLabels:
      k8s-app: vsphere-cloud-controller-manager
  template:
    metadata:
      labels:
        k8s-app: vsphere-cloud-controller-manager
    spec:
      priorityClassName: system-node-critical
      containers:
      - args:
        - --v=2
        - --cloud-provider=vsphere
        - --cloud-config=/etc/cloud/vsphere.conf
        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.21.0
        imagePullPolicy: IfNotPresent
        name: vsphere-cloud-controller-manager
        resources:
          requests:
            cpu: 200m
        volumeMounts:
        - mountPath: /etc/cloud
          name: vsphere-config-volume
          readOnly: true
      hostNetwork: true
      serviceAccountName: cloud-controller-manager
      tolerations:
      - effect: NoSchedule
        key: node.cloudprovider.kubernetes.io/uninitialized
        value: "true"
      - effect: NoSchedule
        key: node-role.kubernetes.io/master
      - effect: NoSchedule
        key: node.kubernetes.io/not-ready
      volumes:
      - configMap:
          name: vsphere-cloud-config
        name: vsphere-config-volume
      nodeSelector:
        node-role.kubernetes.io/master: ""
  updateStrategy:
    type: RollingUpdate

```

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
