### PR TITLE
Create OpenAPIV3 schema for kapp-controller package and generate package with the schema

### DIFF
--- a/addons/packages/kapp-controller/0.30.0/bundle/config/schema.yaml
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/schema.yaml
@@ -1,0 +1,45 @@
+#! schema.yaml
+
+#@data/values-schema
+#@schema/desc "OpenAPIv3 Schema for kapp-controller"
+---
+#@schema/desc "The namespace value used by older templates, will overwrite with top level namespace of present, for backward compatibility"
+namespace: kapp-controller
+#@schema/desc "Configuration for kapp-controller"
+kappController:
+  #@schema/desc "The namespace value used by older templates, will overwrite with top level namespace of present, for backward compatibility"
+  #@schema/nullable
+  namespace: kapp-controller
+  #@schema/desc "Whether to create namespace specified for kapp-controller"
+  createNamespace: true
+  #@schema/desc "The namespace value used for global packaging resources. Any Package and PackageMetadata CRs within that namespace will be included in all other namespaces on the cluster, without duplicating them"
+  globalNamespace: tanzu-package-repo-global
+  deployment:
+    #@schema/desc "The coreDNSIP will be injected into /etc/resolv.conf of kapp-controller pod"
+    #@schema/nullable
+    coreDNSIP: ""
+    #@schema/desc "HostNetwork of kapp-controller deployment"
+    #@schema/nullable
+    hostNetwork: ""
+    #@schema/desc "PriorityClassName of kapp-controller deployment"
+    #@schema/nullable
+    priorityClassName: ""
+    #@schema/desc "Concurrency of kapp-controller deployment"
+    concurrency: 4
+    #@schema/desc "kapp-controller deployment tolerations"
+    tolerations: ["toleration1"]
+    #@schema/desc "Bind port for kapp-controller API"
+    apiPort: 10350
+    #@schema/desc "Address for metrics server"
+    metricsBindAddress: ":8080"
+  config:
+    #@schema/desc "A cert chain of trusted CA certs. These will be added to the system-wide cert pool of trusted CA's"
+    caCerts: ""
+    #@schema/desc "The url/ip of a proxy for kapp controller to use when making network requests"
+    httpProxy: ""
+    #@schema/desc "The url/ip of a TLS capable proxy for kapp-controller to use when making network requests"
+    httpsProxy: ""
+    #@schema/desc "A comma delimited list of domain names which kapp-controller should bypass the proxy for when making requests"
+    noProxy: ""
+    #@schema/desc "A comma delimited list of hostnames for which kapp-controller should skip TLS verification"
+    dangerousSkipTLSVerify: ""

--- a/addons/packages/kapp-controller/0.30.0/bundle/config/schema.yaml
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/schema.yaml
@@ -3,11 +3,11 @@
 #@data/values-schema
 #@schema/desc "OpenAPIv3 Schema for kapp-controller"
 ---
-#@schema/desc "The namespace value used by older templates, will overwrite with top level namespace of present, for backward compatibility"
+#@schema/desc "The namespace in which to deploy kapp-controller"
 namespace: kapp-controller
 #@schema/desc "Configuration for kapp-controller"
 kappController:
-  #@schema/desc "The namespace value used by older templates, will overwrite with top level namespace of present, for backward compatibility"
+  #@schema/desc "The namespace value used by older templates, will overwrite with top level namespace if present, for backward compatibility"
   #@schema/nullable
   namespace: kapp-controller
   #@schema/desc "Whether to create namespace specified for kapp-controller"
@@ -18,10 +18,10 @@ kappController:
     #@schema/desc "The coreDNSIP will be injected into /etc/resolv.conf of kapp-controller pod"
     #@schema/nullable
     coreDNSIP: ""
-    #@schema/desc "HostNetwork of kapp-controller deployment"
+    #@schema/desc "Host networking requested for kapp-controller pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified"
     #@schema/nullable
     hostNetwork: ""
-    #@schema/desc "PriorityClassName of kapp-controller deployment"
+    #@schema/desc "The priority value that various system components use to find the priority of the kapp-controller pod"
     #@schema/nullable
     priorityClassName: ""
     #@schema/desc "Concurrency of kapp-controller deployment"

--- a/addons/packages/kapp-controller/0.30.0/bundle/config/schema.yaml
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/schema.yaml
@@ -18,7 +18,7 @@ kappController:
     #@schema/desc "The coreDNSIP will be injected into /etc/resolv.conf of kapp-controller pod"
     #@schema/nullable
     coreDNSIP: ""
-    #@schema/desc "Host networking requested for kapp-controller pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified"
+    #@schema/desc "Host network of kapp-controller deployment"
     #@schema/nullable
     hostNetwork: ""
     #@schema/desc "The priority value that various system components use to find the priority of the kapp-controller pod"

--- a/addons/packages/kapp-controller/0.30.0/package.yaml
+++ b/addons/packages/kapp-controller/0.30.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/kapp-controller@sha256:001bb2cb7274d29b2146e9717c80c3672a99e40afdc2fbc442f4f77a32d6f90d
+          image: projects.registry.vmware.com/tce/kapp-controller@sha256:491a4a19fcb0bea4d99d7c087bb061cae88d569ca029b2d230b3814fde84692c
       template:
       - ytt:
           paths:
@@ -32,7 +32,7 @@ spec:
         namespace:
           type: string
           default: kapp-controller
-          description: The namespace value used by older templates, will overwrite with top level namespace of present, for backward compatibility
+          description: The namespace in which to deploy kapp-controller
         kappController:
           type: object
           additionalProperties: false
@@ -42,7 +42,7 @@ spec:
               type: string
               default: null
               nullable: true
-              description: The namespace value used by older templates, will overwrite with top level namespace of present, for backward compatibility
+              description: The namespace value used by older templates, will overwrite with top level namespace if present, for backward compatibility
             createNamespace:
               type: boolean
               default: true
@@ -64,12 +64,12 @@ spec:
                   type: string
                   default: null
                   nullable: true
-                  description: HostNetwork of kapp-controller deployment
+                  description: Host networking requested for kapp-controller pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified
                 priorityClassName:
                   type: string
                   default: null
                   nullable: true
-                  description: PriorityClassName of kapp-controller deployment
+                  description: The priority value that various system components use to find the priority of the kapp-controller pod
                 concurrency:
                   type: integer
                   default: 4

--- a/addons/packages/kapp-controller/0.30.0/package.yaml
+++ b/addons/packages/kapp-controller/0.30.0/package.yaml
@@ -5,21 +5,111 @@ metadata:
 spec:
   refName: kapp-controller.community.tanzu.vmware.com
   version: 0.30.0
-  releaseNotes: "kapp-controller 0.30.0 https://github.com/vmware-tanzu/carvel-kapp-controller"
+  releaseNotes: kapp-controller 0.30.0 https://github.com/vmware-tanzu/carvel-kapp-controller
   licenses:
-    - "Apache 2.0"
+  - Apache 2.0
   template:
     spec:
       fetch:
-        - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:26428e5233c6fa610a950c216c8e3eee5c76ce05e5385e8291b6acd91dc5bc26
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/kapp-controller@sha256:001bb2cb7274d29b2146e9717c80c3672a99e40afdc2fbc442f4f77a32d6f90d
       template:
-        - ytt:
-            paths:
-              - config/
-        - kbld:
-            paths:
-              - "-"
-              - .imgpkg/images.yml
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
       deploy:
-        - kapp: {}
+      - kapp: {}
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      description: OpenAPIv3 Schema for kapp-controller
+      properties:
+        namespace:
+          type: string
+          default: kapp-controller
+          description: The namespace value used by older templates, will overwrite with top level namespace of present, for backward compatibility
+        kappController:
+          type: object
+          additionalProperties: false
+          description: Configuration for kapp-controller
+          properties:
+            namespace:
+              type: string
+              default: null
+              nullable: true
+              description: The namespace value used by older templates, will overwrite with top level namespace of present, for backward compatibility
+            createNamespace:
+              type: boolean
+              default: true
+              description: Whether to create namespace specified for kapp-controller
+            globalNamespace:
+              type: string
+              default: tanzu-package-repo-global
+              description: The namespace value used for global packaging resources. Any Package and PackageMetadata CRs within that namespace will be included in all other namespaces on the cluster, without duplicating them
+            deployment:
+              type: object
+              additionalProperties: false
+              properties:
+                coreDNSIP:
+                  type: string
+                  default: null
+                  nullable: true
+                  description: The coreDNSIP will be injected into /etc/resolv.conf of kapp-controller pod
+                hostNetwork:
+                  type: string
+                  default: null
+                  nullable: true
+                  description: HostNetwork of kapp-controller deployment
+                priorityClassName:
+                  type: string
+                  default: null
+                  nullable: true
+                  description: PriorityClassName of kapp-controller deployment
+                concurrency:
+                  type: integer
+                  default: 4
+                  description: Concurrency of kapp-controller deployment
+                tolerations:
+                  type: array
+                  description: kapp-controller deployment tolerations
+                  items:
+                    type: string
+                    default: toleration1
+                  default: []
+                apiPort:
+                  type: integer
+                  default: 10350
+                  description: Bind port for kapp-controller API
+                metricsBindAddress:
+                  type: string
+                  default: :8080
+                  description: Address for metrics server
+            config:
+              type: object
+              additionalProperties: false
+              properties:
+                caCerts:
+                  type: string
+                  default: ""
+                  description: A cert chain of trusted CA certs. These will be added to the system-wide cert pool of trusted CA's
+                httpProxy:
+                  type: string
+                  default: ""
+                  description: The url/ip of a proxy for kapp controller to use when making network requests
+                httpsProxy:
+                  type: string
+                  default: ""
+                  description: The url/ip of a TLS capable proxy for kapp-controller to use when making network requests
+                noProxy:
+                  type: string
+                  default: ""
+                  description: A comma delimited list of domain names which kapp-controller should bypass the proxy for when making requests
+                dangerousSkipTLSVerify:
+                  type: string
+                  default: ""
+                  description: A comma delimited list of hostnames for which kapp-controller should skip TLS verification

--- a/addons/packages/kapp-controller/0.30.0/package.yaml
+++ b/addons/packages/kapp-controller/0.30.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/kapp-controller@sha256:491a4a19fcb0bea4d99d7c087bb061cae88d569ca029b2d230b3814fde84692c
+          image: projects.registry.vmware.com/tce/kapp-controller@sha256:713530834c0849526b95dfa48027aa510c5fc1ec29a585a817a0918a542ce135
       template:
       - ytt:
           paths:
@@ -64,7 +64,7 @@ spec:
                   type: string
                   default: null
                   nullable: true
-                  description: Host networking requested for kapp-controller pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified
+                  description: Host network of kapp-controller deployment
                 priorityClassName:
                   type: string
                   default: null

--- a/addons/packages/package-overlay/package-overlay.yaml
+++ b/addons/packages/package-overlay/package-overlay.yaml
@@ -4,6 +4,12 @@
 #@overlay/match by=overlay.subset({"kind":"Package"}),expects="1+"
 ---
 spec:
-#@overlay/replace
+  #@overlay/match missing_ok=True
+  valuesSchema: {}
+
+#@overlay/match by=overlay.subset({"kind":"Package"}),expects="1+"
+---
+spec:
+  #@overlay/replace
   valuesSchema:
     openAPIv3:  #@ yaml.decode(data.values.openapi)["components"]["schemas"]["dataValues"]

--- a/hack/packages/check-sample-values-and-render-ytt.sh
+++ b/hack/packages/check-sample-values-and-render-ytt.sh
@@ -30,6 +30,7 @@ BUNDLE_DIR="${VERSION_DIR}/bundle"
 CONFIG_DIR="${BUNDLE_DIR}/config"
 NC='\033[0m' # No Color
 GREEN='\033[0;32m'
+RED='\033[0;31m'
 
 check_sample_values_and_render_ytt() {
   sample_values_dir="${VERSION_DIR}/sample-values"
@@ -41,7 +42,10 @@ check_sample_values_and_render_ytt() {
   fi
   cd "${CONFIG_DIR}" || exit
 	${yttCmd} > /dev/null
-	echo -e "${GREEN}===> ytt manifests successfully rendered for ${PACKAGE}/${VERSION}${NC}"
+	status=$?
+
+	[ $status -eq 0 ] && echo -e "${GREEN}===> ytt manifests successfully rendered for ${PACKAGE}/${VERSION}${NC}" || echo -e "${RED}===> $yttCmd failed. ytt manifests could not be generated!!${NC}"
+
 }
 
 check_sample_values_and_render_ytt

--- a/hack/packages/verify-openapischema-for-package.sh
+++ b/hack/packages/verify-openapischema-for-package.sh
@@ -45,7 +45,7 @@ verify_openapischema_for_package() {
       yq e '.components.schemas.dataValues' generated-openapi-schema.yaml > schema-contents.yaml
       yq e '.spec.valuesSchema.openAPIv3' ../package.yaml > package-schema-contents.yaml
       diffyaml schema-contents.yaml package-schema-contents.yaml
-      echo -e "${GREEN}===> OpenAPIv3 contents match successful for schema and package${NC}"
+      echo -e "${GREEN}===> OpenAPIv3 contents successfully matched for schema and package${NC}"
     else
       echo -e "${RED}===> ytt manifests could not be generated!!${NC}"
       exit 1

--- a/hack/packages/verify-openapischema-for-package.sh
+++ b/hack/packages/verify-openapischema-for-package.sh
@@ -40,10 +40,16 @@ verify_openapischema_for_package() {
     mkdir -p "${ARTIFACTS_DIR}"
     cd "${ARTIFACTS_DIR}" || exit
     ytt -f ../bundle/config/schema.yaml --data-values-schema-inspect -o openapi-v3 > generated-openapi-schema.yaml
-    yq e '.components.schemas.dataValues' generated-openapi-schema.yaml > schema-contents.yaml
-    yq e '.spec.valuesSchema.openAPIv3' ../package.yaml > package-schema-contents.yaml
-    diffyaml schema-contents.yaml package-schema-contents.yaml
-    echo -e "${GREEN}===> OpenAPIv3 contents match successful for schema and package${NC}"
+    status=$?
+    if [ $status -eq 0 ]; then
+      yq e '.components.schemas.dataValues' generated-openapi-schema.yaml > schema-contents.yaml
+      yq e '.spec.valuesSchema.openAPIv3' ../package.yaml > package-schema-contents.yaml
+      diffyaml schema-contents.yaml package-schema-contents.yaml
+      echo -e "${GREEN}===> OpenAPIv3 contents match successful for schema and package${NC}"
+    else
+      echo -e "${RED}===> ytt manifests could not be generated!!${NC}"
+      exit 1
+    fi
   fi
 }
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
- [x] Create OpenAPIV3 schema for kapp-controller package and generate package with the schema (0.30.0)
- [x] Fix bug in package-overlay.yaml
- [x] Add checks to scripts to error out when ytt manifests not generated successfully

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Create OpenAPIV3 schema for kapp-controller package and generate package with the schema 
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2766 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested with following ytt commands locally:
* make generate-openapischema-package PACKAGE=kapp-controller VERSION=0.30.0
* make push-package PACKAGE=kapp-controller VERSION=0.30.0 TAG=0.30.0

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
ytt version => 0.38.0
kapp version => 0.37.0
yq version => 4.11.1