### PR TITLE
Bump vsphere-csi to 2.4.0 GA

### DIFF
--- a/addons/packages/vsphere-csi/2.4.1/bundle/.imgpkg/images.yml
+++ b/addons/packages/vsphere-csi/2.4.1/bundle/.imgpkg/images.yml
@@ -2,11 +2,11 @@
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
-    kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1-rc.1
-  image: gcr.io/cloud-provider-vsphere/csi/release/driver@sha256:4c3f5c76075fcbc5d35466aaf9646819dbcb1bc37655add28bb9d50d87ca18dd
+    kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1
+  image: gcr.io/cloud-provider-vsphere/csi/release/driver@sha256:c25d9d24a22d6d787dbbe7fe1cc0734113da252f5e1e3dc86429230aa9047fb3
 - annotations:
-    kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.1-rc.1
-  image: gcr.io/cloud-provider-vsphere/csi/release/syncer@sha256:60d926984a3a344166d8a2323994862f0fbc679a31925625febb0b814bc29faa
+    kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.1
+  image: gcr.io/cloud-provider-vsphere/csi/release/syncer@sha256:5c6757f836ee104bba886f0adce1690de66a6c75c1d566c6d5a03b081029a980
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
   image: k8s.gcr.io/sig-storage/csi-attacher@sha256:80dec81b679a733fda448be92a2331150d99095947d04003ecff3dbd7f2a476a

--- a/addons/packages/vsphere-csi/2.4.1/bundle/config/upstream/vsphere-csi/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/addons/packages/vsphere-csi/2.4.1/bundle/config/upstream/vsphere-csi/manifests/vanilla/vsphere-csi-driver.yaml
@@ -255,7 +255,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -312,7 +312,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.1-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.1
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
@@ -416,7 +416,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -563,7 +563,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"

--- a/addons/packages/vsphere-csi/2.4.1/bundle/vendir.lock.yml
+++ b/addons/packages/vsphere-csi/2.4.1/bundle/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Update CSI images to 2.4.1 rc1 (#1450)
-      sha: ad2b4a7e2a40646872f51d1fb7877108aa1c0a46
+      commitTitle: set v2.4.1 image version (#1473)
+      sha: 7a87157940d2d2bcf69b81e004d9f5b7da92b43c
       tags:
-      - v2.4.1-rc.1
+      - v2.4.1
     path: vsphere-csi
   path: config/upstream
 kind: LockConfig

--- a/addons/packages/vsphere-csi/2.4.1/bundle/vendir.yml
+++ b/addons/packages/vsphere-csi/2.4.1/bundle/vendir.yml
@@ -7,6 +7,6 @@ directories:
   - path: vsphere-csi
     git:
       url: git@github.com:kubernetes-sigs/vsphere-csi-driver.git
-      ref: ad2b4a7e2a40646872f51d1fb7877108aa1c0a46
+      ref: 7a87157940d2d2bcf69b81e004d9f5b7da92b43c
     includePaths:
       - manifests/vanilla/vsphere-csi-driver.yaml

--- a/addons/packages/vsphere-csi/2.4.1/package.yaml
+++ b/addons/packages/vsphere-csi/2.4.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:11931736732d6f283cd65e680e3149803c9c085fc0eabf53d59ad6568282bb6e
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:c615f4a95de0161f244f644cfb512449ef8b2c233e63541d16fa44bcd7bd28b6
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Bump CSI package to 2.4.1 GA, CSI release https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.4.1

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Bump CSI package to 2.4.1 GA
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Ran ytt command locally

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
