### PR TITLE
Add prefix to data hash, so it cannot be parsed as integer.

### DIFF
--- a/addons/packages/vsphere-cpi/1.22.4/bundle/config/overlays/update-daemonset.yaml
+++ b/addons/packages/vsphere-cpi/1.22.4/bundle/config/overlays/update-daemonset.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       #@overlay/match missing_ok=True
       annotations:
-        vsphere-cpi/data-values-hash: #@ "{}".format(sha256.sum(yaml.encode(values))[:7])
+        vsphere-cpi/data-values-hash: #@ "h-{}".format(sha256.sum(yaml.encode(values))[:7])
     spec:
       #@overlay/match missing_ok=True
       nodeSelector:

--- a/addons/packages/vsphere-cpi/1.22.4/test/vsphere_cpi_test.go
+++ b/addons/packages/vsphere-cpi/1.22.4/test/vsphere_cpi_test.go
@@ -105,8 +105,15 @@ vsphereCPI:
 				Expect(transformEnvVarsToMap(containerEnvVars)).To(HaveKeyWithValue("NO_PROXY", "10.10.10.2,example.com"))
 			})
 		})
-	})
 
+		It("renders a data value hash starts with prefix and not parsable as an integer", func() {
+			Expect(err).NotTo(HaveOccurred())
+			daemonSet := parseDaemonSet(output)
+			hash, exist := daemonSet.Spec.Template.Annotations["vsphere-cpi/data-values-hash"]
+			Expect(exist).To(BeTrue())
+			Expect(hash).Should(HavePrefix("h-"))
+		})
+	})
 })
 
 func transformEnvVarsToMap(envVars []corev1.EnvVar) map[string]string {

--- a/addons/packages/vsphere-csi/2.4.0/bundle/config/overlays/update-csi-driver.yaml
+++ b/addons/packages/vsphere-csi/2.4.0/bundle/config/overlays/update-csi-driver.yaml
@@ -76,7 +76,7 @@ spec:
     metadata:
       labels:
         #@overlay/match missing_ok=True
-        vsphere-csi/data-values-hash: #@ "{}".format(sha256.sum(yaml.encode(values))[:7])
+        vsphere-csi/data-values-hash: #@ "h-{}".format(sha256.sum(yaml.encode(values))[:7])
     spec:
       containers:
         #@overlay/match by=overlay.subset({"name": "vsphere-csi-node"})


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We observe scenarios that some data value hash, e,g, `5386e49` will be treated as an integer by the ytt template. And kubectl cannot apply the rendered yaml file. Submit a fix that prefix "h-" before the hash to enforce it as a string.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add prefix to data hash, so it cannot be parsed as integer.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Unit test of  the vsphere-cpi addon.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
