### PR TITLE
Recommend docker desktop <= 4.2.0

### DIFF
--- a/docs/site/content/docs/assets/prereq-mac.md
+++ b/docs/site/content/docs/assets/prereq-mac.md
@@ -5,7 +5,31 @@
 |Arch: x86; ARM (M1) currently unsupported |
 |RAM: 6 GB |
 |CPU: 2|
-|[Docker Desktop for Mac](https://docs.docker.com/desktop/mac/install/)|
+|[Docker Desktop for Mac; Version <= 4.2.0](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-420)|
 |[Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/) |
 |Latest version of Chrome, Firefox, Safari, Internet Explorer, or  Edge|
+
+#### Check the cgroup version 
+
+1. Check the cgroup by running the following command:
+
+    ```sh
+    docker info | grep -i cgroup 
+    ```
+
+    You should see the following output:
+
+    ```sh
+    Cgroup Driver: cgroupfs
+    Cgroup Version: 1
+    ```
+
+2. If you see cgroup version 2, you are running an incompatible version of
+   Docker Desktop. To resolve this, we recommend running [Docker Desktop
+   4.2.0](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-420).
+
+    > In a future release, we'll support cgroupsv2 which will resolve this issue.
+    > Please follow [issue
+    > 2798](https://github.com/vmware-tanzu/community-edition/issues/2798) for
+    > progress.
 

--- a/docs/site/content/docs/assets/prereq-windows.md
+++ b/docs/site/content/docs/assets/prereq-windows.md
@@ -4,8 +4,33 @@
 |:--- |
 |RAM: 8 GB|
 |CPU: 2|
-|[Docker Desktop for Windows](https://docs.docker.com/desktop/windows/install/)|
+|[Docker Desktop for Windows](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-420)|
 |[Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/) |
 |Latest version of Chrome, Firefox, Safari, Internet Explorer, or  Edge|
 
 Note: Bootstrapping a cluster to Docker from a Windows bootstrap machine is currently experimental.
+
+#### Check the cgroup version 
+
+1. Check the cgroup by running the following command:
+
+    ```sh
+    docker info | grep -i cgroup 
+    ```
+
+    You should see the following output:
+
+    ```sh
+    Cgroup Driver: cgroupfs
+    Cgroup Version: 1
+    ```
+
+2. If you see cgroup version 2, you are running an incompatible version of
+   Docker Desktop. To resolve this, we recommend running [Docker Desktop
+   4.2.0](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-420).
+
+    > In a future release, we'll support cgroupsv2 which will resolve this issue.
+    > Please follow [issue
+    > 2798](https://github.com/vmware-tanzu/community-edition/issues/2798) for
+    > progress.
+


### PR DESCRIPTION
## What this PR does / why we need it

Due to our inability to support bootstrapping when cgroups2 is
active[0], this adds documentation to recommend Mac and Windows users
have an appropriate version.

[0]: https://github.com/vmware-tanzu/community-edition/issues/2798

Signed-off-by: joshrosso <rossoj@vmware.com>

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Document need for cgroupsv2 in bootstrapping for Mac and Windows (Docker Desktop).
```

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/2798 

## Describe testing done for PR

Run `hugo serve` evaluate pages with pre-reqs.

![image](https://user-images.githubusercontent.com/6200057/148866957-bae3e004-47d8-4a47-b743-84c0323242d5.png)

![image](https://user-images.githubusercontent.com/6200057/148866969-b73e3cad-6050-412f-a4e6-c1aebe55d28c.png)

## Special notes for your reviewer

Review the above.
