### PR TITLE
Add overlay to update ServiceAccount namespace on ClusterRoleBinding for Gatekeeper package

### DIFF
--- a/addons/packages/gatekeeper/3.2.3/bundle/config/overlays/overlay-namespace.yaml
+++ b/addons/packages/gatekeeper/3.2.3/bundle/config/overlays/overlay-namespace.yaml
@@ -18,6 +18,13 @@ subjects:
 - kind: ServiceAccount
   namespace: #@ data.values.namespace
 
+#@overlay/match by=overlay.subset({"kind":"ClusterRoleBinding"})
+---
+subjects:
+#@overlay/match by=overlay.subset({"namespace": "gatekeeper-system"})
+- kind: ServiceAccount
+  namespace: #@ data.values.namespace
+
 #@overlay/match by=overlay.subset({"kind":"ValidatingWebhookConfiguration"})
 ---
 webhooks:

--- a/addons/packages/gatekeeper/3.2.3/package.yaml
+++ b/addons/packages/gatekeeper/3.2.3/package.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/gatekeeper@sha256:b7a2102712f4de53f1d46532d468b5af5f1bfba60d5b9c6d1cffe59967b9077d
+            image: projects.registry.vmware.com/tce/gatekeeper@sha256:508b518a00956f8cf365666541db34023461913937d93c4492fb585be8d5de20
       template:
         - ytt:
             paths:

--- a/addons/packages/gatekeeper/3.7.0/bundle/config/overlay/overlay-namespace.yaml
+++ b/addons/packages/gatekeeper/3.7.0/bundle/config/overlay/overlay-namespace.yaml
@@ -18,6 +18,13 @@ subjects:
   - kind: ServiceAccount
     namespace: #@ data.values.namespace
 
+#@overlay/match by=overlay.subset({"kind":"ClusterRoleBinding"})
+---
+subjects:
+#@overlay/match by=overlay.subset({"namespace": "gatekeeper-system"})
+- kind: ServiceAccount
+  namespace: #@ data.values.namespace
+
 #@overlay/match by=overlay.subset({"kind":"ValidatingWebhookConfiguration"})
 ---
 webhooks:

--- a/addons/packages/gatekeeper/3.7.0/package.yaml
+++ b/addons/packages/gatekeeper/3.7.0/package.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/gatekeeper@sha256:5c9dfb323fe18024adfbdf97c0edf0ab8409e179f9dd9b686a383e291d35b959
+            image: projects.registry.vmware.com/tce/gatekeeper@sha256:af58b5e95bf53dde9c82c7112a2f62dca749e9f2adf3b2488e3ae0b5ba80852a
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it

Fix for bug in Gatekeeper version 3.2.3 and 3.70 when attempting to use a namespace other than  the default`gatekeeper-system`


## Details for the Release Notes
```release-note
Fixes bug where gatekeeper namespace override would cause deployment of the package to fail.
```

## Which issue(s) this PR fixes
Fixes #2639 

## Describe testing done for PR
Verified the ytt using `ytt --data-value namespace=gatekeeper-test -f bundle/config | grep gatekeeper-system` from inside the addons/packages and ensured no lines are returned. (Current code returns 1 line for the ClusterRoleBinding)
Tested deploying packages locally.

## Special notes for your reviewer
Discussions around Gatekeeper testing improvements suggested handling the updated testing in a separate PR.