### PR TITLE
Move the sample value directory out of package bundle

### DIFF
--- a/docs/site/content/docs/latest/designs/package-process.md
+++ b/docs/site/content/docs/latest/designs/package-process.md
@@ -458,7 +458,7 @@ spec:
 
 Follow the below mentioned steps to get started on generating openAPIv3 schema and specifying it in a package.
 This process works for both kinds of packages: one which have sample values defined like csi, cpi; also for ones which don't like secretgen-controller and kapp-controller to name a few.
-For packages which have sample values, assumption is sample-values directory exists under bundle directory.
+For packages which have sample values, assumption is sample-values directory exists under version directory.
 
 1. Create a schema file (`schema.yaml`) for given data values file. In ytt, before a Data Value can be used in a template, it must be declared. This is typically done via Data Values Schema
    Check out [How to write Schema](https://carvel.dev/ytt/docs/latest/how-to-write-schema/), to explore the different annotations that can be used when writing a schema.

--- a/hack/packages/check-sample-values-and-render-ytt.sh
+++ b/hack/packages/check-sample-values-and-render-ytt.sh
@@ -32,12 +32,12 @@ NC='\033[0m' # No Color
 GREEN='\033[0;32m'
 
 check_sample_values_and_render_ytt() {
-  sample_values_dir="${BUNDLE_DIR}/sample-values"
+  sample_values_dir="${VERSION_DIR}/sample-values"
 
   yttCmd="ytt -f ."
   if [ -d "${sample_values_dir}" ]
   then
-    yttCmd="${yttCmd} -f ../sample-values/*.yaml"
+    yttCmd="${yttCmd} -f ../../sample-values/*.yaml"
   fi
   cd "${CONFIG_DIR}" || exit
 	${yttCmd} > /dev/null


### PR DESCRIPTION
## What this PR does / why we need it
Move the sample values directory out of package bundle.
This prevents these values being pushed as a part of image package bundle

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: (https://github.com/vmware-tanzu/community-edition/pull/2719#discussion_r781689045)

## Describe testing done for PR
Tested with and without sample values

