### PR TITLE
Docs: Overflow scroll for wide tables

### DIFF
--- a/docs/site/themes/template/assets/scss/_docs.scss
+++ b/docs/site/themes/template/assets/scss/_docs.scss
@@ -317,10 +317,12 @@
             padding-right: 20px;
         }
         table {
-            border: 1px solid $table-border;
+            border: 0;
             border-collapse: collapse;
             margin-bottom: 20px;
             width: 100%;
+            overflow-x: auto;
+            display: block;
 
             thead th {
                 background-color: $table-head-bg;


### PR DESCRIPTION
Signed-off-by: Garry Ing <ging@vmware.com>

## What this PR does / why we need it
This fixes an issue with the right navigation overlapping tables for visitors viewing docs on narrow browser windows. The overflow pattern is similar to how GitHub renders wide tables without introducing line-breaks. This is mainly an issue for package documentation.

Before:
<img width="854" alt="Screen Shot 2021-12-07 at 4 41 50 PM" src="https://user-images.githubusercontent.com/227587/145110679-7622d802-b3d3-4802-8a25-26fb76de03a6.png">

After:
<img width="863" alt="Screen Shot 2021-12-07 at 4 42 30 PM" src="https://user-images.githubusercontent.com/227587/145110699-c577ef54-46a4-4e5c-82fc-1441a0ea09a8.png">

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2151 

## Describe testing done for PR
- `hugo server`
- Navigate to `/docs/latest/package-readme-contour-1.17.1/`
- Scroll to `Configuration Reference`

## Special notes for your reviewer
This introduces some width changes to other tables. Tables will not extend the full width of the content area if strings are short.
