### PR TITLE
Set unmanaged-cluster aliases to agreed list

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/main.go
+++ b/cli/cmd/plugin/unmanaged-cluster/main.go
@@ -16,7 +16,7 @@ var description = `Deploy and manage single-node, static, Tanzu clusters.`
 
 var descriptor = cliv1alpha1.PluginDescriptor{
 	Name:        "unmanaged-cluster",
-	Aliases:     []string{"um", "un", "unmanaged"},
+	Aliases:     []string{"um", "uc", "unmanaged"},
 	Description: description,
 	Group:       cliv1alpha1.RunCmdGroup,
 }


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Based on [conversations](https://github.com/vmware-tanzu/community-edition/pull/2376#discussion_r781311340), we've decided to set the unmanaged-cluster
aliases to:

- um
- uc
- unmanaged

This is a minor fix to update that list of aliases that are provided on
plugin registration.