### PR TITLE
correction in the curl path for aws cli installation

### DIFF
--- a/hack/ensure-dependencies.sh
+++ b/hack/ensure-dependencies.sh
@@ -188,11 +188,10 @@ case "${BUILD_OS}" in
     rm awscliv2.zip
     ;;
   Darwin)
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    unzip awscliv2.zip
-    sudo ./aws/install -i
+    curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "awscliv2.pkg"
+    sudo installer -pkg awscliv2.pkg -target /
     rm -rf ./aws
-    rm awscliv2.zip
+    rm awscliv2.pkg
     ;;
 esac
 fi


### PR DESCRIPTION
Signed-off-by: Aman Sharma <amansh@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR will correct the file path for the aws cli installation in `hack/ensure-dependencies.sh`.
## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Correction in hack/ensure-dependencies.sh
```
## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2652

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
- Run `hack/ensure-dependencies.sh`
- Run aws command
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
none