### PR TITLE
Create OpenAPIV3 schema for metrics-server package and generate package with the schema

### DIFF
--- a/addons/packages/metrics-server/0.5.1/README.md
+++ b/addons/packages/metrics-server/0.5.1/README.md
@@ -14,21 +14,19 @@ The following configuration values can be set to customize the Metrics Server in
 
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
-| `namespace` | Optional | The namespace in which to deploy resources. Default: kube-system |
+| `namespace` | Optional | The namespace in which metrics-server is deployed. Default: kube-system |
 
 ### Metrics Server Configuration
 
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
-| `metricsServer.createNamespace` | Optional | A boolean that indicates whether to create the namespace specified. Default value is `true`. |
-| `metricsServer.namespace` | Optional | The namespace value used by older templates, will overwrite will top level namespace of present, keep for backward compatibility. Default value is `null`. |
-| `metricsServer.config.securePort` | Optional | The port that Metrics Server binds to. Default: `4443`. |
-| `metricsServer.config.updateStrategy` | Optional | The update strategy of the deployment. Default: `RollingUpdate` |
-| `metricsServer.config.probe.failureThreshold` | Optional | Probe failure threshold. Default: `3`. |
-| `metricsServer.config.probe.periodSeconds` | Optional | Probe period. Default: `10` . |
-| `metricsServer.config.nodeSelector.key` | Optional | Select which node should Metrics-server pod runs on. Default: `null`. |
-| `metricsServer.config.nodeSelector.value` | Optional | Select which node should Metrics-server pod runs on. Default: `null`. |
-| `metricsServer.config.apiServiceInsecureTLS`| Optional | Insecure connection between API service. Default: `True`. |
+| `metricsServer.createNamespace` | Optional | Whether to create namespace specified for metrics-server. Default value is `true`. |
+| `metricsServer.namespace` | Optional | The namespace value used by older templates, will be overwriten if top level namespace is present, kept for backward compatibility. Default value is `null`. |
+| `metricsServer.config.securePort` | Optional | TThe HTTPS secure port used by metrics-server. Default: `4443`. |
+| `metricsServer.config.updateStrategy` | Optional | TThe update strategy of the metrics-server deployment. Default: `RollingUpdate` |
+| `metricsServer.config.probe.failureThreshold` | Optional | Probe failureThreshold of metrics-server deployment. Default: `3`. |
+| `metricsServer.config.probe.periodSeconds` | Optional | Probe period of metrics-server deployment. Default: `10` . |
+| `metricsServer.config.apiServiceInsecureTLS`| Optional | Whether to enable insecure TLS for metrics-server api service. Default: `True`. |
 
 ## Usage Example
 

--- a/addons/packages/metrics-server/0.5.1/bundle/config/schema.yaml
+++ b/addons/packages/metrics-server/0.5.1/bundle/config/schema.yaml
@@ -1,0 +1,29 @@
+#! schema.yaml
+
+#@data/values-schema
+#@schema/desc "OpenAPIv3 Schema for metrics-server"
+---
+#@schema/desc "The namespace in which metrics-server is deployed"
+namespace: kube-system
+metricsServer:
+  #@schema/desc "The namespace value used by older templates, will be overwriten if top level namespace is present, kept for backward compatibility"
+  #@schema/nullable
+  namespace: kube-system
+  #@schema/desc "Whether to create namespace specified for metrics-server"
+  createNamespace: true
+  config:
+    #@schema/desc "The HTTPS secure port used by metrics-server"
+    securePort: 4443
+    #@schema/desc "The update strategy of the metrics-server deployment"
+    updateStrategy: RollingUpdate
+    #@schema/desc "Arguments passed into metrics-server container"
+    args: [""]
+    probe:
+      #@schema/desc "Probe failureThreshold of metrics-server deployment"
+      failureThreshold: 3
+      #@schema/desc "Probe period of metrics-server deployment"
+      periodSeconds: 10
+    #@schema/desc "Whether to enable insecure TLS for metrics-server api service"
+    apiServiceInsecureTLS: true
+    #@schema/desc "Metrics-server deployment tolerations"
+    tolerations: [""]

--- a/addons/packages/metrics-server/0.5.1/package.yaml
+++ b/addons/packages/metrics-server/0.5.1/package.yaml
@@ -3,23 +3,88 @@ kind: Package
 metadata:
   name: metrics-server.community.tanzu.vmware.com.0.5.1
 spec:
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      description: OpenAPIv3 Schema for metrics-server
+      properties:
+        namespace:
+          type: string
+          default: kube-system
+          description: The namespace in which metrics-server is deployed
+        metricsServer:
+          type: object
+          additionalProperties: false
+          properties:
+            namespace:
+              type: string
+              default: null
+              nullable: true
+              description: The namespace value used by older templates, will be overwriten if top level namespace is present, kept for backward compatibility
+            createNamespace:
+              type: boolean
+              default: true
+              description: Whether to create namespace specified for metrics-server
+            config:
+              type: object
+              additionalProperties: false
+              properties:
+                securePort:
+                  type: integer
+                  default: 4443
+                  description: The HTTPS secure port used by metrics-server
+                updateStrategy:
+                  type: string
+                  default: RollingUpdate
+                  description: The update strategy of the metrics-server deployment
+                args:
+                  type: array
+                  description: Arguments passed into metrics-server container
+                  items:
+                    type: string
+                    default: ""
+                  default: []
+                probe:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    failureThreshold:
+                      type: integer
+                      default: 3
+                      description: Probe failureThreshold of metrics-server deployment
+                    periodSeconds:
+                      type: integer
+                      default: 10
+                      description: Probe period of metrics-server deployment
+                apiServiceInsecureTLS:
+                  type: boolean
+                  default: true
+                  description: Whether to enable insecure TLS for metrics-server api service
+                tolerations:
+                  type: array
+                  description: Metrics-server deployment tolerations
+                  items:
+                    type: string
+                    default: ""
+                  default: []
   refName: metrics-server.community.tanzu.vmware.com
   version: 0.5.1
-  releaseNotes: "metrics-server 0.5.1 https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.5.1"
+  releaseNotes: metrics-server 0.5.1 https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.5.1
   licenses:
-    - "Apache 2.0"
+  - Apache 2.0
   template:
     spec:
       fetch:
-        - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/metrics-server@sha256:393e7aa6c89f55229e9559f82165c3a51fe408c4c7dd4b72409844513b8caf83
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/metrics-server@sha256:32578c15a2e03423d12aacc39ff94fa6795e6dfe70cb43b13a1940d77f3cb0b8
       template:
-        - ytt:
-            paths:
-              - config/
-        - kbld:
-            paths:
-              - "-"
-              - .imgpkg/images.yml
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
       deploy:
-        - kapp: {}
+      - kapp: {}


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Create OpenAPIV3 schema for metrics-server package and generate package with the schema

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Create OpenAPIV3 schema for metrics-server package and generate package with the schema
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2803 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested with ytt commands

$ make generate-openapischema-package PACKAGE=metrics-server VERSION=0.5.1

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
YTT version needs to be bumped to latest (0.38.0)
