### PR TITLE
Add BUILD_VERSION and a way to manually trigger a daily build

### DIFF
--- a/.github/workflows/build-daily.yaml
+++ b/.github/workflows/build-daily.yaml
@@ -1,6 +1,8 @@
 name: Build - Daily Official Build
 
 on:
+  repository_dispatch:
+    types: [manual-daily-build]
   schedule:
     - cron: "0 0 * * *"
 
@@ -59,6 +61,7 @@ jobs:
         env:
           GCP_BUCKET_SA: ${{ secrets.GCP_BUCKET_SA }}
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
+          TCE_CI_BUILD: true
         shell: bash
         run: |
           make upload-daily-build

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ version:
 
 .PHONY: upload-daily-build
 upload-daily-build:
-	./hack/dailybuild/publish-daily-build.sh
+	BUILD_VERSION=$(BUILD_VERSION) ./hack/dailybuild/publish-daily-build.sh
 
 .PHONY: package-release
 package-release:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This allows for people with permission, to trigger a failed daily build manually. In addition, this calls out this is a CI build and the required (missing) variables to trigger a daily build.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA
## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA