### PR TITLE
Adding Antrea agent tweak configmap

### DIFF
--- a/addons/packages/antrea/1.2.3/bundle/config/kapp-config.yaml
+++ b/addons/packages/antrea/1.2.3/bundle/config/kapp-config.yaml
@@ -13,8 +13,10 @@ rebaseRules:
   resourceMatchers:
   - anyMatcher:
       matchers:
+      - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1alpha1.stats.antrea.io}
       - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1alpha1.stats.antrea.tanzu.vmware.com}
       - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1beta1.controlplane.antrea.tanzu.vmware.com}
-      - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1beta1.networking.antrea.tanzu.vmware.com}
+      - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1beta1.system.antrea.io}
       - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1beta1.system.antrea.tanzu.vmware.com}
+      - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1beta2.controlplane.antrea.io}
       - kindNamespaceNameMatcher: {kind: APIService, namespace: kube-system, name: v1beta2.controlplane.antrea.tanzu.vmware.com}

--- a/addons/packages/antrea/1.2.3/bundle/config/overlay/antrea_overlay.yaml
+++ b/addons/packages/antrea/1.2.3/bundle/config/overlay/antrea_overlay.yaml
@@ -219,7 +219,7 @@ tlsCipherSuites: #@ values.antrea.config.tlsCipherSuites
 #! legacyCRDMirroring: true
 #@ end
 
-#@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-config-t8cc9bfb6t"}})
+#@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-config-822fk25299"}})
 ---
 kind: ConfigMap
 data:

--- a/addons/packages/antrea/1.2.3/bundle/config/upstream/antrea.yaml
+++ b/addons/packages/antrea/1.2.3/bundle/config/upstream/antrea.yaml
@@ -669,6 +669,8 @@ spec:
                     to:
                       items:
                         properties:
+                          fqdn:
+                            type: string
                           group:
                             type: string
                           ipBlock:
@@ -1778,6 +1780,8 @@ spec:
                               matchLabels:
                                 x-kubernetes-preserve-unknown-fields: true
                             type: object
+                          fqdn:
+                            type: string
                           ipBlock:
                             properties:
                               cidr:
@@ -2404,8 +2408,11 @@ spec:
                       enum:
                       - User
                       - Group
+                      - ServiceAccount
                       type: string
                     name:
+                      type: string
+                    namespace:
                       type: string
                   type: object
                 type: array
@@ -3421,7 +3428,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
   - pods
   - namespaces
   - services
@@ -3430,6 +3436,15 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+  - list
+  - patch
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -3483,6 +3498,14 @@ rules:
   - configmaps
   verbs:
   - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - antrea-config-822fk25299
+  resources:
+  - configmaps
+  verbs:
+  - get
 - apiGroups:
   - apiregistration.k8s.io
   resourceNames:
@@ -3756,6 +3779,19 @@ subjects:
 ---
 apiVersion: v1
 data:
+  antrea-agent-tweaker.conf: |-
+    # Enable disableUdpTunnelOffload will disable udp tunnel offloading feature on kubernetes node's default interface.
+    # By default, no actions will be taken.
+    disableUdpTunnelOffload: false
+kind: ConfigMap
+metadata:
+  labels:
+    app: antrea
+  name: antrea-agent-tweaker-g56hc6fh8t
+  namespace: kube-system
+---
+apiVersion: v1
+data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
@@ -3901,8 +3937,7 @@ data:
     # https://golang.org/pkg/crypto/tls/#pkg-constants
     # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
     # prefer TLS1.3 Cipher Suites whenever possible.
-    #tlsCipherSuites:
-
+    tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     #tlsMinVersion:
   antrea-cni.conflist: |
@@ -3943,6 +3978,9 @@ data:
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: false
 
+    # Run Kubernetes NodeIPAMController with Antrea.
+    #  NodeIPAM: false
+
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
     # `antrea-controller` container must be set to the same value.
@@ -3964,7 +4002,7 @@ data:
     # https://golang.org/pkg/crypto/tls/#pkg-constants
     # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
     # prefer TLS1.3 Cipher Suites whenever possible.
-    #tlsCipherSuites:
+    tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
 
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     #tlsMinVersion:
@@ -3982,12 +4020,37 @@ data:
     # API groups. After adding the annotation, legacy CRDs can be deleted safely without impacting
     # new CRDs.
     #legacyCRDMirroring: true
+
+    # Enable usage reporting (telemetry) to VMware.
+    #enableUsageReporting: false
+    nodeIPAM:
+    # Enable the integrated Node IPAM controller within the Antrea controller.
+    #  enableNodeIPAM: false
+
+    # CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
+    # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+    #  clusterCIDRs: []
+
+    # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+    # Value ignored when enableNodeIPAM is false.
+    #  serviceCIDR:
+    #  serviceCIDRv6:
+
+    # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+    # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
+    #  nodeCIDRMaskSizeIPv4: 24
+
+    # Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+    # or when IPv6 Pod CIDR is not configured. Valid range is 64 to 126.
+    #  nodeCIDRMaskSizeIPv6: 64
+
+    enterpriseAntrea: true
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-t8cc9bfb6t
+  name: antrea-config-822fk25299
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4058,8 +4121,9 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-t8cc9bfb6t
+          value: antrea-config-822fk25299
         image: antrea/antrea-ubuntu:v1.2.3
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -4108,7 +4172,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-t8cc9bfb6t
+          name: antrea-config-822fk25299
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4272,6 +4336,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         image: antrea/antrea-ubuntu:v1.2.3
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
             command:
@@ -4332,6 +4397,7 @@ spec:
         command:
         - start_ovs
         image: antrea/antrea-ubuntu:v1.2.3
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
             command:
@@ -4366,6 +4432,7 @@ spec:
       - command:
         - install_cni
         image: antrea/antrea-ubuntu:v1.2.3
+        imagePullPolicy: IfNotPresent
         name: install-cni
         resources:
           requests:
@@ -4388,6 +4455,29 @@ spec:
           readOnly: true
         - mountPath: /var/run/antrea
           name: host-var-run-antrea
+      - args:
+        - --config
+        - /etc/antrea/antrea-agent-tweaker.conf
+        command:
+        - antrea-agent-tweaker
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: antrea/antrea-ubuntu:v1.2.3
+        name: antrea-agent-tweaker
+        resources:
+          requests:
+            cpu: 100m
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+        volumeMounts:
+        - mountPath: /etc/antrea/antrea-agent-tweaker.conf
+          name: antrea-agent-tweaker-config
+          subPath: antrea-agent-tweaker.conf
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -4401,8 +4491,11 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-t8cc9bfb6t
+          name: antrea-config-822fk25299
         name: antrea-config
+      - configMap:
+          name: antrea-agent-tweaker-g56hc6fh8t
+        name: antrea-agent-tweaker-config
       - hostPath:
           path: /etc/cni/net.d
         name: host-cni-conf
@@ -4584,6 +4677,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - clusternetworkpolicies
     scope: Cluster
@@ -4606,6 +4700,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - networkpolicies
     scope: Namespaced
@@ -4629,7 +4724,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-    - DELETE
     resources:
     - clustergroups
     scope: Cluster

--- a/addons/packages/antrea/1.2.3/package.yaml
+++ b/addons/packages/antrea/1.2.3/package.yaml
@@ -13,7 +13,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/antrea@sha256:d7b634d7814b93d31d6eb92b260ef3701a05858ee7c3706bb79ff3218a02026e
+            image: projects.registry.vmware.com/tce/antrea@sha256:9bf2c1bbaf4570a7128c03702f71c7aa05582ae1fce1ca35792d732ea4a8b7b9
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
Adding antrea agent tweak configmap for UDP offset

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Antrea capability to disable UDP tunnel offload
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/2682
