### PR TITLE
Fix cleanup of aws workload cluster kubeconfig entry in aws management and workload cluster E2E test

### DIFF
--- a/test/aws/deploy-tce-managed.sh
+++ b/test/aws/deploy-tce-managed.sh
@@ -62,6 +62,8 @@ function delete_workload_cluster {
         fi
         sleep 5
     done
+    # since tanzu cluster delete does not delete workload cluster kubeconfig entry
+    kubeconfig_cleanup "${WLD_CLUSTER_NAME}"
     echo "Workload cluster ${WLD_CLUSTER_NAME} successfully deleted"
 }
 


### PR DESCRIPTION
## What this PR does / why we need it

Fixes cleanup of AWS workload cluster kubeconfig entry in AWS management and workload cluster E2E test. This was missed as part of #2489 (#2481)

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

Related: #2481 

## Describe testing done for PR

--

## Special notes for your reviewer

--
