### PR TITLE
[E2E][Azure] Update Azure VM Image Billing Plan SKU

### DIFF
--- a/test/azure/deploy-management-and-workload-cluster.sh
+++ b/test/azure/deploy-management-and-workload-cluster.sh
@@ -48,9 +48,11 @@ echo "Setting MANAGEMENT_CLUSTER_NAME to ${MANAGEMENT_CLUSTER_NAME}"
 echo "Setting WORKLOAD_CLUSTER_NAME to ${WORKLOAD_CLUSTER_NAME}"
 
 export VM_IMAGE_PUBLISHER="vmware-inc"
-# The value k8s-1dot21dot2-ubuntu-2004 comes from latest TKG BOM file based on OS arch, OS name and OS version
-# provided in test/azure/cluster-config.yaml
-export VM_IMAGE_BILLING_PLAN_SKU="k8s-1dot21dot2-ubuntu-2004"
+# The value k8s-1dot21dot5-ubuntu-2004 comes from latest TKG BOM file based on OS arch, OS name and OS version
+# provided in test/azure/cluster-config.yaml. This value needs to be changed manually whenever there's going to
+# be a change in the underlying Tanzu Framework CLI version (management-cluster and cluster plugins) causing new
+# TKr BOMs to be used with new Azure VM images which have different image billing plan SKU
+export VM_IMAGE_BILLING_PLAN_SKU="k8s-1dot21dot5-ubuntu-2004"
 export VM_IMAGE_OFFER="tkg-capi"
 
 


### PR DESCRIPTION
## What this PR does / why we need it

Update Azure VM Image Billing Plan SKU. This is to match the SKU from the latest TKr bom used in `tanzu-framework`v0.10.0

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #2574

## Describe testing done for PR

Reruns of existing Azure pipelines passed after accepting the Azure VM Image Billing plan SKU. Example - https://github.com/vmware-tanzu/community-edition/runs/4217728775?check_suite_focus=true#step:5:2022 (old), https://github.com/vmware-tanzu/community-edition/runs/4231869877?check_suite_focus=true#step:5:2034 (old)

Check the latest attempt for the above failed runs - https://github.com/vmware-tanzu/community-edition/runs/4263995456?check_suite_focus=true , https://github.com/vmware-tanzu/community-edition/runs/4263996056?check_suite_focus=true

## Special notes for your reviewer

All details are present in #2574 , specifically at https://github.com/vmware-tanzu/community-edition/issues/2574#issuecomment-974030726