### PR TITLE
[E2E] Uninstall using uninstall script before installing using install script

### DIFF
--- a/test/build-tce.sh
+++ b/test/build-tce.sh
@@ -28,6 +28,7 @@ elif [[ $BUILD_OS == "Darwin" ]]; then
         pushd build/tce-darwin-arm64*/ || exit 1
     fi
 fi
+./uninstall.sh || { error "TCE CLEANUP (UNINSTALLATION) FAILED!"; exit 1; }
 ./install.sh || { error "TCE INSTALLATION FAILED!"; exit 1; }
 popd || exit 1
 echo "TCE version..."


### PR DESCRIPTION
## What this PR does / why we need it

[E2E] Uninstall using uninstall script before installing using install script. This is to help with cleanup of the environment in case there's any tanzu data

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #2577 

## Describe testing done for PR

--

## Special notes for your reviewer

--