### PR TITLE
Fix links in community page

### DIFF
--- a/docs/site/content/community/_index.html
+++ b/docs/site/content/community/_index.html
@@ -28,7 +28,7 @@ layout: section
                 <img src="/img/illustrations/join-the-conversation.jpg" height="100" alt="" />
             </div>
             <div class="content">
-                <h3><a href="{{ .Site.Params.slack_url }}">Join the conversation</a></h3>
+                <h3><a href="https://kubernetes.slack.com/archives/C02GY94A8KT">Join the conversation</a></h3>
                 <p>Need more help? Ready to help others? Join the <a href="https://groups.google.com/g/tanzu-community-edition">Tanzu Community Edition Google Group</a> and <a href="https://kubernetes.slack.com/archives/C02GY94A8KT">#tanzu-community-edition channel</a> in the Kubernetes Slack workspace for expert advice and guidance on using Tanzu Community Edition. Help us grow and learn from each other by sharing your experiences, telling us about what you are building, and letting us know how we can improve Tanzu Community Edition.</p>
                 <p>(Note: If you aren't already a member of the Kubernetes Slack workspace, please <a href="https://slack.k8s.io/">request an invitation</a>.)</p>
             </div>
@@ -38,9 +38,9 @@ layout: section
                 <img src="/img/illustrations/meet-with-us.png" height="100" alt=""/>
             </div>
             <div class="content">
-                <h3><a href="#">Meet with us</a></h3>
+                <h3><a href="https://vmware.zoom.us/j/95308746628?pwd=NlBxVmxrUXlQcnBjamxldVY1MjMvdz09">Meet with us</a></h3>
                 <p>For the latest updates from the Tanzu Community Edition development team, tune into our Community Meetings on the first and third Wednesday of every month at 11:00 AM PT/2:00 PM ET/8:00 PM CET. The team also hosts Office Hours on the second and fourth Wednesday at the same time; these are open-format discussions, so bring your questions and expect lively discussion!</p>
-                <p>Join the Community <a href="{{ .Site.Params.slack_url }}">Slack Channel</a> or <a href="https://groups.google.com/g/tanzu-community-edition">Google Group</a> to get updates on the project and invitations to community meetings.</p>
+                <p>Join the Community <a href="https://kubernetes.slack.com/archives/C02GY94A8KT">Slack Channel</a> or <a href="https://groups.google.com/g/tanzu-community-edition">Google Group</a> to get updates on the project and invitations to community meetings.</p>
                 <ul>
                     <li><a href="https://vmware.zoom.us/j/95308746628?pwd=NlBxVmxrUXlQcnBjamxldVY1MjMvdz09">Meeting Zoom link</a></li>
                     <li><a href="https://hackmd.io/CiuO4V0AT6WL_TgA47MXBA">Upcoming meeting schedule/topics</a></li>


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
Fixes 3 links in the [community page](https://tanzucommunityedition.io/community/#):


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```none

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2767 

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
I don't know why the slack_url param is not rendering, it looks fine in config.yaml - faster to hard code it in to get the link fixed. I don't think this is a value that is going to change so no advantage to having a param for it that I can think of. 