### PR TITLE
Add verification for mtu in calico 3.19.1

### DIFF
--- a/addons/packages/calico/3.19.1/bundle/config/overlay/calico_overlay.yaml
+++ b/addons/packages/calico/3.19.1/bundle/config/overlay/calico_overlay.yaml
@@ -143,6 +143,7 @@ spec:
 data:
   #@ if/end values.infraProvider == "azure":
   calico_backend: "vxlan"
+  #@ if/end hasattr(values.calico.config, 'vethMTU'):
   veth_mtu: #@ values.calico.config.vethMTU
   #@overlay/replace via=configure_ipam_by_ip_family
   cni_network_config:

--- a/addons/packages/calico/3.19.1/package.yaml
+++ b/addons/packages/calico/3.19.1/package.yaml
@@ -14,7 +14,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/calico@sha256:fdd6c102b3095aceace71bf540625e060d6fb2428279e375542115de44e8e02d
+            image: projects.registry.vmware.com/tce/calico@sha256:653878196814bdef0ced6b796752cade746248547bd6986abea9b029807f8d2b
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
Add verification for vethMTU in calico 3.19.1 to prevent vethMTU undefined

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/2610

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Ran make test for Calico 3.19.1 package.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
