### PR TITLE
unmanaged-cluster: remove usage of grey log text

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/log/log.go
+++ b/cli/cmd/plugin/unmanaged-cluster/log/log.go
@@ -16,11 +16,10 @@ import (
 )
 
 const (
-	ColorRed         = "\033[31m"
-	ColorBlue        = "\033[34m"
-	ColorLightGreen  = "\033[32m"
-	ColorBrightBlack = "\033[90m"
-	colorReset       = "\033[0m"
+	ColorNone       = "\033[0m"
+	ColorRed        = "\033[31m"
+	ColorBlue       = "\033[34m"
+	ColorLightGreen = "\033[32m"
 
 	// The following are a set of emoji codes that can be used
 	// with the Event and Eventf logging methods in this package.
@@ -397,7 +396,7 @@ func processStyle(l *CMDLogger, message string) string {
 	// apply color value to entire message
 	if l.color != "" {
 		message = l.color + message
-		message += colorReset
+		message += ColorNone
 	}
 
 	return message

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -144,8 +144,8 @@ func (t *TanzuUnmanaged) Deploy(scConfig *config.UnmanagedClusterConfig) error {
 	if err != nil {
 		return err
 	}
-	log.Style(outputIndent, logger.ColorBrightBlack).Infof("Rendered Config: %s\n", configFp)
-	log.Style(outputIndent, logger.ColorBrightBlack).Infof("Bootstrap Logs: %s\n", bootstrapLogsFp)
+	log.Style(outputIndent, logger.ColorNone).Infof("Rendered Config: %s\n", configFp)
+	log.Style(outputIndent, logger.ColorNone).Infof("Bootstrap Logs: %s\n", bootstrapLogsFp)
 
 	log.Event(logger.WrenchEmoji, "Processing Tanzu Kubernetes Release\n")
 	t.bom, err = parseTKRBom(bomFileName)
@@ -156,16 +156,16 @@ func (t *TanzuUnmanaged) Deploy(scConfig *config.UnmanagedClusterConfig) error {
 	// 3. Resolve all required images
 	// base image
 	log.Event(logger.PictureEmoji, "Selected base image\n")
-	log.Style(outputIndent, logger.ColorBrightBlack).Infof("%s\n", t.bom.GetTKRNodeImage())
+	log.Style(outputIndent, logger.ColorNone).Infof("%s\n", t.bom.GetTKRNodeImage())
 	scConfig.NodeImage = t.bom.GetTKRNodeImage()
 
 	// core package repository
 	log.Event(logger.PackageEmoji, "Selected core package repository\n")
-	log.Style(outputIndent, logger.ColorBrightBlack).Infof("%s\n", t.bom.GetTKRCoreRepoBundlePath())
+	log.Style(outputIndent, logger.ColorNone).Infof("%s\n", t.bom.GetTKRCoreRepoBundlePath())
 	// core user package repositories
 	log.Event(logger.PackageEmoji, "Selected additional package repositories\n")
 	for _, additionalRepo := range t.bom.GetAdditionalRepoBundlesPaths() {
-		log.Style(outputIndent, logger.ColorBrightBlack).Infof("%s\n", additionalRepo)
+		log.Style(outputIndent, logger.ColorNone).Infof("%s\n", additionalRepo)
 	}
 	// kapp-controller
 	err = resolveKappBundle(t)
@@ -173,7 +173,7 @@ func (t *TanzuUnmanaged) Deploy(scConfig *config.UnmanagedClusterConfig) error {
 		return fmt.Errorf("failed resolving kapp-controller bundle. Error: %s", err.Error())
 	}
 	log.Event(logger.PackageEmoji, "Selected kapp-controller image bundle\n")
-	log.Style(outputIndent, logger.ColorBrightBlack).Infof("%s\n", t.kappControllerBundle.GetRegistryURL())
+	log.Style(outputIndent, logger.ColorNone).Infof("%s\n", t.kappControllerBundle.GetRegistryURL())
 
 	// 4. Create the cluster
 	log.Eventf(logger.RocketEmoji, "Creating cluster %s\n", scConfig.ClusterName)
@@ -183,8 +183,8 @@ func (t *TanzuUnmanaged) Deploy(scConfig *config.UnmanagedClusterConfig) error {
 	}
 
 	kcBytes := createdCluster.Kubeconfig
-	log.Style(outputIndent, logger.ColorBrightBlack).Info("To troubleshoot, use:\n")
-	log.Style(outputIndent, logger.ColorBrightBlack).Infof("kubectl ${COMMAND} --kubeconfig %s\n", scConfig.KubeconfigPath)
+	log.Style(outputIndent, logger.ColorNone).Info("To troubleshoot, use:\n")
+	log.Style(outputIndent, logger.ColorNone).Infof("kubectl ${COMMAND} --kubeconfig %s\n", scConfig.KubeconfigPath)
 
 	// 5. Install kapp-controller
 	kc, err := kapp.New(kcBytes)
@@ -220,7 +220,7 @@ func (t *TanzuUnmanaged) Deploy(scConfig *config.UnmanagedClusterConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to resolve a CNI package. Error: %s", err.Error())
 	}
-	log.Style(outputIndent, logger.ColorBrightBlack).Infof("%s:%s\n", t.selectedCNIPkg.fqPkgName, t.selectedCNIPkg.pkgVersion)
+	log.Style(outputIndent, logger.ColorNone).Infof("%s:%s\n", t.selectedCNIPkg.fqPkgName, t.selectedCNIPkg.pkgVersion)
 	err = installCNI(pkgClient, t)
 	if err != nil {
 		return fmt.Errorf("failed to install the CNI package. Error: %s", err.Error())
@@ -237,11 +237,11 @@ func (t *TanzuUnmanaged) Deploy(scConfig *config.UnmanagedClusterConfig) error {
 	log.Event(logger.GreenCheckEmoji, "Cluster created\n")
 	log.Eventf(logger.ControllerEmoji, "kubectl context set to %s\n\n", scConfig.ClusterName)
 	// provide user example commands to run
-	log.Style(0, logger.ColorBrightBlack).Infof("View available packages:\n")
+	log.Style(0, logger.ColorNone).Infof("View available packages:\n")
 	log.Style(outputIndent, logger.ColorLightGreen).Infof("tanzu package available list\n")
-	log.Style(0, logger.ColorBrightBlack).Infof("View running pods:\n")
+	log.Style(0, logger.ColorNone).Infof("View running pods:\n")
 	log.Style(outputIndent, logger.ColorLightGreen).Infof("kubectl get po -A\n")
-	log.Style(0, logger.ColorBrightBlack).Infof("Delete this cluster:\n")
+	log.Style(0, logger.ColorNone).Infof("Delete this cluster:\n")
 	log.Style(outputIndent, logger.ColorLightGreen).Infof("tanzu unmanaged delete %s\n", scConfig.ClusterName)
 	return nil
 }
@@ -443,7 +443,7 @@ func createClusterDirectory(clusterName string) (string, error) {
 }
 
 func getTkrBom(registry string) (string, error) {
-	log.Style(outputIndent, logger.ColorBrightBlack).Infof("%s\n", registry)
+	log.Style(outputIndent, logger.ColorNone).Infof("%s\n", registry)
 	expectedBomName := buildFilesystemSafeBomName(registry)
 
 	bomPath, err := getUnmanagedBomPath()
@@ -467,7 +467,7 @@ func getTkrBom(registry string) (string, error) {
 	// if the expected bom is already in the config directory, don't download it again. return early
 	for _, file := range items {
 		if file.Name() == expectedBomName {
-			log.Style(outputIndent, logger.ColorBrightBlack).Infof("TKR exists at %s\n", filepath.Join(bomPath, file.Name()))
+			log.Style(outputIndent, logger.ColorNone).Infof("TKR exists at %s\n", filepath.Join(bomPath, file.Name()))
 			return file.Name(), nil
 		}
 	}
@@ -519,7 +519,7 @@ func blockForBomImage(b tkr.TkrImageReader, bomPath, expectedBomName string) err
 	// start a go routine to animate the downloading logs while the imgpkg libraries get the bom image
 	ctx, cancel := context.WithCancel(context.Background())
 	go func(ctx context.Context) {
-		log.Style(outputIndent, logger.ColorBrightBlack).AnimateProgressWithOptions(
+		log.Style(outputIndent, logger.ColorNone).AnimateProgressWithOptions(
 			logger.AnimatorWithContext(ctx),
 			logger.AnimatorWithMaxLen(maxProgressLength),
 			logger.AnimatorWithMessagef("Downloading to: %s", f),
@@ -535,7 +535,7 @@ func blockForBomImage(b tkr.TkrImageReader, bomPath, expectedBomName string) err
 
 	// Once downloading is done, cancel the logging animation go routine and log completion
 	cancel()
-	log.Style(outputIndent, logger.ColorBrightBlack).ReplaceLinef("Downloaded to: %s", f)
+	log.Style(outputIndent, logger.ColorNone).ReplaceLinef("Downloaded to: %s", f)
 
 	return nil
 }
@@ -592,7 +592,7 @@ func blockForPullingBaseImage(cm cluster.ClusterManager, scConfig *config.Unmana
 	// start a go routine to animate the downloading logs while the docker exec gets the image
 	ctx, cancel := context.WithCancel(context.Background())
 	go func(ctx context.Context) {
-		log.Style(outputIndent, logger.ColorBrightBlack).AnimateProgressWithOptions(
+		log.Style(outputIndent, logger.ColorNone).AnimateProgressWithOptions(
 			logger.AnimatorWithContext(ctx),
 			logger.AnimatorWithMaxLen(maxProgressLength),
 			logger.AnimatorWithMessagef("Pulling base image"),
@@ -608,7 +608,7 @@ func blockForPullingBaseImage(cm cluster.ClusterManager, scConfig *config.Unmana
 
 	// once we're done, cancel the go routine animation and log final message
 	cancel()
-	log.Style(outputIndent, logger.ColorBrightBlack).ReplaceLinef("Base image downloaded")
+	log.Style(outputIndent, logger.ColorNone).ReplaceLinef("Base image downloaded")
 
 	return nil
 }
@@ -617,7 +617,7 @@ func blockForClusterCreate(cm cluster.ClusterManager, scConfig *config.Unmanaged
 	// start a go routine to animate the downloading logs while the docker exec gets the image
 	ctx, cancel := context.WithCancel(context.Background())
 	go func(ctx context.Context) {
-		log.Style(outputIndent, logger.ColorBrightBlack).AnimateProgressWithOptions(
+		log.Style(outputIndent, logger.ColorNone).AnimateProgressWithOptions(
 			logger.AnimatorWithContext(ctx),
 			logger.AnimatorWithMaxLen(maxProgressLength),
 			logger.AnimatorWithMessagef("Creating cluster"),
@@ -633,7 +633,7 @@ func blockForClusterCreate(cm cluster.ClusterManager, scConfig *config.Unmanaged
 
 	// Once done, cancel the go routine animations and log final message
 	cancel()
-	log.Style(outputIndent, logger.ColorBrightBlack).ReplaceLinef("Cluster created")
+	log.Style(outputIndent, logger.ColorNone).ReplaceLinef("Cluster created")
 
 	return kc, nil
 }
@@ -667,7 +667,7 @@ func blockForKappStatus(kappDeployment *v1.Deployment, kc kapp.KappManager) {
 	ctx, cancel := context.WithCancel(context.Background())
 	status := make(chan string, 1)
 	go func(ctx context.Context) {
-		log.Style(outputIndent, logger.ColorBrightBlack).AnimateProgressWithOptions(
+		log.Style(outputIndent, logger.ColorNone).AnimateProgressWithOptions(
 			logger.AnimatorWithContext(ctx),
 			logger.AnimatorWithMaxLen(maxProgressLength),
 			logger.AnimatorWithMessagef("kapp-controller status: %s"),
@@ -682,7 +682,7 @@ func blockForKappStatus(kappDeployment *v1.Deployment, kc kapp.KappManager) {
 		status <- kappState
 		if kappState == "Running" {
 			cancel()
-			log.Style(outputIndent, logger.ColorBrightBlack).ReplaceLinef("kapp-controller status: %s", kappState)
+			log.Style(outputIndent, logger.ColorNone).ReplaceLinef("kapp-controller status: %s", kappState)
 			break
 		}
 		time.Sleep(1 * time.Second)
@@ -702,7 +702,7 @@ func blockForRepoStatus(repo *v1alpha1.PackageRepository, pkgClient packages.Pac
 	ctx, cancel := context.WithCancel(context.Background())
 	status := make(chan string, 1)
 	go func(ctx context.Context) {
-		log.Style(outputIndent, logger.ColorBrightBlack).AnimateProgressWithOptions(
+		log.Style(outputIndent, logger.ColorNone).AnimateProgressWithOptions(
 			logger.AnimatorWithContext(ctx),
 			logger.AnimatorWithMaxLen(maxProgressLength),
 			logger.AnimatorWithMessagef("Core package repo status: %s"),
@@ -722,7 +722,7 @@ func blockForRepoStatus(repo *v1alpha1.PackageRepository, pkgClient packages.Pac
 		}
 		if pkgStatus == "Reconcile succeeded" {
 			cancel()
-			log.Style(outputIndent, logger.ColorBrightBlack).ReplaceLinef("Core package repo status: %s", pkgStatus)
+			log.Style(outputIndent, logger.ColorNone).ReplaceLinef("Core package repo status: %s", pkgStatus)
 			break
 		}
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
This commit removes the usage of grey log text in favor of no text
stylization in bootstrapping.

This approach introduces ColorNone rather than trying to stylize under
a white value. This is because many modern terminal emulators let you
overwrite the meaning of white. This will result in the terminal's
default "no style". ColorBrightBlack has been removed since it is no
longer used; it can be re-introduces should it be used in the future.

This usage of they grey text was intended to focus the eye on
Event/Eventf commands. However, based on terminal stylization, we found
that this darker text had a high-variance in visibility. Atop that, we
should do more research in the realm of accessibility before dimming out
such text as a default value.
