### PR TITLE
Fix Pinniped supervisor cm overlay

### DIFF
--- a/addons/packages/pinniped/0.12.0/bundle/config/overlay/pinniped-supervisor-cm.yaml
+++ b/addons/packages/pinniped/0.12.0/bundle/config/overlay/pinniped-supervisor-cm.yaml
@@ -11,8 +11,10 @@ names:
 #@ end
 
 #@ supervisor_metadata = overlay.subset({"metadata": {"name": "pinniped-supervisor-static-config"}})
-#@overlay/match by=overlay.and_op(overlay.subset({"kind": "ConfigMap"}), supervisor_metadata)
+#@overlay/match when=1, by=overlay.and_op(overlay.subset({"kind": "ConfigMap"}), supervisor_metadata)
 ---
+#@overlay/match when=1
 data:
   #@overlay/replace via=lambda original,_: yaml.encode(overlay.apply(yaml.decode(original), edit_secret()))
+  #@overlay/match when=1
   pinniped.yaml:


### PR DESCRIPTION
## What this PR does / why we need it
Added logic to prevent templating failure when `pinniped-supervisor-static-config` ConfigMap is not found, like on a workload cluster.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: NONE

## Describe testing done for PR
Created vSphere workload cluster with updated Pinniped package to verify change.

## Special notes for your reviewer

