### PR TITLE
Doc - Minor doc fix for windows install topic.

### DIFF
--- a/docs/site/content/docs/assets/cli-install-windows.md
+++ b/docs/site/content/docs/assets/cli-install-windows.md
@@ -14,7 +14,6 @@
 
     > Both `docker` and `kubectl` are required to be present on the system, but are not explicit Chocolatey dependencies.
     > Installing the Tanzu Community Edition package will extract the binaries and configure the plugin repositories. This might take a minute.
-    > Using an explicit version is required for now.
 
 1. The `tanzu` command will be added to your `$PATH` variable automatically by Chocolatey.
 


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
Removes incorrect reference to windows install command requiring a version parameter 

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```none

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2389 

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
