### PR TITLE
Rename e2e pipelines to be more precise that they test workload clusters

### DIFF
--- a/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
@@ -1,4 +1,4 @@
-name: E2E Test - AWS Management Cluster
+name: E2E Test - AWS Management and Workload Cluster
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
   e2e-aws-managed-test:
     # Only run this job if we're in the main repo, not a fork.
     if: github.repository == 'vmware-tanzu/community-edition'
-    name: E2E AWS Management Cluster Test
+    name: E2E AWS Management and Workload Cluster Test
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
@@ -36,7 +36,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v1
 
-      - name: Run E2E Tests
+      - name: Run AWS Management and Workload Cluster E2E Tests
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -48,4 +48,4 @@ jobs:
           sudo sysctl net/netfilter/nf_conntrack_max=131072
 
           go env -w GOFLAGS=-mod=mod
-          make aws-management-cluster-e2e-test
+          make aws-management-and-workload-cluster-e2e-test

--- a/.github/workflows/e2e-vsphere-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-vsphere-management-and-workload-cluster.yaml
@@ -1,4 +1,4 @@
-name: E2E Test - vSphere Management Cluster
+name: E2E Test - vSphere Management and Workload Cluster
 
 on:
   schedule:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   e2e-vsphere-management-cluster-test:
-    name: E2E vSphere Management Cluster Test
+    name: E2E vSphere Management and Workload Cluster Test
     # Only run this job if we're in the main repo, not a fork.
     if: github.repository == 'vmware-tanzu/community-edition'
     runs-on: vsphere-e2e-runner
@@ -20,7 +20,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v1
 
-      - name: Run vSphere Management Cluster E2E Test
+      - name: Run vSphere Management and Workload Cluster E2E Test
         env:
           VSPHERE_MANAGEMENT_CLUSTER_ENDPOINT: ${{ secrets.VSPHERE_MANAGEMENT_CLUSTER_ENDPOINT }}
           VSPHERE_WORKLOAD_CLUSTER_ENDPOINT: ${{ secrets.VSPHERE_WORKLOAD_CLUSTER_ENDPOINT }}
@@ -37,4 +37,4 @@ jobs:
           # Workaround for issue https://github.com/kubernetes-sigs/kind/issues/2240
           sudo sysctl net/netfilter/nf_conntrack_max=131072
 
-          make vsphere-management-cluster-e2e-test
+          make vsphere-management-and-workload-cluster-e2e-test

--- a/Makefile
+++ b/Makefile
@@ -368,35 +368,36 @@ makefile:
 
 ##### BUILD TARGETS #####
 
-# TCE AWS management Cluster E2E Test
-aws-management-cluster-e2e-test:
+# AWS Management + Workload Cluster E2E Test
+aws-management-and-workload-cluster-e2e-test:
 	test/aws/deploy-tce-managed.sh
 
-# TCE AWS Standalone Cluster E2E Test
+# AWS Standalone Cluster E2E Test
 aws-standalone-cluster-e2e-test:
 	test/aws/deploy-tce-standalone.sh
+
+# Azure Management + Workload Cluster E2E Test
+azure-management-and-workload-cluster-e2e-test:
+	test/azure/deploy-management-and-workload-cluster.sh
 
 # Azure Standalone Cluster E2E Test
 azure-standalone-cluster-e2e-test:
 	test/azure/deploy-standalone-cluster.sh
 
-azure-management-and-workload-cluster-e2e-test:
-	test/azure/deploy-management-and-workload-cluster.sh
-
-# TCE Docker Standalone Cluster E2E Test
-tce-docker-standalone-cluster-e2e-test:
-	test/docker/run-tce-docker-standalone-cluster.sh
-
-# TCE Docker Managed Cluster E2E Test
-tce-docker-managed-cluster-e2e-test:
+# Docker Management + Workload Cluster E2E Test
+docker-management-and-cluster-e2e-test:
 	test/docker/run-tce-docker-managed-cluster.sh
 
-# TCE vSphere Standalone Cluster E2E Test
+# Docker Standalone Cluster E2E Test
+docker-standalone-cluster-e2e-test:
+	test/docker/run-tce-docker-standalone-cluster.sh
+
+# vSphere Management + Workload Cluster E2E Test
+vsphere-management-and-workload-cluster-e2e-test:
+	test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
+
+# vSphere Standalone Cluster E2E Test
 vsphere-standalone-cluster-e2e-test:
 	test/vsphere/run-tce-vsphere-standalone-cluster.sh
-
-# TCE vSphere Management + Workload Cluster E2E Test
-vsphere-management-cluster-e2e-test:
-	test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
 
 ##### E2E TESTS #####

--- a/test/README.md
+++ b/test/README.md
@@ -18,7 +18,7 @@
                 - aws:
 
                     ```shell
-                    make aws-management-cluster-e2e-test
+                    make aws-management-and-workload-cluster-e2e-test
                     ```
 
                 - azure:
@@ -30,7 +30,7 @@
                 - docker:
 
                     ```shell
-                    make tce-docker-managed-cluster-e2e-test:
+                    make docker-management-and-cluster-e2e-test:
                     ```
 
             - Standalone Cluster deployment automation on:
@@ -49,7 +49,7 @@
                 - docker:
 
                     ```shell
-                    make tce-docker-standalone-cluster-e2e-test
+                    make docker-standalone-cluster-e2e-test
                     ```
 
                 - vSphere:

--- a/test/vsphere/vsphere-management-and-workload-cluster-e2e-test.md
+++ b/test/vsphere/vsphere-management-and-workload-cluster-e2e-test.md
@@ -47,7 +47,7 @@ Since our VMC environment is all in a private network, we use a self hosted GitH
 
 ### Running the test
 
-The E2E test's starting point is a bash script - `test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh`. This script can be invoked standalone, or one can use `Makefile` target `vsphere-management-cluster-e2e-test` to run the E2E tests like this `make vsphere-management-cluster-e2e-test`
+The E2E test's starting point is a bash script - `test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh`. This script can be invoked standalone, or one can use `Makefile` target `vsphere-management-and-workload-cluster-e2e-test` to run the E2E tests like this `make vsphere-management-and-workload-cluster-e2e-test`
 
 The script gives meaningful errors when required parameters (environment variables) are missing
 


### PR DESCRIPTION
## What this PR does / why we need it

Rename e2e pipelines to be more precise that they test workload clusters
- `make` target rename
- Workflow display name rename
- Workflow yaml file name rename

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

--

## Describe testing done for PR

--

## Special notes for your reviewer

There is an impact due to this change - since GitHub Actions shows workflows based on the workflow yaml file name in it's URL, for example - https://github.com/vmware-tanzu/community-edition/actions/workflows/e2e-aws-management-cluster.yaml , renaming workflow yaml files would mean we will not be able to see older runs using the older URL, and the new URL would show only new runs after the workflow file rename. Not sure if we can see the runs if we have the exact run URL, like https://github.com/vmware-tanzu/community-edition/actions/runs/1469284028

Also, I haven't changed the name of the scripts, for example, the current script names are not consistent and not precise, we could change that too -

- `test/aws/deploy-tce-standalone.sh` - could change it to `test/aws/deploy-standalone-cluster.sh`
- `test/aws/deploy-tce-managed.sh` - could change it to `test/aws/deploy-management-and-workload-cluster.sh`
- `test/docker/run-tce-docker-managed-cluster.sh` - could change it to `test/docker/deploy-management-and-workload-cluster.sh`
- `test/vsphere/run-tce-vsphere-standalone-cluster.sh` - could change it to `test/vsphere/deploy-standalone-cluster.sh`
- `test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh` - could change it to `test/vsphere/deploy-management-and-workload-cluster.sh`

Also, the `make` target names are too big for now, we could try to see if we can shorten it, for example, it's currently -

`azure-management-and-workload-cluster-e2e-test` - we could change it to something like `azure-management-and-workload-cluster-e2e` or `azure-management-and-workload-cluster-test`