### PR TITLE
[E2E] Fix cleanup of kind cluster when standalone-cluster or management-cluster delete fails

### DIFF
--- a/test/aws/deploy-tce-managed.sh
+++ b/test/aws/deploy-tce-managed.sh
@@ -31,7 +31,7 @@ function delete_management_cluster {
     echo "$@"
     export AWS_REGION="us-east-2"
     export CLUSTER_NAME="${MGMT_CLUSTER_NAME}"
-    tanzu management-cluster delete "${CLUSTER_NAME}" -y || { kubeconfig_cleanup "${CLUSTER_NAME}"; aws-nuke-tear-down "MANAGEMENT CLUSTER DELETION FAILED! Deleting the cluster using AWS-NUKE..." "${CLUSTER_NAME}"; }
+    tanzu management-cluster delete "${CLUSTER_NAME}" -y || { delete_kind_cluster; kubeconfig_cleanup "${CLUSTER_NAME}"; aws-nuke-tear-down "MANAGEMENT CLUSTER DELETION FAILED! Deleting the cluster using AWS-NUKE..." "${CLUSTER_NAME}"; }
 }
 
 function nuke_management_and_workload_clusters {

--- a/test/aws/deploy-tce-standalone.sh
+++ b/test/aws/deploy-tce-standalone.sh
@@ -34,7 +34,7 @@ echo "Setting CLUSTER_NAME to ${CLUSTER_NAME}..."
 # Cleanup function
 function delete_cluster {
     echo "$@"
-    tanzu standalone-cluster delete ${CLUSTER_NAME} -y || { kubeconfig_cleanup ${CLUSTER_NAME}; aws-nuke-tear-down "STANDALONE CLUSTER DELETION FAILED! Deleting the cluster using AWS-NUKE..."; }
+    tanzu standalone-cluster delete ${CLUSTER_NAME} -y || { delete_kind_cluster; kubeconfig_cleanup ${CLUSTER_NAME}; aws-nuke-tear-down "STANDALONE CLUSTER DELETION FAILED! Deleting the cluster using AWS-NUKE..."; }
 }
 
 function create_standalone_cluster {

--- a/test/azure/deploy-management-and-workload-cluster.sh
+++ b/test/azure/deploy-management-and-workload-cluster.sh
@@ -58,6 +58,7 @@ function cleanup_management_cluster {
     echo "Using azure CLI to cleanup ${MANAGEMENT_CLUSTER_NAME} management cluster resources"
     export CLUSTER_NAME="${MANAGEMENT_CLUSTER_NAME}"
     set_azure_env_vars
+    delete_kind_cluster
     kubeconfig_cleanup ${CLUSTER_NAME}
     azure_cluster_cleanup || error "MANAGEMENT CLUSTER CLEANUP USING azure CLI FAILED! Please manually delete any ${MANAGEMENT_CLUSTER_NAME} management cluster resources using Azure Web UI"
     unset_azure_env_vars

--- a/test/azure/deploy-standalone-cluster.sh
+++ b/test/azure/deploy-standalone-cluster.sh
@@ -63,7 +63,8 @@ function cleanup_standalone_cluster {
 function delete_cluster_or_cleanup {
     echo "Deleting standalone cluster"
     time tanzu standalone-cluster delete ${CLUSTER_NAME} -y || {
-        error "STANDALONE CLUSTER DELETION FAILED!";
+        error "STANDALONE CLUSTER DELETION FAILED!"
+        delete_kind_cluster
         cleanup_standalone_cluster
         return 1
     }

--- a/test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
+++ b/test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
@@ -53,6 +53,7 @@ export MANAGEMENT_CLUSTER_NAME="test-management-cluster-${random_id}"
 export WORKLOAD_CLUSTER_NAME="test-workload-cluster-${random_id}"
 
 function cleanup_management_cluster {
+    delete_kind_cluster
     kubeconfig_cleanup ${MANAGEMENT_CLUSTER_NAME}
     echo "Using govc to cleanup ${MANAGEMENT_CLUSTER_NAME} management cluster resources"
     govc_cleanup ${MANAGEMENT_CLUSTER_NAME} || error "MANAGEMENT CLUSTER CLEANUP USING GOVC FAILED! Please manually delete any ${MANAGEMENT_CLUSTER_NAME} management cluster resources using vCenter Web UI"

--- a/test/vsphere/run-tce-vsphere-standalone-cluster.sh
+++ b/test/vsphere/run-tce-vsphere-standalone-cluster.sh
@@ -62,7 +62,6 @@ time tanzu standalone-cluster create ${CLUSTER_NAME} --file "${cluster_config_fi
 
 "${TCE_REPO_PATH}/test/check-tce-cluster-creation.sh" ${CLUSTER_NAME}-admin@${CLUSTER_NAME} || {
     error "STANDALONE CLUSTER CREATION CHECK FAILED!"
-    delete_kind_cluster
     cleanup
     exit 1
 }
@@ -72,6 +71,7 @@ echo "Deleting standalone cluster"
 
 time tanzu standalone-cluster delete ${CLUSTER_NAME} -y || {
     error "STANDALONE CLUSTER DELETION FAILED!"
+    delete_kind_cluster
     cleanup
     exit 1
 }


### PR DESCRIPTION
## What this PR does / why we need it

Fixes cleanup of kind cluster when standalone-cluster or management-cluster delete fails. Also removes unnecessary cleanup of kind cluster

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #2533 

## Describe testing done for PR

--

## Special notes for your reviewer

--