### PR TITLE
Bumps standalone-cluster plugin to `v0.10.0`

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/main.go
+++ b/cli/cmd/plugin/standalone-cluster/main.go
@@ -24,10 +24,11 @@ Warning - Standalone clusters will be deprecated in a future release of Tanzu Co
 Create clusters without a dedicated management cluster`,
 	Group: cliv1alpha1.RunCmdGroup,
 
-	// Since standalone cluster is being deprecated, no changes are being made to it's dependencies,
-	// and cli.BuildVersion was deprecated in the build version of tanzu framework v0.10.0,
-	// we need to manually set the plugin version in order to compile
-	Version: "v0.9.1",
+	// Since standalone cluster is being deprecated, no changes or feature adds
+	// are to be made to it's dependencies or core functionality.
+	// Since cli.BuildVersion was deprecated in the build version of tanzu framework v0.10.0,
+	// we need to manually set the plugin version in order to compile with hack/builder
+	Version: "v0.10.0",
 }
 
 var (

--- a/hack/release/package-release.sh
+++ b/hack/release/package-release.sh
@@ -67,7 +67,8 @@ for env in ${ENVS}; do
     cp -f "${ROOT_FRAMEWORK_ARTFACTS_ADMIN_DIR}/codegen/${FRAMEWORK_BUILD_VERSION}/tanzu-codegen-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-codegen${extension}"
 
     # TCE bits (New folder structure using tanzu-framework main)
-    cp -f "${ROOT_TCE_ARTIFACTS_DIR}/standalone-cluster/v0.9.1/tanzu-standalone-cluster-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-standalone-cluster${extension}"
+    # the standalone cluster plugin is locked to v0.10.0 due to deprecation and is not tied to the TCE build version
+    cp -f "${ROOT_TCE_ARTIFACTS_DIR}/standalone-cluster/v0.10.0/tanzu-standalone-cluster-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-standalone-cluster${extension}"
     cp -f "${ROOT_TCE_ARTIFACTS_DIR}/conformance/${TCE_BUILD_VERSION}/tanzu-conformance-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-conformance${extension}"
     cp -f "${ROOT_TCE_ARTIFACTS_DIR}/diagnostics/${TCE_BUILD_VERSION}/tanzu-diagnostics-${binaryname}${extension}" "${PACKAGE_DIR}/bin/tanzu-plugin-diagnostics${extension}"
 


### PR DESCRIPTION
## What this PR does / why we need it
Bumps the standalone-cluster plugin to version `v0.10.0` to reflect the new `-t` timeout feature that made it into the plugin recently.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Bumps standalone-cluster to version v0.10.0
```

## Which issue(s) this PR fixes
Fixes: #2572

## Describe testing done for PR
`make relase` and ran the `./install.sh` script. `tanzu standalone-cluster  version` shows v0.10.0

## Special notes for your reviewer
N/a
