### PR TITLE
Save TF artifacts and artifacts-admin for GA and Non-GA Releases

### DIFF
--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -115,19 +115,33 @@ jobs:
           asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.zip
           asset_content_type: application/zip
-      - name: Upload Artifacts to Staging Bucket
+      - name: Upload TCE Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: ./artifacts
           destination: tce-cli-plugins-staging
           credentials: ${{ secrets.GCP_BUCKET_SA }}
-      - name: Upload Artifacts to Update Bucket
-        id: upload-artifacts-update
+      - name: Upload TCE Artifacts to Update Bucket
+        id: upload-tce-artifacts-update
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: ./artifacts
           destination: tce-cli-plugins
+          credentials: ${{ secrets.GCP_BUCKET_SA }}
+      - name: Upload TF Artifacts to Update Bucket
+        id: upload-tf-artifacts-update
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: /tmp/tce-release/tanzu-framework/artifacts
+          destination: tce-framework-cli-plugins
+          credentials: ${{ secrets.GCP_BUCKET_SA }}
+      - name: Upload TF Admin Artifacts to Update Bucket
+        id: upload-tf-artifacts-admin-update
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: /tmp/tce-release/tanzu-framework/artifacts-admin
+          destination: tce-framework-cli-plugins-admin
           credentials: ${{ secrets.GCP_BUCKET_SA }}
       - name: Commit Next Dev Version
         env:

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -116,19 +116,33 @@ jobs:
           asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.zip
           asset_content_type: application/zip
-      - name: Upload Artifacts to Staging Bucket
+      - name: Upload TCE Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: ./artifacts
           destination: tce-cli-plugins-staging
           credentials: ${{ secrets.GCP_BUCKET_SA }}
-      - name: Upload Artifacts to Update Bucket
-        id: upload-artifacts-update
+      - name: Upload TCE Artifacts to Update Bucket
+        id: upload-tce-artifacts-update
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: ./artifacts
           destination: tce-cli-plugins
+          credentials: ${{ secrets.GCP_BUCKET_SA }}
+      - name: Upload TF Artifacts to Update Bucket
+        id: upload-tf-artifacts-update
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: /tmp/tce-release/tanzu-framework/artifacts
+          destination: tce-framework-cli-plugins
+          credentials: ${{ secrets.GCP_BUCKET_SA }}
+      - name: Upload TF Admin Artifacts to Update Bucket
+        id: upload-tf-artifacts-admin-update
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: /tmp/tce-release/tanzu-framework/artifacts-admin
+          destination: tce-framework-cli-plugins-admin
           credentials: ${{ secrets.GCP_BUCKET_SA }}
       - name: Commit Next Dev Version
         env:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
We technically need to save the Tanzu Framework binaries to the update bucket because there are currently compile/build time flags that change the behavior of the binary. This uploads them to newly created buckets until we get the Tanzu CLI update functionality working. For the v0.9.0 and v0.9.1 TCE releases, I uploaded the corresponding binaries to those buckets by hand.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Save TF artifacts and artifacts-admin for GA and NON-GA Releases
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA