### PR TITLE
Align ako statefulset resource limit

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
@@ -95,8 +95,8 @@ spec:
                   fieldPath: metadata.namespace
           resources:
             limits:
-              cpu: 250m
-              memory: 300Mi
+              cpu: 350m
+              memory: 400Mi
             requests:
               cpu: 100m
               memory: 200Mi

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/values.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/values.yaml
@@ -56,8 +56,8 @@ loadBalancerAndIngressService:
       value: ""
     resources:
       limits:
-        cpu: 250m
-        memory: 300Mi
+        cpu: 350m
+        memory: 400Mi
       request:
         cpu: 100m
         memory: 200Mi


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

AKO increases resource limit upper boundary in the new release version, we should align the default limit with it.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

Fixes large scale AKO pod OOMKilled issue

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
