### PR TITLE
Use regex for copyright header year match

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,7 @@ linters-settings:
       const:
        - LICENSE: Apache-2.0
       regexp:
-       YEAR: 20\d*-*\d*
+       YEAR: (?:20\d{2} |20\d{2}-2\d{3})
     template: |-
       Copyright {{ YEAR }} VMware Tanzu Community Edition contributors. All Rights Reserved.
       SPDX-License-Identifier: {{ LICENSE }}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Our policy is to have the copyright header reflect the year the file was
created, or a range from when it was created to the most recent
modification. With the existing header linting config in place, it would
expect that range to be updated even if there were no code changes,
which is not what we want to enforce.

This changes the linting config to use a regex that will accept either a
range or an individual year. This also matches what has been done in the
tanzu-framework repo.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```