### PR TITLE
urllinter: moving urllinter in TCE under hack dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,8 @@ actionlint:
 	actionlint -shellcheck=
 
 urllint:
-	go install github.com/JitenPalaparthi/urllinter@v0.2.0
-	urllinter --path=./ --config=hack/check/.urllintconfig.yaml --summary=true --details=Fail
+	cd ./hack/urllinter && go build -o urllinter main.go
+	hack/urllinter/urllinter --path=./ --config=hack/check/.urllintconfig.yaml --summary=true --details=Fail
 
 imagelint:
 	cd ./hack/imagelinter && go build -o imagelinter main.go

--- a/hack/urllinter/Makefile
+++ b/hack/urllinter/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+.DEFAULT_GOAL:=help
+
+help: ## Display this help message
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+lint: ## Run Go code linting. Requires the $GOLANGCI_LINT env var to be set.
+ifeq ($(origin GOLANGCI_LINT),undefined)
+	@echo "Error! GOLANGCI_LINT env var not set"
+else
+	$(GOLANGCI_LINT) run -v --timeout=5m
+endif
+
+get-deps: ## Get all go dependencies
+	go mod download
+
+test:
+	@echo "N/A: No unit tests for hack/packages"
+
+e2e-test:
+	@echo "N/A: No e2e tests for hack/packages"
+
+build: ## Build the executable
+	go build -o urllinter main.go
+
+run: ## Run the asset program to upload assets and releases. Requires the $BUILD_VERSION env var to be set.
+ifeq ($(origin BUILD_VERSION),undefined)
+	@echo "Error! BUILD_VERSION env var not set"
+else
+endif
+

--- a/hack/urllinter/README.md
+++ b/hack/urllinter/README.md
@@ -1,0 +1,56 @@
+# urllinter
+
+urllinter is used to verify and validate URLs or links.This linter gathers all URLs(based on configuration), check them by calling http requests.
+
+## The problem
+
+Each and every URL or link in this repo must be in working state.It is practically difficult to check each of the URLs manually and ensure they are working.
+
+## Solution
+
+urllinter pasrses all files (path provided in configuration) and stores them.Iteratively it checks whether the URL is working or not.All failure cases are marked as Fail and success cases are marked as Pass.
+
+## Configuration
+
+urllinter supports few configurations.The below is the default configuration file.
+
+```yaml
+---
+includeExts:
+- ".yaml"
+- ".sh"
+- ".yml"
+- ".md"
+excludeLinks:
+- "http://localhost"
+- "https://localhost"
+- "http://127.0.0.1"
+- "https://127.0.0.1"
+- "http://0.0.0.0"
+- "https://0.0.0.0"
+- "https://vault.example.com:8200"
+- "$"
+- "<"
+- ">"
+- "@"
+excludeFiles:
+- "cli/"
+- .git/
+- docs/
+- ".gitignore"
+- ".github/"
+acceptStatusCodes:
+- 200
+- 201
+- 302
+- 401
+- 403
+```
+
+## How to run urllinter
+
+- ```go run main.go --path <any valid path or it takes only current working directory> -- config <provide config path or default path will be taken> --summary=true --details=fail```
+
+- To manually run urllinter, user must download(clone) the source code.
+
+- Navigate to the root directory and run the following make command ```make urllint```

--- a/hack/urllinter/config/urllintconfig.yaml
+++ b/hack/urllinter/config/urllintconfig.yaml
@@ -1,0 +1,37 @@
+---
+includeExts:
+- ".sh"
+- ".md"
+- ".yaml"
+- ".yml"
+excludeLinks:
+- "http://localhost"
+- "https://localhost"
+- "http://127.0.0.1"
+- "https://127.0.0.1"
+- "http://0.0.0.0"
+- "https://0.0.0.0"
+- "https://vault.example.com:8200"
+- "https://harbor-"
+- "https://github.com/vmware-tanzu/"
+- "http://helloworld-go.default.18.204.46.247.xip.io"
+- "https://example.com"
+- "http://zipkin.istio-system.svc.cluster.local"
+- "https://kubernetes.default.svc"
+- "https://api.github.com/repos/vmware-tanzu/tce/"
+- "http://minio:9000"
+- "$"
+- "<"
+- ">"
+- "@"
+excludePaths:
+- ".git/"
+- ".gitignore"
+- ".github/"
+- "../tce/addons/packages/harbor"
+acceptStatusCodes:
+- 200
+- 201
+- 302
+- 401
+- 403

--- a/hack/urllinter/go.mod
+++ b/hack/urllinter/go.mod
@@ -1,0 +1,8 @@
+module github.com/vmware-tanzu/community-edition/hack/urllinter
+
+go 1.17
+
+require (
+	gopkg.in/yaml.v2 v2.4.0
+	mvdan.cc/xurls/v2 v2.3.0
+)

--- a/hack/urllinter/go.sum
+++ b/hack/urllinter/go.sum
@@ -1,0 +1,15 @@
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+mvdan.cc/xurls/v2 v2.3.0 h1:59Olnbt67UKpxF1EwVBopJvkSUBmgtb468E4GVWIZ1I=
+mvdan.cc/xurls/v2 v2.3.0/go.mod h1:AjuTy7gEiUArFMjgBBDU4SMxlfUYsRokpJQgNWOt3e4=

--- a/hack/urllinter/main.go
+++ b/hack/urllinter/main.go
@@ -1,0 +1,66 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	_ "embed"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	linturl "github.com/vmware-tanzu/community-edition/hack/urllinter/pkg/lint"
+)
+
+var (
+	//go:embed config/urllintconfig.yaml
+	data string
+)
+
+func main() {
+	// get the current working directory
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	var pathFlag = flag.String("path", wd, "path to be provided")                                    // default is current working directory
+	var configPathFlag = flag.String("config", "", "path for the configuration file to be provided") // default config is the config.json file that is there in the urllint path
+	var showSumary = flag.Bool("summary", false, "to get summary pass summary=true;to off either dont pass or summary=false")
+	var detailedSummary = flag.String("details", "Fail", "detailed summary can be Fail,Pass")
+	flag.Parse()
+	var llint *linturl.LinkLintConfig
+	if *configPathFlag == "" {
+		llint, err = linturl.NewFromContent([]byte(data))
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		llint, err = linturl.New(*configPathFlag)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	err = llint.Init(*pathFlag)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("The following is the path that lint is working on: ", *pathFlag)
+
+	isFatal := llint.LintAll()
+
+	if *showSumary {
+		llint.ShowSummary()
+		fmt.Println()
+	}
+	switch *detailedSummary {
+	case "Fail", "fail", "FAIL":
+		llint.ShowFailSummary()
+	case "Pass", "pass", "PASS":
+		llint.ShowPassSummary()
+	}
+
+	if isFatal {
+		os.Exit(1)
+	}
+}

--- a/hack/urllinter/pkg/lint/lint.go
+++ b/hack/urllinter/pkg/lint/lint.go
@@ -1,0 +1,221 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
+	xurls "mvdan.cc/xurls/v2"
+)
+
+type LinkLintConfig struct {
+	IncludeExts       []string              `yaml:"includeExts"`
+	ExcludeLinks      []string              `yaml:"excludeLinks"`
+	ExcludePaths      []string              `yaml:"excludePaths"`
+	AcceptStatusCodes []int                 `yaml:"acceptStatusCodes"`
+	LinkMap           map[string][]LinkLint // consists map as the key and file details as values
+}
+
+type LinkLint struct {
+	Path     string
+	Line     string
+	Position Position
+	Message  string
+	Status   string
+}
+type Position struct {
+	Row, Col int
+}
+
+func New(configFile string) (*LinkLintConfig, error) {
+	if configFile == "" {
+		return nil, errors.New("configuration file cannot be empty")
+	}
+	file, err := os.ReadFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+	llc := &LinkLintConfig{}
+	err = yaml.Unmarshal(file, llc)
+	if err != nil {
+		return nil, err
+	}
+	llc.LinkMap = make(map[string][]LinkLint)
+	return llc, nil
+}
+
+func NewFromContent(content []byte) (*LinkLintConfig, error) {
+	llc := &LinkLintConfig{}
+	err := yaml.Unmarshal(content, llc)
+	if err != nil {
+		return nil, err
+	}
+	llc.LinkMap = make(map[string][]LinkLint)
+	return llc, nil
+}
+
+func (llc *LinkLintConfig) Init(dir string) error {
+	err := filepath.Walk(dir,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			for _, exclude := range llc.ExcludePaths {
+				if strings.HasPrefix(path, exclude) {
+					return nil
+				} else if strings.HasPrefix(exclude, "*.") {
+					if filepath.Ext(path) == filepath.Ext(exclude) {
+						return nil
+					}
+				} else if string(exclude[len(exclude)-1]) != "/" { // its a file
+					if path == exclude {
+						return nil
+					}
+				}
+			}
+			ext := filepath.Ext(path)
+			for _, ex := range llc.IncludeExts {
+				if ext == ex {
+					err = llc.ReadFile(path)
+					if err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		})
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (llc *LinkLintConfig) ReadFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	count := 1
+	rxStrict := xurls.Strict()
+	for s.Scan() {
+		skip := false
+		line := strings.Trim(s.Text(), " ")
+		link := rxStrict.FindString(line)
+		col := strings.Index(s.Text(), link)
+		// ignore lines
+		// if the line is commented then skip it
+		// This is for go or programming comments only
+
+		// if len(line) >= 2 && line[:2] == "//" {
+		// 	continue
+		// }
+		// // comments for yaml or yml files. Do not consider that line if line start with a comment
+		// if len(line) > 1 && line[:1] == "#" {
+		// 	continue
+		// }
+		// // comments for yaml or yml files. If there is comment in the line take only uncommented part
+		// index := strings.Index(line, "#")
+		// if index > 0 {
+		// 	line = line[0:index]
+		// }
+		// // This is for go or programming code only as comments in yaml files start with #
+		// // start
+		// if len(line) >= 2 && line[:2] == "/*" {
+		// 	//TODO here
+		// 	skip = true
+		// }
+		// if strings.Contains(line, "*/") {
+		// 	skip = false
+		// }
+		// if skip {
+		// 	continue
+		// }
+
+		if len(link) >= 8 && strings.ToLower(strings.Trim(link, " ")[0:4]) != "http" { // do not consider it as url if it dies not start with http or https
+			continue
+		}
+		for _, l := range llc.ExcludeLinks {
+			if strings.Contains(link, l) {
+				skip = true
+				break
+			}
+		}
+		if link != "" && !skip {
+			llints := llc.LinkMap[link]
+			llc.LinkMap[link] = append(llints, LinkLint{Path: path, Line: link, Position: Position{Row: count, Col: col}, Status: "", Message: ""})
+		}
+		count++
+	}
+	err = s.Err()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (llc *LinkLintConfig) LintAll() bool {
+	isFatal := false
+	count := 0
+	for key := range llc.LinkMap {
+		count++
+		fmt.Println("Currently checking ", count, " url(s) out of ", len(llc.LinkMap))
+		if !IsURL(key) {
+			isFatal = true
+			llc.OnFail("Invalid URL", key)
+			continue
+		}
+		/* #nosec G402 */
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+
+		cli := &http.Client{Transport: tr}
+		ctx := context.Background()
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, key, bytes.NewBuffer([]byte("")))
+		resp, err := cli.Do(req)
+
+		if err != nil {
+			isFatal = true
+			llc.OnFail(err.Error(), key)
+			continue
+		}
+		accepted := false
+		for _, code := range llc.AcceptStatusCodes {
+			if code == resp.StatusCode {
+				llc.OnPass("http Status-code "+strconv.Itoa(resp.StatusCode), key)
+				accepted = true
+				break
+			}
+		}
+		defer resp.Body.Close()
+		if accepted {
+			continue
+		} else {
+			isFatal = true
+			llc.OnFail("http Status-code "+strconv.Itoa(resp.StatusCode), key)
+		}
+	}
+
+	return isFatal
+}
+
+func IsURL(str string) bool {
+	u, err := url.Parse(str)
+	return err == nil && u.Scheme != "" && u.Host != ""
+}

--- a/hack/urllinter/pkg/lint/summary.go
+++ b/hack/urllinter/pkg/lint/summary.go
@@ -1,0 +1,95 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import "fmt"
+
+const (
+	colorReset = "\033[0m" // Reset
+	colorBlue  = "\033[34m"
+	colorRed   = "\033[31m" // Fail
+	passConst  = "Pass"
+	failConst  = "Fail"
+	//	colorPurple  = "\033[35m" // Not Identified
+	colorGreen = "\033[32m"
+
+//	colorMagenta = "\033[35m" // Pull Failed
+)
+
+func (llc *LinkLintConfig) ShowSummary() {
+	pass := 0
+	fail := 0
+	for _, lls := range llc.LinkMap {
+		if len(lls) > 0 {
+			ll := lls[0]
+			switch ll.Status {
+			case string(passConst):
+				pass += len(lls)
+			case string(failConst):
+				fail += len(lls)
+			}
+		}
+	}
+	fmt.Println("-------------------------------", string(colorGreen), "Summary", string(colorReset), "---------------------------------------------")
+	fmt.Println("Total  Links                 :", len(llc.LinkMap))
+	fmt.Println("Total  Occurrences           :", pass+fail)
+	fmt.Println("Total", string(colorBlue), string(passConst), string(colorReset), "                :", pass)
+	fmt.Println("Total", string(colorRed), string(failConst), string(colorReset), "                :", fail)
+	fmt.Println("[Note:All totals for Pass|Fail are based on number of files]")
+	fmt.Println("---------------------------------------------------------------------------------------")
+}
+
+func (llc *LinkLintConfig) ShowFailSummary() {
+	fmt.Println("-------------------------------", string(colorGreen), "Fail Summary", string(colorReset), "---------------------------------------------")
+	fail := Summary(llc, failConst)
+	fmt.Println("Total", string(colorRed), string(failConst), string(colorReset), "          :", fail)
+	fmt.Println("---------------------------------------------------------------------------------------")
+}
+
+func (llc *LinkLintConfig) ShowPassSummary() {
+	fmt.Println("-------------------------------", string(colorGreen), "Pass Summary", string(colorReset), "---------------------------------------------")
+	pass := Summary(llc, passConst)
+	fmt.Println("Total", string(colorBlue), string(passConst), string(colorReset), "          :", pass)
+	fmt.Println("---------------------------------------------------------------------------------------")
+}
+
+func Summary(llc *LinkLintConfig, statusConst string) int {
+	count := 0
+	for _, lls := range llc.LinkMap {
+		if len(lls) > 0 {
+			ll := lls[0]
+			if ll.Status == statusConst {
+				count += len(lls)
+				fmt.Println("File Path:", ll.Path)
+				fmt.Println("URL:", ll.Line)
+				fmt.Println("Url Position:", ll.Position.Row, ":", ll.Position.Col)
+				fmt.Println("Message:", ll.Message)
+				fmt.Println("")
+			}
+		}
+	}
+	return count
+}
+
+func (llc *LinkLintConfig) OnPass(message, link string) {
+	URLDetails(llc, colorBlue, link, message, passConst)
+}
+
+func (llc *LinkLintConfig) OnFail(message, link string) {
+	URLDetails(llc, colorRed, link, message, failConst)
+}
+
+func URLDetails(llc *LinkLintConfig, color, link, message, statusConst string) {
+	fmt.Println("Status:", color, statusConst, string(colorReset))
+	fmt.Println("URL:    ", link)
+	fmt.Println("Error:  ", message)
+	fmt.Println("Total ", len(llc.LinkMap[link]), " file(s) contain(s) this URL")
+	for i, ll := range llc.LinkMap[link] {
+		fmt.Println("File Path:", ll.Path)
+		fmt.Println("URL Position:", ll.Position.Row, ":", ll.Position.Col)
+		llc.LinkMap[link][i].Message = message
+		llc.LinkMap[link][i].Status = statusConst
+	}
+	fmt.Println()
+}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR is moving urllinter from [here](https://github.com/JitenPalaparthi/urllinter) to `hack` dir.

Files which are changed in this PR
- `Makefile`: Previously make target for urllinter was installing the urllinter from other repo now we are running it from `hack` dir only.
- `hack/urllinter/main.go`:  The import location for `linturl` is changed in this file.
- `hack/urllinter/go.mod`: The name of module is changed.
- To resolve all the linters errors like unused variables, duplication of code, extra spaces and other errors showed by `golangci-lint` the code is changed a bit.
## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
moving urllinter in TCE under hack dir
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2948 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Run `make urllint` and it is running fine. 
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
