### PR TITLE
Default kapp controller packge DNSPolicy

### DIFF
--- a/addons/packages/kapp-controller/0.30.0/bundle/config/overlays/update-deployment.yaml
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/overlays/update-deployment.yaml
@@ -29,9 +29,12 @@ spec:
           #@overlay/match by="name"
           - name: KAPPCTRL_API_PORT
             value: #@ str(values.kappController.deployment.apiPort)
-      #@ if/end values.kappController.deployment.hostNetwork:
+      #@ if values.kappController.deployment.hostNetwork:
       hostNetwork: #@ values.kappController.deployment.hostNetwork
+      dnsPolicy: ClusterFirstWithHostNet
+      #@ end
       #@ if/end values.kappController.deployment.dnsPolicy:
+      #@yaml/map-key-override
       dnsPolicy: #@ values.kappController.deployment.dnsPolicy
       #@ if/end values.kappController.deployment.priorityClassName:
       priorityClassName: #@ values.kappController.deployment.priorityClassName

--- a/addons/packages/kapp-controller/0.30.0/package.yaml
+++ b/addons/packages/kapp-controller/0.30.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:7c76992622268f37e504235de680f1d4eef8c74d71c3f6c9d629a80673dd0840
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:6fa7447e9886f5af7cca18ad21ccef608c121c54c58fd196fb129cd2a8adddce
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Default kapp controller packge DNSPolicy to be ClusterFirstWithHostNet when hostNetwork is set

Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
As per recommanded by (For Pods running with hostNetwork, you should explicitly set its DNS policy "ClusterFirstWithHostNet".) https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
Default the dnsPolicy to be `ClusterFirstWithHostNet` when hostNetwork is set to true.

Still allow dnsPolicy as a param to override the config.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Default kapp controller packge DNSPolicy to be ClusterFirstWithHostNet when hostNetwork is set
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
locally generating manifests using different options. The results are as expected.

```
hostNetwork: null
dnsPolicy: null
->
empty
```

```
hostNetwork: true
dnsPolicy: null
->
hostNetwork: true
dnsPolicy: ClusterFirstWithHostNet
```

```
hostNetwork: true
dnsPolicy: someValue
->
hostNetwork: true
dnsPolicy: someValue
```

```
hostNetwork: false
dnsPolicy: someValue
->
dnsPolicy: someValue
```

```
hostNetwork: false
dnsPolicy: null
->
empty
```
