### PR TITLE
Remove latest folder from TF GCP buckets

### DIFF
--- a/hack/release/cut-release.sh
+++ b/hack/release/cut-release.sh
@@ -213,6 +213,10 @@ for dir in ./*/
 do
   dir=${dir%*/}
   echo "dir: ${dir}"
+
+  # some tf directories also contain a "latest" subfolder that needs to be deleted
+  rm -rf ./latest
+
   pushd "${dir}/${FRAMEWORK_BUILD_VERSION}" || exit 1
   # delete all binaries
   rm -rf ./test
@@ -230,6 +234,10 @@ for dir in ./*/
 do
   dir=${dir%*/}
   echo "dir: ${dir}"
+
+  # some tf directories also contain a "latest" subfolder that needs to be deleted
+  rm -rf ./latest
+
   pushd "${dir}/${FRAMEWORK_BUILD_VERSION}" || exit 1
   # delete all binaries
   rm -rf ./test


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
In the latest tag (https://github.com/vmware-tanzu/community-edition/runs/4218396036?check_suite_focus=true), we inadvently uploaded the `latest` folder for the `core` plugin. Seen here in the last few lines:

```
3s
Run google-github-actions/upload-cloud-storage@main
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/manifest.yaml to gs://tce-tanzu-cli-framework/artifacts/manifest.yaml
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/core/plugin.yaml to gs://tce-tanzu-cli-framework/artifacts/core/plugin.yaml
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/cluster/plugin.yaml to gs://tce-tanzu-cli-framework/artifacts/cluster/plugin.yaml
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/kubernetes-release/plugin.yaml to gs://tce-tanzu-cli-framework/artifacts/kubernetes-release/plugin.yaml
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/login/plugin.yaml to gs://tce-tanzu-cli-framework/artifacts/login/plugin.yaml
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/management-cluster/plugin.yaml to gs://tce-tanzu-cli-framework/artifacts/management-cluster/plugin.yaml
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/package/plugin.yaml to gs://tce-tanzu-cli-framework/artifacts/package/plugin.yaml
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/pinniped-auth/plugin.yaml to gs://tce-tanzu-cli-framework/artifacts/pinniped-auth/plugin.yaml
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/secret/plugin.yaml to gs://tce-tanzu-cli-framework/artifacts/secret/plugin.yaml
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/core/latest/tanzu-core-darwin_amd64 to gs://tce-tanzu-cli-framework/artifacts/core/latest/tanzu-core-darwin_amd64
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/core/latest/tanzu-core-darwin_arm64 to gs://tce-tanzu-cli-framework/artifacts/core/latest/tanzu-core-darwin_arm64
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/core/latest/tanzu-core-linux_amd64 to gs://tce-tanzu-cli-framework/artifacts/core/latest/tanzu-core-linux_amd64
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/core/latest/tanzu-core-windows_amd64.exe to gs://tce-tanzu-cli-framework/artifacts/core/latest/tanzu-core-windows_amd64.exe
```

This outright deletes the folder since they aren't needed.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Remove latest folder from TF GCP buckets
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA