### PR TITLE
[E2E] delete kind bootstrap cluster created for deletion only when management cluster deletion fails

### DIFF
--- a/test/azure/deploy-management-and-workload-cluster.sh
+++ b/test/azure/deploy-management-and-workload-cluster.sh
@@ -60,7 +60,6 @@ function cleanup_management_cluster {
     echo "Using azure CLI to cleanup ${MANAGEMENT_CLUSTER_NAME} management cluster resources"
     export CLUSTER_NAME="${MANAGEMENT_CLUSTER_NAME}"
     set_azure_env_vars
-    delete_kind_cluster
     kubeconfig_cleanup ${CLUSTER_NAME}
     azure_cluster_cleanup || error "MANAGEMENT CLUSTER CLEANUP USING azure CLI FAILED! Please manually delete any ${MANAGEMENT_CLUSTER_NAME} management cluster resources using Azure Web UI"
     unset_azure_env_vars
@@ -289,6 +288,7 @@ kubeconfig_cleanup ${WORKLOAD_CLUSTER_NAME}
 
 delete_management_cluster || {
     collect_management_cluster_diagnostics ${MANAGEMENT_CLUSTER_NAME}
+    delete_kind_cluster
     cleanup_management_cluster
     exit 1
 }

--- a/test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
+++ b/test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
@@ -53,7 +53,6 @@ export MANAGEMENT_CLUSTER_NAME="test-management-cluster-${random_id}"
 export WORKLOAD_CLUSTER_NAME="test-workload-cluster-${random_id}"
 
 function cleanup_management_cluster {
-    delete_kind_cluster
     kubeconfig_cleanup ${MANAGEMENT_CLUSTER_NAME}
     echo "Using govc to cleanup ${MANAGEMENT_CLUSTER_NAME} management cluster resources"
     govc_cleanup ${MANAGEMENT_CLUSTER_NAME} || error "MANAGEMENT CLUSTER CLEANUP USING GOVC FAILED! Please manually delete any ${MANAGEMENT_CLUSTER_NAME} management cluster resources using vCenter Web UI"
@@ -259,6 +258,7 @@ kubeconfig_cleanup ${WORKLOAD_CLUSTER_NAME}
 
 delete_management_cluster || {
     collect_management_cluster_diagnostics ${MANAGEMENT_CLUSTER_NAME}
+    delete_kind_cluster
     cleanup_management_cluster
     exit 1
 }


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #2533 - https://github.com/vmware-tanzu/community-edition/issues/2533#issuecomment-978795910 . Fixes some issues in #2548 

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #2533 

## Describe testing done for PR

I'll update here all links after I do the tests

Full green test where there are no failures - https://github.com/karuppiah7890/community-edition/runs/4366382786?check_suite_focus=true

Failure when doing cluster check (using `kubectl cluster-info`) - https://github.com/karuppiah7890/community-edition/runs/4378510233?check_suite_focus=true - cleanup happens correctly, without any errors

## Special notes for your reviewer

Should we also absorb any errors here? -

https://github.com/vmware-tanzu/community-edition/blob/65dc609f95b3e78dda4c06e9662e0abee7a8bb02/test/util/utils.sh#L12

To avoid issues like https://github.com/vmware-tanzu/community-edition/issues/2533#issuecomment-978796801

The downside is during cluster creation failure, if kind bootstrap cluster is not deleted, then our cleanup script will not work as bootstrap cluster will keep trying to create the cluster. But deletion not happening is a rare case I guess, only basic reason I can think of this can happen is - the docker container doesn't exist in the first place

And during cluster deletion, if cluster deletion using bootstrap cluster fails, and bootstrap cluster is not deleted and error is absorbed, it's not a problem I guess, at least theoretically. However our cleanup script will also try to delete resources, bootstrap cluster will also to delete resources. But I'm not sure

The other downside is, docker containers remain when deletion fails, again, rare case, as I don't see popular reasons for it