### PR TITLE
[Antrea] Disable UDP tunnel offload option

### DIFF
--- a/addons/packages/antrea/1.2.3/README.md
+++ b/addons/packages/antrea/1.2.3/README.md
@@ -19,10 +19,12 @@ The following configuration values can be set to customize the antrea installati
 
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
-| `antrea.config.serviceCIDR` | Optional | The service CIDR to use. Default: `10.96.0.0/12` |
+| `antrea.config.serviceCIDR` | Optional | The service IPv4 CIDR to use. Default: `10.96.0.0/12` |
+| `antrea.config.serviceCIDRv6` | Optional | The service IPv6 CIDR to use. Default: nil |
 | `antrea.config.trafficEncapMode` | Optional | The traffic encapsulation mode. Default: `encap` |
 | `antrea.config.noSNAT` | Optional | Boolean flag to enable/disable SNAT. Default: `false`. |
 | `antrea.config.defaultMTU` | Optional | MTU to use. Default: `null` (Antrea will autodetect). |
+| `antrea.config.disableUdpTunnelOffload` | Optional | Disable UDP tunnel offload feature on default NIC. Default: `false` |
 | `antrea.config.featureGates.AntreaProxy` | Optional | Boolean flag to enable/disable antrea proxy. Default: `false`. |
 | `antrea.config.featureGates.AntreaPolicy` | Optional | Boolean flag to enable/disable antrea policy. Default: `true`. |
 | `antrea.config.featureGates.AntreaTraceFlow` | Optional | Boolean flag to enable/disable antrea traceflow. Default: `false`. |

--- a/addons/packages/antrea/1.2.3/bundle/config/overlay/antrea_overlay.yaml
+++ b/addons/packages/antrea/1.2.3/bundle/config/overlay/antrea_overlay.yaml
@@ -219,12 +219,31 @@ tlsCipherSuites: #@ values.antrea.config.tlsCipherSuites
 #! legacyCRDMirroring: true
 #@ end
 
+
+#@ def antrea_agent_tweaker_conf():
+
+#! Enable disableUdpTunnelOffload will disable udp tunnel offloading feature on kubernetes node's default interface.
+#! By default, no actions will be taken.
+disableUdpTunnelOffload: #@ values.antrea.config.disableUdpTunnelOffload
+#@ end
+
+
+#! Antrea agent and controller configuration
 #@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-config-822fk25299"}})
 ---
 kind: ConfigMap
 data:
   antrea-agent.conf: #@ yaml.encode(antrea_agent_conf())
   antrea-controller.conf: #@ yaml.encode(antrea_controller_conf())
+
+
+#! Antrea agent tweaker configuration
+#@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-agent-tweaker-g56hc6fh8t"}})
+---
+kind: ConfigMap
+data:
+  antrea-agent-tweaker.conf: #@ yaml.encode(antrea_agent_tweaker_conf())
+
 
 #@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name": "antrea-controller"}})
 ---

--- a/addons/packages/antrea/1.2.3/bundle/config/values.yaml
+++ b/addons/packages/antrea/1.2.3/bundle/config/values.yaml
@@ -9,6 +9,7 @@ antrea:
     serviceCIDRv6: null
     trafficEncapMode: encap
     noSNAT: false
+    disableUdpTunnelOffload: false
     #! Setting defaultMTU to null since antrea-agent will discover the MTU of the Node's primary interface and
     #! also adjust MTU to accommodate for tunnel encapsulation overhead.
     defaultMTU: null

--- a/addons/packages/antrea/1.2.3/package.yaml
+++ b/addons/packages/antrea/1.2.3/package.yaml
@@ -13,7 +13,7 @@ spec:
       syncPeriod: 5m
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/antrea@sha256:9bf2c1bbaf4570a7128c03702f71c7aa05582ae1fce1ca35792d732ea4a8b7b9
+            image: projects.registry.vmware.com/tce/antrea@sha256:6bc659b8f1bcd90208bf90be5f3e1085252bb8b9655cc5a3f1c9a2bcc6ab1ffb
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
Latest Antrea has a configMap enabling/disabling the tunnel offload configuration, this PR adds a setting enabling
configuration the data via YTT variables.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
Fixes: https://github.com/vmware-tanzu/community-edition/issues/2724

## Describe testing done for PR
Unit tests for render added in the PR
