### PR TITLE
Docs: Fix Medium Zoom selector to exclude side nav images

### DIFF
--- a/docs/site/themes/template/assets/js/main.js
+++ b/docs/site/themes/template/assets/js/main.js
@@ -128,5 +128,5 @@ document.addEventListener('DOMContentLoaded', function(){
     createCopyButtons();
 
     // Load the medium-zoom library and attach based on css selector
-    mediumZoom('.docs img')
+    mediumZoom('.docs-content img')
 });


### PR DESCRIPTION
Signed-off-by: Garry Ing <ging@vmware.com>

## What this PR does / why we need it
- Fixes an issue when clicking on the GitHub icon in the right column invokes Medium Zoom overlay on the icon

## Details for the Release Notes (PLEASE PROVIDE)

## Which issue(s) this PR fixes
Fixes: #

## Describe testing done for PR
- `hugo serve`
- Navigate to `/docs/latest/`
- Click GitHub icon in right column
- Navigate back to docs tab from the opened link

## Special notes for your reviewer
