### PR TITLE
packages/contour: Expose loadBalancerIP in config

### DIFF
--- a/addons/packages/contour/1.18.2/README.md
+++ b/addons/packages/contour/1.18.2/README.md
@@ -138,6 +138,7 @@ You can configure the following:
 | `contour.logLevel` | `info` | The Contour log level. Valid values are `info` and `debug`. |
 | `envoy.service.type` | `LoadBalancer` | The type of Kubernetes service to provision for Envoy. Valid values are `LoadBalancer`, `NodePort`, and `ClusterIP`. |
 | `envoy.service.externalTrafficPolicy` | `Local` | The external traffic policy for the Envoy service. Valid values are `Local` and `Cluster`.  If `envoy.service.type` is `ClusterIP`, this field is ignored. |
+| `envoy.service.loadBalancerIP` | (none) | The desired load balancer IP for the Envoy service. If `envoy.service.type` is not `LoadBalancer`, this field is ignored. |
 | `envoy.service.annotations` | (none) | Annotations to set on the Envoy service. |
 | `envoy.service.nodePorts.http` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
 | `envoy.service.nodePorts.https` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes. |

--- a/addons/packages/contour/1.18.2/bundle/config/overlays/update-envoy-service.yaml
+++ b/addons/packages/contour/1.18.2/bundle/config/overlays/update-envoy-service.yaml
@@ -25,7 +25,7 @@ spec:
     #@ end
   #@ end
 
-  #@ if data.values.envoy.service.type == "LoadBalancer":
+  #@ if data.values.envoy.service.loadBalancerIP and data.values.envoy.service.type == "LoadBalancer":
   loadBalancerIP: #@ data.values.envoy.service.loadBalancerIP
   #@ end
 

--- a/addons/packages/contour/1.18.2/bundle/config/overlays/update-envoy-service.yaml
+++ b/addons/packages/contour/1.18.2/bundle/config/overlays/update-envoy-service.yaml
@@ -26,6 +26,7 @@ spec:
   #@ end
 
   #@ if data.values.envoy.service.loadBalancerIP and data.values.envoy.service.type == "LoadBalancer":
+  #@overlay/match missing_ok=True
   loadBalancerIP: #@ data.values.envoy.service.loadBalancerIP
   #@ end
 

--- a/addons/packages/contour/1.18.2/bundle/config/overlays/update-envoy-service.yaml
+++ b/addons/packages/contour/1.18.2/bundle/config/overlays/update-envoy-service.yaml
@@ -25,6 +25,10 @@ spec:
     #@ end
   #@ end
 
+  #@ if data.values.envoy.service.type == "LoadBalancer":
+  loadBalancerIP: #@ data.values.envoy.service.loadBalancerIP
+  #@ end
+
   #@ if data.values.envoy.service.type == "NodePort" or data.values.envoy.service.type == "LoadBalancer":
   #@ if/end data.values.envoy.service.externalTrafficPolicy:
   externalTrafficPolicy: #@ data.values.envoy.service.externalTrafficPolicy

--- a/addons/packages/contour/1.18.2/bundle/config/values.yaml
+++ b/addons/packages/contour/1.18.2/bundle/config/values.yaml
@@ -26,6 +26,11 @@ envoy:
     #! The type of Kubernetes service to provision for Envoy.
     type: LoadBalancer
 
+    #! The desired load balancer IP.  If type is not "LoadBalancer, this field is ignored.
+    #! It is up to the cloud provider whether to honor this request.  If null, then load balancer IP
+    #! will be assigned by the cloud provider.
+    loadBalancerIP: null
+
     #! The external traffic policy for the Envoy service. If type is "ClusterIP", this field is ignored.
     externalTrafficPolicy: Local
 

--- a/addons/packages/contour/1.18.2/package.yaml
+++ b/addons/packages/contour/1.18.2/package.yaml
@@ -72,7 +72,6 @@ spec:
                 loadBalancerIP:
                   type: string
                   description: The desired load balancer IP for the Envoy service.
-                  default: Local
                 annotations:
                   type: object
                   additionalProperties: string

--- a/addons/packages/contour/1.18.2/package.yaml
+++ b/addons/packages/contour/1.18.2/package.yaml
@@ -69,6 +69,10 @@ spec:
                   type: string
                   description: The external traffic policy for the Envoy service.
                   default: Local
+                loadBalancerIP:
+                  type: string
+                  description: The desired load balancer IP for the Envoy service.
+                  default: Local
                 annotations:
                   type: object
                   additionalProperties: string

--- a/addons/packages/contour/1.19.1/README.md
+++ b/addons/packages/contour/1.19.1/README.md
@@ -138,6 +138,7 @@ You can configure the following:
 | `contour.logLevel` | `info` | The Contour log level. Valid values are `info` and `debug`. |
 | `envoy.service.type` | `LoadBalancer` | The type of Kubernetes service to provision for Envoy. Valid values are `LoadBalancer`, `NodePort`, and `ClusterIP`. |
 | `envoy.service.externalTrafficPolicy` | `Local` | The external traffic policy for the Envoy service. Valid values are `Local` and `Cluster`.  If `envoy.service.type` is `ClusterIP`, this field is ignored. |
+| `envoy.service.loadBalancerIP` | (none) | The desired load balancer IP for the Envoy service. If `envoy.service.type` is not `LoadBalancer`, this field is ignored. |
 | `envoy.service.annotations` | (none) | Annotations to set on the Envoy service. |
 | `envoy.service.nodePorts.http` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
 | `envoy.service.nodePorts.https` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes. |

--- a/addons/packages/contour/1.19.1/bundle/config/overlays/update-envoy-service.yaml
+++ b/addons/packages/contour/1.19.1/bundle/config/overlays/update-envoy-service.yaml
@@ -25,7 +25,7 @@ spec:
     #@ end
   #@ end
 
-  #@ if data.values.envoy.service.type == "LoadBalancer":
+  #@ if data.values.envoy.service.loadBalancerIP and data.values.envoy.service.type == "LoadBalancer":
   loadBalancerIP: #@ data.values.envoy.service.loadBalancerIP
   #@ end
 

--- a/addons/packages/contour/1.19.1/bundle/config/overlays/update-envoy-service.yaml
+++ b/addons/packages/contour/1.19.1/bundle/config/overlays/update-envoy-service.yaml
@@ -26,6 +26,7 @@ spec:
   #@ end
 
   #@ if data.values.envoy.service.loadBalancerIP and data.values.envoy.service.type == "LoadBalancer":
+  #@overlay/match missing_ok=True
   loadBalancerIP: #@ data.values.envoy.service.loadBalancerIP
   #@ end
 

--- a/addons/packages/contour/1.19.1/bundle/config/overlays/update-envoy-service.yaml
+++ b/addons/packages/contour/1.19.1/bundle/config/overlays/update-envoy-service.yaml
@@ -25,6 +25,10 @@ spec:
     #@ end
   #@ end
 
+  #@ if data.values.envoy.service.type == "LoadBalancer":
+  loadBalancerIP: #@ data.values.envoy.service.loadBalancerIP
+  #@ end
+
   #@ if data.values.envoy.service.type == "NodePort" or data.values.envoy.service.type == "LoadBalancer":
   #@ if/end data.values.envoy.service.externalTrafficPolicy:
   externalTrafficPolicy: #@ data.values.envoy.service.externalTrafficPolicy

--- a/addons/packages/contour/1.19.1/bundle/config/values.yaml
+++ b/addons/packages/contour/1.19.1/bundle/config/values.yaml
@@ -26,6 +26,11 @@ envoy:
     #! The type of Kubernetes service to provision for Envoy.
     type: LoadBalancer
 
+    #! The desired load balancer IP.  If type is not "LoadBalancer, this field is ignored.
+    #! It is up to the cloud provider whether to honor this request.  If null, then load balancer IP
+    #! will be assigned by the cloud provider.
+    loadBalancerIP: null
+
     #! The external traffic policy for the Envoy service. If type is "ClusterIP", this field is ignored.
     externalTrafficPolicy: Local
 

--- a/addons/packages/contour/1.19.1/package.yaml
+++ b/addons/packages/contour/1.19.1/package.yaml
@@ -72,7 +72,6 @@ spec:
                 loadBalancerIP:
                   type: string
                   description: The desired load balancer IP for the Envoy service.
-                  default: Local
                 annotations:
                   type: object
                   additionalProperties: string

--- a/addons/packages/contour/1.19.1/package.yaml
+++ b/addons/packages/contour/1.19.1/package.yaml
@@ -69,6 +69,10 @@ spec:
                   type: string
                   description: The external traffic policy for the Envoy service.
                   default: Local
+                loadBalancerIP:
+                  type: string
+                  description: The desired load balancer IP for the Envoy service.
+                  default: Local
                 annotations:
                   type: object
                   additionalProperties: string

--- a/docs/site/content/docs/latest/designs/package-management.md
+++ b/docs/site/content/docs/latest/designs/package-management.md
@@ -116,6 +116,7 @@ tanzu package available get contour.community.tanzu.vmware.com/1.17.1 --values-s
   envoy.logLevel                       info            string   The Envoy log level.
   envoy.service.annotations            <nil>           object   Annotations to set on the Envoy service.
   envoy.service.externalTrafficPolicy  Local           string   The external traffic policy for the Envoy service.
+  envoy.service.loadBalancerIP         <nil>           string   If type == LoadBalancer, the desired load balancer IP for the Envoy service.
   envoy.service.nodePorts.http         <nil>           integer  If type == NodePort, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes.
   envoy.service.nodePorts.https        <nil>           integer  If type == NodePort, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes.
   envoy.service.type                   LoadBalancer    string   The type of Kubernetes service to provision for Envoy.

--- a/docs/site/content/docs/latest/docker-monitoring-stack.md
+++ b/docs/site/content/docs/latest/docker-monitoring-stack.md
@@ -215,6 +215,7 @@ This is only a subset of the configuration parameters available in Contour. To d
   envoy.service.type                   LoadBalancer    string   The type of Kubernetes service to provision for Envoy.
   envoy.service.annotations            <nil>           object   Annotations to set on the Envoy service.
   envoy.service.externalTrafficPolicy  Local           string   The external traffic policy for the Envoy service.
+  envoy.service.loadBalancerIP         <nil>           string   If type == LoadBalancer, the desired load balancer IP for the Envoy service.
   envoy.service.nodePorts.http         <nil>           integer  If type == NodePort, the node port number to expose Envoys HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes.
   envoy.service.nodePorts.https        <nil>           integer  If type == NodePort, the node port number to expose Envoys HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes.
   envoy.terminationGracePeriodSeconds  300             integer  The termination grace period, in seconds, for the Envoy pods.

--- a/docs/site/content/docs/latest/package-management.md
+++ b/docs/site/content/docs/latest/package-management.md
@@ -294,6 +294,7 @@ tanzu package install ${NAME} \
       envoy.logLevel                       info            string   The Envoy log level.
       envoy.service.annotations            <nil>           object   Annotations to set on the Envoy service.
       envoy.service.externalTrafficPolicy  Local           string   The external traffic policy for the Envoy service.
+      envoy.service.loadBalancerIP         <nil>           string   If type == LoadBalancer, the desired load balancer IP for the Envoy service.
       envoy.service.nodePorts.http         <nil>           integer  If type == NodePort, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes.
       envoy.service.nodePorts.https        <nil>           integer  If type == NodePort, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes.
       envoy.service.type                   LoadBalancer    string   The type of Kubernetes service to provision for Envoy.

--- a/docs/site/content/docs/latest/package-readme-contour-1.19.1.md
+++ b/docs/site/content/docs/latest/package-readme-contour-1.19.1.md
@@ -138,6 +138,7 @@ You can configure the following:
 | `contour.logLevel` | `info` | The Contour log level. Valid values are `info` and `debug`. |
 | `envoy.service.type` | `LoadBalancer` | The type of Kubernetes service to provision for Envoy. Valid values are `LoadBalancer`, `NodePort`, and `ClusterIP`. |
 | `envoy.service.externalTrafficPolicy` | `Local` | The external traffic policy for the Envoy service. Valid values are `Local` and `Cluster`.  If `envoy.service.type` is `ClusterIP`, this field is ignored. |
+| `envoy.service.loadBalancerIP` | (none) | The desired load balancer IP for the Envoy service. If `envoy.service.type` is not `LoadBalancer`, this field is ignored. |
 | `envoy.service.annotations` | (none) | Annotations to set on the Envoy service. |
 | `envoy.service.nodePorts.http` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
 | `envoy.service.nodePorts.https` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes. |

--- a/docs/site/content/docs/latest/vsphere-monitoring-stack.md
+++ b/docs/site/content/docs/latest/vsphere-monitoring-stack.md
@@ -223,6 +223,7 @@ This is only a subset of the configuration parameters available in Contour. To d
   envoy.service.type                   LoadBalancer    string   The type of Kubernetes service to provision for Envoy.
   envoy.service.annotations            <nil>           object   Annotations to set on the Envoy service.
   envoy.service.externalTrafficPolicy  Local           string   The external traffic policy for the Envoy service.
+  envoy.service.loadBalancerIP         <nil>           string   If type == LoadBalancer, the desired load balancer IP for the Envoy service.
   envoy.service.nodePorts.http         <nil>           integer  If type == NodePort, the node port number to expose Envoys HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes.
   envoy.service.nodePorts.https        <nil>           integer  If type == NodePort, the node port number to expose Envoys HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes.
   envoy.terminationGracePeriodSeconds  300             integer  The termination grace period, in seconds, for the Envoy pods.


### PR DESCRIPTION
If applied, this commit will all a user to specify desired load balancer IP address for Contour's Envoy service.

Fixes #2622

Signed-off-by: Dodd Pfeffer <dpfeffer@vmware.com>

## Describe testing done for PR
I'm not quite sure how to test this.

## Special notes for your reviewer
I attempted to find all relavent docs that would need to be updated as well.
I felt making the update to the latest patch release of the last two minors was sufficient.  I'm open to feedback.