### PR TITLE
Add kapp controller init container to configure cluster DNS access

### DIFF
--- a/addons/packages/kapp-controller/0.30.0/bundle/config/overlays/update-deployment.yaml
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/overlays/update-deployment.yaml
@@ -1,5 +1,5 @@
 #@ load("@ytt:overlay", "overlay")
-#@ load("/values.star", "values")
+#@ load("/values.star", "values", "generateBashCmdForDNS")
 #@ load("@ytt:yaml", "yaml")
 
 #@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name": "kapp-controller"}})
@@ -29,15 +29,42 @@ spec:
           #@overlay/match by="name"
           - name: KAPPCTRL_API_PORT
             value: #@ str(values.kappController.deployment.apiPort)
-      #@ if values.kappController.deployment.hostNetwork:
-      hostNetwork: #@ values.kappController.deployment.hostNetwork
-      dnsPolicy: ClusterFirstWithHostNet
+        #@ if values.kappController.deployment.coreDNSIP:
+        volumeMounts:
+          - mountPath: /etc
+            name: etc
+        #@ end
+      #@ if values.kappController.deployment.coreDNSIP:
+      #! Using init container bypasses the restriction of not having root access in main container
+      #! It modifies /etc/resolv.conf which is shared to main container
+      initContainers:
+      - args:
+        - -c
+        - #@ generateBashCmdForDNS(values.kappController.deployment.coreDNSIP)
+        command:
+        - /bin/sh
+        #! Beware, update this image with each version bump!!!!!!!
+        #! This image needs to be the same as the image used in basefile
+        image: ghcr.io/vmware-tanzu/carvel-kapp-controller@sha256:46f9c4e78d80a322ae3159cb97069350b445b974664f4aead0ab4ad593d79f45
+        name: init-kapp-controller
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /kapp-etc
+          name: etc
       #@ end
-      #@ if/end values.kappController.deployment.dnsPolicy:
-      #@yaml/map-key-override
-      dnsPolicy: #@ values.kappController.deployment.dnsPolicy
+      #@ if/end values.kappController.deployment.hostNetwork:
+      hostNetwork: #@ values.kappController.deployment.hostNetwork
       #@ if/end values.kappController.deployment.priorityClassName:
       priorityClassName: #@ values.kappController.deployment.priorityClassName
       #@ if hasattr(values.kappController.deployment, 'tolerations') and values.kappController.deployment.tolerations:
       tolerations: #@ values.kappController.deployment.tolerations
+      #@ end
+      #@ if values.kappController.deployment.coreDNSIP:
+      volumes:
+        #@overlay/append
+        - emptyDir:
+            medium: Memory
+          name: etc
       #@ end

--- a/addons/packages/kapp-controller/0.30.0/bundle/config/values.star
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/values.star
@@ -8,3 +8,11 @@ if hasattr(values.kappController, 'namespace') and values.kappController.namespa
 else:
     kappNamespace = values.namespace
 end
+
+def generateBashCmdForDNS(coreDNSIP):
+    # This command added the coreDNS IP as the first entry of resolv.conf
+    # In this way, Kapp Controller will have cluster IP access,
+    # and still able to resolve enternal urls when core DNS is unavailable
+
+    return "cp /etc/resolv.conf /etc/resolv.conf.bak; sed '1 i nameserver " + coreDNSIP + "' /etc/resolv.conf.bak > /etc/resolv.conf; rm /etc/resolv.conf.bak; cp -R /etc/* /kapp-etc"
+end

--- a/addons/packages/kapp-controller/0.30.0/bundle/config/values.yaml
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/values.yaml
@@ -7,8 +7,9 @@ kappController:
   createNamespace: true
   globalNamespace: tanzu-package-repo-global
   deployment:
+    #! The coreDNSIP will be injected into /etc/resolv.conf of kapp-controller pod
+    coreDNSIP: null
     hostNetwork: null
-    dnsPolicy: null
     priorityClassName: null
     concurrency: 4
     tolerations: []

--- a/addons/packages/kapp-controller/0.30.0/package.yaml
+++ b/addons/packages/kapp-controller/0.30.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:6fa7447e9886f5af7cca18ad21ccef608c121c54c58fd196fb129cd2a8adddce
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:26428e5233c6fa610a950c216c8e3eee5c76ce05e5385e8291b6acd91dc5bc26
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
As required by TAP team, kapp controller needs to access the service in the cluster. However, kapp controller will not be able to access cluster DNS when it's using hostNetwork.

In case hostNetwork is enabled, adding a initContainer to add core DNS IP into `/etc/resolv.conf` of kapp-controller pod. The `/etc` folder is shared using a volume mount.

The reason of using init container to edit `resolv.conf` is because kapp controller pod doesn't have root access to edit the file.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add cluster DNS access to Kapp-Controller pod when hostNetwork is enabled.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #Kapp controller unable to access in cluster service when hostNetwork is enabled.

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Downstream test pipelines are successful.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
