### PR TITLE
Wiring velero e2e-test with e2e-framework

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -40,7 +40,7 @@ var (
 	addonsCfg        *PackageConfiguration
 	ConfigVal        *Config
 	MetallbInstalled bool
-	VeleroInstalled bool
+	VeleroInstalled  bool
 )
 
 func init() {
@@ -188,13 +188,13 @@ func runPackageTest(pkgName, version string) error {
 
 	// Install velero to run the test
 	if pkgName == "velero" {
-        err := testdata.InstallVelero(version)
-        if err != nil {
-            log.Println("Error while installing Velero", err)
-            return err
-        }
-        VeleroInstalled = true
-    }
+		err := testdata.InstallVelero(version)
+		if err != nil {
+			log.Println("Error while installing Velero", err)
+			return err
+		}
+		VeleroInstalled = true
+	}
 
 	mydir, err := os.Getwd()
 	if err != nil {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -40,6 +40,7 @@ var (
 	addonsCfg        *PackageConfiguration
 	ConfigVal        *Config
 	MetallbInstalled bool
+	VeleroInstalled bool
 )
 
 func init() {
@@ -184,6 +185,16 @@ func runPackageTest(pkgName, version string) error {
 		log.Println("Error while changing directory :", err)
 		return err
 	}
+
+	// Install velero to run the test
+	if pkgName == "velero" {
+        err := testdata.InstallVelero(version)
+        if err != nil {
+            log.Println("Error while installing Velero", err)
+            return err
+        }
+        VeleroInstalled = true
+    }
 
 	mydir, err := os.Getwd()
 	if err != nil {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -46,6 +46,11 @@ var _ = AfterSuite(func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 
+		if e2e.VeleroInstalled {
+            err := testdata.UnsinstallVelero()
+            Expect(err).NotTo(HaveOccurred())
+        }
+
 		// delete the cluster
 		if e2e.ConfigVal.ClusterCleanupRequired {
 			log.Println("Deleting the cluster created")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -47,9 +47,9 @@ var _ = AfterSuite(func() {
 		}
 
 		if e2e.VeleroInstalled {
-            err := testdata.UnsinstallVelero()
-            Expect(err).NotTo(HaveOccurred())
-        }
+			err := testdata.UnsinstallVelero()
+			Expect(err).NotTo(HaveOccurred())
+		}
 
 		// delete the cluster
 		if e2e.ConfigVal.ClusterCleanupRequired {

--- a/test/e2e/testdata/install_dependencies.go
+++ b/test/e2e/testdata/install_dependencies.go
@@ -31,22 +31,22 @@ func InstallMetallb() error {
 	return nil
 }
 func InstallVelero(version string) error {
-	
-	isVeleroInstall,_ := u.Kubectl(nil, "get", "apps", "velero", "-o=jsonpath={..status.conditions[0].status}")
+
+	isVeleroInstall, _ := u.Kubectl(nil, "get", "apps", "velero", "-o=jsonpath={..status.conditions[0].status}")
 	if isVeleroInstall != "True" {
-    	_,err := u.Tanzu(nil, "package", "install", "velero", "--package-name","velero.community.tanzu.vmware.com","--version",version, "--values-file", u.WorkingDir+"/testdata/velero/velero_values.yaml")
-    	if err != nil {
-        	fmt.Printf("%s", err)
-        	return err
-    	}
+		_, err := u.Tanzu(nil, "package", "install", "velero", "--package-name", "velero.community.tanzu.vmware.com", "--version", version, "--values-file", u.WorkingDir+"/testdata/velero/velero_values.yaml")
+		if err != nil {
+			fmt.Printf("%s", err)
+			return err
+		}
 	}
 
-    return nil;
+	return nil
 }
 
 func UnsinstallVelero() error {
-    _, err := u.Tanzu(nil, "package", "installed", "delete", "velero", "-y")
-    if err != nil {
+	_, err := u.Tanzu(nil, "package", "installed", "delete", "velero", "-y")
+	if err != nil {
 		fmt.Printf("%s", err)
 	}
 	return err

--- a/test/e2e/testdata/install_dependencies.go
+++ b/test/e2e/testdata/install_dependencies.go
@@ -30,6 +30,27 @@ func InstallMetallb() error {
 
 	return nil
 }
+func InstallVelero(version string) error {
+	
+	isVeleroInstall,_ := u.Kubectl(nil, "get", "apps", "velero", "-o=jsonpath={..status.conditions[0].status}")
+	if isVeleroInstall != "True" {
+    	_,err := u.Tanzu(nil, "package", "install", "velero", "--package-name","velero.community.tanzu.vmware.com","--version",version, "--values-file", u.WorkingDir+"/testdata/velero/velero_values.yaml")
+    	if err != nil {
+        	fmt.Printf("%s", err)
+        	return err
+    	}
+	}
+
+    return nil;
+}
+
+func UnsinstallVelero() error {
+    _, err := u.Tanzu(nil, "package", "installed", "delete", "velero", "-y")
+    if err != nil {
+		fmt.Printf("%s", err)
+	}
+	return err
+}
 
 func UninstallMetallb() error {
 	_, err := u.Kubectl(nil, "delete", "-f", u.WorkingDir+"/testdata/metal-lb/namespace.yaml")

--- a/test/e2e/testdata/velero/velero_values.yaml
+++ b/test/e2e/testdata/velero/velero_values.yaml
@@ -15,7 +15,7 @@ backupStorageLocation:
     provider: aws
     default: true
     objectStorage:
-      bucket: velero-e2e-test-backup
+      bucket: tce-velero-e2e-test-backup
       prefix: backup
     configAWS:
       region: us-east-1

--- a/test/e2e/testdata/velero/velero_values.yaml
+++ b/test/e2e/testdata/velero/velero_values.yaml
@@ -1,0 +1,23 @@
+---
+namespace: velero
+deployRestic: false
+credential:
+  useDefaultSecret: true
+  name: cloud-credentials
+  secretContents:
+    cloud: |
+      [default]
+      aws_access_key_id=${AWS_ACCESS_KEY}
+      aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+backupStorageLocation:
+  name: backup
+  spec:
+    provider: aws
+    default: true
+    objectStorage:
+      bucket: velero-e2e-test-backup
+      prefix: backup
+    configAWS:
+      region: us-east-1
+volumeSnapshotLocation:
+  snapshotsEnabled: false


### PR DESCRIPTION
Signed-off-by: Aman Sharma <amansh@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR will wire the e2e-test for Velero with the e2e-framework under `test/e2e` which includes the installation and deletion of the package whenever we run `ginkgo -v -- --packages="velero" --version="1.6.3" --guest-cluster-name="tce-mycluster"`.
## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Velero e2e-test wiring with e2e-framework
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: # NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Run `ginkgo -v -- --packages="velero" --version="1.6.3" --guest-cluster-name="tce-mycluster"` to test velero and the working of e2e-framework.
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
The prerequisites handled for velero in e2e-framework is in the similar way we did for external-dns.  