### PR TITLE
Fix custom tls cert in Pinniped 0.12.0

### DIFF
--- a/addons/packages/pinniped/0.12.0/bundle/config/overlay/pinniped-supervisor-cm.yaml
+++ b/addons/packages/pinniped/0.12.0/bundle/config/overlay/pinniped-supervisor-cm.yaml
@@ -1,0 +1,18 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:data", "data")
+#@ load("/libs/constants.lib.yaml", "pinniped_tls_secret_name")
+
+#@ def edit_secret():
+#@overlay/match when=1
+names:
+  #@overlay/match when=1
+  defaultTLSCertificateSecret: #@ pinniped_tls_secret_name()
+#@ end
+
+#@ supervisor_metadata = overlay.subset({"metadata": {"name": "pinniped-supervisor-static-config"}})
+#@overlay/match by=overlay.and_op(overlay.subset({"kind": "ConfigMap"}), supervisor_metadata)
+---
+data:
+  #@overlay/replace via=lambda original,_: yaml.encode(overlay.apply(yaml.decode(original), edit_secret()))
+  pinniped.yaml:


### PR DESCRIPTION
## What this PR does / why we need it
This PR fixes an issue where the `defaultTLSCertificateSecret` was hardcoded in the Pinniped 0.12.0 package.  Now if a user specifies a custom secret, it will get picked up by the package.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
This PR fixes an issue where the `defaultTLSCertificateSecret` was hardcoded in the Pinniped 0.12.0 package.  Now if a user specifies a custom secret, it will get picked up by the package.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NONE

## Describe testing done for PR
- Created a Pinniped custom tls secret on a TKG 1.5.0 cluster and updated the Pinniped addon secret with the tls secret name per these instructions: https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.4/vmware-tanzu-kubernetes-grid-14/GUID-cluster-lifecycle-custom-pinniped-certificates.html
- Saw via the supervisor ConfigMap that the `defaultTLSCertificateSecret` was still set to the default rather than the custom one
- Updated the package with the changes in this PR, saw via the supervisor ConfigMap that the `defaultTLSCertificateSecret` was set to custom tls secret specified in the Pinniped addon secret.

## Special notes for your reviewer
Feel free to contact me for additional information.
