### PR TITLE
Add update strategy annotation for calico controllers

### DIFF
--- a/addons/packages/calico/3.11.3/bundle/config/overlay/calico_overlay.yaml
+++ b/addons/packages/calico/3.11.3/bundle/config/overlay/calico_overlay.yaml
@@ -14,6 +14,7 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
+    kapp.k14s.io/update-strategy: always-replace
 
 #@overlay/match by=overlay.subset({"kind":"DaemonSet", "metadata": {"name": "calico-node"}})
 ---

--- a/addons/packages/calico/3.11.3/package.yaml
+++ b/addons/packages/calico/3.11.3/package.yaml
@@ -13,7 +13,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/calico@sha256:136b5b12aef94910a082988998dd8cd2e84ecc42598b0fb248da93d99dd41edd
+            image: projects.registry.vmware.com/tce/calico@sha256:6a64577ef47ce4a1868d7c956cefbdeb3dd04ce80e229ff5da84a6f3c1603093
       template:
         - ytt:
             paths:

--- a/addons/packages/calico/3.11.3/test/calico_test.go
+++ b/addons/packages/calico/3.11.3/test/calico_test.go
@@ -33,8 +33,12 @@ var _ = Describe("Calico Ytt Templates", func() {
 		fileValuesStar        = filepath.Join(configDir, "values.star")
 	)
 
-	desiredAnnotations := map[string]string{
+	desiredDaemonSetAnnotations := map[string]string{
 		"kapp.k14s.io/disable-default-label-scoping-rules": "",
+	}
+	desiredDeploymentAnnotations := map[string]string{
+		"kapp.k14s.io/disable-default-label-scoping-rules": "",
+		"kapp.k14s.io/update-strategy":                     "always-replace",
 	}
 
 	BeforeEach(func() {
@@ -109,8 +113,8 @@ data:
 			Expect(err).NotTo(HaveOccurred())
 			daemonSet := parseDaemonSet(output)
 			deployment := parseDeployment(output)
-			Expect(daemonSet.Annotations).To(Equal(desiredAnnotations))
-			Expect(deployment.Annotations).To(Equal(desiredAnnotations))
+			Expect(daemonSet.Annotations).To(Equal(desiredDaemonSetAnnotations))
+			Expect(deployment.Annotations).To(Equal(desiredDeploymentAnnotations))
 		})
 	})
 

--- a/addons/packages/calico/3.19.1/bundle/config/overlay/calico_overlay.yaml
+++ b/addons/packages/calico/3.19.1/bundle/config/overlay/calico_overlay.yaml
@@ -14,6 +14,7 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
+    kapp.k14s.io/update-strategy: always-replace
 
 #@overlay/match by=overlay.subset({"kind":"DaemonSet", "metadata": {"name": "calico-node"}})
 ---

--- a/addons/packages/calico/3.19.1/package.yaml
+++ b/addons/packages/calico/3.19.1/package.yaml
@@ -14,7 +14,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/calico@sha256:653878196814bdef0ced6b796752cade746248547bd6986abea9b029807f8d2b
+            image: projects.registry.vmware.com/tce/calico@sha256:5dc11a449f0945acc4000ee8b1a28ddd414288bf421ea294f188ad085cd0bce5
       template:
         - ytt:
             paths:

--- a/addons/packages/calico/3.19.1/test/calico_test.go
+++ b/addons/packages/calico/3.19.1/test/calico_test.go
@@ -33,8 +33,12 @@ var _ = Describe("Calico Ytt Templates", func() {
 		fileValuesStar        = filepath.Join(configDir, "values.star")
 	)
 
-	desiredAnnotations := map[string]string{
+	desiredDaemonSetAnnotations := map[string]string{
 		"kapp.k14s.io/disable-default-label-scoping-rules": "",
+	}
+	desiredDeploymentAnnotations := map[string]string{
+		"kapp.k14s.io/disable-default-label-scoping-rules": "",
+		"kapp.k14s.io/update-strategy":                     "always-replace",
 	}
 
 	BeforeEach(func() {
@@ -115,8 +119,8 @@ data:
 			Expect(err).NotTo(HaveOccurred())
 			daemonSet := parseDaemonSet(output)
 			deployment := parseDeployment(output)
-			Expect(daemonSet.Annotations).To(Equal(desiredAnnotations))
-			Expect(deployment.Annotations).To(Equal(desiredAnnotations))
+			Expect(daemonSet.Annotations).To(Equal(desiredDaemonSetAnnotations))
+			Expect(deployment.Annotations).To(Equal(desiredDeploymentAnnotations))
 		})
 	})
 
@@ -201,8 +205,8 @@ data:
 			Expect(err).NotTo(HaveOccurred())
 			daemonSet := parseDaemonSet(output)
 			deployment := parseDeployment(output)
-			Expect(daemonSet.Annotations).To(Equal(desiredAnnotations))
-			Expect(deployment.Annotations).To(Equal(desiredAnnotations))
+			Expect(daemonSet.Annotations).To(Equal(desiredDaemonSetAnnotations))
+			Expect(deployment.Annotations).To(Equal(desiredDeploymentAnnotations))
 		})
 	})
 


### PR DESCRIPTION
## What this PR does / why we need it
When the old version of calico is installed with packageInstall, the calico-kube-controllers contains some kapp labels in `LabelSelectors` because it does not have the annotation `kapp.k14s.io/disable-default-label-scoping-rules: ""`, but the new version of it has this annotation so the kapp `LabelSelectors` are removed. During package updating, this cause the error of updating immutable field `LabelSelectors`. So we need to remove and create the calico-kube-controllers during updating it.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/2387

## Describe testing done for PR
Added test cases and ran make test for Calico 3.11.3 and 3.19.1 package.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
