### PR TITLE
Collect additional object data

### DIFF
--- a/cli/cmd/plugin/diagnostics/pkg/collect_bootstrap.go
+++ b/cli/cmd/plugin/diagnostics/pkg/collect_bootstrap.go
@@ -82,7 +82,7 @@ func collectBoostrapDiags() error {
 			crashdexec.StarlarkModule{Name: libScript, Source: bytes.NewReader(libData)},
 		)
 		if err != nil {
-			log.Printf("Warn: bootstrap script failed, skipping: cluster%s: %s: ", cluster, err)
+			log.Printf("Warn: bootstrap script failed, skipping %s: %s: ", cluster, err)
 			continue
 		}
 	}

--- a/cli/cmd/plugin/diagnostics/scripts/bootstrap_cluster.star
+++ b/cli/cmd/plugin/diagnostics/scripts/bootstrap_cluster.star
@@ -8,8 +8,10 @@ def diagnose_bootstrap_clusters(kubeconfig, cluster, workdir, outputdir):
         "capi-kubeadm-control-plane-system",
         "capi-system",
         "capi-webhook-system",
-        "capv-system",
         "capa-system",
+        "capd-system",
+        "capv-system",
+        "capz-system",
         "cert-manager",
         "tkg-system",
     ]
@@ -33,6 +35,9 @@ def diagnose_bootstrap_clusters(kubeconfig, cluster, workdir, outputdir):
     k8sconf = kube_config(path=kubeconfig)
 
     capture_k8s_objects(k8sconf, cluster, nspaces)
+    capture_pod_describe(workdir=wd,k8sconf=kubeconfig,context=None,namespaces=nspaces)
+    capture_node_describe(workdir=wd, k8sconf=kubeconfig, context=None)
+    capture_summary(workdir=wd, k8sconf=kubeconfig, context=None)
 
     arc_file = "{}/bootstrap.{}.diagnostics.tar.gz".format(outputdir, cluster)
     log(prefix="Info", msg="Archiving: {}".format(arc_file))

--- a/cli/cmd/plugin/diagnostics/scripts/lib.star
+++ b/cli/cmd/plugin/diagnostics/scripts/lib.star
@@ -8,6 +8,35 @@ def prog_checks():
 
     return True
 
+def capture_summary(workdir,k8sconf,context):
+    if not context:
+        command = "kubectl get po,deploy,cluster,kubeadmcontrolplane,machine,machinedeployment -A --kubeconfig {}".format(k8sconf)
+    else:
+        command = "kubectl get po,deploy,cluster,kubeadmcontrolplane,machine,machinedeployment -A --kubeconfig {} --context {}".format(k8sconf,context)
+
+    capture_local(cmd=command,workdir=workdir,file_name="cluster-summary.txt")
+
+
+def capture_pod_describe(workdir,k8sconf,context,namespaces):
+    wd = "{}/describe".format(workdir)
+
+    for ns in namespaces:
+        if not context:
+            command = "kubectl describe po --kubeconfig {} -n {}".format(k8sconf, ns)
+        else:
+            command = "kubectl describe po --kubeconfig {} --context {} -n {}".format(k8sconf, context, ns)
+
+        capture_local(cmd=command,workdir=wd,file_name="{}_pods.txt".format(ns))
+
+def capture_node_describe(workdir, k8sconf, context):
+    wd = "{}/describe".format(workdir)
+    if not context:
+        command = "kubectl describe nodes --kubeconfig {}".format(k8sconf)
+    else:
+        command = "kubectl describe nodes --kubeconfig {} --context {}".format(k8sconf, context)
+
+    capture_local(cmd=command,workdir=wd,file_name="nodes.txt")
+
 def capture_node_diagnostics(nodes):
     log(prefix="Info", msg="Capturing information for {} nodes".format(len(nodes)))
     capture(cmd="sudo df -i", resources=nodes)

--- a/cli/cmd/plugin/diagnostics/scripts/management_cluster.star
+++ b/cli/cmd/plugin/diagnostics/scripts/management_cluster.star
@@ -17,9 +17,16 @@ def diagnose_management_cluster(workdir, kubeconfig, cluster_name, context_name,
         "tkg-system",
         "kube-system",
         "tkr-system",
+        "capa-system",
+        "capd-system",
+        "capv-system",
+        "capz-system",
     ]
 
     capture_k8s_objects(k8sconfig, cluster_name, nspaces)
+    capture_pod_describe(workdir=workdir,k8sconf=kubeconfig,context=context_name,namespaces=nspaces)
+    capture_node_describe(workdir=workdir,k8sconf=kubeconfig,context=context_name)
+    capture_summary(workdir=workdir,k8sconf=kubeconfig,context=context_name)
 
     arc_file = "{}/management-cluster.{}.diagnostics.tar.gz".format(outputdir, cluster_name)
     log(prefix="Info", msg="Archiving: {}".format(arc_file))

--- a/cli/cmd/plugin/diagnostics/scripts/standalone_cluster.star
+++ b/cli/cmd/plugin/diagnostics/scripts/standalone_cluster.star
@@ -17,10 +17,16 @@ def diagnose_standalone_cluster(workdir, kubeconfig, cluster_name, context_name,
         "tkg-system",
         "kube-system",
         "tkr-system",
-        "capd-system"
+        "capa-system",
+        "capd-system",
+        "capv-system",
+        "capz-system",
     ]
 
     capture_k8s_objects(k8sconfig, cluster_name, nspaces)
+    capture_pod_describe(workdir=workdir,k8sconf=kubeconfig,context=context_name,namespaces=nspaces)
+    capture_node_describe(workdir=workdir,k8sconf=kubeconfig,context=context_name)
+    capture_summary(workdir=workdir,k8sconf=kubeconfig,context=context_name)
 
     arc_file = "{}/standalone-cluster.{}.diagnostics.tar.gz".format(outputdir, cluster_name)
     log(prefix="Info", msg="Archiving: {}".format(arc_file))

--- a/cli/cmd/plugin/diagnostics/scripts/workload_cluster.star
+++ b/cli/cmd/plugin/diagnostics/scripts/workload_cluster.star
@@ -17,14 +17,16 @@ def diagnose_workload_cluster(workdir, infra, kubeconfig, cluster_name, context_
         "tkg-system",
         "kube-system",
         "tkr-system",
+        "capa-system",
+        "capd-system",
+        "capv-system",
+        "capz-system",
     ]
 
-    if infra == "aws":
-        nspaces.append("capa-system")
-    else:
-        nspaces.append("capv-system")
-
-    capture_k8s_objects(k8sconfig, cluster_name, nspaces)
+    capture_k8s_objects(k8sconfig, cluster_name,nspaces)
+    capture_pod_describe(workdir=workdir,k8sconf=kubeconfig,context=context_name,namespaces=nspaces)
+    capture_node_describe(workdir=workdir,k8sconf=kubeconfig,context=context_name)
+    capture_summary(workdir=workdir,k8sconf=kubeconfig,context=context_name)
 
     arc_file = "{}/workload-cluster.{}.diagnostics.tar.gz".format(outputdir, cluster_name)
     log(prefix="Info", msg="Archiving: {}".format(arc_file))


### PR DESCRIPTION
## What this PR does / why we need it
This PR collects additional resource information including
* explicit collection from capa, capd, capv, capz system namespaces
* Summary of running pods, deployments, apps
* Summary of pod and node events

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Diagnostics collects additional resource information and cluster summary
```

## Which issue(s) this PR fixes
Fixes: #2508 
Fixes: #2585 

## Describe testing done for PR
Create tanzu clusters on docker, then run tanzu diagnostics.

