### PR TITLE
Replace deprecated linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,8 +34,6 @@ linters-settings:
     min-complexity: 15
   goimports:
     local-prefixes: github.com/vmware-tanzu
-  golint:
-    min-confidence: 0
   govet:
     check-shadowing: true
     settings:
@@ -45,8 +43,6 @@ linters-settings:
           - (github.com/aunum/log").Warnf
           - (github.com/aunum/log").Errorf
           - (github.com/aunum/log").Fatalf
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
   nolintlint:
@@ -71,18 +67,17 @@ linters:
     - gofmt
     - goheader
     - goimports
-    - golint
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - maligned
     - misspell
     - nakedret
     - noctx
     - nolintlint
     - rowserrcheck
+    - revive
     - staticcheck
     - structcheck
     - stylecheck


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We have a couple of deprecated linters to be run by golangci-lint,
resulting in these errors when running lint checks:

```
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
WARN [runner] The linter 'maligned' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.  Replaced by govet 'fieldalignment'.
```

Following the suggested replacements, this removes the 'golint' linter
and adds the 'revive' one. We were already using 'govet', so this just
removes the 'maligned' linter.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Running `make lint` from the root of the repo will run the lint checks on all modules in the repo. No errors uncovered.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
