### PR TITLE
document workaround for known issue in external-dns

### DIFF
--- a/addons/packages/external-dns/0.10.0/README.md
+++ b/addons/packages/external-dns/0.10.0/README.md
@@ -246,6 +246,45 @@ stringData:
 
 ### 5. Install the ExternalDNS package
 
+*Known Issue*: The ingress resource has changed API groups in k8s 1.22. This
+causes an issue with the current package RBAC settings for external-dns.
+
+To workaround this issue there are two options:
+
+* If you do not require the `--source=ingress`, remove it from the
+  data-values.yaml before installing external-dns.
+* Otherwise, apply the following resources to your cluster before installing
+  the package. Ensure that the subjects namespace for the ClusterRoleBinding is
+  the same namespace you will be installing external-dns into.
+
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns-workaround
+rules:
+- apiGroups: ['networking.k8s.io']
+  resources: ['ingresses']
+  verbs: ['get', 'watch', 'list']
+- apiGroups: ['']
+  resources: ['nodes']
+  verbs: ['watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer-workaround
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns-workaround
+subjects:
+  - kind: ServiceAccount
+    name: external-dns
+    namespace: external-dns
+```
+
 Configure the ExternalDNS package to use your new AWS hosted zone. Start by
 editing the configuration file. You may use the sample configuration files given
 in this document as a template.


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
There is a known issue with the external-dns ingress source and k8s 1.22. This PR adds documentation to work around the issue for those who have yet to consume the latest released packages.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to: #2741 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Followed the steps to use our fix and saw external-dns no longer had RBAC issues.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
