### PR TITLE
Add dnsPolicy to kapp controller package

### DIFF
--- a/addons/packages/kapp-controller/0.30.0/bundle/config/overlays/update-deployment.yaml
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/overlays/update-deployment.yaml
@@ -31,6 +31,8 @@ spec:
             value: #@ str(values.kappController.deployment.apiPort)
       #@ if/end values.kappController.deployment.hostNetwork:
       hostNetwork: #@ values.kappController.deployment.hostNetwork
+      #@ if/end values.kappController.deployment.dnsPolicy:
+      dnsPolicy: #@ values.kappController.deployment.dnsPolicy
       #@ if/end values.kappController.deployment.priorityClassName:
       priorityClassName: #@ values.kappController.deployment.priorityClassName
       #@ if hasattr(values.kappController.deployment, 'tolerations') and values.kappController.deployment.tolerations:

--- a/addons/packages/kapp-controller/0.30.0/bundle/config/values.yaml
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/values.yaml
@@ -8,6 +8,7 @@ kappController:
   globalNamespace: tanzu-package-repo-global
   deployment:
     hostNetwork: null
+    dnsPolicy: null
     priorityClassName: null
     concurrency: 4
     tolerations: []

--- a/addons/packages/kapp-controller/0.30.0/package.yaml
+++ b/addons/packages/kapp-controller/0.30.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:58e983f78ed9bf1c87c121dc679ecdb116d82eb5a38c8c7d2f8eed3951105b9a
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:7c76992622268f37e504235de680f1d4eef8c74d71c3f6c9d629a80673dd0840
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Kapp controller package should be able to configure dnsPolicy so it can use in cluster DNS when hostNetwork is enabled.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add dnsPolicy configuration to kapp controller package 0.30.0
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Locally generated and validated the manifests

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
