### PR TITLE
addons/packages/pinniped: bump to Dex v2.30.2

### DIFF
--- a/addons/packages/pinniped/0.12.0/bundle/.imgpkg/images.yml
+++ b/addons/packages/pinniped/0.12.0/bundle/.imgpkg/images.yml
@@ -9,12 +9,12 @@ images:
           url: docker.io/getpinniped/pinniped-server:v0.12.0
   image: index.docker.io/getpinniped/pinniped-server@sha256:767fbfa1c7064b07afc96139689240654c971dac319e7014e48ac721d014c7fd
 - annotations:
-    kbld.carvel.dev/id: projects.registry.vmware.com/tce/dex:v2.27.0_vmware.1
+    kbld.carvel.dev/id: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
     kbld.carvel.dev/origins: |
       - resolved:
-          tag: v2.27.0_vmware.1
-          url: projects.registry.vmware.com/tce/dex:v2.27.0_vmware.1
-  image: projects.registry.vmware.com/tce/dex@sha256:29efd6577e37d1546a7406bafec085a1da40ac7185abb6debcc9634c47731d45
+          tag: v2.30.2_vmware.1
+          url: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+  image: projects.registry.vmware.com/tce/dex@sha256:b9e2f32b864f83a5f3e7b555b876c40665576bc09b20de745b3675238fd7657d
 - annotations:
     kbld.carvel.dev/id: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
     kbld.carvel.dev/origins: |

--- a/addons/packages/pinniped/0.12.0/bundle/config/overlay/dex-deployment.yaml
+++ b/addons/packages/pinniped/0.12.0/bundle/config/overlay/dex-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.27.0_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex


### PR DESCRIPTION
## What this PR does / why we need it

Dex v2.27.0 does not work on Kubernetes 1.22 because it uses `apiextensions.k8s.io/v1beta1` which is no longer served.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Pinniped package now uses Dex v2.30.2
```

## Which issue(s) this PR fixes

None

## Describe testing done for PR

Deployed package in existing cluster, configured LDAP upstream, validated that it worked on 1.22 cluster

## Special notes for your reviewer

None