### PR TITLE
feat: Add velero release 1.7.1

### DIFF
--- a/addons/packages/velero/1.7.1/README.md
+++ b/addons/packages/velero/1.7.1/README.md
@@ -256,7 +256,7 @@ the first option in those instructions.
     cat > values.yaml <<EOF
     ---
     namespace: velero
-    restic: 
+    restic:
       create: false
     credential:
       useDefaultSecret: true

--- a/addons/packages/velero/1.7.1/README.md
+++ b/addons/packages/velero/1.7.1/README.md
@@ -1,0 +1,381 @@
+# Velero
+
+This package provides safe operations to backup, restore, perform disaster recovery, and migrate Tanzu Community Edition cluster resources and persistent volumes using the open source tool [Velero](https://velero.io/).
+
+## Supported Providers
+
+The following table shows the providers this package can work with.
+
+| AWS  |  Azure  | vSphere  | Docker |
+|:---:|:---:|:---:|:---:|
+| ✅  |  ✅  | 🚫  | ✅  |
+
+## Components
+
+* Velero Deployment
+* Restic DaemonSet
+
+### Custom Resources
+
+Each Velero operation – on-demand backup, scheduled backup, restore – is a custom resource, defined with a Kubernetes [Custom Resource Definition (CRD)](https://kubernetes.io/docs/concepts/api-extension/custom-resources/#customresourcedefinitions) and stored in [etcd](https://github.com/coreos/etcd).  Each time these operations are run, an equivalent Kubernetes object is created and saved to storage.
+
+Because of this Kubernetes native way that Velero operates, you are not restricted to backing up the entire etcd. You can back up or restore all objects in a Tanzu Community Edition cluster, or you can also filter what object to operate on by type, namespace, and/or label.
+
+### CLI
+
+Once the Velero package is installed, you will need to have the Velero CLI to run operations on the command line. Please see this documentation for how to install it: [Velero CLI install](https://velero.io/docs/v1.6/basic-install/#install-the-cli).
+
+### Storage
+
+Velero needs an object storage where to save all resource backups and the information about snapshot backups.
+
+Velero treats object storage as the source of truth. It continuously checks to see that the correct backup resources are always present. If there is a properly formatted backup file in the storage bucket, but no corresponding backup resource in the Kubernetes API, Velero synchronizes the information from object storage to Kubernetes. This allows restore functionality to work in a cluster migration scenario, where the original backup objects do not exist in the new cluster. Likewise, if a backup object exists in Kubernetes but not in object storage, it will be deleted from Kubernetes since the backup tarball no longer exists. To learn more, please see the documentation: [How Velero works](https://velero.io/docs/v1.6/how-velero-works/).
+
+### Server
+
+Velero runs on the cluster as a deployment alongside installed plugins that are specific to storage providers for backup and snapshot operations. It also includes controllers that process the custom resources to perform backups, restores, and all related operations.
+
+## Providers
+
+The Tanzu Community Edition Velero package provides support for these providers out of the box with minimal configuration.
+
+| Provider                          | Object Store        | Volume Snapshotter           | Plugin Provider Repo                    | Setup Instructions            |
+|-----------------------------------|---------------------|------------------------------|-----------------------------------------|-------------------------------|
+| [Amazon Web Services (AWS)](https://aws.amazon.com)    | AWS S3              | AWS EBS                      | [Velero plugin for AWS](https://github.com/vmware-tanzu/velero-plugin-for-aws)              | [AWS Plugin Setup](https://github.com/vmware-tanzu/velero-plugin-for-aws#setup)        |
+| [Microsoft Azure](https://azure.com)                                       | Azure Blob Storage  | Azure Managed Disks          | [Velero plugin for Microsoft Azure](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure) | [Azure Plugin Setup](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#setup)      |
+| [VMware vSphere](https://github.com/vmware-tanzu/velero-plugin-for-vsphere) | N/A                | 🚫 vSphere Volumes  (on the roadmap)            | [VMware vSphere](https://github.com/vmware-tanzu/velero-plugin-for-vsphere)                    | [vSphere Plugin Setup](https://github.com/vmware-tanzu/velero-plugin-for-vsphere#velero-plugin-for-vsphere-installation-and-configuration-details)
+
+Some other third-party storage providers, like MinIO, DigitalOcean, and others, support the same S3 API that the **AWS Velero plugin** uses.  For more information please see: [S3-Compatible object store providers for Velero](https://velero.io/docs/v1.6/supported-providers/#s3-compatible-object-store-providers).
+
+## Configuration
+
+The following configuration values can be set to customize the Velero installation for the different components.
+
+### Global
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `namespace` | Optional | The namespace in which to deploy Velero. |
+
+### Storage settings
+
+#### Global configurations for storage
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `backupStorageLocation.name` | Required | The name of the Backup Storage Location. |
+| `backupStorageLocation.provider` | Required | The cloud provider to use. One of: `aws`, `azure`. |
+| `backupStorageLocation.default` | Optional | Indicates if this location is the default backup storage location. |
+| `backupStorageLocation.objectStorage.bucket` | Required | The storage bucket where backups are to be uploaded. |
+| `backupStorageLocation.objectStorage.prefix` | Optional | The directory inside a storage bucket where backups are to be uploaded. |
+
+#### AWS storage
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `backupStorageLocation.configAWS.region` | Required | The AWS region where the S3 bucket is located. |
+
+#### Azure storage
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `backupStorageLocation.configAzure.resourceGroup` | Required | The name of the resource group containing the storage account for this backup storage location. |
+| `backupStorageLocation.configAzure.storageAccount` | Required | The name of the storage account for this backup storage location. |
+| `backupStorageLocation.configAzure.storageAccountKeyEnvVar` | Required | Required if using a storage account access key to authenticate rather than a service principal. |
+| `backupStorageLocation.configAzure.subscriptionId` | Optional | The the ID of the subscription for this backup storage location. |
+
+### Volume snapshot settings
+
+#### Global configurations for snapshotting
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `volumeSnapshotLocation.snapshotsEnabled` | Required | Indicates whether to create a volumesnapshotlocation CR. If false => disable the snapshot feature. |
+| `volumeSnapshotLocation.name` | Required | The name of the volume snapshot location where snapshots are being taken. |
+| `volumeSnapshotLocation.spec.provider` | Required | The name for the volume snapshot provider. Required if snapshots are enabled. Valid values are `aws` and `azure` |
+
+#### AWS volumes
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `volumeSnapshotLocation.spec.configAWS.region` | Required | The AWS region where the volumes/snapshots are located |
+| `volumeSnapshotLocation.spec.configAWS.profile` | Optional | The AWS profile within the credentials file to use for the volume snapshot location. Default is "default". |
+
+#### Azure volumes
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `volumeSnapshotLocation.spec.configAzure.apiTimeout` | Optional | Indicates how long to wait for an Azure API request to complete before timeout. Defaults to 2m0s. |
+| `volumeSnapshotLocation.spec.configAzure.resourceGroup` | Optional | The name of the resource group where volume snapshots should be stored, if different from the cluster's resource group. |
+| `volumeSnapshotLocation.spec.configAzure.subscriptionId` | Optional | The ID of the subscription where volume snapshots should be stored, if different from the cluster's subscription. Requires "resourceGroup" to also be set. |
+| `volumeSnapshotLocation.spec.configAzure.incremental` | Optional | Azure offers the option to take full or incremental snapshots of managed disks. Set this parameter to true, to take incremental snapshots. If the parameter is omitted or set to false, full snapshots are taken (default). |
+
+### Advanced
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `rbac.create` | Optional | Whether to create the Velero Role and RoleBinding to give all permissions to the namespace to Velero.|
+| `rbac.name` | Optional |  A new name for the cluster RolBinding. Default is `velero`. |
+| `rbac.clusterAdministrator` | Optional | Whether to create the ClusterRoleBinding to give administrator permissions to Velero. `rbac.create` must also be set to `true`.|
+| `rbac.roleRefName` | Optional | Name of the cluster role to reference. Default is `cluster-admin`.|
+| `rbac.clusterRoleAPIGroups` | Optional |  The name of the API groups that contain the resources for the cluster role.|
+| `rbac.clusterRoleVerbs` | Optional |  The set of verbs that apply to the secret resources contained in this rule. |
+| `serviceAccount.name` | Optional |  The name of the ServiceAccount the RoleBinding should reference. |
+| `serviceAccount.annotations` | Optional |  Annotations for the ServiceAccount the RoleBinding should reference. |
+| `serviceAccount.labels` | Optional |  Labels for the ServiceAccount the RoleBinding should reference. |
+| `restic.create` | Optional | Whether to deploy the restic daemonset. |
+| `restic.defaultVolumesToRestic` | Optional | Bool flag to configure Velero server to use restic by default to backup all pod volumes on all backups. |
+| `restic.defaultResticPruneFrequency` | Optional | How often 'restic prune' is run for restic repositories by default. |
+| `restic.cpuLimit` | Optional | CPU limit for restic pod. A value of "0" is treated as unbounded. (default "1000m"). |
+| `restic.cpuRequest` | Optional | CPU request for restic pod. A value of "0" is treated as unbounded. (default "500m"). |
+| `restic.memoryLimit` | Optional | Memory limit for restic pod. A value of "0" is treated as unbounded. (default "1Gi"). |
+| `restic.memoryRequest` | Optional | Memory request for restic pod. A value of "0" is treated as unbounded. (default "512Mi"). |
+
+## Installation
+
+The Velero package can easily be installed to a cluster. However, for the package to function, you must configure settings for your cloud provider.
+
+### AWS Configuration
+
+To configure Velero for AWS, you will first need to setup your AWS account. Your account will need the
+following:
+
+* An S3 bucket to store the backups
+* IAM user with permissions to access EC2 and S3
+
+There are multiple ways to configure your AWS account. Detailed instructions and other options can be found in the [velero-plugin-for-aws](https://github.com/vmware-tanzu/velero-plugin-for-aws#setup) setup instructions. This guide follows
+the first option in those instructions.
+
+> You will also need the AWS CLI to complete these steps. Follow the [user guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) to install it if needed.
+
+1. Create an S3 bucket to store backups.
+
+    ```shell
+    export BUCKET=<< bucket name >>
+    export REGION=<< region >>
+    aws s3api create-bucket \
+        --bucket ${BUCKET} \
+        --region ${REGION}
+    ```
+
+1. Create an IAM user. This user will be explicitly for use with Velero, and given the appropriate permissions to perform backups.
+
+    ```shell
+    aws iam create-user --user-name velero
+    ```
+
+1. Create the policy that gives the necessary S3 and EC2 permissions.
+
+    ```shell
+    cat > velero-policy.json <<EOF
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:DescribeVolumes",
+                    "ec2:DescribeSnapshots",
+                    "ec2:CreateTags",
+                    "ec2:CreateVolume",
+                    "ec2:CreateSnapshot",
+                    "ec2:DeleteSnapshot"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:DeleteObject",
+                    "s3:PutObject",
+                    "s3:AbortMultipartUpload",
+                    "s3:ListMultipartUploadParts"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::${BUCKET}/*"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListBucket"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::${BUCKET}"
+                ]
+            }
+        ]
+    }
+    EOF
+    ```
+
+    Apply the policy to the `velero` IAM user.
+
+    ```shell
+    aws iam put-user-policy \
+      --user-name velero \
+      --policy-name velero \
+      --policy-document file://velero-policy.json
+    ```
+
+1. Create an access key for the `velero` user.
+
+    ```shell
+    aws iam create-access-key --user-name velero
+    ```
+
+    The response will look like the following:
+
+    ```json
+    {
+        "AccessKey": {
+            "UserName": "velero",
+            "AccessKeyId": "AKIA4CRA12345EXAMPLE",
+            "Status": "Active",
+            "SecretAccessKey": "RbJSykwB1Z3c094BKgfJi2YzBCG12345EXAMPLE",
+            "CreateDate": "2021-09-23T15:32:15+00:00"
+        }
+    }
+    ```
+
+    > Be sure to save the `AccessKeyId` and `SecretAccessKey` values in a safe place. This is the only time that you will
+    > have access to these values.
+
+1. Create a `values.yaml` file to configure the package to use AWS. Values that you will need to provide are:
+
+    * Bucket name
+    * Region
+    * AWS Access Key
+    * AWS Secret Access Key
+
+    ```shell
+    export AWS_ACCESS_KEY=<< AWS ACCESS KEY >>
+    export AWS_SECRET_ACCESS_KEY=<< AWS SECRET ACCESS KEY >>
+
+    cat > values.yaml <<EOF
+    ---
+    namespace: velero
+    restic: 
+      create: false
+    credential:
+      useDefaultSecret: true
+      name: cloud-credentials
+      secretContents:
+        cloud: |
+          [default]
+          aws_access_key_id=${AWS_ACCESS_KEY}
+          aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    backupStorageLocation:
+      name: backup
+      spec:
+        provider: aws
+        default: true
+        objectStorage:
+          bucket: ${BUCKET}
+          prefix: backup
+        configAWS:
+          region: ${REGION}
+    volumeSnapshotLocation:
+      snapshotsEnabled: true
+      name: default
+      spec:
+        provider: aws
+        configAWS:
+          region: ${REGION}
+    EOF
+    ```
+
+1. Install the Velero package.
+
+    ```sh
+    tanzu package install velero --package-name velero.community.tanzu.vmware.com --version 1.7.1 --values-file values.yaml
+    ```
+
+1. Verify that the Velero package was properly installed.
+
+    ```sh
+    tanzu package installed list
+    | Retrieving installed packages...
+      NAME    PACKAGE-NAME                       PACKAGE-VERSION  STATUS
+      velero  velero.community.tanzu.vmware.com  1.7.1            Reconcile succeeded
+    ```
+
+## Usage Example
+
+This walkthrough guides you through an example disaster recovery scenario that leverages the Velero package. You must deploy the package before attempting this walkthrough.
+
+⚠️ Note: For more advanced use cases and documentation, see the official Velero [documentation](https://velero.io/docs/latest/).
+
+In the following steps, you will simulate a disaster scenario. Specifically, you will deploy a stateless workload, create a backup, delete the workload, and restore it from the backup.
+
+1. Download the Velero CLI from the GitHub [releases](https://github.com/vmware-tanzu/velero/releases/latest) page. The following steps assume you have installed Velero into your PATH.
+
+1. Create a new namespace for this example:
+
+    ```sh
+    kubectl create ns velero-example
+    ```
+
+1. Deploy a sample workload into the new namespace:
+
+    ```sh
+    kubectl create deploy -n velero-example nginx --image=nginx
+    ```
+
+1. Verify the workload is up and running:
+
+    ```sh
+    kubectl get pods -n velero-example
+    ```
+
+    The output should be similar to the following:
+
+    ```sh
+    NAME                     READY   STATUS    RESTARTS   AGE
+    nginx-6799fc88d8-mm47k   1/1     Running   0          7s
+    ```
+
+1. Create a backup of the `velero-example` namespace:
+
+    ```sh
+    velero create backup velero-example --include-namespaces velero-example
+    ```
+
+1. Verify the backup completed successfully:
+
+    ```sh
+    velero describe backup velero-example
+    ```
+
+    The output shows the "Phase" of the backup, which should be `Completed`.
+
+1. Delete the `velero-example` namespace to simulate a disaster scenario:
+
+    ```sh
+    kubectl delete ns velero-example
+    ```
+
+1. Verify that the namespace has been deleted:
+
+    ```sh
+    kubectl get ns
+    ```
+
+1. Restore the namespace from the velero backup:
+
+    ```sh
+    velero create restore --from-backup velero-example
+    ```
+
+1. Validate that the `velero-example` namespace has been restored:
+
+    ```sh
+    kubectl get ns velero-example
+    ```
+
+1. Validate that the workload has been restored:
+
+    ```sh
+    kubectl get pods -n velero-example
+    ```

--- a/addons/packages/velero/1.7.1/bundle/.imgpkg/bundle.yaml
+++ b/addons/packages/velero/1.7.1/bundle/.imgpkg/bundle.yaml
@@ -1,0 +1,9 @@
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: Bundle
+metadata:
+  name: velero
+authors:
+- name: Xun Jiang
+  email: jxun@vmware.com
+websites:
+- url: https://velero.io/

--- a/addons/packages/velero/1.7.1/bundle/.imgpkg/images.yml
+++ b/addons/packages/velero/1.7.1/bundle/.imgpkg/images.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- annotations:
+    kbld.carvel.dev/id: velero/velero-plugin-for-aws@sha256:145b4298e22b823ac5ec7fd834886e2c27a38a01df5ff7ff1b991b861f78d71e
+  image: index.docker.io/velero/velero-plugin-for-aws@sha256:145b4298e22b823ac5ec7fd834886e2c27a38a01df5ff7ff1b991b861f78d71e
+- annotations:
+    kbld.carvel.dev/id: velero/velero-plugin-for-microsoft-azure@sha256:a5ed9ea783d45985b4232e59b8c2557aa651de997f2cd56811acf53d93856e88
+  image: index.docker.io/velero/velero-plugin-for-microsoft-azure@sha256:a5ed9ea783d45985b4232e59b8c2557aa651de997f2cd56811acf53d93856e88
+- annotations:
+    kbld.carvel.dev/id: velero/velero:@sha256:db351b09fbe5ef96299d6a38f99d519c531b07b082152c976a782f3f39a022f2
+  image: index.docker.io/velero/velero@sha256:db351b09fbe5ef96299d6a38f99d519c531b07b082152c976a782f3f39a022f2
+kind: ImagesLock

--- a/addons/packages/velero/1.7.1/bundle/config/helpers.lib.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/helpers.lib.yaml
@@ -1,0 +1,15 @@
+#@ load("@ytt:overlay", "overlay")
+
+#! Use this library for helper functions.
+
+#! non_empty takes a YAML node (a key) and return it containing only the
+#! non empty keys nexted under it.
+#@ def non_empty(node):
+#@   result = {}
+#@   for key in node:
+#@     if not node[key] == "" and not node[key] == None:
+#@       result[key] = node[key]
+#@     end
+#@   end
+#@   return result
+#@ end

--- a/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-backupstoragelocation.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-backupstoragelocation.yaml
@@ -1,0 +1,34 @@
+#@ load("/values.star", "values")
+#@ load("/values.star", "resource")
+#@ load("@ytt:overlay", "overlay")
+#@ load("/helpers.lib.yaml", "non_empty")
+
+#@overlay/match by=overlay.subset(resource("BackupStorageLocation", "default"))
+---
+#@overlay/match-child-defaults missing_ok=True
+metadata:
+  name: #@ values.backupStorageLocation.name
+#@overlay/match-child-defaults missing_ok=True
+spec:
+  provider: #@ values.backupStorageLocation.spec.provider
+  default: #@ values.backupStorageLocation.spec.default
+  backupSyncPeriod: #@ values.backupStorageLocation.spec.backupSyncPeriod
+  validationFrequency: #@ values.backupStorageLocation.spec.validationFrequency
+  accessMode: #@ values.backupStorageLocation.spec.accessMode
+  objectStorage: #@ non_empty(values.backupStorageLocation.spec.objectStorage)
+  #@ if not values.credential.useDefaultSecret:
+  credential:
+    name:   #@ values.backupStorageLocation.spec.existingSecret.name
+    key:   #@ values.backupStorageLocation.spec.existingSecret.key
+  #@ end
+
+#@overlay/match by=overlay.subset(resource("BackupStorageLocation", values.backupStorageLocation.name))
+---
+#@overlay/match-child-defaults missing_ok=True
+spec:
+  #@overlay/replace
+  #@ if/end values.backupStorageLocation.spec.provider == "aws":
+  config: #@ non_empty(values.backupStorageLocation.spec.configAWS)
+  #@overlay/replace
+  #@ if/end values.backupStorageLocation.spec.provider == "azure":
+  config: #@ non_empty(values.backupStorageLocation.spec.configAzure)

--- a/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-changerules.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-changerules.yaml
@@ -1,0 +1,46 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("/values.star", "values")
+#@ load("/values.star", "resource")
+#@ load("/values.star", "secret_name")
+
+#@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata":{"name":"restic"}})
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/update-strategy: "skip"
+
+#@overlay/match by=overlay.subset(resource("ClusterRoleBinding", values.rbac.name))
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/update-strategy: "skip"
+
+#@overlay/match by=overlay.subset({"kind": "CustomResourceDefinition", "spec":{"group":"velero.io"}}),expects=[11]
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/update-strategy: "skip"
+
+#@ if values.credential.useDefaultSecret:
+#@overlay/match by=overlay.subset(resource("Secret", "cloud-credentials"))
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/update-strategy: "skip"
+#@ end
+
+#@overlay/match by=overlay.subset(resource("Namespace", values.namespace))
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/update-strategy: "skip"

--- a/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-deployment.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-deployment.yaml
@@ -1,0 +1,40 @@
+#@ load("/values.star", "values")
+#@ load("/values.star", "resource")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset(resource("Deployment", "velero"))
+---
+spec:
+  template:
+    spec:
+      containers:
+      #@overlay/match by="name"
+      - name: velero
+        env:
+         #@overlay/match by="name"
+         #@overlay/remove
+         #@ if/end not values.backupStorageLocation.spec.provider == "aws" and not values.volumeSnapshotLocation.spec.provider == "aws":
+        - name: AWS_SHARED_CREDENTIALS_FILE
+        #@overlay/match by="name"
+        #@overlay/remove
+        #@ if/end not values.backupStorageLocation.spec.provider == "azure" and not values.volumeSnapshotLocation.spec.provider == "azure":
+        - name: AZURE_CREDENTIALS_FILE
+        args:
+          #@ if values.restic.create and values.restic.defaultVolumesToRestic:
+          #@overlay/append
+          - --default-volumes-to-restic=true
+          #@ end
+
+          #@ if values.restic.create and values.restic.defaultResticPruneFrequency != 0:
+          #@overlay/append
+          - #@ "--default-restic-prune-frequency={}".format(values.restic.defaultResticPruneFrequency)
+          #@ end
+      initContainers:
+      #@overlay/match by="name"
+      #@overlay/remove
+      #@ if/end not values.backupStorageLocation.spec.provider == "aws" and not values.volumeSnapshotLocation.spec.provider == "aws":
+      - name: velero-plugin-for-aws
+      #@overlay/match by="name"
+      #@overlay/remove
+      #@ if/end not values.backupStorageLocation.spec.provider == "azure" and not values.volumeSnapshotLocation.spec.provider == "azure":
+      - name: velero-plugin-for-microsoft-azure

--- a/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-metadata.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-metadata.yaml
@@ -1,0 +1,57 @@
+#@ load("/values.star", "values")
+#@ load("@ytt:overlay", "overlay")
+#@ load("/values.star", "velero_app")
+#@ load("/values.star", "labels")
+
+#! Note: use this file to set Velero specific metadata for all resources created
+#! by Velero.
+
+#@overlay/match by=overlay.subset({"kind": "Namespace"}),expects=[1]
+---
+metadata:
+  name: #@ values.namespace
+
+#@overlay/match by=overlay.subset({"kind": "Deployment"}),expects=[1]
+---
+#@overlay/match-child-defaults missing_ok=True
+metadata:
+  labels: #@ labels()
+  namespace: #@ values.namespace
+
+#@overlay/match by=overlay.subset({"kind": "DaemonSet"}),expects="0+"
+---
+#@overlay/match-child-defaults missing_ok=True
+metadata:
+  labels: #@ labels()
+  namespace: #@ values.namespace
+
+#@overlay/match by=overlay.subset({"kind": "Secret"}),expects="1+"
+---
+#@overlay/match-child-defaults missing_ok=True
+metadata:
+  labels: #@ labels()
+  namespace: #@ values.namespace
+
+#@overlay/match by=overlay.subset({"kind": "BackupStorageLocation"}),expects="1+"
+---
+#@overlay/match-child-defaults missing_ok=True
+metadata:
+  labels: #@ labels()
+  namespace: #@ values.namespace
+
+#@overlay/match by=overlay.subset({"kind": "VolumeSnapshotLocation"}),expects="1+"
+---
+#@overlay/match-child-defaults missing_ok=True
+metadata:
+  labels: #@ labels()
+  namespace: #@ values.namespace
+
+#@ if values.rbac.create and values.rbac.clusterAdministrator:
+
+#@overlay/match by=overlay.subset({"kind": "ServiceAccount"}),expects=[1]
+---
+#@overlay/match-child-defaults missing_ok=True
+metadata:
+  labels: #@ labels()
+  namespace: #@ values.namespace
+#@ end

--- a/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-rbac.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-rbac.yaml
@@ -1,0 +1,60 @@
+#@ load("/values.star", "values")
+#@ load("@ytt:overlay", "overlay")
+#@ load("/values.star", "labels")
+#@ load("/helpers.lib.yaml", "non_empty")
+
+#@ if values.rbac.create and values.rbac.clusterAdministrator:
+
+#@overlay/match by=overlay.subset({"kind": "ClusterRoleBinding"}),expects=[1]
+---
+#@overlay/match-child-defaults missing_ok=True
+metadata:
+  name: #@ values.rbac.name
+roleRef:
+  name: #@ values.rbac.roleRefName
+subjects:
+- kind: ServiceAccount
+  #@ non_empty(values.serviceAccount)
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-reader
+rules:
+- apiGroups: #@ values.rbac.clusterRoleAPIGroups
+  #!
+  #! at the HTTP level, the name of the resource for accessing Secret
+  #! objects is "secrets"
+  resources: ["secrets"]
+  verbs: #@ values.rbac.clusterRoleVerbs
+#@ end
+
+#@ if values.rbac.create:
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: velero-server
+rules:
+  - apiGroups:
+      - velero.io
+    verbs:
+      - "*"
+    resources:
+      - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels: #@ labels()
+  name: velero-server
+subjects:
+  - kind: ServiceAccount
+    name: #@ values.serviceAccount.name
+roleRef:
+  kind: Role
+  name: #@ values.rbac.roleRefName
+  apiGroup: rbac.authorization.k8s.io
+#@ end

--- a/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-restic.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-restic.yaml
@@ -1,0 +1,33 @@
+#@ load("/values.star", "values")
+#@ load("/values.star", "resource")
+#@ load("@ytt:overlay", "overlay")
+
+#@ if values.restic.create:
+#@overlay/match by=overlay.subset(resource("DaemonSet", "restic"))
+---
+spec:
+  template:
+    spec:
+      containers:
+      #@overlay/match by=overlay.subset({"name":"restic"})
+      - name: restic
+        resources:
+          limits:
+            #@ if/end values.restic.cpuLimit != "1000m":
+            #@overlay/replace
+            cpu: #@ values.restic.cpuLimit
+            #@ if/end values.restic.memoryLimit != "1Gi":
+            #@overlay/replace
+            memory: #@ values.restic.memoryLimit
+          requests:
+            #@ if/end values.restic.cpuRequest != "500m":
+            #@overlay/replace
+            cpu: #@ values.restic.cpuRequest
+            #@ if/end values.restic.memoryRequest != "512Mi":
+            #@overlay/replace
+            memory: #@ values.restic.memoryRequest
+#@ else:
+#@overlay/match by=overlay.subset(resource("DaemonSet", "restic"))
+---
+#@overlay/remove
+#@ end

--- a/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-secrets.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-secrets.yaml
@@ -1,0 +1,52 @@
+#@ load("/values.star", "values")
+#@ load("/values.star", "resource")
+#@ load("/values.star", "secret_name")
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:base64", "base64")
+
+#@ if not values.credential.useDefaultSecret:
+#@overlay/match by=overlay.subset(resource("Secret", "cloud-credentials"))
+#@overlay/remove
+---
+
+#@ else:
+#@overlay/match by=overlay.subset(resource("Secret", "cloud-credentials"))
+---
+#@overlay/match-child-defaults missing_ok=True
+metadata:
+    name: #@ secret_name()
+type: Opaque
+#@overlay/match-child-defaults missing_ok=True
+data:
+    cloud: #@ base64.encode(values.credential.secretContents.cloud)
+    #@ if/end values.credential.extraEnvVars:
+    extraEnvVars: #@ base64.encode(values.credential.extraEnvVars)
+    #@ if/end values.credential.extraSecretRef:
+    extraSecretRef: #@ base64.encode(values.credential.extraSecretRef)
+#@ end
+
+#@overlay/match by=overlay.subset(resource("Deployment", "velero"))
+---
+spec:
+  template:
+    spec:
+      volumes:
+        #@overlay/match by=overlay.subset({"name":"cloud-credentials"})
+        #@overlay/replace
+          - name: cloud-credentials
+            secret:
+              secretName: #@ secret_name()
+
+#@ if/end values.restic.create:
+#@overlay/match by=overlay.subset(resource("DaemonSet", "restic"))
+---
+#@overlay/match-child-defaults missing_ok=True
+spec:
+  template:
+    spec:
+      volumes:
+        #@overlay/match by=overlay.subset({"name":"cloud-credentials"})
+        #@overlay/replace
+          - name: cloud-credentials
+            secret:
+              secretName: #@ secret_name()

--- a/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-volumesnapshotlocation.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/overlays/velero/overlay-volumesnapshotlocation.yaml
@@ -1,0 +1,33 @@
+#@ load("/values.star", "values")
+#@ load("/values.star", "resource")
+#@ load("@ytt:overlay", "overlay")
+#@ load("/helpers.lib.yaml", "non_empty")
+
+#@ if values.volumeSnapshotLocation.snapshotsEnabled:
+
+#@overlay/match by=overlay.subset(resource("VolumeSnapshotLocation", "default"))
+---
+#@overlay/match-child-defaults missing_ok=True
+metadata:
+  name: #@ values.volumeSnapshotLocation.name
+#@overlay/match-child-defaults missing_ok=True
+spec:
+  provider: #@ values.volumeSnapshotLocation.spec.provider
+
+#@overlay/match by=overlay.subset(resource("VolumeSnapshotLocation", values.volumeSnapshotLocation.name))
+---
+#@overlay/match-child-defaults missing_ok=True
+spec:
+  #@overlay/replace
+  #@ if/end values.volumeSnapshotLocation.spec.provider == "aws":
+  config: #@ non_empty(values.volumeSnapshotLocation.spec.configAWS)
+  #@overlay/replace
+  #@ if/end values.volumeSnapshotLocation.spec.provider == "azure":
+  config: #@ non_empty(values.volumeSnapshotLocation.spec.configAzure)
+
+#@ else:
+#@overlay/match by=overlay.subset(resource("VolumeSnapshotLocation", "default"))
+---
+#@overlay/remove
+
+#@ end

--- a/addons/packages/velero/1.7.1/bundle/config/upstream/velero/velero.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/upstream/velero/velero.yaml
@@ -1,0 +1,3801 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: backups.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    singular: backup
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Backup is a Velero resource that represents the capture of
+          Kubernetes cluster state at a point in time (API objects and associated
+          volume state).
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource
+              this object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackupSpec defines the specification for a Velero backup.
+            properties:
+              defaultVolumesToRestic:
+                description: DefaultVolumesToRestic specifies whether restic should
+                  be used to take a backup of all pod volumes by default.
+                type: boolean
+              excludedNamespaces:
+                description: ExcludedNamespaces contains a list of namespaces that
+                  are not included in the backup.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              excludedResources:
+                description: ExcludedResources is a slice of resource names that
+                  are not included in the backup.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              hooks:
+                description: Hooks represent custom behaviors that should be executed
+                  at different phases of the backup.
+                properties:
+                  resources:
+                    description: Resources are hooks that should be executed when
+                      backing up individual instances of a resource.
+                    items:
+                      description: BackupResourceHookSpec defines one or more BackupResourceHooks
+                        that should be executed based on the rules defined for namespaces,
+                        resources, and label selector.
+                      properties:
+                        excludedNamespaces:
+                          description: ExcludedNamespaces specifies the namespaces
+                            to which this hook spec does not apply.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        excludedResources:
+                          description: ExcludedResources specifies the resources
+                            to which this hook spec does not apply.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        includedNamespaces:
+                          description: IncludedNamespaces specifies the namespaces
+                            to which this hook spec applies. If empty, it applies
+                            to all namespaces.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        includedResources:
+                          description: IncludedResources specifies the resources
+                            to which this hook spec applies. If empty, it applies
+                            to all resources.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        labelSelector:
+                          description: LabelSelector, if specified, filters the
+                            resources to which this hook spec applies.
+                          nullable: true
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values
+                                      array must be non-empty. If the operator is
+                                      Exists or DoesNotExist, the values array must
+                                      be empty. This array is replaced during a
+                                      strategic merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        name:
+                          description: Name is the name of this hook.
+                          type: string
+                        post:
+                          description: PostHooks is a list of BackupResourceHooks
+                            to execute after storing the item in the backup. These
+                            are executed after all "additional items" from item
+                            actions are processed.
+                          items:
+                            description: BackupResourceHook defines a hook for a
+                              resource.
+                            properties:
+                              exec:
+                                description: Exec defines an exec hook.
+                                properties:
+                                  command:
+                                    description: Command is the command and arguments
+                                      to execute.
+                                    items:
+                                      type: string
+                                    minItems: 1
+                                    type: array
+                                  container:
+                                    description: Container is the container in the
+                                      pod where the command should be executed.
+                                      If not specified, the pod's first container
+                                      is used.
+                                    type: string
+                                  onError:
+                                    description: OnError specifies how Velero should
+                                      behave if it encounters an error executing
+                                      this hook.
+                                    enum:
+                                    - Continue
+                                    - Fail
+                                    type: string
+                                  timeout:
+                                    description: Timeout defines the maximum amount
+                                      of time Velero should wait for the hook to
+                                      complete before considering the execution
+                                      a failure.
+                                    type: string
+                                required:
+                                - command
+                                type: object
+                            required:
+                            - exec
+                            type: object
+                          type: array
+                        pre:
+                          description: PreHooks is a list of BackupResourceHooks
+                            to execute prior to storing the item in the backup.
+                            These are executed before any "additional items" from
+                            item actions are processed.
+                          items:
+                            description: BackupResourceHook defines a hook for a
+                              resource.
+                            properties:
+                              exec:
+                                description: Exec defines an exec hook.
+                                properties:
+                                  command:
+                                    description: Command is the command and arguments
+                                      to execute.
+                                    items:
+                                      type: string
+                                    minItems: 1
+                                    type: array
+                                  container:
+                                    description: Container is the container in the
+                                      pod where the command should be executed.
+                                      If not specified, the pod's first container
+                                      is used.
+                                    type: string
+                                  onError:
+                                    description: OnError specifies how Velero should
+                                      behave if it encounters an error executing
+                                      this hook.
+                                    enum:
+                                    - Continue
+                                    - Fail
+                                    type: string
+                                  timeout:
+                                    description: Timeout defines the maximum amount
+                                      of time Velero should wait for the hook to
+                                      complete before considering the execution
+                                      a failure.
+                                    type: string
+                                required:
+                                - command
+                                type: object
+                            required:
+                            - exec
+                            type: object
+                          type: array
+                      required:
+                      - name
+                      type: object
+                    nullable: true
+                    type: array
+                type: object
+              includeClusterResources:
+                description: IncludeClusterResources specifies whether cluster-scoped
+                  resources should be included for consideration in the backup.
+                nullable: true
+                type: boolean
+              includedNamespaces:
+                description: IncludedNamespaces is a slice of namespace names to
+                  include objects from. If empty, all namespaces are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              includedResources:
+                description: IncludedResources is a slice of resource names to include
+                  in the backup. If empty, all resources are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              labelSelector:
+                description: LabelSelector is a metav1.LabelSelector to filter with
+                  when adding individual objects to the backup. If empty or nil,
+                  all objects are included. Optional.
+                nullable: true
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the
+                        key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship
+                            to a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a
+                            strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              metadata:
+                properties:
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              orderedResources:
+                additionalProperties:
+                  type: string
+                description: OrderedResources specifies the backup order of resources
+                  of specific Kind. The map key is the Kind name and value is a
+                  list of resource names separated by commas. Each resource name
+                  has format "namespace/resourcename".  For cluster resources, simply
+                  use "resourcename".
+                nullable: true
+                type: object
+              snapshotVolumes:
+                description: SnapshotVolumes specifies whether to take cloud snapshots
+                  of any PV's referenced in the set of objects included in the Backup.
+                nullable: true
+                type: boolean
+              storageLocation:
+                description: StorageLocation is a string containing the name of
+                  a BackupStorageLocation where the backup should be stored.
+                type: string
+              ttl:
+                description: TTL is a time.Duration-parseable string describing
+                  how long the Backup should be retained for.
+                type: string
+              volumeSnapshotLocations:
+                description: VolumeSnapshotLocations is a list containing names
+                  of VolumeSnapshotLocations associated with this backup.
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: BackupStatus captures the current status of a Velero backup.
+            properties:
+              completionTimestamp:
+                description: CompletionTimestamp records the time a backup was completed.
+                  Completion time is recorded even on failed backups. Completion
+                  time is recorded before uploading the backup object. The server's
+                  time is used for CompletionTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              errors:
+                description: Errors is a count of all error messages that were generated
+                  during execution of the backup.  The actual errors are in the
+                  backup's log file in object storage.
+                type: integer
+              expiration:
+                description: Expiration is when this Backup is eligible for garbage-collection.
+                format: date-time
+                nullable: true
+                type: string
+              formatVersion:
+                description: FormatVersion is the backup format version, including
+                  major, minor, and patch version.
+                type: string
+              phase:
+                description: Phase is the current state of the Backup.
+                enum:
+                - New
+                - FailedValidation
+                - InProgress
+                - Completed
+                - PartiallyFailed
+                - Failed
+                - Deleting
+                type: string
+              progress:
+                description: Progress contains information about the backup's execution
+                  progress. Note that this information is best-effort only -- if
+                  Velero fails to update it during a backup for any reason, it may
+                  be inaccurate/stale.
+                nullable: true
+                properties:
+                  itemsBackedUp:
+                    description: ItemsBackedUp is the number of items that have
+                      actually been written to the backup tarball so far.
+                    type: integer
+                  totalItems:
+                    description: TotalItems is the total number of items to be backed
+                      up. This number may change throughout the execution of the
+                      backup due to plugins that return additional related items
+                      to back up, the velero.io/exclude-from-backup label, and various
+                      other filters that happen as items are processed.
+                    type: integer
+                type: object
+              startTimestamp:
+                description: StartTimestamp records the time a backup was started.
+                  Separate from CreationTimestamp, since that value changes on restores.
+                  The server's time is used for StartTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              validationErrors:
+                description: ValidationErrors is a slice of all validation errors
+                  (if applicable).
+                items:
+                  type: string
+                nullable: true
+                type: array
+              version:
+                description: 'Version is the backup format major version. Deprecated:
+                  Please see FormatVersion'
+                type: integer
+              volumeSnapshotsAttempted:
+                description: VolumeSnapshotsAttempted is the total number of attempted
+                  volume snapshots for this backup.
+                type: integer
+              volumeSnapshotsCompleted:
+                description: VolumeSnapshotsCompleted is the total number of successfully
+                  completed volume snapshots for this backup.
+                type: integer
+              warnings:
+                description: Warnings is a count of all warning messages that were
+                  generated during execution of the backup. The actual warnings
+                  are in the backup's log file in object storage.
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: backupstoragelocations.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: BackupStorageLocation
+    listKind: BackupStorageLocationList
+    plural: backupstoragelocations
+    shortNames:
+    - bsl
+    singular: backupstoragelocation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Backup Storage Location status such as Available/Unavailable
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: LastValidationTime is the last time the backup store location
+        was validated
+      jsonPath: .status.lastValidationTime
+      name: Last Validated
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Default backup storage location
+      jsonPath: .spec.default
+      name: Default
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: BackupStorageLocation is a location where Velero stores backup
+          objects
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource
+              this object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackupStorageLocationSpec defines the desired state of
+              a Velero BackupStorageLocation
+            properties:
+              accessMode:
+                description: AccessMode defines the permissions for the backup storage
+                  location.
+                enum:
+                - ReadOnly
+                - ReadWrite
+                type: string
+              backupSyncPeriod:
+                description: BackupSyncPeriod defines how frequently to sync backup
+                  API objects from object storage. A value of 0 disables sync.
+                nullable: true
+                type: string
+              config:
+                additionalProperties:
+                  type: string
+                description: Config is for provider-specific configuration fields.
+                type: object
+              credential:
+                description: Credential contains the credential information intended
+                  to be used with this location
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be
+                      a valid secret key.
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+              default:
+                description: Default indicates this location is the default backup
+                  storage location.
+                type: boolean
+              objectStorage:
+                description: ObjectStorageLocation specifies the settings necessary
+                  to connect to a provider's object storage.
+                properties:
+                  bucket:
+                    description: Bucket is the bucket to use for object storage.
+                    type: string
+                  caCert:
+                    description: CACert defines a CA bundle to use when verifying
+                      TLS connections to the provider.
+                    format: byte
+                    type: string
+                  prefix:
+                    description: Prefix is the path inside a bucket to use for Velero
+                      storage. Optional.
+                    type: string
+                required:
+                - bucket
+                type: object
+              provider:
+                description: Provider is the provider of the backup storage.
+                type: string
+              validationFrequency:
+                description: ValidationFrequency defines how frequently to validate
+                  the corresponding object storage. A value of 0 disables validation.
+                nullable: true
+                type: string
+            required:
+            - objectStorage
+            - provider
+            type: object
+          status:
+            description: BackupStorageLocationStatus defines the observed state
+              of BackupStorageLocation
+            properties:
+              accessMode:
+                description: "AccessMode is an unused field. \n Deprecated: there
+                  is now an AccessMode field on the Spec and this field will be
+                  removed entirely as of v2.0."
+                enum:
+                - ReadOnly
+                - ReadWrite
+                type: string
+              lastSyncedRevision:
+                description: "LastSyncedRevision is the value of the `metadata/revision`
+                  file in the backup storage location the last time the BSL's contents
+                  were synced into the cluster. \n Deprecated: this field is no
+                  longer updated or used for detecting changes to the location's
+                  contents and will be removed entirely in v2.0."
+                type: string
+              lastSyncedTime:
+                description: LastSyncedTime is the last time the contents of the
+                  location were synced into the cluster.
+                format: date-time
+                nullable: true
+                type: string
+              lastValidationTime:
+                description: LastValidationTime is the last time the backup store
+                  location was validated the cluster.
+                format: date-time
+                nullable: true
+                type: string
+              phase:
+                description: Phase is the current state of the BackupStorageLocation.
+                enum:
+                - Available
+                - Unavailable
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: deletebackuprequests.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: DeleteBackupRequest
+    listKind: DeleteBackupRequestList
+    plural: deletebackuprequests
+    singular: deletebackuprequest
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: DeleteBackupRequest is a request to delete one or more backups.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource
+              this object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DeleteBackupRequestSpec is the specification for which
+              backups to delete.
+            properties:
+              backupName:
+                type: string
+            required:
+            - backupName
+            type: object
+          status:
+            description: DeleteBackupRequestStatus is the current status of a DeleteBackupRequest.
+            properties:
+              errors:
+                description: Errors contains any errors that were encountered during
+                  the deletion process.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              phase:
+                description: Phase is the current state of the DeleteBackupRequest.
+                enum:
+                - New
+                - InProgress
+                - Processed
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: downloadrequests.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: DownloadRequest
+    listKind: DownloadRequestList
+    plural: downloadrequests
+    singular: downloadrequest
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: DownloadRequest is a request to download an artifact from backup
+          object storage, such as a backup log file.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource
+              this object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DownloadRequestSpec is the specification for a download
+              request.
+            properties:
+              target:
+                description: Target is what to download (e.g. logs for a backup).
+                properties:
+                  kind:
+                    description: Kind is the type of file to download.
+                    enum:
+                    - BackupLog
+                    - BackupContents
+                    - BackupVolumeSnapshots
+                    - BackupResourceList
+                    - RestoreLog
+                    - RestoreResults
+                    type: string
+                  name:
+                    description: Name is the name of the kubernetes resource with
+                      which the file is associated.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+            required:
+            - target
+            type: object
+          status:
+            description: DownloadRequestStatus is the current status of a DownloadRequest.
+            properties:
+              downloadURL:
+                description: DownloadURL contains the pre-signed URL for the target
+                  file.
+                type: string
+              expiration:
+                description: Expiration is when this DownloadRequest expires and
+                  can be deleted by the system.
+                format: date-time
+                nullable: true
+                type: string
+              phase:
+                description: Phase is the current state of the DownloadRequest.
+                enum:
+                - New
+                - Processed
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: podvolumebackups.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: PodVolumeBackup
+    listKind: PodVolumeBackupList
+    plural: podvolumebackups
+    singular: podvolumebackup
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource
+              this object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PodVolumeBackupSpec is the specification for a PodVolumeBackup.
+            properties:
+              backupStorageLocation:
+                description: BackupStorageLocation is the name of the backup storage
+                  location where the restic repository is stored.
+                type: string
+              node:
+                description: Node is the name of the node that the Pod is running
+                  on.
+                type: string
+              pod:
+                description: Pod is a reference to the pod containing the volume
+                  to be backed up.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              repoIdentifier:
+                description: RepoIdentifier is the restic repository identifier.
+                type: string
+              tags:
+                additionalProperties:
+                  type: string
+                description: Tags are a map of key-value pairs that should be applied
+                  to the volume backup as tags.
+                type: object
+              volume:
+                description: Volume is the name of the volume within the Pod to
+                  be backed up.
+                type: string
+            required:
+            - backupStorageLocation
+            - node
+            - pod
+            - repoIdentifier
+            - volume
+            type: object
+          status:
+            description: PodVolumeBackupStatus is the current status of a PodVolumeBackup.
+            properties:
+              completionTimestamp:
+                description: CompletionTimestamp records the time a backup was completed.
+                  Completion time is recorded even on failed backups. Completion
+                  time is recorded before uploading the backup object. The server's
+                  time is used for CompletionTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: Message is a message about the pod volume backup's
+                  status.
+                type: string
+              path:
+                description: Path is the full path within the controller pod being
+                  backed up.
+                type: string
+              phase:
+                description: Phase is the current state of the PodVolumeBackup.
+                enum:
+                - New
+                - InProgress
+                - Completed
+                - Failed
+                type: string
+              progress:
+                description: Progress holds the total number of bytes of the volume
+                  and the current number of backed up bytes. This can be used to
+                  display progress information about the backup operation.
+                properties:
+                  bytesDone:
+                    format: int64
+                    type: integer
+                  totalBytes:
+                    format: int64
+                    type: integer
+                type: object
+              snapshotID:
+                description: SnapshotID is the identifier for the snapshot of the
+                  pod volume.
+                type: string
+              startTimestamp:
+                description: StartTimestamp records the time a backup was started.
+                  Separate from CreationTimestamp, since that value changes on restores.
+                  The server's time is used for StartTimestamps
+                format: date-time
+                nullable: true
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: podvolumerestores.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: PodVolumeRestore
+    listKind: PodVolumeRestoreList
+    plural: podvolumerestores
+    singular: podvolumerestore
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource
+              this object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PodVolumeRestoreSpec is the specification for a PodVolumeRestore.
+            properties:
+              backupStorageLocation:
+                description: BackupStorageLocation is the name of the backup storage
+                  location where the restic repository is stored.
+                type: string
+              pod:
+                description: Pod is a reference to the pod containing the volume
+                  to be restored.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              repoIdentifier:
+                description: RepoIdentifier is the restic repository identifier.
+                type: string
+              snapshotID:
+                description: SnapshotID is the ID of the volume snapshot to be restored.
+                type: string
+              volume:
+                description: Volume is the name of the volume within the Pod to
+                  be restored.
+                type: string
+            required:
+            - backupStorageLocation
+            - pod
+            - repoIdentifier
+            - snapshotID
+            - volume
+            type: object
+          status:
+            description: PodVolumeRestoreStatus is the current status of a PodVolumeRestore.
+            properties:
+              completionTimestamp:
+                description: CompletionTimestamp records the time a restore was
+                  completed. Completion time is recorded even on failed restores.
+                  The server's time is used for CompletionTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: Message is a message about the pod volume restore's
+                  status.
+                type: string
+              phase:
+                description: Phase is the current state of the PodVolumeRestore.
+                enum:
+                - New
+                - InProgress
+                - Completed
+                - Failed
+                type: string
+              progress:
+                description: Progress holds the total number of bytes of the snapshot
+                  and the current number of restored bytes. This can be used to
+                  display progress information about the restore operation.
+                properties:
+                  bytesDone:
+                    format: int64
+                    type: integer
+                  totalBytes:
+                    format: int64
+                    type: integer
+                type: object
+              startTimestamp:
+                description: StartTimestamp records the time a restore was started.
+                  The server's time is used for StartTimestamps
+                format: date-time
+                nullable: true
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: resticrepositories.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: ResticRepository
+    listKind: ResticRepositoryList
+    plural: resticrepositories
+    singular: resticrepository
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource
+              this object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResticRepositorySpec is the specification for a ResticRepository.
+            properties:
+              backupStorageLocation:
+                description: BackupStorageLocation is the name of the BackupStorageLocation
+                  that should contain this repository.
+                type: string
+              maintenanceFrequency:
+                description: MaintenanceFrequency is how often maintenance should
+                  be run.
+                type: string
+              resticIdentifier:
+                description: ResticIdentifier is the full restic-compatible string
+                  for identifying this repository.
+                type: string
+              volumeNamespace:
+                description: VolumeNamespace is the namespace this restic repository
+                  contains pod volume backups for.
+                type: string
+            required:
+            - backupStorageLocation
+            - maintenanceFrequency
+            - resticIdentifier
+            - volumeNamespace
+            type: object
+          status:
+            description: ResticRepositoryStatus is the current status of a ResticRepository.
+            properties:
+              lastMaintenanceTime:
+                description: LastMaintenanceTime is the last time maintenance was
+                  run.
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: Message is a message about the current status of the
+                  ResticRepository.
+                type: string
+              phase:
+                description: Phase is the current state of the ResticRepository.
+                enum:
+                - New
+                - Ready
+                - NotReady
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: restores.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: Restore
+    listKind: RestoreList
+    plural: restores
+    singular: restore
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Restore is a Velero resource that represents the application
+          of resources from a Velero backup to a target Kubernetes cluster.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource
+              this object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RestoreSpec defines the specification for a Velero restore.
+            properties:
+              backupName:
+                description: BackupName is the unique name of the Velero backup
+                  to restore from.
+                type: string
+              excludedNamespaces:
+                description: ExcludedNamespaces contains a list of namespaces that
+                  are not included in the restore.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              excludedResources:
+                description: ExcludedResources is a slice of resource names that
+                  are not included in the restore.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              hooks:
+                description: Hooks represent custom behaviors that should be executed
+                  during or post restore.
+                properties:
+                  resources:
+                    items:
+                      description: RestoreResourceHookSpec defines one or more RestoreResrouceHooks
+                        that should be executed based on the rules defined for namespaces,
+                        resources, and label selector.
+                      properties:
+                        excludedNamespaces:
+                          description: ExcludedNamespaces specifies the namespaces
+                            to which this hook spec does not apply.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        excludedResources:
+                          description: ExcludedResources specifies the resources
+                            to which this hook spec does not apply.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        includedNamespaces:
+                          description: IncludedNamespaces specifies the namespaces
+                            to which this hook spec applies. If empty, it applies
+                            to all namespaces.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        includedResources:
+                          description: IncludedResources specifies the resources
+                            to which this hook spec applies. If empty, it applies
+                            to all resources.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        labelSelector:
+                          description: LabelSelector, if specified, filters the
+                            resources to which this hook spec applies.
+                          nullable: true
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values
+                                      array must be non-empty. If the operator is
+                                      Exists or DoesNotExist, the values array must
+                                      be empty. This array is replaced during a
+                                      strategic merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        name:
+                          description: Name is the name of this hook.
+                          type: string
+                        postHooks:
+                          description: PostHooks is a list of RestoreResourceHooks
+                            to execute during and after restoring a resource.
+                          items:
+                            description: RestoreResourceHook defines a restore hook
+                              for a resource.
+                            properties:
+                              exec:
+                                description: Exec defines an exec restore hook.
+                                properties:
+                                  command:
+                                    description: Command is the command and arguments
+                                      to execute from within a container after a
+                                      pod has been restored.
+                                    items:
+                                      type: string
+                                    minItems: 1
+                                    type: array
+                                  container:
+                                    description: Container is the container in the
+                                      pod where the command should be executed.
+                                      If not specified, the pod's first container
+                                      is used.
+                                    type: string
+                                  execTimeout:
+                                    description: ExecTimeout defines the maximum
+                                      amount of time Velero should wait for the
+                                      hook to complete before considering the execution
+                                      a failure.
+                                    type: string
+                                  onError:
+                                    description: OnError specifies how Velero should
+                                      behave if it encounters an error executing
+                                      this hook.
+                                    enum:
+                                    - Continue
+                                    - Fail
+                                    type: string
+                                  waitTimeout:
+                                    description: WaitTimeout defines the maximum
+                                      amount of time Velero should wait for the
+                                      container to be Ready before attempting to
+                                      run the command.
+                                    type: string
+                                required:
+                                - command
+                                type: object
+                              init:
+                                description: Init defines an init restore hook.
+                                properties:
+                                  initContainers:
+                                    description: InitContainers is list of init
+                                      containers to be added to a pod during its
+                                      restore.
+                                    items:
+                                      description: A single application container
+                                        that you want to run within a pod.
+                                      properties:
+                                        args:
+                                          description: 'Arguments to the entrypoint.
+                                            The docker image''s CMD is used if this
+                                            is not provided. Variable references
+                                            $(VAR_NAME) are expanded using the container''s
+                                            environment. If a variable cannot be
+                                            resolved, the reference in the input
+                                            string will be unchanged. Double $$
+                                            are reduced to a single $, which allows
+                                            for escaping the $(VAR_NAME) syntax:
+                                            i.e. "$$(VAR_NAME)" will produce the
+                                            string literal "$(VAR_NAME)". Escaped
+                                            references will never be expanded, regardless
+                                            of whether the variable exists or not.
+                                            Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                          items:
+                                            type: string
+                                          type: array
+                                        command:
+                                          description: 'Entrypoint array. Not executed
+                                            within a shell. The docker image''s
+                                            ENTRYPOINT is used if this is not provided.
+                                            Variable references $(VAR_NAME) are
+                                            expanded using the container''s environment.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. Double $$ are reduced to
+                                            a single $, which allows for escaping
+                                            the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Cannot be updated. More info:
+                                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                          items:
+                                            type: string
+                                          type: array
+                                        env:
+                                          description: List of environment variables
+                                            to set in the container. Cannot be updated.
+                                          items:
+                                            description: EnvVar represents an environment
+                                              variable present in a Container.
+                                            properties:
+                                              name:
+                                                description: Name of the environment
+                                                  variable. Must be a C_IDENTIFIER.
+                                                type: string
+                                              value:
+                                                description: 'Variable references
+                                                  $(VAR_NAME) are expanded using
+                                                  the previously defined environment
+                                                  variables in the container and
+                                                  any service environment variables.
+                                                  If a variable cannot be resolved,
+                                                  the reference in the input string
+                                                  will be unchanged. Double $$ are
+                                                  reduced to a single $, which allows
+                                                  for escaping the $(VAR_NAME) syntax:
+                                                  i.e. "$$(VAR_NAME)" will produce
+                                                  the string literal "$(VAR_NAME)".
+                                                  Escaped references will never
+                                                  be expanded, regardless of whether
+                                                  the variable exists or not. Defaults
+                                                  to "".'
+                                                type: string
+                                              valueFrom:
+                                                description: Source for the environment
+                                                  variable's value. Cannot be used
+                                                  if value is not empty.
+                                                properties:
+                                                  configMapKeyRef:
+                                                    description: Selects a key of
+                                                      a ConfigMap.
+                                                    properties:
+                                                      key:
+                                                        description: The key to
+                                                          select.
+                                                        type: string
+                                                      name:
+                                                        description: 'Name of the
+                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful
+                                                          fields. apiVersion, kind,
+                                                          uid?'
+                                                        type: string
+                                                      optional:
+                                                        description: Specify whether
+                                                          the ConfigMap or its key
+                                                          must be defined
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                  fieldRef:
+                                                    description: 'Selects a field
+                                                      of the pod: supports metadata.name,
+                                                      metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                                      `metadata.annotations[''<KEY>'']`,
+                                                      spec.nodeName, spec.serviceAccountName,
+                                                      status.hostIP, status.podIP,
+                                                      status.podIPs.'
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of
+                                                          the schema the FieldPath
+                                                          is written in terms of,
+                                                          defaults to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the
+                                                          field to select in the
+                                                          specified API version.
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                  resourceFieldRef:
+                                                    description: 'Selects a resource
+                                                      of the container: only resources
+                                                      limits and requests (limits.cpu,
+                                                      limits.memory, limits.ephemeral-storage,
+                                                      requests.cpu, requests.memory
+                                                      and requests.ephemeral-storage)
+                                                      are currently supported.'
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container
+                                                          name: required for volumes,
+                                                          optional for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: Specifies the
+                                                          output format of the exposed
+                                                          resources, defaults to
+                                                          "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required:
+                                                          resource to select'
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                  secretKeyRef:
+                                                    description: Selects a key of
+                                                      a secret in the pod's namespace
+                                                    properties:
+                                                      key:
+                                                        description: The key of
+                                                          the secret to select from.  Must
+                                                          be a valid secret key.
+                                                        type: string
+                                                      name:
+                                                        description: 'Name of the
+                                                          referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          TODO: Add other useful
+                                                          fields. apiVersion, kind,
+                                                          uid?'
+                                                        type: string
+                                                      optional:
+                                                        description: Specify whether
+                                                          the Secret or its key
+                                                          must be defined
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        envFrom:
+                                          description: List of sources to populate
+                                            environment variables in the container.
+                                            The keys defined within a source must
+                                            be a C_IDENTIFIER. All invalid keys
+                                            will be reported as an event when the
+                                            container is starting. When a key exists
+                                            in multiple sources, the value associated
+                                            with the last source will take precedence.
+                                            Values defined by an Env with a duplicate
+                                            key will take precedence. Cannot be
+                                            updated.
+                                          items:
+                                            description: EnvFromSource represents
+                                              the source of a set of ConfigMaps
+                                            properties:
+                                              configMapRef:
+                                                description: The ConfigMap to select
+                                                  from
+                                                properties:
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether
+                                                      the ConfigMap must be defined
+                                                    type: boolean
+                                                type: object
+                                              prefix:
+                                                description: An optional identifier
+                                                  to prepend to each key in the
+                                                  ConfigMap. Must be a C_IDENTIFIER.
+                                                type: string
+                                              secretRef:
+                                                description: The Secret to select
+                                                  from
+                                                properties:
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether
+                                                      the Secret must be defined
+                                                    type: boolean
+                                                type: object
+                                            type: object
+                                          type: array
+                                        image:
+                                          description: 'Docker image name. More
+                                            info: https://kubernetes.io/docs/concepts/containers/images
+                                            This field is optional to allow higher
+                                            level config management to default or
+                                            override container images in workload
+                                            controllers like Deployments and StatefulSets.'
+                                          type: string
+                                        imagePullPolicy:
+                                          description: 'Image pull policy. One of
+                                            Always, Never, IfNotPresent. Defaults
+                                            to Always if :latest tag is specified,
+                                            or IfNotPresent otherwise. Cannot be
+                                            updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                          type: string
+                                        lifecycle:
+                                          description: Actions that the management
+                                            system should take in response to container
+                                            lifecycle events. Cannot be updated.
+                                          properties:
+                                            postStart:
+                                              description: 'PostStart is called
+                                                immediately after a container is
+                                                created. If the handler fails, the
+                                                container is terminated and restarted
+                                                according to its restart policy.
+                                                Other management of the container
+                                                blocks until the hook completes.
+                                                More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                              properties:
+                                                exec:
+                                                  description: One and only one
+                                                    of the following should be specified.
+                                                    Exec specifies the action to
+                                                    take.
+                                                  properties:
+                                                    command:
+                                                      description: Command is the
+                                                        command line to execute
+                                                        inside the container, the
+                                                        working directory for the
+                                                        command  is root ('/') in
+                                                        the container's filesystem.
+                                                        The command is simply exec'd,
+                                                        it is not run inside a shell,
+                                                        so traditional shell instructions
+                                                        ('|', etc) won't work. To
+                                                        use a shell, you need to
+                                                        explicitly call out to that
+                                                        shell. Exit status of 0
+                                                        is treated as live/healthy
+                                                        and non-zero is unhealthy.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  description: HTTPGet specifies
+                                                    the http request to perform.
+                                                  properties:
+                                                    host:
+                                                      description: Host name to
+                                                        connect to, defaults to
+                                                        the pod IP. You probably
+                                                        want to set "Host" in httpHeaders
+                                                        instead.
+                                                      type: string
+                                                    httpHeaders:
+                                                      description: Custom headers
+                                                        to set in the request. HTTP
+                                                        allows repeated headers.
+                                                      items:
+                                                        description: HTTPHeader
+                                                          describes a custom header
+                                                          to be used in HTTP probes
+                                                        properties:
+                                                          name:
+                                                            description: The header
+                                                              field name
+                                                            type: string
+                                                          value:
+                                                            description: The header
+                                                              field value
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      description: Path to access
+                                                        on the HTTP server.
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Name or number
+                                                        of the port to access on
+                                                        the container. Number must
+                                                        be in the range 1 to 65535.
+                                                        Name must be an IANA_SVC_NAME.
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      description: Scheme to use
+                                                        for connecting to the host.
+                                                        Defaults to HTTP.
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  description: 'TCPSocket specifies
+                                                    an action involving a TCP port.
+                                                    TCP hooks not yet supported
+                                                    TODO: implement a realistic
+                                                    TCP lifecycle hook'
+                                                  properties:
+                                                    host:
+                                                      description: 'Optional: Host
+                                                        name to connect to, defaults
+                                                        to the pod IP.'
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Number or name
+                                                        of the port to access on
+                                                        the container. Number must
+                                                        be in the range 1 to 65535.
+                                                        Name must be an IANA_SVC_NAME.
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              description: 'PreStop is called immediately
+                                                before a container is terminated
+                                                due to an API request or management
+                                                event such as liveness/startup probe
+                                                failure, preemption, resource contention,
+                                                etc. The handler is not called if
+                                                the container crashes or exits.
+                                                The reason for termination is passed
+                                                to the handler. The Pod''s termination
+                                                grace period countdown begins before
+                                                the PreStop hooked is executed.
+                                                Regardless of the outcome of the
+                                                handler, the container will eventually
+                                                terminate within the Pod''s termination
+                                                grace period. Other management of
+                                                the container blocks until the hook
+                                                completes or until the termination
+                                                grace period is reached. More info:
+                                                https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                              properties:
+                                                exec:
+                                                  description: One and only one
+                                                    of the following should be specified.
+                                                    Exec specifies the action to
+                                                    take.
+                                                  properties:
+                                                    command:
+                                                      description: Command is the
+                                                        command line to execute
+                                                        inside the container, the
+                                                        working directory for the
+                                                        command  is root ('/') in
+                                                        the container's filesystem.
+                                                        The command is simply exec'd,
+                                                        it is not run inside a shell,
+                                                        so traditional shell instructions
+                                                        ('|', etc) won't work. To
+                                                        use a shell, you need to
+                                                        explicitly call out to that
+                                                        shell. Exit status of 0
+                                                        is treated as live/healthy
+                                                        and non-zero is unhealthy.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  description: HTTPGet specifies
+                                                    the http request to perform.
+                                                  properties:
+                                                    host:
+                                                      description: Host name to
+                                                        connect to, defaults to
+                                                        the pod IP. You probably
+                                                        want to set "Host" in httpHeaders
+                                                        instead.
+                                                      type: string
+                                                    httpHeaders:
+                                                      description: Custom headers
+                                                        to set in the request. HTTP
+                                                        allows repeated headers.
+                                                      items:
+                                                        description: HTTPHeader
+                                                          describes a custom header
+                                                          to be used in HTTP probes
+                                                        properties:
+                                                          name:
+                                                            description: The header
+                                                              field name
+                                                            type: string
+                                                          value:
+                                                            description: The header
+                                                              field value
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      description: Path to access
+                                                        on the HTTP server.
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Name or number
+                                                        of the port to access on
+                                                        the container. Number must
+                                                        be in the range 1 to 65535.
+                                                        Name must be an IANA_SVC_NAME.
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      description: Scheme to use
+                                                        for connecting to the host.
+                                                        Defaults to HTTP.
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  description: 'TCPSocket specifies
+                                                    an action involving a TCP port.
+                                                    TCP hooks not yet supported
+                                                    TODO: implement a realistic
+                                                    TCP lifecycle hook'
+                                                  properties:
+                                                    host:
+                                                      description: 'Optional: Host
+                                                        name to connect to, defaults
+                                                        to the pod IP.'
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Number or name
+                                                        of the port to access on
+                                                        the container. Number must
+                                                        be in the range 1 to 65535.
+                                                        Name must be an IANA_SVC_NAME.
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        livenessProbe:
+                                          description: 'Periodic probe of container
+                                            liveness. Container will be restarted
+                                            if the probe fails. Cannot be updated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          properties:
+                                            exec:
+                                              description: One and only one of the
+                                                following should be specified. Exec
+                                                specifies the action to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The
+                                                    command is simply exec'd, it
+                                                    is not run inside a shell, so
+                                                    traditional shell instructions
+                                                    ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly
+                                                    call out to that shell. Exit
+                                                    status of 0 is treated as live/healthy
+                                                    and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              description: Minimum consecutive failures
+                                                for the probe to be considered failed
+                                                after having succeeded. Defaults
+                                                to 3. Minimum value is 1.
+                                              format: int32
+                                              type: integer
+                                            httpGet:
+                                              description: HTTPGet specifies the
+                                                http request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP.
+                                                    You probably want to set "Host"
+                                                    in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to
+                                                    set in the request. HTTP allows
+                                                    repeated headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used
+                                                      in HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header
+                                                          field name
+                                                        type: string
+                                                      value:
+                                                        description: The header
+                                                          field value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on
+                                                    the HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of
+                                                    the port to access on the container.
+                                                    Number must be in the range
+                                                    1 to 65535. Name must be an
+                                                    IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: Scheme to use for
+                                                    connecting to the host. Defaults
+                                                    to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              description: 'Number of seconds after
+                                                the container has started before
+                                                liveness probes are initiated. More
+                                                info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              description: How often (in seconds)
+                                                to perform the probe. Default to
+                                                10 seconds. Minimum value is 1.
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              description: Minimum consecutive successes
+                                                for the probe to be considered successful
+                                                after having failed. Defaults to
+                                                1. Must be 1 for liveness and startup.
+                                                Minimum value is 1.
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              description: 'TCPSocket specifies
+                                                an action involving a TCP port.
+                                                TCP hooks not yet supported TODO:
+                                                implement a realistic TCP lifecycle
+                                                hook'
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of
+                                                    the port to access on the container.
+                                                    Number must be in the range
+                                                    1 to 65535. Name must be an
+                                                    IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              description: Optional duration in
+                                                seconds the pod needs to terminate
+                                                gracefully upon probe failure. The
+                                                grace period is the duration in
+                                                seconds after the processes running
+                                                in the pod are sent a termination
+                                                signal and the time when the processes
+                                                are forcibly halted with a kill
+                                                signal. Set this value longer than
+                                                the expected cleanup time for your
+                                                process. If this value is nil, the
+                                                pod's terminationGracePeriodSeconds
+                                                will be used. Otherwise, this value
+                                                overrides the value provided by
+                                                the pod spec. Value must be non-negative
+                                                integer. The value zero indicates
+                                                stop immediately via the kill signal
+                                                (no opportunity to shut down). This
+                                                is a beta field and requires enabling
+                                                ProbeTerminationGracePeriod feature
+                                                gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                                is used if unset.
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              description: 'Number of seconds after
+                                                which the probe times out. Defaults
+                                                to 1 second. Minimum value is 1.
+                                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          description: Name of the container specified
+                                            as a DNS_LABEL. Each container in a
+                                            pod must have a unique name (DNS_LABEL).
+                                            Cannot be updated.
+                                          type: string
+                                        ports:
+                                          description: List of ports to expose from
+                                            the container. Exposing a port here
+                                            gives the system additional information
+                                            about the network connections a container
+                                            uses, but is primarily informational.
+                                            Not specifying a port here DOES NOT
+                                            prevent that port from being exposed.
+                                            Any port which is listening on the default
+                                            "0.0.0.0" address inside a container
+                                            will be accessible from the network.
+                                            Cannot be updated.
+                                          items:
+                                            description: ContainerPort represents
+                                              a network port in a single container.
+                                            properties:
+                                              containerPort:
+                                                description: Number of port to expose
+                                                  on the pod's IP address. This
+                                                  must be a valid port number, 0
+                                                  < x < 65536.
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                description: What host IP to bind
+                                                  the external port to.
+                                                type: string
+                                              hostPort:
+                                                description: Number of port to expose
+                                                  on the host. If specified, this
+                                                  must be a valid port number, 0
+                                                  < x < 65536. If HostNetwork is
+                                                  specified, this must match ContainerPort.
+                                                  Most containers do not need this.
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                description: If specified, this
+                                                  must be an IANA_SVC_NAME and unique
+                                                  within the pod. Each named port
+                                                  in a pod must have a unique name.
+                                                  Name for the port that can be
+                                                  referred to by services.
+                                                type: string
+                                              protocol:
+                                                description: Protocol for port.
+                                                  Must be UDP, TCP, or SCTP. Defaults
+                                                  to "TCP".
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            - protocol
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          description: 'Periodic probe of container
+                                            service readiness. Container will be
+                                            removed from service endpoints if the
+                                            probe fails. Cannot be updated. More
+                                            info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          properties:
+                                            exec:
+                                              description: One and only one of the
+                                                following should be specified. Exec
+                                                specifies the action to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The
+                                                    command is simply exec'd, it
+                                                    is not run inside a shell, so
+                                                    traditional shell instructions
+                                                    ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly
+                                                    call out to that shell. Exit
+                                                    status of 0 is treated as live/healthy
+                                                    and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              description: Minimum consecutive failures
+                                                for the probe to be considered failed
+                                                after having succeeded. Defaults
+                                                to 3. Minimum value is 1.
+                                              format: int32
+                                              type: integer
+                                            httpGet:
+                                              description: HTTPGet specifies the
+                                                http request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP.
+                                                    You probably want to set "Host"
+                                                    in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to
+                                                    set in the request. HTTP allows
+                                                    repeated headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used
+                                                      in HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header
+                                                          field name
+                                                        type: string
+                                                      value:
+                                                        description: The header
+                                                          field value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on
+                                                    the HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of
+                                                    the port to access on the container.
+                                                    Number must be in the range
+                                                    1 to 65535. Name must be an
+                                                    IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: Scheme to use for
+                                                    connecting to the host. Defaults
+                                                    to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              description: 'Number of seconds after
+                                                the container has started before
+                                                liveness probes are initiated. More
+                                                info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              description: How often (in seconds)
+                                                to perform the probe. Default to
+                                                10 seconds. Minimum value is 1.
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              description: Minimum consecutive successes
+                                                for the probe to be considered successful
+                                                after having failed. Defaults to
+                                                1. Must be 1 for liveness and startup.
+                                                Minimum value is 1.
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              description: 'TCPSocket specifies
+                                                an action involving a TCP port.
+                                                TCP hooks not yet supported TODO:
+                                                implement a realistic TCP lifecycle
+                                                hook'
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of
+                                                    the port to access on the container.
+                                                    Number must be in the range
+                                                    1 to 65535. Name must be an
+                                                    IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              description: Optional duration in
+                                                seconds the pod needs to terminate
+                                                gracefully upon probe failure. The
+                                                grace period is the duration in
+                                                seconds after the processes running
+                                                in the pod are sent a termination
+                                                signal and the time when the processes
+                                                are forcibly halted with a kill
+                                                signal. Set this value longer than
+                                                the expected cleanup time for your
+                                                process. If this value is nil, the
+                                                pod's terminationGracePeriodSeconds
+                                                will be used. Otherwise, this value
+                                                overrides the value provided by
+                                                the pod spec. Value must be non-negative
+                                                integer. The value zero indicates
+                                                stop immediately via the kill signal
+                                                (no opportunity to shut down). This
+                                                is a beta field and requires enabling
+                                                ProbeTerminationGracePeriod feature
+                                                gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                                is used if unset.
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              description: 'Number of seconds after
+                                                which the probe times out. Defaults
+                                                to 1 second. Minimum value is 1.
+                                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resources:
+                                          description: 'Compute Resources required
+                                            by this container. Cannot be updated.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the
+                                                maximum amount of compute resources
+                                                allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted
+                                                for a container, it defaults to
+                                                Limits if that is explicitly specified,
+                                                otherwise to an implementation-defined
+                                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                        securityContext:
+                                          description: 'SecurityContext defines
+                                            the security options the container should
+                                            be run with. If set, the fields of SecurityContext
+                                            override the equivalent fields of PodSecurityContext.
+                                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              description: 'AllowPrivilegeEscalation
+                                                controls whether a process can gain
+                                                more privileges than its parent
+                                                process. This bool directly controls
+                                                if the no_new_privs flag will be
+                                                set on the container process. AllowPrivilegeEscalation
+                                                is true always when the container
+                                                is: 1) run as Privileged 2) has
+                                                CAP_SYS_ADMIN'
+                                              type: boolean
+                                            capabilities:
+                                              description: The capabilities to add/drop
+                                                when running containers. Defaults
+                                                to the default set of capabilities
+                                                granted by the container runtime.
+                                              properties:
+                                                add:
+                                                  description: Added capabilities
+                                                  items:
+                                                    description: Capability represent
+                                                      POSIX capabilities type
+                                                    type: string
+                                                  type: array
+                                                drop:
+                                                  description: Removed capabilities
+                                                  items:
+                                                    description: Capability represent
+                                                      POSIX capabilities type
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            privileged:
+                                              description: Run container in privileged
+                                                mode. Processes in privileged containers
+                                                are essentially equivalent to root
+                                                on the host. Defaults to false.
+                                              type: boolean
+                                            procMount:
+                                              description: procMount denotes the
+                                                type of proc mount to use for the
+                                                containers. The default is DefaultProcMount
+                                                which uses the container runtime
+                                                defaults for readonly paths and
+                                                masked paths. This requires the
+                                                ProcMountType feature flag to be
+                                                enabled.
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              description: Whether this container
+                                                has a read-only root filesystem.
+                                                Default is false.
+                                              type: boolean
+                                            runAsGroup:
+                                              description: The GID to run the entrypoint
+                                                of the container process. Uses runtime
+                                                default if unset. May also be set
+                                                in PodSecurityContext.  If set in
+                                                both SecurityContext and PodSecurityContext,
+                                                the value specified in SecurityContext
+                                                takes precedence.
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              description: Indicates that the container
+                                                must run as a non-root user. If
+                                                true, the Kubelet will validate
+                                                the image at runtime to ensure that
+                                                it does not run as UID 0 (root)
+                                                and fail to start the container
+                                                if it does. If unset or false, no
+                                                such validation will be performed.
+                                                May also be set in PodSecurityContext.  If
+                                                set in both SecurityContext and
+                                                PodSecurityContext, the value specified
+                                                in SecurityContext takes precedence.
+                                              type: boolean
+                                            runAsUser:
+                                              description: The UID to run the entrypoint
+                                                of the container process. Defaults
+                                                to user specified in image metadata
+                                                if unspecified. May also be set
+                                                in PodSecurityContext.  If set in
+                                                both SecurityContext and PodSecurityContext,
+                                                the value specified in SecurityContext
+                                                takes precedence.
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              description: The SELinux context to
+                                                be applied to the container. If
+                                                unspecified, the container runtime
+                                                will allocate a random SELinux context
+                                                for each container.  May also be
+                                                set in PodSecurityContext.  If set
+                                                in both SecurityContext and PodSecurityContext,
+                                                the value specified in SecurityContext
+                                                takes precedence.
+                                              properties:
+                                                level:
+                                                  description: Level is SELinux
+                                                    level label that applies to
+                                                    the container.
+                                                  type: string
+                                                role:
+                                                  description: Role is a SELinux
+                                                    role label that applies to the
+                                                    container.
+                                                  type: string
+                                                type:
+                                                  description: Type is a SELinux
+                                                    type label that applies to the
+                                                    container.
+                                                  type: string
+                                                user:
+                                                  description: User is a SELinux
+                                                    user label that applies to the
+                                                    container.
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              description: The seccomp options to
+                                                use by this container. If seccomp
+                                                options are provided at both the
+                                                pod & container level, the container
+                                                options override the pod options.
+                                              properties:
+                                                localhostProfile:
+                                                  description: localhostProfile
+                                                    indicates a profile defined
+                                                    in a file on the node should
+                                                    be used. The profile must be
+                                                    preconfigured on the node to
+                                                    work. Must be a descending path,
+                                                    relative to the kubelet's configured
+                                                    seccomp profile location. Must
+                                                    only be set if type is "Localhost".
+                                                  type: string
+                                                type:
+                                                  description: "type indicates which
+                                                    kind of seccomp profile will
+                                                    be applied. Valid options are:
+                                                    \n Localhost - a profile defined
+                                                    in a file on the node should
+                                                    be used. RuntimeDefault - the
+                                                    container runtime default profile
+                                                    should be used. Unconfined -
+                                                    no profile should be applied."
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              description: The Windows specific
+                                                settings applied to all containers.
+                                                If unspecified, the options from
+                                                the PodSecurityContext will be used.
+                                                If set in both SecurityContext and
+                                                PodSecurityContext, the value specified
+                                                in SecurityContext takes precedence.
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  description: GMSACredentialSpec
+                                                    is where the GMSA admission
+                                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                    inlines the contents of the
+                                                    GMSA credential spec named by
+                                                    the GMSACredentialSpecName field.
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  description: GMSACredentialSpecName
+                                                    is the name of the GMSA credential
+                                                    spec to use.
+                                                  type: string
+                                                hostProcess:
+                                                  description: HostProcess determines
+                                                    if a container should be run
+                                                    as a 'Host Process' container.
+                                                    This field is alpha-level and
+                                                    will only be honored by components
+                                                    that enable the WindowsHostProcessContainers
+                                                    feature flag. Setting this field
+                                                    without the feature flag will
+                                                    result in errors when validating
+                                                    the Pod. All of a Pod's containers
+                                                    must have the same effective
+                                                    HostProcess value (it is not
+                                                    allowed to have a mix of HostProcess
+                                                    containers and non-HostProcess
+                                                    containers).  In addition, if
+                                                    HostProcess is true then HostNetwork
+                                                    must also be set to true.
+                                                  type: boolean
+                                                runAsUserName:
+                                                  description: The UserName in Windows
+                                                    to run the entrypoint of the
+                                                    container process. Defaults
+                                                    to the user specified in image
+                                                    metadata if unspecified. May
+                                                    also be set in PodSecurityContext.
+                                                    If set in both SecurityContext
+                                                    and PodSecurityContext, the
+                                                    value specified in SecurityContext
+                                                    takes precedence.
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          description: 'StartupProbe indicates that
+                                            the Pod has successfully initialized.
+                                            If specified, no other probes are executed
+                                            until this completes successfully. If
+                                            this probe fails, the Pod will be restarted,
+                                            just as if the livenessProbe failed.
+                                            This can be used to provide different
+                                            probe parameters at the beginning of
+                                            a Pod''s lifecycle, when it might take
+                                            a long time to load data or warm a cache,
+                                            than during steady-state operation.
+                                            This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          properties:
+                                            exec:
+                                              description: One and only one of the
+                                                following should be specified. Exec
+                                                specifies the action to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The
+                                                    command is simply exec'd, it
+                                                    is not run inside a shell, so
+                                                    traditional shell instructions
+                                                    ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly
+                                                    call out to that shell. Exit
+                                                    status of 0 is treated as live/healthy
+                                                    and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              description: Minimum consecutive failures
+                                                for the probe to be considered failed
+                                                after having succeeded. Defaults
+                                                to 3. Minimum value is 1.
+                                              format: int32
+                                              type: integer
+                                            httpGet:
+                                              description: HTTPGet specifies the
+                                                http request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP.
+                                                    You probably want to set "Host"
+                                                    in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to
+                                                    set in the request. HTTP allows
+                                                    repeated headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used
+                                                      in HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header
+                                                          field name
+                                                        type: string
+                                                      value:
+                                                        description: The header
+                                                          field value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on
+                                                    the HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of
+                                                    the port to access on the container.
+                                                    Number must be in the range
+                                                    1 to 65535. Name must be an
+                                                    IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: Scheme to use for
+                                                    connecting to the host. Defaults
+                                                    to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              description: 'Number of seconds after
+                                                the container has started before
+                                                liveness probes are initiated. More
+                                                info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              description: How often (in seconds)
+                                                to perform the probe. Default to
+                                                10 seconds. Minimum value is 1.
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              description: Minimum consecutive successes
+                                                for the probe to be considered successful
+                                                after having failed. Defaults to
+                                                1. Must be 1 for liveness and startup.
+                                                Minimum value is 1.
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              description: 'TCPSocket specifies
+                                                an action involving a TCP port.
+                                                TCP hooks not yet supported TODO:
+                                                implement a realistic TCP lifecycle
+                                                hook'
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of
+                                                    the port to access on the container.
+                                                    Number must be in the range
+                                                    1 to 65535. Name must be an
+                                                    IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              description: Optional duration in
+                                                seconds the pod needs to terminate
+                                                gracefully upon probe failure. The
+                                                grace period is the duration in
+                                                seconds after the processes running
+                                                in the pod are sent a termination
+                                                signal and the time when the processes
+                                                are forcibly halted with a kill
+                                                signal. Set this value longer than
+                                                the expected cleanup time for your
+                                                process. If this value is nil, the
+                                                pod's terminationGracePeriodSeconds
+                                                will be used. Otherwise, this value
+                                                overrides the value provided by
+                                                the pod spec. Value must be non-negative
+                                                integer. The value zero indicates
+                                                stop immediately via the kill signal
+                                                (no opportunity to shut down). This
+                                                is a beta field and requires enabling
+                                                ProbeTerminationGracePeriod feature
+                                                gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                                is used if unset.
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              description: 'Number of seconds after
+                                                which the probe times out. Defaults
+                                                to 1 second. Minimum value is 1.
+                                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          description: Whether this container should
+                                            allocate a buffer for stdin in the container
+                                            runtime. If this is not set, reads from
+                                            stdin in the container will always result
+                                            in EOF. Default is false.
+                                          type: boolean
+                                        stdinOnce:
+                                          description: Whether the container runtime
+                                            should close the stdin channel after
+                                            it has been opened by a single attach.
+                                            When stdin is true the stdin stream
+                                            will remain open across multiple attach
+                                            sessions. If stdinOnce is set to true,
+                                            stdin is opened on container start,
+                                            is empty until the first client attaches
+                                            to stdin, and then remains open and
+                                            accepts data until the client disconnects,
+                                            at which time stdin is closed and remains
+                                            closed until the container is restarted.
+                                            If this flag is false, a container processes
+                                            that reads from stdin will never receive
+                                            an EOF. Default is false
+                                          type: boolean
+                                        terminationMessagePath:
+                                          description: 'Optional: Path at which
+                                            the file to which the container''s termination
+                                            message will be written is mounted into
+                                            the container''s filesystem. Message
+                                            written is intended to be brief final
+                                            status, such as an assertion failure
+                                            message. Will be truncated by the node
+                                            if greater than 4096 bytes. The total
+                                            message length across all containers
+                                            will be limited to 12kb. Defaults to
+                                            /dev/termination-log. Cannot be updated.'
+                                          type: string
+                                        terminationMessagePolicy:
+                                          description: Indicate how the termination
+                                            message should be populated. File will
+                                            use the contents of terminationMessagePath
+                                            to populate the container status message
+                                            on both success and failure. FallbackToLogsOnError
+                                            will use the last chunk of container
+                                            log output if the termination message
+                                            file is empty and the container exited
+                                            with an error. The log output is limited
+                                            to 2048 bytes or 80 lines, whichever
+                                            is smaller. Defaults to File. Cannot
+                                            be updated.
+                                          type: string
+                                        tty:
+                                          description: Whether this container should
+                                            allocate a TTY for itself, also requires
+                                            'stdin' to be true. Default is false.
+                                          type: boolean
+                                        volumeDevices:
+                                          description: volumeDevices is the list
+                                            of block devices to be used by the container.
+                                          items:
+                                            description: volumeDevice describes
+                                              a mapping of a raw block device within
+                                              a container.
+                                            properties:
+                                              devicePath:
+                                                description: devicePath is the path
+                                                  inside of the container that the
+                                                  device will be mapped to.
+                                                type: string
+                                              name:
+                                                description: name must match the
+                                                  name of a persistentVolumeClaim
+                                                  in the pod
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                        volumeMounts:
+                                          description: Pod volumes to mount into
+                                            the container's filesystem. Cannot be
+                                            updated.
+                                          items:
+                                            description: VolumeMount describes a
+                                              mounting of a Volume within a container.
+                                            properties:
+                                              mountPath:
+                                                description: Path within the container
+                                                  at which the volume should be
+                                                  mounted.  Must not contain ':'.
+                                                type: string
+                                              mountPropagation:
+                                                description: mountPropagation determines
+                                                  how mounts are propagated from
+                                                  the host to container and the
+                                                  other way around. When not set,
+                                                  MountPropagationNone is used.
+                                                  This field is beta in 1.10.
+                                                type: string
+                                              name:
+                                                description: This must match the
+                                                  Name of a Volume.
+                                                type: string
+                                              readOnly:
+                                                description: Mounted read-only if
+                                                  true, read-write otherwise (false
+                                                  or unspecified). Defaults to false.
+                                                type: boolean
+                                              subPath:
+                                                description: Path within the volume
+                                                  from which the container's volume
+                                                  should be mounted. Defaults to
+                                                  "" (volume's root).
+                                                type: string
+                                              subPathExpr:
+                                                description: Expanded path within
+                                                  the volume from which the container's
+                                                  volume should be mounted. Behaves
+                                                  similarly to SubPath but environment
+                                                  variable references $(VAR_NAME)
+                                                  are expanded using the container's
+                                                  environment. Defaults to "" (volume's
+                                                  root). SubPathExpr and SubPath
+                                                  are mutually exclusive.
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                        workingDir:
+                                          description: Container's working directory.
+                                            If not specified, the container runtime's
+                                            default will be used, which might be
+                                            configured in the container image. Cannot
+                                            be updated.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeout:
+                                    description: Timeout defines the maximum amount
+                                      of time Velero should wait for the initContainers
+                                      to complete.
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              includeClusterResources:
+                description: IncludeClusterResources specifies whether cluster-scoped
+                  resources should be included for consideration in the restore.
+                  If null, defaults to true.
+                nullable: true
+                type: boolean
+              includedNamespaces:
+                description: IncludedNamespaces is a slice of namespace names to
+                  include objects from. If empty, all namespaces are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              includedResources:
+                description: IncludedResources is a slice of resource names to include
+                  in the restore. If empty, all resources in the backup are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              labelSelector:
+                description: LabelSelector is a metav1.LabelSelector to filter with
+                  when restoring individual objects from the backup. If empty or
+                  nil, all objects are included. Optional.
+                nullable: true
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the
+                        key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship
+                            to a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a
+                            strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              namespaceMapping:
+                additionalProperties:
+                  type: string
+                description: NamespaceMapping is a map of source namespace names
+                  to target namespace names to restore into. Any source namespaces
+                  not included in the map will be restored into namespaces of the
+                  same name.
+                type: object
+              preserveNodePorts:
+                description: PreserveNodePorts specifies whether to restore old
+                  nodePorts from backup.
+                nullable: true
+                type: boolean
+              restorePVs:
+                description: RestorePVs specifies whether to restore all included
+                  PVs from snapshot (via the cloudprovider).
+                nullable: true
+                type: boolean
+              scheduleName:
+                description: ScheduleName is the unique name of the Velero schedule
+                  to restore from. If specified, and BackupName is empty, Velero
+                  will restore from the most recent successful backup created from
+                  this schedule.
+                type: string
+            required:
+            - backupName
+            type: object
+          status:
+            description: RestoreStatus captures the current status of a Velero restore
+            properties:
+              completionTimestamp:
+                description: CompletionTimestamp records the time the restore operation
+                  was completed. Completion time is recorded even on failed restore.
+                  The server's time is used for StartTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              errors:
+                description: Errors is a count of all error messages that were generated
+                  during execution of the restore. The actual errors are stored
+                  in object storage.
+                type: integer
+              failureReason:
+                description: FailureReason is an error that caused the entire restore
+                  to fail.
+                type: string
+              phase:
+                description: Phase is the current state of the Restore
+                enum:
+                - New
+                - FailedValidation
+                - InProgress
+                - Completed
+                - PartiallyFailed
+                - Failed
+                type: string
+              progress:
+                description: Progress contains information about the restore's execution
+                  progress. Note that this information is best-effort only -- if
+                  Velero fails to update it during a restore for any reason, it
+                  may be inaccurate/stale.
+                nullable: true
+                properties:
+                  itemsRestored:
+                    description: ItemsRestored is the number of items that have
+                      actually been restored so far
+                    type: integer
+                  totalItems:
+                    description: TotalItems is the total number of items to be restored.
+                      This number may change throughout the execution of the restore
+                      due to plugins that return additional related items to restore
+                    type: integer
+                type: object
+              startTimestamp:
+                description: StartTimestamp records the time the restore operation
+                  was started. The server's time is used for StartTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              validationErrors:
+                description: ValidationErrors is a slice of all validation errors
+                  (if applicable)
+                items:
+                  type: string
+                nullable: true
+                type: array
+              warnings:
+                description: Warnings is a count of all warning messages that were
+                  generated during execution of the restore. The actual warnings
+                  are stored in object storage.
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: schedules.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: Schedule
+    listKind: ScheduleList
+    plural: schedules
+    singular: schedule
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Schedule is a Velero resource that represents a pre-scheduled
+          or periodic Backup that should be run.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource
+              this object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ScheduleSpec defines the specification for a Velero schedule
+            properties:
+              schedule:
+                description: Schedule is a Cron expression defining when to run
+                  the Backup.
+                type: string
+              template:
+                description: Template is the definition of the Backup to be run
+                  on the provided schedule
+                properties:
+                  defaultVolumesToRestic:
+                    description: DefaultVolumesToRestic specifies whether restic
+                      should be used to take a backup of all pod volumes by default.
+                    type: boolean
+                  excludedNamespaces:
+                    description: ExcludedNamespaces contains a list of namespaces
+                      that are not included in the backup.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  excludedResources:
+                    description: ExcludedResources is a slice of resource names
+                      that are not included in the backup.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  hooks:
+                    description: Hooks represent custom behaviors that should be
+                      executed at different phases of the backup.
+                    properties:
+                      resources:
+                        description: Resources are hooks that should be executed
+                          when backing up individual instances of a resource.
+                        items:
+                          description: BackupResourceHookSpec defines one or more
+                            BackupResourceHooks that should be executed based on
+                            the rules defined for namespaces, resources, and label
+                            selector.
+                          properties:
+                            excludedNamespaces:
+                              description: ExcludedNamespaces specifies the namespaces
+                                to which this hook spec does not apply.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            excludedResources:
+                              description: ExcludedResources specifies the resources
+                                to which this hook spec does not apply.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            includedNamespaces:
+                              description: IncludedNamespaces specifies the namespaces
+                                to which this hook spec applies. If empty, it applies
+                                to all namespaces.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            includedResources:
+                              description: IncludedResources specifies the resources
+                                to which this hook spec applies. If empty, it applies
+                                to all resources.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            labelSelector:
+                              description: LabelSelector, if specified, filters
+                                the resources to which this hook spec applies.
+                              nullable: true
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are
+                                    ANDed.
+                                  items:
+                                    description: A label selector requirement is
+                                      a selector that contains values, a key, and
+                                      an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's
+                                          relationship to a set of values. Valid
+                                          operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If
+                                          the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array
+                                          is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value".
+                                    The requirements are ANDed.
+                                  type: object
+                              type: object
+                            name:
+                              description: Name is the name of this hook.
+                              type: string
+                            post:
+                              description: PostHooks is a list of BackupResourceHooks
+                                to execute after storing the item in the backup.
+                                These are executed after all "additional items"
+                                from item actions are processed.
+                              items:
+                                description: BackupResourceHook defines a hook for
+                                  a resource.
+                                properties:
+                                  exec:
+                                    description: Exec defines an exec hook.
+                                    properties:
+                                      command:
+                                        description: Command is the command and
+                                          arguments to execute.
+                                        items:
+                                          type: string
+                                        minItems: 1
+                                        type: array
+                                      container:
+                                        description: Container is the container
+                                          in the pod where the command should be
+                                          executed. If not specified, the pod's
+                                          first container is used.
+                                        type: string
+                                      onError:
+                                        description: OnError specifies how Velero
+                                          should behave if it encounters an error
+                                          executing this hook.
+                                        enum:
+                                        - Continue
+                                        - Fail
+                                        type: string
+                                      timeout:
+                                        description: Timeout defines the maximum
+                                          amount of time Velero should wait for
+                                          the hook to complete before considering
+                                          the execution a failure.
+                                        type: string
+                                    required:
+                                    - command
+                                    type: object
+                                required:
+                                - exec
+                                type: object
+                              type: array
+                            pre:
+                              description: PreHooks is a list of BackupResourceHooks
+                                to execute prior to storing the item in the backup.
+                                These are executed before any "additional items"
+                                from item actions are processed.
+                              items:
+                                description: BackupResourceHook defines a hook for
+                                  a resource.
+                                properties:
+                                  exec:
+                                    description: Exec defines an exec hook.
+                                    properties:
+                                      command:
+                                        description: Command is the command and
+                                          arguments to execute.
+                                        items:
+                                          type: string
+                                        minItems: 1
+                                        type: array
+                                      container:
+                                        description: Container is the container
+                                          in the pod where the command should be
+                                          executed. If not specified, the pod's
+                                          first container is used.
+                                        type: string
+                                      onError:
+                                        description: OnError specifies how Velero
+                                          should behave if it encounters an error
+                                          executing this hook.
+                                        enum:
+                                        - Continue
+                                        - Fail
+                                        type: string
+                                      timeout:
+                                        description: Timeout defines the maximum
+                                          amount of time Velero should wait for
+                                          the hook to complete before considering
+                                          the execution a failure.
+                                        type: string
+                                    required:
+                                    - command
+                                    type: object
+                                required:
+                                - exec
+                                type: object
+                              type: array
+                          required:
+                          - name
+                          type: object
+                        nullable: true
+                        type: array
+                    type: object
+                  includeClusterResources:
+                    description: IncludeClusterResources specifies whether cluster-scoped
+                      resources should be included for consideration in the backup.
+                    nullable: true
+                    type: boolean
+                  includedNamespaces:
+                    description: IncludedNamespaces is a slice of namespace names
+                      to include objects from. If empty, all namespaces are included.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  includedResources:
+                    description: IncludedResources is a slice of resource names
+                      to include in the backup. If empty, all resources are included.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  labelSelector:
+                    description: LabelSelector is a metav1.LabelSelector to filter
+                      with when adding individual objects to the backup. If empty
+                      or nil, all objects are included. Optional.
+                    nullable: true
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values.
+                                If the operator is In or NotIn, the values array
+                                must be non-empty. If the operator is Exists or
+                                DoesNotExist, the values array must be empty. This
+                                array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs.
+                          A single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is
+                          "key", the operator is "In", and the values array contains
+                          only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  metadata:
+                    properties:
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  orderedResources:
+                    additionalProperties:
+                      type: string
+                    description: OrderedResources specifies the backup order of
+                      resources of specific Kind. The map key is the Kind name and
+                      value is a list of resource names separated by commas. Each
+                      resource name has format "namespace/resourcename".  For cluster
+                      resources, simply use "resourcename".
+                    nullable: true
+                    type: object
+                  snapshotVolumes:
+                    description: SnapshotVolumes specifies whether to take cloud
+                      snapshots of any PV's referenced in the set of objects included
+                      in the Backup.
+                    nullable: true
+                    type: boolean
+                  storageLocation:
+                    description: StorageLocation is a string containing the name
+                      of a BackupStorageLocation where the backup should be stored.
+                    type: string
+                  ttl:
+                    description: TTL is a time.Duration-parseable string describing
+                      how long the Backup should be retained for.
+                    type: string
+                  volumeSnapshotLocations:
+                    description: VolumeSnapshotLocations is a list containing names
+                      of VolumeSnapshotLocations associated with this backup.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              useOwnerReferencesInBackup:
+                description: UseOwnerReferencesBackup specifies whether to use OwnerReferences
+                  on backups created by this Schedule.
+                nullable: true
+                type: boolean
+            required:
+            - schedule
+            - template
+            type: object
+          status:
+            description: ScheduleStatus captures the current state of a Velero schedule
+            properties:
+              lastBackup:
+                description: LastBackup is the last time a Backup was run for this
+                  Schedule schedule
+                format: date-time
+                nullable: true
+                type: string
+              phase:
+                description: Phase is the current phase of the Schedule
+                enum:
+                - New
+                - Enabled
+                - FailedValidation
+                type: string
+              validationErrors:
+                description: ValidationErrors is a slice of all validation errors
+                  (if applicable)
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: serverstatusrequests.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: ServerStatusRequest
+    listKind: ServerStatusRequestList
+    plural: serverstatusrequests
+    shortNames:
+    - ssr
+    singular: serverstatusrequest
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ServerStatusRequest is a request to access current status information
+          about the Velero server.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource
+              this object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServerStatusRequestSpec is the specification for a ServerStatusRequest.
+            type: object
+          status:
+            description: ServerStatusRequestStatus is the current status of a ServerStatusRequest.
+            properties:
+              phase:
+                description: Phase is the current lifecycle phase of the ServerStatusRequest.
+                enum:
+                - New
+                - Processed
+                type: string
+              plugins:
+                description: Plugins list information about the plugins running
+                  on the Velero server
+                items:
+                  description: PluginInfo contains attributes of a Velero plugin
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                nullable: true
+                type: array
+              processedTimestamp:
+                description: ProcessedTimestamp is when the ServerStatusRequest
+                  was processed by the ServerStatusRequestController.
+                format: date-time
+                nullable: true
+                type: string
+              serverVersion:
+                description: ServerVersion is the Velero server version.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: volumesnapshotlocations.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: VolumeSnapshotLocation
+    listKind: VolumeSnapshotLocationList
+    plural: volumesnapshotlocations
+    singular: volumesnapshotlocation
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: VolumeSnapshotLocation is a location where Velero stores volume
+          snapshots.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource
+              this object represents. Servers may infer this from the endpoint the
+              client submits requests to. Cannot be updated. In CamelCase. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeSnapshotLocationSpec defines the specification for
+              a Velero VolumeSnapshotLocation.
+            properties:
+              config:
+                additionalProperties:
+                  type: string
+                description: Config is for provider-specific configuration fields.
+                type: object
+              provider:
+                description: Provider is the provider of the volume storage.
+                type: string
+            required:
+            - provider
+            type: object
+          status:
+            description: VolumeSnapshotLocationStatus describes the current status
+              of a Velero VolumeSnapshotLocation.
+            properties:
+              phase:
+                description: VolumeSnapshotLocationPhase is the lifecycle phase
+                  of a Velero VolumeSnapshotLocation.
+                enum:
+                - Available
+                - Unavailable
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: velero
+spec: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: velero
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: velero
+  namespace: velero
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: velero
+  namespace: velero
+---
+apiVersion: v1
+data:
+  cloud:
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: cloud-credentials
+  namespace: velero
+type: Opaque
+---
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: default
+  namespace: velero
+spec:
+  config:
+    region: minio
+  default: true
+  objectStorage:
+    bucket: velero
+  provider: aws
+---
+apiVersion: velero.io/v1
+kind: VolumeSnapshotLocation
+metadata:
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: default
+  namespace: velero
+spec:
+  config:
+    region: minio
+  provider: aws
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: velero
+  namespace: velero
+spec:
+  selector:
+    matchLabels:
+      deploy: velero
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        component: velero
+        deploy: velero
+    spec:
+      containers:
+      - args:
+        - server
+        - --features=
+        command:
+        - /velero
+        env:
+        - name: VELERO_SCRATCH_DIR
+          value: /scratch
+        - name: VELERO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LD_LIBRARY_PATH
+          value: /plugins
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /credentials/cloud
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /credentials/cloud
+        - name: AZURE_CREDENTIALS_FILE
+          value: /credentials/cloud
+        - name: ALIBABA_CLOUD_CREDENTIALS_FILE
+          value: /credentials/cloud
+        image: velero/velero:@sha256:db351b09fbe5ef96299d6a38f99d519c531b07b082152c976a782f3f39a022f2
+        imagePullPolicy: IfNotPresent
+        name: velero
+        ports:
+        - containerPort: 8085
+          name: metrics
+        resources:
+          limits:
+            cpu: "1"
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /plugins
+          name: plugins
+        - mountPath: /scratch
+          name: scratch
+        - mountPath: /credentials
+          name: cloud-credentials
+      initContainers:
+      - image: velero/velero-plugin-for-aws@sha256:145b4298e22b823ac5ec7fd834886e2c27a38a01df5ff7ff1b991b861f78d71e
+        imagePullPolicy: IfNotPresent
+        name: velero-velero-plugin-for-aws
+        resources: {}
+        volumeMounts:
+        - mountPath: /target
+          name: plugins
+      - image: velero/velero-plugin-for-microsoft-azure@sha256:a5ed9ea783d45985b4232e59b8c2557aa651de997f2cd56811acf53d93856e88
+        imagePullPolicy: IfNotPresent
+        name: velero-plugin-for-microsoft-azure
+        resources: {}
+        volumeMounts:
+        - mountPath: /target
+          name: plugins
+      restartPolicy: Always
+      serviceAccountName: velero
+      volumes:
+      - emptyDir: {}
+        name: plugins
+      - emptyDir: {}
+        name: scratch
+      - name: cloud-credentials
+        secret:
+          secretName: cloud-credentials
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  creationTimestamp: null
+  labels:
+    component: velero
+  name: restic
+  namespace: velero
+spec:
+  selector:
+    matchLabels:
+      name: restic
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        component: velero
+        name: restic
+    spec:
+      containers:
+      - args:
+        - restic
+        - server
+        - --features=
+        command:
+        - /velero
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: VELERO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: VELERO_SCRATCH_DIR
+          value: /scratch
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /credentials/cloud
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /credentials/cloud
+        - name: AZURE_CREDENTIALS_FILE
+          value: /credentials/cloud
+        - name: ALIBABA_CLOUD_CREDENTIALS_FILE
+          value: /credentials/cloud
+        image: velero/velero:@sha256:db351b09fbe5ef96299d6a38f99d519c531b07b082152c976a782f3f39a022f2
+        imagePullPolicy: IfNotPresent
+        name: restic
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /host_pods
+          mountPropagation: HostToContainer
+          name: host-pods
+        - mountPath: /scratch
+          name: scratch
+        - mountPath: /credentials
+          name: cloud-credentials
+      securityContext:
+        runAsUser: 0
+      serviceAccountName: velero
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet/pods
+        name: host-pods
+      - emptyDir: {}
+        name: scratch
+      - name: cloud-credentials
+        secret:
+          secretName: cloud-credentials
+  updateStrategy: {}
+

--- a/addons/packages/velero/1.7.1/bundle/config/values.star
+++ b/addons/packages/velero/1.7.1/bundle/config/values.star
@@ -1,0 +1,92 @@
+load("@ytt:data", "data")
+load("@ytt:assert", "assert")
+load("@ytt:overlay", "overlay")
+
+#! Use this library for functions that operate on the values data.
+
+# helpers
+def secret_name():
+  if values.credential.useDefaultSecret:
+    return values.credential.name
+  end
+  return values.backupStorageLocation.spec.existingSecret.name
+end
+
+def resource(kind, name):
+  return {"kind": kind,"metadata":{"name": name}}
+end
+
+def labels():
+  return {"component": "velero"}
+end
+
+# validations
+def validate_storage():
+  values.backupStorageLocation.spec.provider or assert.fail("backupStorageLocation needs a provider, velero needs at least one backup storage location")
+  values.backupStorageLocation.spec.objectStorage.bucket or assert.fail("backupStorageLocation needs a bucket")
+end
+
+# Note: aws and azure are the only object storage providers that the TCE Velero package supports.
+# Neither vSphere or Docker provides storage.
+def validate_storage_provider():
+  providers = ["aws", "azure"]
+  if values.backupStorageLocation.spec.provider:
+    values.backupStorageLocation.spec.provider in providers or assert.fail("infrastructure provider should be either aws or azure")
+  end
+end
+
+# Note: Docker does not provide snapshotting capabilities.
+def validate_snapshot_provider():
+  if values.volumeSnapshotLocation.snapshotsEnabled:
+    providers = ["aws", "azure", "vsphere"]
+    if values.volumeSnapshotLocation.spec.provider:
+      values.volumeSnapshotLocation.spec.provider in providers or assert.fail("a snapshot provider should be either aws, vsphere  or azure")
+    end
+  end
+end
+
+def validate_provider_config():
+  if values.backupStorageLocation.spec.provider == "aws":
+    values.backupStorageLocation.spec.configAWS.region or assert.fail("a region must be set for the AWS backup storage location")
+  end
+  if values.backupStorageLocation.spec.provider == "azure":
+    values.backupStorageLocation.spec.configAzure.resourceGroup or assert.fail("a resourceGroup must be set for the Azure backup storage location")
+    values.backupStorageLocation.spec.configAzure.storageAccount or assert.fail("a storageAccount must be set for the Azure backup storage location")
+  end
+  if values.volumeSnapshotLocation.snapshotsEnabled:
+    if values.volumeSnapshotLocation.spec.provider == "aws":
+      values.volumeSnapshotLocation.spec.configAWS.region or assert.fail("a region must be set for the AWS volume snapshot location")
+    end
+  end
+end
+
+def validate_secret():
+  if values.credential.useDefaultSecret:
+    values.credential.name or assert.fail("must specify a name for the default secret to be used by Velero")
+    values.credential.secretContents or assert.fail("must specify the content for the default secret to be used by Velero")
+    values.credential.secretContents.cloud != None or assert.fail("the default secret must have a key named `cloud`")
+    values.credential.secretContents.cloud or assert.fail("the default secret key `cloud` must contain the raw credentials")
+  else:
+    values.backupStorageLocation.spec.existingSecret.name or assert.fail("must specify the name of the existing secret to be used by Velero")
+    values.backupStorageLocation.spec.existingSecret.key or assert.fail("must specify the key of the existing secret to be used by Velero")
+  end
+end
+
+def validate_velero():
+  validate_funcs = [
+    validate_storage_provider,
+    validate_snapshot_provider,
+    validate_provider_config,
+    validate_storage,
+    validate_secret,
+  ]
+   for validate_func in validate_funcs:
+     validate_func()
+   end
+end
+
+# export
+values = data.values
+velero_app = overlay.subset({"metadata": {"labels": labels()}})
+
+validate_velero()

--- a/addons/packages/velero/1.7.1/bundle/config/values.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/values.yaml
@@ -1,0 +1,188 @@
+#@data/values
+
+---
+#! The namespace in which to deploy Velero.
+namespace: velero
+
+#! restic related configuration
+restic: 
+  #! Whether to deploy the restic daemonset.
+  create: false
+  #! Bool flag to configure Velero server to use restic by default to backup all pod volumes on all backups. Optional.
+  defaultVolumesToRestic: false
+  #! How often 'restic prune' is run for restic repositories by default. Optional.
+  defaultResticPruneFrequency: 0 
+  #! CPU limit for restic pod. A value of "0" is treated as unbounded. Optional. (default "1000m")
+  cpuLimit: 1000m
+  #! CPU request for restic pod. A value of "0" is treated as unbounded. Optional. (default "500m")
+  cpuRequest: 500m
+  #! Memory limit for restic pod. A value of "0" is treated as unbounded. Optional. (default "1Gi")
+  memoryLimit: 1Gi
+  #! Memory request for restic pod. A value of "0" is treated as unbounded. Optional. (default "512Mi")
+  memoryRequest: 512Mi
+
+#! credential contains configuration for the secret to be used by the Velero deployment and the restic Daemonset, which
+#! should contain credentials for the cloud provider IAM account set up for Velero.
+#! For full documentation, see: https://velero.io/docs/v1.6/locations/#create-a-storage-location-that-uses-unique-credentials.
+credential:
+  #! Whether the secret created by default should be used as the source of IAM account credentials. If not set to `true`, the
+  #! secret to be used must be indicated in the `backupStorageLocation.spec.existingSecret`. If set to `true`, the raw content must
+  #! be specified below in the `credential.secretContents.cloud`.
+  useDefaultSecret: true
+  #! name is the name of the secret to configure if `credential.useDefaultSecret` is true. Required if `useDefaultSecret` is true.
+  name: cloud-credentials
+  #! secretContents is the data to be stored in the default Velero secret.
+  #! For the default secret, the key must be named `cloud`, and the value corresponds to the entire content of your IAM credentials file.
+  #! Note that the format will be different for different providers, please check their documentation. Required if `useDefaultSecret` is true.
+  secretContents:
+    cloud: |
+      [default]
+      aws_access_key_id=minio
+      aws_secret_access_key=minio123
+   #! additional key/value pairs to be used as environment variables such as "DIGITALOCEAN_TOKEN: <your-key>". Values will be stored in the secret.
+  extraEnvVars:
+  #! extraSecretRef is the name of any pre-existing secret (if any) in the namespace where Velero is installed and
+  #! that will be used to load environment variables into velero and restic.
+  #! Secret should be in format - https://kubernetes.io/docs/concepts/configuration/secret/#use-case-as-container-environment-variables
+  extraSecretRef:
+#! backupStorageLocation is how locations where Velero can store backups are represented in the cluster via the
+#! BackupStorageLocation CRD. Backups can be stored in a number of locations, and Velero must have at least one BackupStorageLocation.
+#! For documentation, see https://velero.io/docs/v1.6/api-types/backupstoragelocation/.
+backupStorageLocation:
+  #! name is the name of the backup storage location where backups should be stored. If a name is not provided,
+  #! a backup storage location will be created with the name "default". Required.
+  name: default
+  #! spec contains configurations for a backup storage location.
+  spec:
+    #! provider is the name of the object store plugin to use to connect to this location. Required.
+    provider: aws
+    #! default indicates if this location is the default backup storage location. Optional.
+    default: true
+    #! backupSyncPeriod indicates how frequently Velero should synchronize backups in object storage.
+    #! Set this to 0s to disable sync.
+    backupSyncPeriod: 1m
+    #! validationFrequency indicates how frequently Velero should validate the object storage (if it is
+    #! still connected, for example). Set this to 0s to disable validation.
+    validationFrequency: 1m
+    #! accessMode is how Velero can access the backup storage location. Valid values are ReadWrite, ReadOnly. Default is ReadWrite.
+    accessMode: ReadWrite
+    #! existingSecret should be a secret separately created in the namespace where Velero is installed. Applies only
+    #! if `credential.useDefaultSecret` is set to `false`. Optional.
+    #! For documentation on how to use: https://velero.io/docs/v1.6/locations/#create-a-storage-location-that-uses-unique-credentials.
+    existingSecret:
+      #! name is the name of the secret.
+      name:
+      #! key used within the secret.
+      key:
+    #! objectStorage is a set of configurations specific to the object store.
+    objectStorage:
+      #! bucket is the name of the bucket to store backups in. Required.
+      bucket: velero
+      #! caCert defines a base64 encoded CA bundle to use when verifying TLS connections to the provider. Optional.
+      caCert:
+      #! prefix is the directory under which all Velero data should be stored within the bucket. Optional.
+      prefix:
+    #! configAWS contains configuration specific to the AWS plugin.
+    #! For the original documentation: https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.2.1/backupstoragelocation.md.
+    configAWS:
+      #! region is the AWS region where the bucket is located. Queried from the AWS S3 API if not provided. Set to
+      #! "minio" if using a local storage service like MinIO.
+      #! Note: when used, MinIO must be run as a standalone. See the documentation:
+      #! https://docs.min.io/minio/baremetal/installation/deploy-minio-standalone.html. Required.
+      region: minio
+      #! s3ForcePathStyle indicates whether to use path-style addressing instead of virtual hosted bucket addressing. Set to "true"
+      #! if using a local storage service like MinIO. Defaults to false.
+      s3ForcePathStyle:
+      #! You can specify the AWS S3 URL here for explicitness, but Velero can already generate it from
+      #! "region" and "bucket". This field is primarily for local storage services like MinIO. Optional.
+      s3Url: #! "http://minio:9000"
+      #! If specified, use this instead of "s3Url" when generating download URLs (e.g., for logs). This
+      #! field is primarily for local storage services like MinIO. Optional.
+      publicUrl: #! "https://minio.mycluster.com"
+      #! serverSideEncryption is the name of the server-side encryption algorithm to use for uploading objects, e.g. "AES256".
+      #! If using SSE-KMS and "kmsKeyId" is specified, this field will automatically be set to "aws:kms"
+      #! so does not need to be specified by the user. Optional.
+      serverSideEncryption: #! AES256
+      #! kmsKeyId specifies an AWS KMS key ID (formatted per the example) or alias (formatted as "alias/<KMS-key-alias-name>")
+      #! to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly
+      #! granting key usage rights. Optional.
+      kmsKeyId: #! "502b409c-4da1-419f-a16e-eif453b3i49f"
+      #! signatureVersion is the version of the signature algorithm used to create signed URLs that are used by velero CLI to
+      #! download backups or fetch logs. Possible versions are "1" and "4". Usually the default version
+      #! 4 is correct, but some S3-compatible providers like Quobyte only support version 1. defaults to "4".
+      signatureVersion:
+      #! profile is the AWS profile within the credentials file to use for the backup storage location. Defaults to "default".
+      profile:
+      #! insecureSkipTLSVerify is set to "true" if you do not want to verify the TLS certificate when connecting to the
+      #! object store -- like for self-signed certs with MinIO. This is susceptible to man-in-the-middle
+      #! attacks and is not recommended for production. Defaults to false.
+      insecureSkipTLSVerify:
+    #! configAzure contains configuration specific to the Azure plugin.
+    #! For the original documentation: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/v1.2.1/backupstoragelocation.md.
+    configAzure:
+      #! resourceGroup is the name of the resource group containing the storage account for this backup storage location. Required.
+      resourceGroup:
+      #! storageAccount is the name of the storage account for this backup storage location. Required.
+      storageAccount:
+      #! storageAccountKeyEnvVar is the environment variable in $AZURE_CREDENTIALS_FILE that contains storage account key for this backup storage location.
+      #! Required if using a storage account access key to authenticate rather than a service principal.
+      storageAccountKeyEnvVar:
+      #! subscriptionId is the ID of the subscription for this backup storage location. Optional.
+      subscriptionId:
+      #! blockSizeInBytes is the block size, in bytes, to use when uploading objects to Azure blob storage.
+      #! See https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs#about-block-blobs
+      #! for more information on block blobs.
+      #! Optional (defaults to 104857600, i.e. 100MB).
+      blockSizeInBytes:
+#! volumeSnapshotLocation is how a volume snapshot location in which to store the volume snapshots created for a backup
+#! in the cluster via the VolumeSnapshotLocation CRD.
+#! For documentation, see https://velero.io/docs/v1.6/api-types/volumesnapshotlocation/.
+volumeSnapshotLocation:
+  #! snapshotsEnabled Indicates whether to create a volumesnapshotlocation CR. If false => disable the snapshot feature.
+  snapshotsEnabled: true
+  #! name is the name of the volume snapshot location where snapshots are being taken. Required.
+  name: default
+  #! provider is the name for the volume snapshot provider. If omitted
+  #! `configuration.provider` will be used instead.
+  #! spec contains configurations for a volume snapshot location.
+  spec:
+    #! provider is the name for the volume snapshot provider.
+    provider: aws
+    #! configAWS contains configuration specific to the AWS plugin.
+    #! For the original documentation: https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.2.1/backupstoragelocation.md.
+    configAWS:
+      #! region is the AWS region where the volumes/snapshots are located. Required.
+      region: minio
+      #! profile is the AWS profile within the credentials file to use for the volume snapshot location. Default is "default".
+      profile:
+    #! configAzure contains configuration specific to the Azure plugin.
+    #! For the original documentation: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/v1.2.1/volumesnapshotlocation.md.
+    configAzure:
+      #! apiTimeout indicates how long to wait for an Azure API request to complete before timeout. Defaults to 2m0s.
+      apiTimeout:
+      #! resourceGroup is the name of the resource group where volume snapshots should be stored, if different from the cluster's resource group. Optional.
+      resourceGroup:
+      #! subscriptionId is the ID of the subscription where volume snapshots should be stored, if different from the cluster's subscription. Requires "resourceGroup" to also be set. Optional.
+      subscriptionId:
+      #! Azure offers the option to take full or incremental snapshots of managed disks.
+      #! - Set this parameter to true, to take incremental snapshots.
+      #! - If the parameter is omitted or set to false, full snapshots are taken (default).
+      #! Optional.
+      incremental:
+    #! configvSphere contains configuration specific to the vSphere plugin. TODO.
+    configvSphere: #! TODO.
+#! Settings for additional Velero resources.
+rbac:
+  #! Whether to create the Velero role and role binding to give all permissions to the namespace to Velero.
+  create: false
+  #! Whether to create the cluster role binding to give administrator permissions to Velero
+  clusterAdministrator: false
+  name: velero
+  roleRefName: cluster-admin
+  clusterRoleAPIGroups: [""]
+  clusterRoleVerbs: ["get", "watch", "list"]
+#! Information about the Kubernetes service account Velero uses.
+serviceAccount:
+  name: velero
+  annotations:
+  labels:

--- a/addons/packages/velero/1.7.1/bundle/config/values.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/values.yaml
@@ -5,13 +5,13 @@
 namespace: velero
 
 #! restic related configuration
-restic: 
-  #! Whether to deploy the restic daemonset.
+restic:
+  #! Whether to deploy the Restic DaemonSet.
   create: false
   #! Bool flag to configure Velero server to use restic by default to backup all pod volumes on all backups. Optional.
   defaultVolumesToRestic: false
   #! How often 'restic prune' is run for restic repositories by default. Optional.
-  defaultResticPruneFrequency: 0 
+  defaultResticPruneFrequency: 0
   #! CPU limit for restic pod. A value of "0" is treated as unbounded. Optional. (default "1000m")
   cpuLimit: 1000m
   #! CPU request for restic pod. A value of "0" is treated as unbounded. Optional. (default "500m")

--- a/addons/packages/velero/1.7.1/bundle/vendir.lock.yml
+++ b/addons/packages/velero/1.7.1/bundle/vendir.lock.yml
@@ -1,0 +1,7 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - manual: {}
+    path: velero
+  path: config/upstream
+kind: LockConfig

--- a/addons/packages/velero/1.7.1/bundle/vendir.yml
+++ b/addons/packages/velero/1.7.1/bundle/vendir.yml
@@ -1,0 +1,8 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.12.0
+directories:
+- path: config/upstream
+  contents:
+  - path: velero
+    manual: {}

--- a/addons/packages/velero/1.7.1/package.yaml
+++ b/addons/packages/velero/1.7.1/package.yaml
@@ -404,7 +404,8 @@ spec:
               default: velero
             annotations:
               type: object
-              additionalProperties: string
+              additionalProperties:
+                type: string
               description: Annotations to set on the Velero service account.
               default: {}
             labels:

--- a/addons/packages/velero/1.7.1/package.yaml
+++ b/addons/packages/velero/1.7.1/package.yaml
@@ -41,37 +41,37 @@ spec:
               default: false
             defaultVolumesToRestic:
               description: >
-                Bool flag to configure Velero server to use restic by default to backup 
+                Bool flag to configure Velero server to use restic by default to backup
                 all pod volumes on all backups. Optional.
               type: boolean
               default: false
             defaultResticPruneFrequency:
               description: >
-                How often 'restic prune' is run for restic repositories by default. 
+                How often 'restic prune' is run for restic repositories by default.
                 Optional.
               type: integer
               default: 0
             cpuLimit:
               description: >
-                CPU limit for restic pod. A value of "0" is treated as unbounded. 
+                CPU limit for restic pod. A value of "0" is treated as unbounded.
                 Optional. (default "1000m")
               type: string
               default: 1000m
             cpuRequest:
               description: >
-                CPU request for restic pod. A value of "0" is treated as unbounded. 
+                CPU request for restic pod. A value of "0" is treated as unbounded.
                 Optional. (default "500m")
               type: string
               default: 500m
             memoryLimit:
               description: >
-                Memory limit for restic pod. A value of "0" is treated as unbounded. 
+                Memory limit for restic pod. A value of "0" is treated as unbounded.
                 Optional. (default "1Gi")
               type: string
               default: 1Gi
             memoryRequest:
               description: >
-                Memory request for restic pod. A value of "0" is treated as unbounded. 
+                Memory request for restic pod. A value of "0" is treated as unbounded.
                 Optional. (default "512Mi")
               type: string
               default: 500Mi

--- a/addons/packages/velero/1.7.1/package.yaml
+++ b/addons/packages/velero/1.7.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: demo.goharbor.io/tce/velero@sha256:d719cadcccb13b756222b4c78c7e125d8f39427a470860e17490c46c923d5ddc
+            image: projects.registry.vmware.com/tce/velero@sha256:fe89fb0897df4f9df2665c305909c6cc5cda42bacf2fbfc2e111764e0431baf8
       template:
         - ytt:
             paths:

--- a/addons/packages/velero/1.7.1/package.yaml
+++ b/addons/packages/velero/1.7.1/package.yaml
@@ -410,7 +410,6 @@ spec:
               default: {}
             labels:
               type: object
-              additionalProperties: array
-              description: Labels to set on the Velero service account.
-              items:
+              additionalProperties:
                 type: string
+              description: Labels to set on the Velero service account.

--- a/addons/packages/velero/1.7.1/package.yaml
+++ b/addons/packages/velero/1.7.1/package.yaml
@@ -1,0 +1,415 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: velero.community.tanzu.vmware.com.1.7.1
+spec:
+  refName: velero.community.tanzu.vmware.com
+  version: 1.7.1
+  releaseNotes: "velero 1.7.1 https://github.com/vmware-tanzu/velero/releases/tag/v1.7.1"
+  licenses:
+    - "Apache 2.0"
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: demo.goharbor.io/tce/velero@sha256:d719cadcccb13b756222b4c78c7e125d8f39427a470860e17490c46c923d5ddc
+      template:
+        - ytt:
+            paths:
+              - config/
+        - kbld:
+            paths:
+              - "-"
+              - .imgpkg/images.yml
+      deploy:
+        - kapp: {}
+  valuesSchema:
+    openAPIv3:
+      title: velero.community.tanzu.vmware.com.1.7.1 values schema
+      properties:
+        namespace:
+          type: string
+          description: The namespace in which to deploy Velero.
+          default: velero
+        restic:
+          type: object
+          description: restic related configuration
+          properties:
+            create:
+              type: boolean
+              description: Whether to deploy the restic daemonset.
+              default: false
+            defaultVolumesToRestic:
+              description: >
+                Bool flag to configure Velero server to use restic by default to backup 
+                all pod volumes on all backups. Optional.
+              type: boolean
+              default: false
+            defaultResticPruneFrequency:
+              description: >
+                How often 'restic prune' is run for restic repositories by default. 
+                Optional.
+              type: integer
+              default: 0
+            cpuLimit:
+              description: >
+                CPU limit for restic pod. A value of "0" is treated as unbounded. 
+                Optional. (default "1000m")
+              type: string
+              default: 1000m
+            cpuRequest:
+              description: >
+                CPU request for restic pod. A value of "0" is treated as unbounded. 
+                Optional. (default "500m")
+              type: string
+              default: 500m
+            memoryLimit:
+              description: >
+                Memory limit for restic pod. A value of "0" is treated as unbounded. 
+                Optional. (default "1Gi")
+              type: string
+              default: 1Gi
+            memoryRequest:
+              description: >
+                Memory request for restic pod. A value of "0" is treated as unbounded. 
+                Optional. (default "512Mi")
+              type: string
+              default: 500Mi
+        credential:
+          type: object
+          description: >
+            Configuration for the secret to be used by the Velero deployment and the restic Daemonset,
+            which should contain credentials for the cloud provider IAM account set up for Velero.
+            For full documentation, see: https://velero.io/docs/v1.6/locations/#create-a-storage-location-that-uses-unique-credentials.
+          properties:
+            useDefaultSecret:
+              type: boolean
+              description: >
+                Whether the secret created by default should be used as the source of IAM account credentials.
+                If not set to `true`, the secret to be used must be indicated in the
+                `backupStorageLocation.spec.existingSecret`. If set to `true`, the raw content must be specified below
+                in the `credential.secretContents.cloud`.
+              default: true
+            name:
+              type: string
+              description: >
+                The name of the secret to configure if `credential.useDefaultSecret` is true.
+                Required if `useDefaultSecret` is true.
+              default: cloud-credentials
+            secretContents:
+              type: string
+              description: |
+                secretContents is the data to be stored in the default Velero secret. For the default secret, the key
+                must be named `cloud`, and the value corresponds to the entire content of your IAM credentials file.
+                Note that the format will be different for different providers, please check their documentation.
+                Required if `useDefaultSecret` is true.
+                Example:
+                cloud: |
+                  aws_access_key_id=<redacted>
+                  aws_secret_access_key=<redacted>
+              default: ""
+            extraEnvVars:
+              type: string
+              description: >
+                additional key/value pairs to be used as environment variables such as "DIGITALOCEAN_TOKEN: <your-key>".
+                Values will be stored in the secret.
+              default: ""
+            extraSecretRef:
+              type: string
+              description: >
+                extraSecretRef is the name of any pre-existing secret (if any) in the namespace where Velero is installed
+                and that will be used to load environment variables into velero and restic. Secret should be in format -
+                https://kubernetes.io/docs/concepts/configuration/secret/#use-case-as-container-environment-variables
+              default: ""
+        backupStorageLocation:
+          type: object
+          description: >
+            Configuration for locations where Velero can store backups represented in the cluster via the
+            BackupStorageLocation CRD. Backups can be stored in a number of locations, and Velero must have at least one
+            BackupStorageLocation. For documentation, see https://velero.io/docs/v1.6/api-types/backupstoragelocation/.
+          properties:
+            name:
+              type: string
+              description: >
+                The name of the backup storage location where backups should be stored. If a name is not provided,
+                a backup storage location will be created with the name "default". Required.
+              default: default
+            spec:
+              type: object
+              description: >
+                Configurations for a backup storage location.
+              properties:
+                provider:
+                  type: string
+                  description: |
+                    The name of the object store plugin used to connect to this location. Required.
+                    Valid values: `aws`, `azure`
+                default:
+                  type: boolean
+                  description:  Indicates if this location is the default backup storage location. Optional.
+                  default: true
+                backupSyncPeriod:
+                  type: string
+                  description: |
+                    Indicates how frequently Velero should synchronize backups in object storage.
+                    Set this to 0s to disable sync.
+                  default: 1m
+                validationFrequency:
+                  type: string
+                  description: |
+                    Indicates how frequently Velero should validate the object storage (if it is still connected, for example).
+                    Set this to 0s to disable validation.
+                  default: 1m
+                accessMode:
+                  type: string
+                  description: |
+                    How Velero can access the backup storage location.
+                    Valid values are `ReadWrite` and `ReadOnly`
+                    Set this to 0s to disable sync.
+                  default: ReadWrite
+                existingSecret:
+                  type: object
+                  description: |
+                    existingSecret should be a secret separately created in the namespace where Velero is installed.
+                    Applies only if `credential.useDefaultSecret` is set to `false`. Optional.
+                    For documentation on how to use: https://velero.io/docs/v1.6/locations/#create-a-storage-location-that-uses-unique-credentials.
+                  properties:
+                    name:
+                      type: string
+                      description: The name of the secret
+                      default: ""
+                    key:
+                      type: string
+                      description: Key used within the secret
+                      default: ""
+                objectStorage:
+                  type: object
+                  description: |
+                    A set of configurations specific to the object store
+                  properties:
+                    bucket:
+                      type: string
+                      description: The name of the bucket to store backups in. Required.
+                      default: ""
+                    caCert:
+                      type: string
+                      description: defines a base64 encoded CA bundle to use when verifying TLS connections to the provider. Optional.
+                      default: ""
+                    prefix:
+                      type: string
+                      description: The directory under which all Velero data should be stored within the bucket. Optional.
+                      default: ""
+                configAWS:
+                  type: object
+                  description: Configuration specific to the AWS plugin.
+                  properties:
+                    region:
+                      type: string
+                      description: |
+                        Region is the AWS region where the bucket is located. Queried from the AWS S3 API if not provided.
+                        Set to  "minio" if using a local storage service like MinIO.
+                        Note: when used, MinIO must be run as a standalone. See the documentation:
+                        https://docs.min.io/minio/baremetal/installation/deploy-minio-standalone.html
+                        Required.
+                      default: ""
+                    s3ForcePathStyle:
+                      type: boolean
+                      description: >
+                        Indicates whether to use path-style addressing instead of virtual hosted bucket addressing. Set to "true"
+                        if using a local storage service like MinIO.
+                      default: false
+                    s3Url:
+                      type: string
+                      description: >
+                        You can specify the AWS S3 URL here for explicitness, but Velero can already generate it from
+                        "region" and "bucket". This field is primarily for local storage services like MinIO. Optional.
+                      default: ""
+                    publicUrl:
+                      type: string
+                      description: >
+                        If specified, use this instead of "s3Url" when generating download URLs (e.g., for logs). This
+                        field is primarily for local storage services like MinIO. Optional.
+                      default: ""
+                    serverSideEncryption:
+                      type: string
+                      description: >
+                        The name of the server-side encryption algorithm to use for uploading objects, e.g. "AES256".
+                        If using SSE-KMS and "kmsKeyId" is specified, this field will automatically be set to "aws:kms"
+                        so does not need to be specified by the user. Optional.
+                      default: "aws:kms"
+                    kmsKeyId:
+                      type: string
+                      description: >
+                        Specifies an AWS KMS key ID (formatted per the example) or alias (formatted as "alias/<KMS-key-alias-name>")
+                        to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly
+                        granting key usage rights. Optional.
+                      default: ""
+                    signatureVersion:
+                      type: string
+                      description: >
+                        The version of the signature algorithm used to create signed URLs that are used by Velero CLI to
+                        download backups or fetch logs. Possible versions are "1" and "4". Usually the default version
+                        4 is correct, but some S3-compatible providers like Quobyte only support version 1.
+                      default: "4"
+                    profile:
+                      type: string
+                      description: The AWS profile within the credentials file to use for the backup storage location.
+                      default: "default"
+                    insecureSkipTLSVerify:
+                      type: boolean
+                      description: >
+                        Set to "true" if you do not want to verify the TLS certificate when connecting to the
+                        object store -- like for self-signed certs with MinIO. This is susceptible to man-in-the-middle
+                        attacks and is not recommended for production.
+                      default: false
+                configAzure:
+                  type: object
+                  description: >
+                    Configuration specific to the Azure plugin. For the original documentation: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/v1.2.1/backupstoragelocation.md.
+                  properties:
+                    resourceGroup:
+                      type: string
+                      description: >
+                        The name of the resource group containing the storage account for this backup storage location. Required.
+                      default: ""
+                    storageAccount:
+                      type: string
+                      description: >
+                        The name of the storage account for this backup storage location. Required.
+                      default: ""
+                    storageAccountKeyEnvVar:
+                      type: string
+                      description: |
+                        The environment variable in $AZURE_CREDENTIALS_FILE that contains storage account key for this backup storage location.
+                        Required if using a storage account access key to authenticate rather than a service principal.
+                      default: ""
+                    subscriptionId:
+                      type: string
+                      description: >
+                        The ID of the subscription for this backup storage location. Optional.
+                      default: ""
+                    blockSizeInBytes:
+                      type: integer
+                      description: |
+                        The block size, in bytes, to use when uploading objects to Azure blob storage.
+                        See https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs#about-block-blobs
+                        for more information on block blobs.
+                      default: 104857600
+        volumeSnapshotLocation:
+          type: object
+          description: >
+            Configuration for volume snapshot location in which to store the volume snapshots created for a backup in
+            the cluster via the VolumeSnapshotLocation CRD. For documentation, see
+            https://velero.io/docs/v1.6/api-types/volumesnapshotlocation/.
+          properties:
+            snapshotEnabled:
+              type: boolean
+              description: >
+                Indicates whether to create a volumesnapshotlocation CR. If false => disable the snapshot feature.
+              default: true
+            name:
+              type: string
+              description: >
+                The name of the volume snapshot location where snapshots are taken. Required.
+              default: "default"
+            provider:
+              type: string
+              description: |
+                The name for the volume snapshot provider.
+                Valid values: `aws`, `azure`
+            configAWS:
+              type: object
+              description: >
+                configAWS contains configuration specific to the AWS plugin. For the original documentation:
+                https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.2.1/backupstoragelocation.md.
+              properties:
+                region:
+                  type: string
+                  description: >
+                    The AWS region where the volumes/snapshots are located. Required.
+                  default: ""
+                profile:
+                  type: string
+                  description: >
+                    The AWS profile within the credentials file to use for the volume snapshot location.
+                  default: "default"
+            configAzure:
+              type: object
+              description: >
+                Configuration specific to the Azure plugin
+              properties:
+                apiTimeout:
+                  type: string
+                  description: >
+                    Indicates how long to wait for an Azure API request to complete before timeout. Defaults to 2m0s.
+                  default: "2m0s"
+                resourceGroup:
+                  type: string
+                  description: >
+                    The name of the resource group where volume snapshots should be stored, if different from the
+                    cluster's resource group. Optional.
+                  default: ""
+                subscriptionId:
+                  type: string
+                  description: >
+                    The ID of the subscription where volume snapshots should be stored, if different from the cluster's
+                    subscription. Requires "resourceGroup" to also be set. Optional.
+                  default: ""
+                incremental:
+                  type: boolean
+                  description: |
+                    Azure offers the option to take full or incremental snapshots of managed disks.
+                    - Set this parameter to true, to take incremental snapshots.
+                    - If the parameter is omitted or set to false, full snapshots are taken (default).
+                    Optional.
+                  default: false
+        rbac:
+          type: object
+          description: Role based access controls for Velero.
+          properties:
+            create:
+              type: boolean
+              description:
+              default: false
+            clusterAdministrator:
+              type: boolean
+              description:
+              default: false
+            name:
+              type: string
+              description: The name of the cluster role binding.
+              default: velero
+            roleRefName:
+              type: string
+              description: The name of the role.
+              default: velero
+            clusterRoleAPIGroups:
+              type: array
+              description: Array of the cluster role API groups.
+              items:
+                type: string
+            clusterRoleVerbs:
+              type: array
+              description: Array of the cluster role verbs.
+              default: ["get", "watch", "list"]
+              items:
+                type: string
+        serviceAccount:
+          type: object
+          description: Information about the Kubernetes service account Velero uses.
+          properties:
+            name:
+              type: string
+              description: The name for the service account
+              default: velero
+            annotations:
+              type: object
+              additionalProperties: string
+              description: Annotations to set on the Velero service account.
+              default: {}
+            labels:
+              type: object
+              additionalProperties: array
+              description: Labels to set on the Velero service account.
+              items:
+                type: string

--- a/addons/packages/velero/1.7.1/test/Makefile
+++ b/addons/packages/velero/1.7.1/test/Makefile
@@ -1,0 +1,25 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ROOT_DIR := $(shell git rev-parse --show-toplevel)
+PLATFORM := $(shell uname | tr '[:upper:]' '[:lower:]')
+VERSION := 1.7.1
+GOPATH ?= "~/go"
+GINKGO_FOCUS ?= Basic
+# Note: Because we are not asking the Velero e2e tests to install Velero, the CLOUD_PROVIDER variable is only meant to indicate
+# if the tests are being run in an environment that supports taking volume snapshots, like AWS, Azure or vSphere. If the
+# tests are running on Docker, set this variable to "kind". Otherwise, set it to anything else.
+CLOUD_PROVIDER ?= notkind
+REGISTRY_CREDENTIAL_FILE ?=
+
+e2e-test:
+	sh -c "rm -rf /tmp/velero-e2e-test &&\
+	mktemp -d /tmp/velero-e2e-test.XXX &&\
+	git clone https://github.com/vmware-tanzu/velero /tmp/velero-e2e-test/velero &&\
+	cd /tmp/velero-e2e-test &&\
+	$(ROOT_DIR)/addons/packages/velero/${VERSION}/test/install-velero-cli.sh v${VERSION} $(PLATFORM) &&\
+	ACK_GINKGO_DEPRECATIONS=1.16.4 \
+	CREDS_FILE=dummyvalue BSL_BUCKET=dummyvalue \
+	GOPATH=$(GOPATH) CLOUD_PROVIDER=$(CLOUD_PROVIDER) REGISTRY_CREDENTIAL_FILE=$(REGISTRY_CREDENTIAL_FILE)  \
+	GINKGO_FOCUS=$(GINKGO_FOCUS) INSTALL_VELERO=false VELERO_CLI=/tmp/velero-e2e-test/velero-v${VERSION}-$(PLATFORM)-amd64/velero  \
+	make -C /tmp/velero-e2e-test/velero/test/e2e run"

--- a/addons/packages/velero/1.7.1/test/README.md
+++ b/addons/packages/velero/1.7.1/test/README.md
@@ -1,0 +1,65 @@
+# Velero e2e tests
+
+## Description
+
+The e2e tests validate end-to-end behavior of Velero backup and restore operations. For full documentation, see: [velero/README.md e2e tests at v1.7.1 · vmware-tanzu/velero](https://github.com/vmware-tanzu/velero/blob/v1.7.1/test/e2e/README.md).
+
+The `make e2e-test` target defined in this directory runs the [Velero e2e tests hosted on the Velero GitHub repository](https://github.com/vmware-tanzu/velero/tree/v1.7.1/test/e2e).
+
+For testing this TCE package, the e2e tests will optout of installing Velero, since we want to test the already installed TCE Velero package. All of the configurations will reflect this condition.
+
+## Prerequisites
+
+Tests can be run in a TCE cluster hosted in any of the cloud providers supported by the Velero package.
+
+1. A running TCE cluster
+1. The necessary storage drivers/provisioners installed.
+1. `kubectl` installed locally.
+1. The `velero.community.tanzu.vmware.com` v1.7.1 package must be installed on the cluster.
+1. The local context needs to be set to the TCE cluster.
+
+⚠️ Please be aware of the limitations for the v1.7.1 of the tests: [velero/test/e2e at v1.7.1 · vmware-tanzu/velero](https://github.com/vmware-tanzu/velero/tree/v1.7.1/test/e2e#limitations).
+
+Note: the tests do not delete any backup/restore resource created during the running of the tests. Feel free to delete them manually, but otherwise that should not interfere with running subsequent tests.
+
+## Test Configuration
+
+1. `GOPATH` - environment variable if it is different from `~/go`. Default is "~/go".
+1. `CLOUD_PROVIDER`-  because we are not asking the Velero e2e tests to install Velero, the `CLOUD_PROVIDER` variable is only meant to indicate if the tests are being run in an environment that supports taking volume snapshots, like AWS, Azure or vSphere, or not. If the tests are running on Docker, set this variable to "kind". Otherwise, set it to anything else. Default is "notkind".
+1. `REGISTRY_CREDENTIAL_FILE` - only needed for tests that trigger the creation of a workload, usually so there can be a snapshot taken. Required in some cases. See format below:
+
+```sh
+{
+    "auths": {
+        "https://index.docker.io/v1/": {
+            "Username": <dockerusername>,
+            "Secret": <dockerpwd>
+        }
+    },
+    "credsStore": "desktop"
+}
+```
+
+## Run Tests
+
+Run the tests from the test directory: `addons/packages/velero/1.7.1/test/` .
+
+🚨 Note: for any test to run successfully, there has to be a BackupStorageLocation that is the default and and that has the status phase of `available` . To verify:
+
+`kubectl get backupstoragelocations.velero.io -n velero` .
+
+⚠️ In the absence of a "focus" flag, all Velero e2e tests will be run, which is not recommended for TCE.
+
+It is recommended that these two tests be run:
+
+* `GINKGO_FOCUS='Basic'` - This is the default. It tests the simple backup and restore of 2 namespaces :
+
+```bash
+GITHUB_TOKEN=$GITHUB_TOKEN make e2e-test
+```
+
+* `GINKGO_FOCUS='Snapshot'` - This test will create a workload
+
+```bash
+GINKGO_FOCUS='Snapshot' GITHUB_TOKEN=$GITHUB_TOKEN REGISTRY_CREDENTIAL_FILE=/Users/carlisiac/.docker/config.json make e2e-test
+```

--- a/addons/packages/velero/1.7.1/test/install-velero-cli.sh
+++ b/addons/packages/velero/1.7.1/test/install-velero-cli.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# set -o errexit
+set -o nounset
+set -o pipefail
+set -e
+
+# Script to download asset file from tag release using GitHub API v3.
+# Inspired by: https://github.com/vmware-tanzu/community-edition/blob/main/hack/get-tce-release.sh
+
+# Should have two arguments, release-tag and file name
+if [ $# -ne 2 ]; then
+	echo "Usage: $0 [tag] [name]"
+	echo "Example: ./install-velero-cli.sh v1.7.1 linux"
+	exit 1
+fi
+
+# Check dependencies exist
+echo "Validating dependencies ..."
+type curl grep sed tr jq
+
+# Define variables
+tag=$1
+name=$2
+
+GH_API="https://api.github.com"
+GH_REPO="$GH_API/repos/vmware-tanzu/velero"
+GH_TAGS="$GH_REPO/releases/tags/$tag"
+AUTH=""
+CURL_ARGS="-LJO#"
+
+# Validate GitHub access token
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+	echo "Warning: No GITHUB_TOKEN variable defined - requests to the GitHub API may be rate limited"
+else
+    AUTH="Authorization: token $GITHUB_TOKEN"
+    curl -o /dev/null -sH "$AUTH" $GH_REPO || { echo "Error: Unauthenticated token or network issue!";  exit 1; }
+fi
+
+# Read asset tags
+assets=$(curl -sH "$AUTH" "$GH_TAGS")
+
+if [[ $(echo "$assets" | jq ".message") = "\"Not Found\"" ]]; then
+	echo "Error: release tag $tag not found! Please enter a valid release tag version. Ex: v1.7.1"
+	echo "Available release tags include:"
+	curl -sH "$AUTH" "${GH_REPO}/releases" | jq "[ .[] | { html_url }]"
+	exit 1
+fi
+
+# Get ID of the asset based on given name.
+id=$(echo "$assets" | jq ".assets[] | select( .browser_download_url | contains(\"${name}-amd64\"))" | jq '.id')
+if [ -z "$id" ]; then
+	echo "Error: Failed to get asset id for release containing substring $name"
+	echo "Please provide a substring for the name of an assetfile. Ex: darwin, linux"
+	echo "Available asset files include:"
+	echo "$assets" | jq "[ .assets[] | { browser_download_url }]"
+	exit 1
+fi
+
+GH_ASSET="$GH_REPO/releases/assets/$id"
+
+# Download asset file
+echo "Downloading asset ..."
+curl $CURL_ARGS -H "$AUTH" -H 'Accept: application/octet-stream' "$GH_ASSET"
+tar xvzf velero-"$tag"-"$name"-amd64.tar.gz

--- a/addons/packages/velero/metadata.yaml
+++ b/addons/packages/velero/metadata.yaml
@@ -9,5 +9,6 @@ spec:
   providerName: VMware
   maintainers:
     - name: Carlisia Thompson
+    - name: Xun Jiang
   categories:
     - "backup"

--- a/addons/packages/velero/metadata.yaml
+++ b/addons/packages/velero/metadata.yaml
@@ -8,7 +8,6 @@ spec:
   shortDescription: "Disaster recovery capabilities"
   providerName: VMware
   maintainers:
-    - name: Carlisia Thompson
     - name: Xun Jiang
   categories:
     - "backup"

--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -48,6 +48,7 @@ packages:
   - name: velero
     versions:
       - 1.6.3
+      - 1.7.1
   - name: whereabouts
     versions:
       - 0.5.0


### PR DESCRIPTION
1. port existing 1.6.3 function to 1.7.1
2. update upstream file to velero 1.7.1
3. add restic support
4. update repos

Signed-off-by: Xun Jiang <jxun@vmware.com>

## What this PR does / why we need it
Add Velero release v1.7.1. Add restic supporting function in v1.7.1

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
1. port existing 1.6.3 function to 1.7.1
2. add restic support in 1.7.1
```

## Which issue(s) this PR fixes

Fixes: #2663

## Describe testing done for PR
Create standalone cluster in Docker. 

GINKGO_FOCUS='Basic' GITHUB_TOKEN=$GITHUB_TOKEN REGISTRY_CREDENTIAL_FILE=/Users/jxun/.docker/config.json make e2e-test
GINKGO_FOCUS='Snapshot' GITHUB_TOKEN=$GITHUB_TOKEN REGISTRY_CREDENTIAL_FILE=/Users/jxun/.docker/config.json make e2e-test

## Special notes for your reviewer
None
