### PR TITLE
2686: Proposal Process Design Doc

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -21,21 +21,7 @@ Maintainers: Given the nature of this project and its relationship to VMware’s
 
 One of the most important aspects in any open source community is the concept of proposals. All large changes to the codebase and/or new features, including ones proposed by maintainers, should be preceded by a proposal in this repository. This process allows for all members of the community to weigh in on the concept (including the technical details), share their comments and ideas, and offer to help. It also ensures that members are not duplicating work or inadvertently stepping on toes by making large conflicting changes.
 
-The project roadmap is defined by accepted proposals.
-
-Proposals should cover the high-level objectives, use cases, and technical recommendations on how to implement. In general, the community member(s) interested in implementing the proposal should be either deeply engaged in the proposal process or be an author of the proposal.
-The proposal should be documented as a separated markdown file pushed to `docs/site/content/docs/latest/designs` in the Tanzu Community Edition repository via PR.
-Use the Proposal Template as a starting point.
-
-## Proposal Lifecycle
-
-The proposal PR follows the GitHub lifecycle of the PR to indicate its status:
-
-Open: Proposal is created and under review and discussion.
-
-Merged: Proposal has been reviewed and is accepted, and labeled “accepted” for tracking purposes.
-
-Closed: Proposal has been reviewed and was rejected, and labeled “rejected” for tracking purposes.
+To understand our proposal process, please review [docs/designs](docs/designs/README.md).
 
 ## Lazy Consensus
 

--- a/docs/designs/2686-proposal-process.md
+++ b/docs/designs/2686-proposal-process.md
@@ -1,0 +1,112 @@
+# Proposing Changes to Tanzu Community Edition
+
+* Proposal: [https://github.com/vmware-tanzu/community-edition/issues/2686](https://github.com/vmware-tanzu/community-edition/issues/2686)
+
+## Introduction
+
+Tanzu Community Edition relies on design proposals to assess the viability of non-trivial changes
+to the project. This document covers details on the proposal process, which can also be used as
+guidelines for how to create a proposal.
+
+## The Proposal Process
+
+The proposal process is the process for reviewing a proposal and reaching a decision about whether
+to accept or decline the proposal.
+
+1. The proposal author [creates a brief issue](https://github.com/vmware-tanzu/community-edition/issues/new)
+   describing the proposal.
+
+   > A design doc is **not** required at this point; although proposal authors
+   > are welcome to create one.
+   >
+   > While we recommend ensuring a proposal is Accepted before starting
+   > non-trivial work, we welcome, and like, implementations that demonstrate the proposal.
+   > However, if a proposal is declined, there is a chance any implementation
+   > work could go to waste.
+
+1. A discussion on the issue tracker aims to triage the proposal into one of three outcomes:
+
+    * Accepted (`proposal/accepted` label)
+    * Declined (`proposal/declined` label)
+    * Needs Design Doc (`proposal/needs-design-doc` label)
+
+   > If the proposal is Accepted or Declined, the process is done.
+
+1. Maintainers determine whether a design doc is required. If it is, a `proposal/needs-design-doc`
+   label is applied.
+
+1. The proposal author creates a [design doc](#design-documents). This facilitates discussions
+   (in a GitHub PR) around the proposal.
+
+1. The proposal author or maintainers notify the community, via [mailing
+   list](tanzu-community-edition@googlegroups.com), that RFCs are open and when
+   we plan to close it.
+
+1. Maintainers review open proposals weekly to move them forward.
+
+## Design Documents
+
+When a design doc is requested, a proposal author should:
+
+1. Create a **branch** on their **fork** of the `community-edition` repository.
+
+1. Create the file `docs/designs/${GH_ISSUE_NUMBER}-${SHORT_PROPOSAL_TITLE}.md`.
+
+1. Use the [template](template.md) to get started.
+
+1. If images will be used, store and reference them in `docs/designs/imgs-${GH_ISSUE_NUMBER}/`.
+
+1. Create a PR against the `vmware-tanzu/community-edition` repository.
+
+    > Authors are encouraged to keep a PR open as they work on the design doc.
+    > If the doc is **not** ready for review, please ensure the [PR is a
+    > draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
+
+_note: PRs for design docs are linted using
+[markdownlint](https://github.com/markdownlint/markdownlint), you can run it
+locally or use `make check`._
+
+## The Review Process
+
+The progress of proposals are tracked in the [Proposal GitHub
+Project](https://github.com/vmware-tanzu/community-edition/projects/13).
+
+The [TCE
+maintainers](https://github.com/vmware-tanzu/community-edition/blob/main/MAINTAINERS.md#maintainers)
+meet weekly to review proposals that have not been Approved or Declined. A
+summary of the discussion for each proposal will be added to the proposal issue
+in GitHub. The outcome of these reviews could be:
+
+* No changes
+* Requests for more details
+* Approving a proposal
+* Declining a proposal
+
+When a proposal involves a dependency or upstream project, such as
+[tanzu-framework](https://github.com/vmware-tanzu/tanzu-framework), a maintainer
+from that project will be asked to join the review process.
+
+When a proposal is completed and ready for review, TCE maintainers will declare
+an initial window to solicit comments (RFC). During this period, we're
+requesting the following from users, community members, and contributors:
+
+* Leave feedback in comments on proposal issues
+* Leave comments on an open design doc PR (if a design doc was created)
+
+If you'd like to discuss a proposal or decision made around a proposal in person, please attend our
+[office hours](https://tanzucommunityedition.io/community), which are open to the public.
+
+## Definitions
+
+* A **proposal** is a GitHub issue referring to a change that must be considered for approval
+  before work should begin. It is labeled with `proposal/pending`.
+
+* A **design document** is a detailed expansion of the proposal. It's submitted
+  as a PR containing a markdown file, which references the proposal issue.
+
+## Attribution
+
+The proposal process found here was influenced and based off:
+
+* [Golang's Proposal Process](https://github.com/golang/proposal)
+* [Cluster API's Proposal Process](https://cluster-api.sigs.k8s.io/contributing#proposal-process-caep)

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -1,0 +1,3 @@
+# PLACEHOLDER
+
+This will be filled in with the contents of [2686-proposal-process.md](2686-proposal-process.md), if accepted.

--- a/docs/designs/template.md
+++ b/docs/designs/template.md
@@ -1,0 +1,196 @@
+<!-- The sections in this template are highly-suggested, but optional. They exist to
+provide an idea of what an in-depth proposal **might** include. If a different
+format fits your proposal, feel free to use it, with the expectation that:
+
+1. You must link to the proposal issue (github) under the title
+1. If you omit sections that are relevant, you may be asked by maintainers to
+   add them in order to best review the proposal. -->
+
+# Title
+
+Keep it simple and descriptive.
+
+* Proposal: < GITHUB ISSUE URL >
+* See Also:
+  * < RELEVANT URL >
+  * < RELEVANT URL >
+
+## Summary
+
+Provide a short summary of what is being proposed. The `Summary` section is
+incredibly important for producing high quality user-focused documentation such
+as release notes or a development roadmap.  It should be possible to collect
+this information before implementation begins in order to avoid requiring
+implementers to split their attention between writing release notes and
+implementing the feature itself.
+
+A good summary is probably at least a paragraph in length.
+
+## Motivation
+
+This section is for explicitly listing the motivation, goals and non-goals of
+this proposal. To support what is being proposed, provide details on why this
+change is important. If user stories are relevant to this proposal, add them
+below.
+
+* Describe why the change is important and the benefits to users.  
+
+### Goals
+
+* List the specific high-level goals of the proposal.
+* How will we know that this has succeeded?
+
+### Non-Goals/Future Work
+
+* What high-levels are out of scope for this proposal?
+* Listing non-goals helps to focus discussion and make progress.
+
+## Proposal
+
+This is where we get down to the nitty gritty of what the proposal actually is.
+Provide a detailed proposal of **what** would be done and **how**; feel free to
+add multiple subsections, diagrams, and config/code snippets
+
+* What is the plan for implementing this feature?
+* What data model changes, additions, or removals are required?
+* Provide a scenario, or example.
+* Use diagrams to communicate concepts, flows of execution, and states.
+
+### User Stories
+
+* Detail the things that people will be able to do if this proposal is implemented.
+* Include as much detail as possible so that people can understand the "how" of the system.
+* The goal here is to make this feel real for users without getting bogged down.
+
+#### Story 1
+
+#### Story 2
+
+### Requirements
+
+Some authors may wish to use requirements in addition to user stories.
+Technical requirements should derived from user stories, and provide a trace from
+use case to design, implementation and test case. Requirements can be prioritised
+using the MoSCoW (MUST, SHOULD, COULD, WON'T) criteria.
+
+The FR and NFR notation is intended to be used as cross-references across a CAEP.
+
+The difference between goals and requirements is that between an executive summary
+and the body of a document. Each requirement should be in support of a goal,
+but narrowly scoped in a way that is verifiable or ideally - testable.
+
+#### Functional Requirements
+
+Functional requirements are the properties that this design should include.
+
+##### FR1
+
+##### FR2
+
+#### Non-Functional Requirements
+
+Non-functional requirements are user expectations of the solution. Include
+considerations for performance, reliability and security.
+
+##### NFR1
+
+##### NFR2
+
+### Implementation Details/Notes/Constraints
+
+* What are some important details that didn't come across above.
+* What are the caveats to the implementation?
+* Go in to as much detail as necessary here.
+* Talk about core concepts and how they relate.
+
+### Security Model
+
+Document the intended security model for the proposal, including implications
+on the Kubernetes RBAC model. Questions you may want to answer include:
+
+* Does this proposal implement security controls or require the need to do so?
+  * If so, consider describing the different roles and permissions with tables.
+* Are their adequate security warnings where appropriate.
+* Are regex expressions going to be used, and are their appropriate defenses
+  against DOS.
+* Is any sensitive data being stored in a secret, and only exists for as long as necessary?
+
+### Risks and Mitigations
+
+* What are the risks of this proposal and how do we mitigate? Think broadly.
+* How will UX be reviewed and by whom?
+* How will security be reviewed and by whom?
+* Consider including folks that also work outside the SIG or subproject.
+
+## Compatibility
+
+If this change impacts compatibility of previous versions of TCE or software
+integrated with TCE, please call it out here. If incompatibilities can be
+mitigated, please add it here.
+
+## Alternatives
+
+The `Alternatives` section is used to highlight and record other possible
+approaches to delivering the value proposed by a proposal.
+
+## Upgrade Strategy
+
+If applicable, how will the component be upgraded? Make sure this is in the test
+plan.
+
+Consider the following in developing an upgrade strategy for this enhancement:
+
+* What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade in order to keep previous behavior?
+
+## Additional Details
+
+### Test Plan
+
+**Note:** *Section not required until targeted at a release.*
+
+Consider the following in developing a test plan for this enhancement:
+
+* Will there be e2e and integration tests, in addition to unit tests?
+* How will it be tested in isolation vs with other components?
+
+No need to outline all of the test cases, just the general strategy.  Anything
+that would count as tricky in the implementation and anything particularly
+challenging to test should be called out.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations).
+
+### Graduation Criteria
+
+**Note:** *Section not required until targeted at a release.*
+
+Define graduation milestones.
+
+These may be defined in terms of API maturity, or as something else. Initial
+proposal should keep this high-level with a focus on what signals will be looked
+at to determine graduation.
+
+Consider the following in developing the graduation criteria for this
+enhancement:
+
+* [Maturity levels (`alpha`, `beta`, `stable`)][maturity-levels]
+* [Deprecation policy][deprecation-policy]
+
+Clearly define what graduation means by either linking to the [API doc
+definition](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning),
+or by redefining what graduation means.
+
+In general, we try to use the same stages (alpha, beta, GA), regardless how the
+functionality is accessed.
+
+[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
+[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
+
+### Version Skew Strategy
+
+If applicable, how will the component handle version skew with other components?
+What are the guarantees? Make sure this is in the test plan.
+
+<!-- Links -->
+[community meeting]: https://hackmd.io/CiuO4V0AT6WL_TgA47MXBA


### PR DESCRIPTION
This design doc covers the proposal process for Tanzu Community Edition.

It attempts to foster:

* Visibility into proposed changes to the project
* Feedback from maintainers, community members, and end-users
* Reaching decisions on proposed changes in a timely manner

Relates to: https://github.com/vmware-tanzu/community-edition/issues/2686