### PR TITLE
Updates deprecation notice in `standalone-cluster`

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/create.go
+++ b/cli/cmd/plugin/standalone-cluster/create.go
@@ -49,12 +49,14 @@ func init() {
 }
 
 func create(cmd *cobra.Command, args []string) error {
-	fmt.Print("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-	fmt.Print("Warning - Standalone clusters will be deprecated in a future release of Tanzu Community Edition\n")
-	fmt.Print("                                   Use at your own Risk\n")
-	fmt.Print("           Checkout the proposal for the standalone cluster replacement:\n")
-	fmt.Print("           https://github.com/vmware-tanzu/community-edition/issues/2266\n")
-	fmt.Print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n\n")
+	fmt.Print("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+	fmt.Print("     Warning - Standalone clusters will be deprecated in a future release of Tanzu Community Edition\n")
+	fmt.Print("                                        Use at your own Risk\n")
+	fmt.Print("\n")
+	fmt.Print(" For a minimal, single node cluster, you can use 'unmanaged-cluster', which replaces 'standalone-clusters'\n")
+	fmt.Print("                                   tanzu unmanaged-cluster create\n")
+	fmt.Print("                                   tanzu unmanaged-cluster delete\n")
+	fmt.Print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n\n")
 
 	var clusterName string
 

--- a/cli/cmd/plugin/standalone-cluster/delete.go
+++ b/cli/cmd/plugin/standalone-cluster/delete.go
@@ -43,12 +43,14 @@ func init() {
 }
 
 func teardown(cmd *cobra.Command, args []string) error {
-	fmt.Print("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-	fmt.Print("Warning - Standalone clusters will be deprecated in a future release of Tanzu Community Edition\n")
-	fmt.Print("                                   Use at your own Risk\n")
-	fmt.Print("           Checkout the proposal for the standalone cluster replacement:\n")
-	fmt.Print("           https://github.com/vmware-tanzu/community-edition/issues/2266\n")
-	fmt.Print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n\n")
+	fmt.Print("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+	fmt.Print("     Warning - Standalone clusters will be deprecated in a future release of Tanzu Community Edition\n")
+	fmt.Print("                                        Use at your own Risk\n")
+	fmt.Print("\n")
+	fmt.Print(" For a minimal, single node cluster, you can use 'unmanaged-cluster', which replaces 'standalone-clusters'\n")
+	fmt.Print("                                   tanzu unmanaged-cluster create\n")
+	fmt.Print("                                   tanzu unmanaged-cluster delete\n")
+	fmt.Print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n\n")
 
 	// validate a cluster name was passed
 	if len(args) < 1 {

--- a/cli/cmd/plugin/standalone-cluster/main.go
+++ b/cli/cmd/plugin/standalone-cluster/main.go
@@ -14,12 +14,14 @@ import (
 var descriptor = cliv1alpha1.PluginDescriptor{
 	Name: "standalone-cluster",
 	Description: `
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-Warning - Standalone clusters will be deprecated in a future release of Tanzu Community Edition
-                                  Use at your own Risk
-	           Checkout the proposal for the standalone cluster replacement:
-	           https://github.com/vmware-tanzu/community-edition/issues/2266
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+     Warning - Standalone clusters will be deprecated in a future release of Tanzu Community Edition
+                                        Use at your own Risk
+
+ For a minimal, single node cluster, you can use 'unmanaged-cluster', which replaces 'standalone-clusters'
+                                   tanzu unmanaged-cluster create
+                                   tanzu unmanaged-cluster delete
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 Create clusters without a dedicated management cluster`,
 	Group: cliv1alpha1.RunCmdGroup,


### PR DESCRIPTION
## What this PR does / why we need it
Now, the standalone cluster deprecation notice mentions the new unmanaged-cluster plugin which will live side by side
with standalone

Gives simple example of how to use `unmanaged-cluster`

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
Build with `make build-cli-plugins-loca` and tested the binaries for formatting in terminal. Example:

![Screen Shot 2022-01-10 at 11 57 39 AM](https://user-images.githubusercontent.com/23109390/148823191-223dc108-2cc0-4082-9b12-323f421ea53e.png)

## Special notes for your reviewer
N/a
