### PR TITLE
Configure environment for daily build correctly

### DIFF
--- a/.github/workflows/build-daily.yaml
+++ b/.github/workflows/build-daily.yaml
@@ -35,9 +35,13 @@ jobs:
           go-version: "1.16"
         id: go
       - name: Config git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         shell: bash
         run: |
           git config --global init.defaultBranch main
+          git config --global pull.rebase true
+          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
       - name: Check out code
         uses: actions/checkout@v1
       - name: Restore Go Cache


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
The daily build is currently failing because the environment is not configured for the correct token to publish the rss feed. This addresses the environment updates. This is identical to how the environment is configured for the release pipelines (example: https://github.com/vmware-tanzu/community-edition/blob/main/.github/workflows/release-nonga.yaml#L36-L42).

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
None
