### PR TITLE
Clean up left files to not block other incoming package installation

### DIFF
--- a/addons/packages/multus-cni/3.7.1/README.md
+++ b/addons/packages/multus-cni/3.7.1/README.md
@@ -14,15 +14,15 @@ The following configuration values can be set to customize the Multus CNI instal
 
 ### Global
 
-| Value | Required/Optional | Description |
-|-------|-------------------|-------------|
-| `namespace` | Optional | The namespace in which to deploy Multus CNI DaemonSet. |
+| Value       | Required/Optional | Description                                            |
+| ----------- | ----------------- | ------------------------------------------------------ |
+| `namespace` | Optional          | The namespace in which to deploy Multus CNI DaemonSet. |
 
 ### Multus CNI configuration
 
-| Value | Required/Optional | Description |
-|-------|-------------------|-------------|
-| `args` | Optional | The args for Multus CNI DaemonSet container. |
+| Value  | Required/Optional | Description                                  |
+| ------ | ----------------- | -------------------------------------------- |
+| `args` | Optional          | The args for Multus CNI DaemonSet container. |
 
 ## Usage Example
 
@@ -79,4 +79,20 @@ This example guides you about attaching another network interface scenario that 
 
     ```bash
     kubectl exec <your-pod> -- ip a
+    ```
+
+## Uninstallation of Multus CNI package
+
+The following steps are used to uninstall the Multus CNI package.
+
+1. Delete the Multus CNI resources through the following command:
+
+    ```bash
+    tanzu package installed delete <multus-cni-pkg-install-name> <-y>
+    ```
+
+1. Remove leftover Multus CNI's network configuration files on the cluster nodes. To remove such resources, one possible way is to use a daemonset to clean up the leftover Multus CNI related network configurations. One example is located at Multus CNI tests folder.
+
+    ```bash
+    kubectl create -f test/e2e/multihomed-testfiles/cleanup.yaml
     ```

--- a/addons/packages/multus-cni/3.7.1/test/e2e/multihomed-testfiles/cleanup.yaml
+++ b/addons/packages/multus-cni/3.7.1/test/e2e/multihomed-testfiles/cleanup.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cleanup-conflists
+  namespace: kube-system
+  labels:
+    name: cleanup-conflists
+spec:
+  selector:
+    matchLabels:
+      name: cleanup-conflists
+  template:
+    metadata:
+      labels:
+        name: cleanup-conflists
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: cleanup-conflists
+        image: quay.io/centos/centos:8
+        command: ["/bin/bash"]
+        args: ["-c", "find /host/etc/cni/net.d /host/opt/cni/bin -name *multus* -type f | xargs -I _ -n 1 rm -f _; sleep 36000"]
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "25Mi"
+          limits:
+            cpu: "20m"
+            memory: "50Mi"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cni-bin
+          mountPath: /host/opt/cni/bin
+        - name: cni
+          mountPath: /host/etc/cni/net.d
+      volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d

--- a/addons/packages/multus-cni/3.7.1/test/e2e/multuscni_test.go
+++ b/addons/packages/multus-cni/3.7.1/test/e2e/multuscni_test.go
@@ -80,6 +80,14 @@ var _ = Describe("Multus CNI Addon E2E Test", func() {
 		utils.ValidateDaemonsetNotFound("kube-system", "kube-multus-ds-amd64")
 		utils.ValidateDaemonsetNotFound("kube-system", "install-cni-plugins")
 		utils.ValidatePodNotFound("default", "macvlan-worker")
+
+		// Clean up leftover files on nodes.
+		_, err = utils.Kubectl(nil, "apply", "-f", filepath.Join(curDir, "multihomed-testfiles/cleanup.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		utils.ValidateDaemonsetReady("kube-system", "cleanup-conflists")
+		_, err = utils.Kubectl(nil, "delete", "-f", filepath.Join(curDir, "multihomed-testfiles/cleanup.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		utils.ValidateDaemonsetNotFound("kube-system", "cleanup-conflists")
 	})
 
 	It("Check macvlan interfaces status", func() {

--- a/addons/packages/test/pkg/utils/validation.go
+++ b/addons/packages/test/pkg/utils/validation.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/onsi/gomega"
@@ -33,7 +34,7 @@ func ValidateDaemonsetReady(namespace, name string) {
 		if err != nil {
 			return false, err
 		}
-		return desiredNumberScheduled == numberReady, nil
+		return strings.Trim(desiredNumberScheduled, "'") != "0" && desiredNumberScheduled == numberReady, nil
 	}, DaemonsetTimeout, DaemonsetCheckInterval).Should(gomega.Equal(true), fmt.Sprintf("%s/%s daemonset was never ready", namespace, name))
 }
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
After deleting Multus resources, the network conflist file is still stored in the node. So when user tries to create another pod, multus's conflist file is always used because it is named as 00-* automatically, thus creation fails.
This PR adds one daemonset to remove the leftover files like 00-multus.conf and multus binary after test finishes.

Maybe related to https://github.com/k8snetworkplumbingwg/multus-cni/issues/461

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2595 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

- Created vSphere workload cluster and install tce-repo 0.9.1
- Run ````make e2e-test````yaml 
- Run ````tanzu package install <fluent-bit>````yaml  as an example, and the fluent-bit related pods is in running state

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
