### PR TITLE
Doc- Add AWS profile limitation to headless install doc

### DIFF
--- a/docs/site/content/docs/latest/aws.md
+++ b/docs/site/content/docs/latest/aws.md
@@ -44,3 +44,5 @@ To configure your AWS account credentials and SSH key pair, perform the followin
    To create a key pair for a region that is not the default in your profile, or set locally as `AWS_DEFAULT_REGION`, include the `--region` option.
 
 1. Log in to your Amazon EC2 dashboard and go to **Network & Security** > **Key Pairs** to verify that the created key pair is registered with your account.
+
+1. Create an AWS profile, for more information, see [Profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-profiles) in the AWS documentation.

--- a/docs/site/content/docs/latest/headless-install.md
+++ b/docs/site/content/docs/latest/headless-install.md
@@ -87,6 +87,8 @@ from the terminal on this machine, pointing to the file in your home directory:
 tanzu management-cluster create --file ~/bs83endsfl.yaml -v 6
 ```
 
+**AWS Limitation:** If you are deploying to AWS, you must recreate the AWS CLI profile on your headless machine. For more information, see [Profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-profiles) in the AWS documentation.
+
 ### Remote UI
 
 Another option is to use the graphical UI to perform the installation, but


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
- Adds missing step to the Prepare to install on AWS
- Adds note on AWS profile limitation to headless install doc 

## Details for the Release Notes (PLEASE PROVIDE)

```NONE

```

## Which issue(s) this PR fixes

Fixes: #2251

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
