### PR TITLE
packages/external-dns: Updates RBAC for k8s v1.22

### DIFF
--- a/addons/packages/external-dns/0.10.0/bundle/config/overlays/overlay-clusterrole.yaml
+++ b/addons/packages/external-dns/0.10.0/bundle/config/overlays/overlay-clusterrole.yaml
@@ -7,3 +7,11 @@ rules:
 - apiGroups: ["projectcontour.io"]
   resources: ["httpproxies"]
   verbs: ["get", "watch", "list"]
+#@overlay/append
+- apiGroups: ['networking.k8s.io']
+  resources: ['ingresses']
+  verbs: ['get', 'watch', 'list']
+#@overlay/append
+- apiGroups: ['']
+  resources: ['nodes']
+  verbs: ['watch']


### PR DESCRIPTION
If applied, this commit will allow service account to observe v1 ingresses and
resolve issue causing external-dns pod to crash in k8s v1.22.

Fixes #2741

Signed-off-by: Dodd Pfeffer <dpfeffer@vmware.com>

Superseeds PR #2759 