### PR TITLE
Add notice to Mac getting started that ARM machines are not supported

### DIFF
--- a/docs/site/content/docs/assets/prereq-linux.md
+++ b/docs/site/content/docs/assets/prereq-linux.md
@@ -1,6 +1,7 @@
 ### Linux Local Bootstrap Machine Prerequisites
 ||
 |:--- |
+|Arch: x86; ARM is currently unsupported|
 |RAM: 6 GB|
 |CPU: 2|
 |[Docker](https://docs.docker.com/engine/install/) <BR> In Docker, you must create the docker group and add your user before you attempt to create a standalone or management cluster. Complete steps 1 to 4 in the [Manage Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) procedure in the Docker documentation.|

--- a/docs/site/content/docs/assets/prereq-mac.md
+++ b/docs/site/content/docs/assets/prereq-mac.md
@@ -2,6 +2,7 @@
 
 ||
 |:--- |
+|Arch: x86; ARM (M1) currently unsupported |
 |RAM: 6 GB |
 |CPU: 2|
 |[Docker Desktop for Mac](https://docs.docker.com/desktop/mac/install/)|


### PR DESCRIPTION
## What this PR does / why we need it

This is related to, but not fully-resolving:

* https://github.com/vmware-tanzu/community-edition/issues/2616

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Provide notice to user that ARM/M1 is unsupported
```

## Which issue(s) this PR fixes

Does not fully-resolve a PR.

## Describe testing done for PR

Run `hugo serve` and verify

## Special notes for your reviewer

The above.