### PR TITLE
Docs: Add docs context condition to footer

### DIFF
--- a/docs/site/themes/template/layouts/partials/getting-started.html
+++ b/docs/site/themes/template/layouts/partials/getting-started.html
@@ -1,8 +1,14 @@
 {{ $latest := (cond (.Site.Params.docs_versioning) .Site.Params.docs_latest "") }}
 <div class="getting-started">
 	<div class="wrapper clearfix">
-		<h2>Ready to dive in?</h2>
-		<p>Our documentation is a great place to start!</p>
-		<a href="/docs/latest/" class="button navy-blue">Documentation</a>
+		{{ if (eq .Page.Section "docs") }}
+			<h2>Join us!</h2>
+			<p>Our open community welcomes all users and contributors</p>
+			<a href="/community/" class="button navy-blue">Community</a>
+		{{ else }}
+			<h2>Ready to dive in?</h2>
+			<p>Our documentation is a great place to start!</p>
+			<a href="/docs/latest/" class="button navy-blue">Documentation</a>
+		{{ end }}
 	</div>
 </div>


### PR DESCRIPTION
Signed-off-by: Garry Ing <ging@vmware.com>

## What this PR does / why we need it
This adds context-aware content so that visitors to `/docs` is presented a call-to-action to join the Community (`/community`) instead of a repeated link to `/docs`.

![Screen Shot 2021-11-11 at 2 09 43 PM](https://user-images.githubusercontent.com/227587/141367581-6cb2b711-3559-44ec-9cb4-e516c7aeb756.png)

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
N/A
```

## Which issue(s) this PR fixes
Fixes: #2400

## Describe testing done for PR
- run `hugo server` as described in the [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)
- Navigate to `/docs`: Observe footer content
- Navigate to other pages: Observe footer content

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
