### PR TITLE
Doc - Add doc for finding name of kind cluster in troubleshooting section

### DIFF
--- a/docs/site/content/docs/latest/tsg-bootstrap.md
+++ b/docs/site/content/docs/latest/tsg-bootstrap.md
@@ -8,12 +8,19 @@ The bootstrap cluster is the key to being able to introspect and understand what
 
 One way to debug your cluster bootstrap issues is to use the `tanzu diagnostics` CLI plugin which comes with Tanzu Community Edition.
 
-### Pre-requisites
+### Prerequisites
 
 Prior to collecting diagnostics data, your local machine must have the following programs in its `$PATH`:
 
 * kind
 * kubectl
+
+### Before you Begin
+
+The kind bootstrap cluster name and the standalone or management cluster name are not related. If there are multiple kind bootstrap clusters present, before you begin debugging, you should determine the name of the kind cluster in one or both of the following files:
+
+* `~/.kube-tkg/tmp/`
+* `~/.config/tanzu/tkg/config.yaml` -  find the cluster name in the `name` parameter and the corresponding kind bootstrap cluster name in the `context` parameter prefixed by `kind-tkg-kind`
 
 ### Collecting bootstrap diagnostics
 


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
Add a before you begin section to the 'Troubleshoot Cluster Bootstrapping' that describes how to find the name of the kind cluster

## Details for the Release Notes (PLEASE PROVIDE)

```NONE

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1716

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
