### PR TITLE
Add upgrade strategy for ako statefulset

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/overlays/overlay-statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/overlays/overlay-statefulset.yaml
@@ -91,6 +91,7 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
+    kapp.k14s.io/update-strategy: always-replace
 spec:
   replicas: #@ values.loadBalancerAndIngressService.config.replica_count
   selector:

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/overlays/overlay-statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/overlays/overlay-statefulset.yaml
@@ -21,6 +21,7 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
+    kapp.k14s.io/update-strategy: always-replace
 spec:
   replicas: #@ values.loadBalancerAndIngressService.config.replica_count
   selector:


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Add upgrade strategy for ako statefulset to avoid ako upgrade error:

```bash
 USEFUL-ERROR-MESSAGE: kapp: Error: Applying update statefulset/ako (apps/v1) namespace: avi-system:
 Updating resource statefulset/ako (apps/v1) namespace: avi-system:
 StatefulSet.apps "ako" is invalid: spec:
 Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden (reason: Invalid)
```


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

TODO

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
