### PR TITLE
Add mtu configuration to calico 3.19.1

### DIFF
--- a/addons/packages/calico/3.19.1/README.md
+++ b/addons/packages/calico/3.19.1/README.md
@@ -20,6 +20,7 @@ The following configuration values can be set to customize the calico installati
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
 | `calico.config.clusterCIDR` | Optional | The pod network CIDR. Default value is empty because it can be auto detected. |
+| `calico.config.vethMTU` | Optional | MTU size. Default is `0`, which means it will be auto detected. |
 
 ## Usage Example
 

--- a/addons/packages/calico/3.19.1/bundle/config/overlay/calico_overlay.yaml
+++ b/addons/packages/calico/3.19.1/bundle/config/overlay/calico_overlay.yaml
@@ -143,5 +143,6 @@ spec:
 data:
   #@ if/end values.infraProvider == "azure":
   calico_backend: "vxlan"
+  veth_mtu: #@ values.calico.config.vethMTU
   #@overlay/replace via=configure_ipam_by_ip_family
   cni_network_config:

--- a/addons/packages/calico/3.19.1/bundle/config/values.yaml
+++ b/addons/packages/calico/3.19.1/bundle/config/values.yaml
@@ -7,3 +7,5 @@ ipFamily: null
 calico:
   config:
     clusterCIDR: null
+    #! "0" as default means MTU will be auto detected
+    vethMTU: "0"

--- a/addons/packages/calico/3.19.1/package.yaml
+++ b/addons/packages/calico/3.19.1/package.yaml
@@ -14,7 +14,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/calico@sha256:2c970371ba25215ce0c70388fb91bfd82db5da983508d8868a039dd80ba0b4f2
+            image: projects.registry.vmware.com/tce/calico@sha256:fdd6c102b3095aceace71bf540625e060d6fb2428279e375542115de44e8e02d
       template:
         - ytt:
             paths:

--- a/addons/packages/calico/3.19.1/test/calico_test.go
+++ b/addons/packages/calico/3.19.1/test/calico_test.go
@@ -120,6 +120,92 @@ data:
 		})
 	})
 
+	Context("customize mtu configuration", func() {
+		BeforeEach(func() {
+			values = `#@data/values
+#@overlay/match-child-defaults missing_ok=True
+---
+infraProvider: vsphere
+calico:
+  config:
+    clusterCIDR: null
+    vethMTU: "1440"
+`
+		})
+
+		It("renders a ConfigMap with a mtu cusomized ipam configuration", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(MatchYAML(`---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  calico_backend: bird
+  cni_network_config: |-
+    {
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "info",
+          "log_file_path": "/var/log/calico/cni/cni.log",
+          "datastore_type": "kubernetes",
+          "nodename": "__KUBERNETES_NODE_NAME__",
+          "mtu": __CNI_MTU__,
+          "ipam": {
+              "type": "calico-ipam"
+          },
+          "policy": {
+              "type": "k8s"
+          },
+          "kubernetes": {
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
+        },
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
+        },
+        {
+          "type": "bandwidth",
+          "capabilities": {"bandwidth": true}
+        }
+      ]
+    }
+  typha_service_name: none
+  veth_mtu: "1440"
+`))
+		})
+
+		It("renders a DaemonSet with container env settings", func() {
+			Expect(err).NotTo(HaveOccurred())
+			daemonSet := parseDaemonSet(output)
+			containerEnvVars := daemonSet.Spec.Template.Spec.Containers[0].Env
+			expectEnvVarValue(containerEnvVars, "IP", "autodetect")
+			expectEnvVarValue(containerEnvVars, "FELIX_IPV6SUPPORT", "false")
+			expectEnvVarValue(containerEnvVars, "CALICO_IPV4POOL_IPIP", "Always")
+			expectEnvVarValue(containerEnvVars, "CALICO_IPV4POOL_VXLAN", "Never")
+
+			Expect(envVarNames(containerEnvVars)).NotTo(ContainElement("CALICO_IPV4POOL_CIDR"))
+			Expect(envVarNames(containerEnvVars)).NotTo(ContainElement("CALICO_IPV6POOL_CIDR"))
+			Expect(envVarNames(containerEnvVars)).NotTo(ContainElement("IP6"))
+			Expect(envVarNames(containerEnvVars)).NotTo(ContainElement("CALICO_ROUTER_ID"))
+			Expect(envVarNames(containerEnvVars)).NotTo(ContainElement("CALICO_IPV6POOL_NAT_OUTGOING"))
+		})
+
+		It("renders the DaemonSet and Deployment with desired annotations", func() {
+			Expect(err).NotTo(HaveOccurred())
+			daemonSet := parseDaemonSet(output)
+			deployment := parseDeployment(output)
+			Expect(daemonSet.Annotations).To(Equal(desiredAnnotations))
+			Expect(deployment.Annotations).To(Equal(desiredAnnotations))
+		})
+	})
+
 	Context("azure configuration with cidr", func() {
 		BeforeEach(func() {
 			values = `#@data/values


### PR DESCRIPTION
## What this PR does / why we need it
After mtu can be auto detected in calico 3.19.1, the mtu configuration should also be kept just in case when it requires manual changes.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->

```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/2610

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Added mtu config test case and ran make test for Calico 3.19.1 package.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
