### PR TITLE
Remove local path from TF uploads to GCP Buckets

### DIFF
--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -134,15 +134,17 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: /tmp/tce-release/tanzu-framework/artifacts
-          destination: tce-framework-cli-plugins
+          destination: tce-framework-cli-plugins/artifacts
           credentials: ${{ secrets.GCP_BUCKET_SA }}
+          parent: false
       - name: Upload TF Admin Artifacts to Update Bucket
         id: upload-tf-artifacts-admin-update
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: /tmp/tce-release/tanzu-framework/artifacts-admin
-          destination: tce-framework-cli-plugins-admin
+          destination: tce-framework-cli-plugins-admin/artifacts-admin
           credentials: ${{ secrets.GCP_BUCKET_SA }}
+          parent: false
       - name: Commit Next Dev Version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
@@ -162,7 +164,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: /tmp/tce-release/tanzu-framework/artifacts
-          destination: tce-tanzu-cli-framework
+          destination: tce-tanzu-cli-framework/artifacts
           credentials: ${{ secrets.GCP_BUCKET_SA }}
           parent: false
       - name: Upload TF Artifacts-Admin to Release Bucket
@@ -170,7 +172,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: /tmp/tce-release/tanzu-framework/artifacts-admin
-          destination: tce-tanzu-cli-framework-admin
+          destination: tce-tanzu-cli-framework-admin/artifacts-admin
           credentials: ${{ secrets.GCP_BUCKET_SA }}
           parent: false
       - name: Upload Cayman Trigger Asset

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -135,15 +135,17 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: /tmp/tce-release/tanzu-framework/artifacts
-          destination: tce-framework-cli-plugins
+          destination: tce-framework-cli-plugins/artifacts
           credentials: ${{ secrets.GCP_BUCKET_SA }}
+          parent: false
       - name: Upload TF Admin Artifacts to Update Bucket
         id: upload-tf-artifacts-admin-update
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: /tmp/tce-release/tanzu-framework/artifacts-admin
-          destination: tce-framework-cli-plugins-admin
+          destination: tce-framework-cli-plugins-admin/artifacts-admin
           credentials: ${{ secrets.GCP_BUCKET_SA }}
+          parent: false
       - name: Commit Next Dev Version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
@@ -163,7 +165,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: /tmp/tce-release/tanzu-framework/artifacts
-          destination: tce-tanzu-cli-framework
+          destination: tce-tanzu-cli-framework/artifacts
           credentials: ${{ secrets.GCP_BUCKET_SA }}
           parent: false
       - name: Upload TF Artifacts-Admin to Release Bucket
@@ -171,7 +173,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: /tmp/tce-release/tanzu-framework/artifacts-admin
-          destination: tce-tanzu-cli-framework-admin
+          destination: tce-tanzu-cli-framework-admin/artifacts-admin
           credentials: ${{ secrets.GCP_BUCKET_SA }}
           parent: false
       - name: Upload Cayman Trigger Asset


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This removes the local path from being included in the upload path to the GCP bucket. As an example in this run:
https://github.com/vmware-tanzu/community-edition/runs/4404576567?check_suite_focus=true

You see:
```
...
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/manifest.yaml to gs://tce-framework-cli-plugins//tmp/tce-release/tanzu-framework/artifacts/manifest.yaml
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/core/plugin.yaml to gs://tce-framework-cli-plugins//tmp/tce-release/tanzu-framework/artifacts/core/plugin.yaml
Uploading file: /tmp/tce-release/tanzu-framework/artifacts/cluster/plugin.yaml to gs://tce-framework-cli-plugins//tmp/tce-release/tanzu-framework/artifacts/cluster/plugin.yaml
...
```

Which is not correct. The change removes `/tmp/tce-release/tanzu-framework`.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA