### PR TITLE
Create OpenAPIV3 schema for calico package and generate package with the schema

### DIFF
--- a/addons/packages/calico/3.19.1/README.md
+++ b/addons/packages/calico/3.19.1/README.md
@@ -12,8 +12,9 @@ The following configuration values can be set to customize the calico installati
 
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
-| `infraProvider` | Required | The cloud provider in use. One of: `aws`, `azure`, `vsphere`, `docker`. |
-| `ipFamily` | Optional | The IP family calico should be configured with. Defaults to `ipv4` One of: `ipv4`, `ipv6`, `ipv4,ipv6` (IPv4-primary dualstack), or `ipv6,ipv4` (IPv6-primary dualstack) |
+| `namespace` | Optional | The namespace in which to deploy resources. Default: kube-system |
+| `infraProvider` | Required | The infrastructure provider in use. One of: `aws`, `azure`, `vsphere`, `docker`. |
+| `ipFamily` | Optional | The IP family calico should be configured with. Defaults to `ipv4`. One of: `ipv4`, `ipv6`, `ipv4,ipv6` (IPv4-primary dualstack), or `ipv6,ipv4` (IPv6-primary dualstack) |
 
 ### calico Configuration
 

--- a/addons/packages/calico/3.19.1/bundle/config/schema.yaml
+++ b/addons/packages/calico/3.19.1/bundle/config/schema.yaml
@@ -1,0 +1,20 @@
+#! schema.yaml
+
+#@data/values-schema
+#@schema/desc "OpenAPIv3 Schema for calico"
+---
+#@schema/desc "The namespace in which calico is deployed"
+namespace: kube-system
+#@schema/desc "Infrastructure provider in use"
+infraProvider: vsphere
+#@schema/desc "The IP family calico should be configured with"
+#@schema/nullable
+ipFamily: "ipv4,ipv6"
+calico:
+  #@schema/desc "Configuration for calico"
+  config:
+    #@schema/desc "The CIDR pool used to assign IP addresses to the pods in the cluster"
+    #@schema/nullable
+    clusterCIDR: "192.168.0.0/16,fd00:100:96::/48"
+    #@schema/desc "Maximum transmission unit setting"
+    vethMTU: "0"

--- a/addons/packages/calico/3.19.1/package.yaml
+++ b/addons/packages/calico/3.19.1/package.yaml
@@ -4,26 +4,63 @@ metadata:
   name: calico.community.tanzu.vmware.com.3.19.1
   namespace: calico
 spec:
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      description: OpenAPIv3 Schema for calico
+      properties:
+        namespace:
+          type: string
+          default: kube-system
+          description: The namespace in which calico is deployed
+        infraProvider:
+          type: string
+          default: vsphere
+          description: Infrastructure provider in use
+        ipFamily:
+          type: string
+          default: null
+          nullable: true
+          description: The IP family calico should be configured with
+        calico:
+          type: object
+          additionalProperties: false
+          properties:
+            config:
+              type: object
+              additionalProperties: false
+              description: Configuration for calico
+              properties:
+                clusterCIDR:
+                  type: string
+                  default: null
+                  nullable: true
+                  description: The CIDR pool used to assign IP addresses to the pods in the cluster
+                vethMTU:
+                  type: string
+                  default: "0"
+                  description: Maximum transmission unit setting
   refName: calico.community.tanzu.vmware.com
   version: 3.19.1
-  releaseNotes: "calico 3.19.1 https://docs.projectcalico.org/archive/v3.19/release-notes/"
+  releaseNotes: calico 3.19.1 https://docs.projectcalico.org/archive/v3.19/release-notes/
   licenses:
-    - "Apache 2.0"
+  - Apache 2.0
   template:
     spec:
       syncPeriod: 5m
       fetch:
-        - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/calico@sha256:5dc11a449f0945acc4000ee8b1a28ddd414288bf421ea294f188ad085cd0bce5
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/calico@sha256:99873e9319bcb4bb47dc3e9e80f6b26b2ff89f336744dc3281d138d6b0a077b5
       template:
-        - ytt:
-            paths:
-              - config/
-        - kbld:
-            paths:
-              - "-"
-              - .imgpkg/images.yml
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
       deploy:
       - kapp:
           rawOptions:
-            - --wait-timeout=30s
+          - --wait-timeout=30s

--- a/hack/packages/check-sample-values-and-render-ytt.sh
+++ b/hack/packages/check-sample-values-and-render-ytt.sh
@@ -13,7 +13,7 @@ VERSION=$2
 
 if [ -z "$PACKAGE" ]
 then
-  echo "check sample values for package failed. must set NAME"
+  echo "check sample values for package failed. must set PACKAGE"
   exit 2
 fi
 


### PR DESCRIPTION
## What this PR does / why we need it
Create OpenAPIV3 schema for calico package and generate package with the schema for calico version 3.19.1
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Details for the Release Notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Create OpenAPIV3 schema for calico package and generate package with the schema
```

## Which issue(s) this PR fixes
Fixes: https://github.com/vmware-tanzu/community-edition/issues/2813
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## Describe testing done for PR
Tested with ytt commands and ran ```make generate-openapischema-package``` and ```make push-package```
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
YTT version needs to be bumped to latest (0.38.0)
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
