### PR TITLE
Smoke Tests for Prometheus, Knative Serving and Grafana

### DIFF
--- a/test/smoke/Makefile
+++ b/test/smoke/Makefile
@@ -4,7 +4,7 @@
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-smoke-test: install-ginkgo  cert-manager fluent-bit local-path-storage contour gatekeeper external-dns multus-cni 
+smoke-test: install-ginkgo cert-manager fluent-bit local-path-storage prometheus knative-serving contour grafana gatekeeper external-dns multus-cni 
 
 install-ginkgo:
 	go get github.com/onsi/ginkgo/ginkgo
@@ -21,6 +21,15 @@ fluent-bit:
 
 local-path-storage:
 	./packages/local-path-storage/0.0.20/local-path-storage-test.sh
+
+prometheus:
+	./packages/prometheus/2.27.0/prometheus-test.sh
+
+knative-serving:
+	./packages/knative-serving/0.22.0/knative-serving-test.sh
+
+grafana:
+	./packages/grafana/7.5.7/grafana-test.sh
 
 external-dns:
 	cd "${ROOT_DIR}"/test/e2e && ginkgo -v -- --packages="external-dns" --version="0.8.0" --guest-cluster-name="tce.public"

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -13,3 +13,5 @@
 3. Fluent-bit: `make fluent-bit`
 4. Local-path-storage: `make local-path-storage`
 5. Gatekeeper: `make gatekeeper`
+6. Prometheus: `make prometheus`
+7. Grafana: `make grafana`

--- a/test/smoke/packages/contour/1.18.2/contour-values.yaml
+++ b/test/smoke/packages/contour/1.18.2/contour-values.yaml
@@ -1,4 +1,4 @@
 ---
 envoy:
   service:
-    type: NodePort
+    type: ClusterIP

--- a/test/smoke/packages/fluent-bit/1.7.5/fluent-bit-test.sh
+++ b/test/smoke/packages/fluent-bit/1.7.5/fluent-bit-test.sh
@@ -7,8 +7,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Checking package is installed or not
+TCE_REPO_PATH="$(git rev-parse --show-toplevel)"
+source "${TCE_REPO_PATH}/test/smoke/packages/utils/smoke-tests-utils.sh"
 
+# Checking package is installed or not
 tanzu package installed list | grep "fluent-bit.community.tanzu.vmware.com" || {
     version=$(tanzu package available list fluent-bit.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
     tanzu package install fluent-bit --package-name fluent-bit.community.tanzu.vmware.com --version "${version}"
@@ -16,10 +18,9 @@ tanzu package installed list | grep "fluent-bit.community.tanzu.vmware.com" || {
 
 pod_name="$(kubectl get pods -n fluent-bit | tail -n 1 | awk '{print $1}')"
 kubectl logs "${pod_name}" -n fluent-bit | grep "Fluent Bit v1.7.5" || {
-    tanzu package installed delete fluent-bit -y
-    printf '\E[31m'; echo "Fluent-bit failed"; printf '\E[0m'
-    exit 1
+    packageCleanup fluent-bit
+    failureMessage fluent-bit
 }
 
-tanzu package installed delete fluent-bit -y
-printf '\E[32m'; echo "Fluent-bit Passed"; printf '\E[0m'
+packageCleanup fluent-bit
+successMessage fluent-bit

--- a/test/smoke/packages/grafana/7.5.7/grafana-test.sh
+++ b/test/smoke/packages/grafana/7.5.7/grafana-test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TCE_REPO_PATH="$(git rev-parse --show-toplevel)"
+# shellcheck source=test/util/utils.sh
+source "${TCE_REPO_PATH}/test/smoke/packages/utils/smoke-tests-utils.sh"
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Checking package is installed or not
+tanzu package installed list | grep "local-path-storage.community.tanzu.vmware.com" || {
+  version=$(tanzu package available list local-path-storage.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+  tanzu package install local-path-storage --package-name local-path-storage.community.tanzu.vmware.com --version "${version}"
+}
+
+tanzu package installed list | grep "contour.community.tanzu.vmware.com" || {
+    version=$(tanzu package available list contour.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+    tanzu package install contour --package-name contour.community.tanzu.vmware.com -f "${MY_DIR}"/../../contour/"${version}"/contour-values.yaml --version "${version}"
+}
+
+tanzu package installed list | grep "cert-manager.community.tanzu.vmware.com" || {
+  version=$(tanzu package available list cert-manager.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+  tanzu package install cert-manager --package-name cert-manager.community.tanzu.vmware.com --version "${version}"
+}
+
+tanzu package installed list | grep "grafana.community.tanzu.vmware.com" || {
+    version=$(tanzu package available list grafana.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+    tanzu package install grafana --package-name grafana.community.tanzu.vmware.com --version "${version}"
+}
+
+grafana_pod="$(kubectl get pod -A | grep "grafana" | awk '{print $2}')" 
+kubectl port-forward "${grafana_pod}" -n grafana 56016:3000 &
+sleep 5s
+
+curl -I http://127.0.0.1:56016/api/health | grep "200" || {
+  packageCleanup local-path-storage contour cert-manager grafana
+  failureMessage grafana
+}
+
+packageCleanup local-path-storage contour cert-manager grafana
+successMessage grafana

--- a/test/smoke/packages/knative-serving/0.22.0/knative-service.yaml
+++ b/test/smoke/packages/knative-serving/0.22.0/knative-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go
+          env:
+            - name: TARGET
+              value: "Go Sample v1"

--- a/test/smoke/packages/knative-serving/0.22.0/knative-serving-test.sh
+++ b/test/smoke/packages/knative-serving/0.22.0/knative-serving-test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TCE_REPO_PATH="$(git rev-parse --show-toplevel)"
+source "${TCE_REPO_PATH}/test/smoke/packages/utils/smoke-tests-utils.sh"
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Checking package is installed or not
+tanzu package installed list | grep "contour.community.tanzu.vmware.com" || {
+    version=$(tanzu package available list contour.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+    tanzu package install contour --package-name contour.community.tanzu.vmware.com -f "${MY_DIR}"/../../contour/"${version}"/contour-values.yaml --version "${version}"
+}
+
+tanzu package installed list | grep "knative-serving.community.tanzu.vmware.com" || {
+    version=$(tanzu package available list knative-serving.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+    tanzu package install knative-serving --package-name knative-serving.community.tanzu.vmware.com -f "${MY_DIR}"/knative-serving-values.yaml --version "${version}"
+}
+
+NAMESPACE_SUFFIX=${RANDOM}
+NAMESPACE="knative-serving-${NAMESPACE_SUFFIX}"
+kubectl create ns ${NAMESPACE}
+
+kubectl apply -n ${NAMESPACE} --filename "${MY_DIR}"/knative-service.yaml
+echo "Waiting for pod to get scale down..."
+sleep 10s
+
+kubectl wait --for=delete --all pod -n ${NAMESPACE} --timeout=360s || {
+    packageCleanup knative-serving contour
+    namespaceCleanup ${NAMESPACE}
+    failureMessage knative-serving
+}
+
+packageCleanup knative-serving contour
+namespaceCleanup ${NAMESPACE}
+successMessage knative-serving

--- a/test/smoke/packages/knative-serving/0.22.0/knative-serving-values.yaml
+++ b/test/smoke/packages/knative-serving/0.22.0/knative-serving-values.yaml
@@ -1,0 +1,4 @@
+---
+domain:
+  type: real
+  name: example.com

--- a/test/smoke/packages/local-path-storage/0.0.20/local-path-storage-test.sh
+++ b/test/smoke/packages/local-path-storage/0.0.20/local-path-storage-test.sh
@@ -7,6 +7,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+TCE_REPO_PATH="$(git rev-parse --show-toplevel)"
+source "${TCE_REPO_PATH}/test/smoke/packages/utils/smoke-tests-utils.sh"
 
 # Checking package is installed or not
 tanzu package installed list | grep "local-path-storage.community.tanzu.vmware.com" || {
@@ -35,12 +37,12 @@ PVC_status="$(kubectl get pvc local-path-pvc -n ${NAMESPACE} -o 'jsonpath={.stat
 
 if [ "${PVC_status}" != "Bound" ]
 then
-    printf '\E[31m'; echo "PVC did not bound to PV. check the storage class name"; printf '\E[0m'
+    printf '\E[31m'; echo "PVC did not bound to PV. check the storage class name"; printf '\E[0m';
 fi
 
 if [ "${Pod_status}" != "True" ]
 then
-    printf '\E[31m'; echo "Pod for PV is not in Running state"; printf '\E[0m'
+    printf '\E[31m'; echo "Pod for PV is not in Running state"; printf '\E[0m';
 fi
 
 kubectl exec volume-test -n ${NAMESPACE} -- sh -c "echo local-path-storage-test > /data/test"
@@ -55,12 +57,11 @@ kubectl wait --for=condition=Ready pod volume-test -n ${NAMESPACE}
 Output="$(kubectl exec volume-test -n ${NAMESPACE} cat /data/test)"
 if [ "${Output}" != "local-path-storage-test" ]
 then
-    printf '\E[31m'; echo "local-path-storage failed"; printf '\E[0m'
-    exit 1
+    ffailureMessage local-path-storage 
 else
-    printf '\E[32m'; echo "local-path-storage Passed"; printf '\E[0m'
+    successMessage local-path-storage 
 fi
 
 kubectl delete pod/volume-test -n ${NAMESPACE}
 kubectl delete persistentvolumeclaim/local-path-pvc -n ${NAMESPACE}
-tanzu package installed delete local-path-storage -y
+packageCleanup local-path-storage 

--- a/test/smoke/packages/prometheus/2.27.0/prometheus-test.sh
+++ b/test/smoke/packages/prometheus/2.27.0/prometheus-test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TCE_REPO_PATH="$(git rev-parse --show-toplevel)"
+source "${TCE_REPO_PATH}/test/smoke/packages/utils/smoke-tests-utils.sh"
+
+
+# Checking package is installed or not
+tanzu package installed list | grep "local-path-storage.community.tanzu.vmware.com" || {
+  version=$(tanzu package available list local-path-storage.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+  tanzu package install local-path-storage --package-name local-path-storage.community.tanzu.vmware.com --version "${version}"
+}
+
+
+tanzu package installed list | grep "prometheus.community.tanzu.vmware.com" || {
+  version=$(tanzu package available list prometheus.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+  tanzu package install prometheus --package-name prometheus.community.tanzu.vmware.com --version "${version}"
+}
+
+prometheus_Pod="$(kubectl get pod -n prometheus | grep "prometheus-kube-state-metrics" | awk '{print $1}')"
+
+kubectl port-forward "${prometheus_Pod}"  -n prometheus  8080:8080 &
+sleep 5s
+
+curl localhost:8080/metrics | less | grep "kube_deployment_created gauge" || {
+    packageCleanup prometheus local-path-storage 
+    failure_msg prometheus
+}
+
+curl localhost:8080/healthz | grep "OK" || {
+    packageCleanup prometheus local-path-storage 
+    failureMessage prometheus
+}
+
+packageCleanup prometheus local-path-storage 
+successMessage prometheus

--- a/test/smoke/packages/utils/smoke-tests-utils.sh
+++ b/test/smoke/packages/utils/smoke-tests-utils.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Clean up func
+
+function packageCleanup() {
+   arr=("$@")
+   for i in "${arr[@]}";
+      do
+          tanzu package installed delete "$i" -y
+      done
+}
+
+function namespaceCleanup() {
+    kubectl delete ns $1
+}
+
+function successMessage() {
+    printf '\E[32m'; echo "$1 passed"; printf '\E[0m'
+}
+
+function failureMessage() {
+    printf '\E[31m'; echo "$1 failed"; printf '\E[0m'
+    exit 1
+}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR includes smoke-tests for:
- Prometheus
- Knative Serving
- Grafana

This is a follow-up PR to [2246](https://github.com/vmware-tanzu/community-edition/pull/2246).
## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add Smoke tests for Prometheus, Knative Serving and Grafana
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
`make smoke-test` is triggered to run all the smoke tests.
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
Please refer to [#2246](https://github.com/vmware-tanzu/community-edition/pull/2246) for complete picture.