### PR TITLE
Skip empty GCP bucket folder for deprecated plugins

### DIFF
--- a/hack/release/cut-release.sh
+++ b/hack/release/cut-release.sh
@@ -186,6 +186,15 @@ for dir in ./*/
 do
   dir=${dir%*/}
   echo "dir: ${dir}"
+
+  # if there isnt a new version of a plugin, delete the plugin folder
+  # because the plugin is now deprecated
+  if [[ ! -d "${dir}/${BUILD_VERSION}" ]]; then
+    echo "skipping ${dir}/${BUILD_VERSION}..."
+    rm -rf "./${dir}"
+    continue
+  fi
+
   pushd "${dir}/${BUILD_VERSION}" || exit 1
   # delete all binaries
   rm -rf ./test


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Skip empty GCP bucket folder for deprecated plugins... we test this by checking to see if a new `plugin/version` folder exists. If it doesn't, don't try to modify the folder for upload to the GCP bucket and actually, we just want to delete the entire plugin folder.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
