### PR TITLE
Updates `standalone-cluster` description with shorter description notice

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/main.go
+++ b/cli/cmd/plugin/standalone-cluster/main.go
@@ -12,19 +12,9 @@ import (
 )
 
 var descriptor = cliv1alpha1.PluginDescriptor{
-	Name: "standalone-cluster",
-	Description: `
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- Warning - Standalone clusters are deprecated and will be removed in a future release of Tanzu Community Edition
-                                        Use at your own Risk
-
- For a minimal, single node cluster, you can use 'unmanaged-cluster', which replaces 'standalone-clusters'
-                                   tanzu unmanaged-cluster create
-                                   tanzu unmanaged-cluster delete
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-Create clusters without a dedicated management cluster`,
-	Group: cliv1alpha1.RunCmdGroup,
+	Name:        "standalone-cluster (!!! deprecated - see unmanaged-cluster !!!)",
+	Description: `(!!! deprecated - see unmanaged-cluster !!!) Create clusters without a dedicated management cluster`,
+	Group:       cliv1alpha1.RunCmdGroup,
 
 	// Since standalone cluster is being deprecated, no changes or feature adds
 	// are to be made to it's dependencies or core functionality.


### PR DESCRIPTION
## What this PR does / why we need it
Shorter deprecation notice in the description:

![Screen Shot 2022-01-10 at 4 26 38 PM](https://user-images.githubusercontent.com/23109390/148854598-aa89dd93-d37a-4755-b1cc-6f927d71afe4.png)

Better UI and should fit in the plugin descriptors table much better

Super open to any and all feedback regarding the wording / copy of this! 😄 

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
N/a

## Special notes for your reviewer
N/a
