### PR TITLE
Add manual cleanup for multus-cni in whereabouts e2e

### DIFF
--- a/addons/packages/whereabouts/0.5.0/test/e2e/whereabouts_test.go
+++ b/addons/packages/whereabouts/0.5.0/test/e2e/whereabouts_test.go
@@ -105,6 +105,15 @@ var _ = Describe("Whereabouts Addon E2E Test", func() {
 		utils.ValidateDaemonsetNotFound("kube-system", "install-cni-plugins")
 		utils.ValidatePodNotFound("default", "multi-nic-pod")
 
+		// Some configuration files are left over on nodes after removing multus-cni package, we need to clean them up manually.
+		// More details are in https://github.com/vmware-tanzu/community-edition/tree/main/addons/packages/multus-cni/3.7.1#uninstallation-of-multus-cni-package
+		_, err = utils.Kubectl(nil, "apply", "-f", filepath.Join(multusCNIDir, "multihomed-testfiles/cleanup.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		utils.ValidateDaemonsetReady("kube-system", "cleanup-conflists")
+		_, err = utils.Kubectl(nil, "delete", "-f", filepath.Join(multusCNIDir, "multihomed-testfiles/cleanup.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		utils.ValidateDaemonsetNotFound("kube-system", "cleanup-conflists")
+
 	})
 
 	It("Check Pod secondary interface", func() {


### PR DESCRIPTION
## What this PR does / why we need it
There's a known issue for multus-cni that some configuration files are left over
after removing multus-cni package, so need to clean them up manually.
More discussion in https://github.com/vmware-tanzu/community-edition/pull/2728


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add manual cleanup for multus-cni in whereabouts e2e
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
