### PR TITLE
Pinniped Package: remove namespace from JWTauthenticator

### DIFF
--- a/addons/packages/pinniped/0.12.0/bundle/config/overlay/pinniped-jwtauthenticator.yaml
+++ b/addons/packages/pinniped/0.12.0/bundle/config/overlay/pinniped-jwtauthenticator.yaml
@@ -1,12 +1,10 @@
 #@ load("@ytt:data", "data")
-#@ load("/libs/constants.lib.yaml", "pinniped_concierge_namespace")
 
 ---
 apiVersion: authentication.concierge.pinniped.dev/v1alpha1
 kind: JWTAuthenticator
 metadata:
   name: tkg-jwt-authenticator
-  namespace: #@ pinniped_concierge_namespace()
 spec:
   audience: #@ data.values.pinniped.supervisor_svc_endpoint
   issuer: #@ data.values.pinniped.supervisor_svc_endpoint


### PR DESCRIPTION
## What this PR does / why we need it

In Pinniped 0.6.0, the `JWTAuthenticator` resource was changed to be cluster-scoped, so it does not need a `namespace`.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

None

## Describe testing done for PR

1. I took a running TKGm 1.5.0 cluster and patched the Pinniped package with the version from the PR and made sure the TKGm IAM E2E tests passes

## Special notes for your reviewer

None