### PR TITLE
Fix recent aws ec2 endpoint not being available

### DIFF
--- a/hack/runner/webhook/go.mod
+++ b/hack/runner/webhook/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.41.1
-	github.com/go-playground/webhooks/v6 v6.0.0-beta.3
+	github.com/go-playground/webhooks/v6 v6.0.0-rc.1
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-github/v39 v39.1.0
 	golang.org/x/net v0.0.0-20211011170408-caeb26a5c8c0 // indirect
@@ -12,5 +12,3 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	k8s.io/klog/v2 v2.20.0
 )
-
-replace github.com/go-playground/webhooks/v6 => github.com/dvonthenen/webhooks/v6 v6.0.0-beta.3.0.20211018213018-c98cc0b89b76

--- a/hack/runner/webhook/go.sum
+++ b/hack/runner/webhook/go.sum
@@ -43,8 +43,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dvonthenen/webhooks/v6 v6.0.0-beta.3.0.20211018213018-c98cc0b89b76 h1:2M5+pFn8LPx46yfJdCYe3GeRKBNteZT2A68DBnkoJJY=
-github.com/dvonthenen/webhooks/v6 v6.0.0-beta.3.0.20211018213018-c98cc0b89b76/go.mod h1:GCocmfMtpJdkEOM1uG9p2nXzg1kY5X/LtvQgtPHUaaA=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -54,6 +52,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-logr/logr v1.0.0 h1:kH951GinvFVaQgy/ki/B3YYmQtRpExGigSJg6O8z5jo=
 github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-playground/webhooks/v6 v6.0.0-rc.1 h1:U78wIkdcCGzMw38BGw2eep542XRsUr3/kGDSjmFFELU=
+github.com/go-playground/webhooks/v6 v6.0.0-rc.1/go.mod h1:GCocmfMtpJdkEOM1uG9p2nXzg1kY5X/LtvQgtPHUaaA=
 github.com/gogits/go-gogs-client v0.0.0-20200905025246-8bb8a50cb355/go.mod h1:cY2AIrMgHm6oOHmR7jY+9TtjzSjQ3iG7tURJG3Y6XH0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
There apparently was a recent change in the API endpoints for ec2 that was causing our GitHub self-hosted runners fail to create ec2 instances using the API. A refresh to the webhook project we depend on resolves the issue.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix recent aws ec2 endpoint not being available
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA