### PR TITLE
Add getting started guide for unmanaged cluster

### DIFF
--- a/docs/site/content/docs/assets/create-unmanaged-cluster.md
+++ b/docs/site/content/docs/assets/create-unmanaged-cluster.md
@@ -1,0 +1,68 @@
+1. Create a cluster named `beepboop`.
+
+    ```sh
+    tanzu unmanaged-cluster create beepboop
+    ```
+
+    > **Tip**: You can use the alias `uc`, instead of `unmanaged-cluster`, in
+    > these commands.
+
+1. Wait for the cluster to initialize.
+
+    ```txt
+    📁 Created cluster directory
+
+    🔧 Resolving Tanzu Kubernetes Release (TKR)
+       projects.registry.vmware.com/tce/tkr:v1.21.5
+       TKR exists at /home/josh/.config/tanzu/tkg/unmanaged-cluster/bom/projects.registry.vmware.com_tce_tkr_v1.21.5
+       Rendered Config: /home/josh/.config/tanzu/tkg/unmanaged-cluster/beepboop/config.yaml
+       Bootstrap Logs: /home/josh/.config/tanzu/tkg/unmanaged-cluster/beepboop/bootstrap.log
+
+    🔧 Processing Tanzu Kubernetes Release
+
+    🎨 Selected base image
+       projects.registry.vmware.com/tce/kind/node:v1.21.5
+
+    📦 Selected core package repository
+       projects.registry.vmware.com/tkg/packages/core/repo:v1.21.2_vmware.1-tkg.1
+
+    📦 Selected additional package repositories
+       projects.registry.vmware.com/tce/main:0.9.1
+
+    📦 Selected kapp-controller image bundle
+       projects.registry.vmware.com/tkg/packages/core/kapp-controller:v0.23.0_vmware.1-tkg.1
+
+    🚀 Creating cluster beepboop
+       Base image downloaded
+       Cluster created
+       To troubleshoot, use:
+       kubectl ${COMMAND} --kubeconfig /home/josh/.config/tanzu/tkg/unmanaged-cluster/beepboop/kube.conf
+
+    📧 Installing kapp-controller
+       kapp-controller status: Running
+
+    📧 Installing package repositories
+       Core package repo status: Reconcile succeeded
+
+    🌐 Installing CNI
+       antrea.tanzu.vmware.com:0.13.3+vmware.1-tkg.1
+
+    ✅ Cluster created
+
+    🎮 kubectl context set to beepboop
+
+    View available packages:
+       tanzu package available list
+    View running pods:
+       kubectl get po -A
+    Delete this cluster:
+       tanzu unmanaged-cluster delete beepboop
+    ```
+
+    > A container image larger than 1GB is used for running clusters. This may
+    > cause your first cluster to take significantly longer to bootstrap than
+    > subsequent clusters.
+
+1. If you have [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+   installed, you can now use it to interact with the
+   cluster.

--- a/docs/site/content/docs/assets/delete-unmanaged-cluster.md
+++ b/docs/site/content/docs/assets/delete-unmanaged-cluster.md
@@ -1,0 +1,24 @@
+1. List the available clusters.
+
+    ```sh
+    tanzu unmanaged-cluster list
+    ```
+
+    > **Tip**: You can use the alias `ls`, instead of `list`, in
+    > the above command.
+
+1. Review the available clusters.
+
+    ```txt
+    NAME      PROVIDER
+    beepboop  kind
+    ```
+
+1. Delete the cluster.
+
+    ```sh
+    tanzu unmanaged-cluster delete beepboop
+    ```
+
+    > **Tip**: You can use the alias `rm`, instead of `delete`, in
+    > the above command.

--- a/docs/site/content/docs/assets/direct-download.md
+++ b/docs/site/content/docs/assets/direct-download.md
@@ -1,0 +1,4 @@
+If you prefer to not use a package manager, you can download releases [on
+GitHub](https://github.com/vmware-tanzu/community-edition/releases). Download
+and unpack the release for your operating system. Then, run the script
+`install.sh` (linux/mac) or `install.bat` (windows) inside.

--- a/docs/site/content/docs/assets/install-homebrew.md
+++ b/docs/site/content/docs/assets/install-homebrew.md
@@ -1,0 +1,15 @@
+1. Install using [homebrew](https://brew.sh).
+
+    ```sh
+    brew install vmware-tanzu/tanzu/tanzu-community-edition
+    ```
+
+1. Run the configure command displayed after homebrew completes installation.
+
+    ```sh
+    {HOMEBREW-INSTALL-LOCATION}/configure-tce.sh
+    ```
+
+    > This puts all the Tanzu plugins in the correct location. The first time
+    > you run the `tanzu` command the installed plugins and plugin repositories
+    > are initialized. This action might take a minute.

--- a/docs/site/content/docs/assets/install-package-to-cluster.md
+++ b/docs/site/content/docs/assets/install-package-to-cluster.md
@@ -1,0 +1,75 @@
+1. List the available package repositories.
+
+    ```sh
+    tanzu package repository list --all-namespaces
+    ```
+
+1. Verify the `STATUS` is `Reconcile succeeded` in the output of the above
+   command.
+
+    ```txt
+    NAME                 REPOSITORY                                           TAG                     STATUS               DETAILS  NAMESPACE
+    tkg-core-repository  projects.registry.vmware.com/tce/main                0.9.1                   Reconcile succeeded           tanzu-package-repo-global
+    tkg-core-repository  projects.registry.vmware.com/tkg/packages/core/repo  v1.21.2_vmware.1-tkg.1  Reconcile succeeded           tkg-system
+    ```
+
+1. List the available packages.
+
+    ```sh
+    tanzu package available list
+    ```
+
+    ```txt
+    NAME                                           DISPLAY-NAME        SHORT-DESCRIPTION
+    cert-manager.community.tanzu.vmware.com        cert-manager        Certificate management
+    contour.community.tanzu.vmware.com             Contour             An ingress controller
+    external-dns.community.tanzu.vmware.com        external-dns        This package provides DNS synchronization functionality.
+    fluent-bit.community.tanzu.vmware.com          fluent-bit          Fluent Bit is a fast Log Processor and Forwarder
+    gatekeeper.community.tanzu.vmware.com          gatekeeper          policy management
+    grafana.community.tanzu.vmware.com             grafana             Visualization and analytics software
+    harbor.community.tanzu.vmware.com              Harbor              OCI Registry
+    knative-serving.community.tanzu.vmware.com     knative-serving     Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers
+    local-path-storage.community.tanzu.vmware.com  local-path-storage  This package provides local path node storage and primarily supports RWO AccessMode.
+    multus-cni.community.tanzu.vmware.com          multus-cni          This package provides the ability for enabling attaching multiple network interfaces to pods in Kubernetes
+    prometheus.community.tanzu.vmware.com          prometheus          A time series database for your metrics
+    velero.community.tanzu.vmware.com              velero              Disaster recovery capabilities
+    ```
+
+1. List the available versions of cert-manager.
+
+    ```sh
+    tanzu package available list cert-manager.community.tanzu.vmware.com
+    ```
+
+    ```txt
+    NAME                                     VERSION  RELEASED-AT
+    cert-manager.community.tanzu.vmware.com  1.3.3    2021-08-06 05:31:21 -0700 MST
+    cert-manager.community.tanzu.vmware.com  1.4.4    2021-08-23 09:47:51 -0700 MST
+    cert-manager.community.tanzu.vmware.com  1.5.3    2021-08-23 10:22:51 -0700 MST
+    ```
+
+1. Install the `1.5.3` version of cert-manager.
+
+    ```sh
+    tanzu package install cert-manager --package-name cert-manager.community.tanzu.vmware.com --version 1.5.3
+    ```
+
+    > If you have `kubectl` installed, you can now view and interact with
+    > cert-manager.
+
+1. Verify the package is now installed.
+
+    ```sh
+    tanzu package installed list
+    ```
+
+    ```txt
+    NAME          PACKAGE-NAME                             PACKAGE-VERSION  STATUS
+    cert-manager  cert-manager.community.tanzu.vmware.com  1.5.3            Reconcile succeeded
+    ```
+
+1. If desired, you can also delete the package using:
+
+    ```sh
+    tanzu package installed delete cert-manager
+    ```

--- a/docs/site/content/docs/assets/prereq-unmanaged-linux.md
+++ b/docs/site/content/docs/assets/prereq-unmanaged-linux.md
@@ -1,0 +1,3 @@
+| Architecture   | CPU | RAM  | Required software |
+|:---------------|:----|:-----|:------------------|
+| x86_64 / amd64 | 1   | 2 GB | [Docker engine](https://docs.docker.com/engine/install) |

--- a/docs/site/content/docs/assets/prereq-unmanaged-mac.md
+++ b/docs/site/content/docs/assets/prereq-unmanaged-mac.md
@@ -1,0 +1,3 @@
+| Architecture   | CPU | RAM  | Required software |
+|:---------------|:----|:-----|:------------------|
+| x86_64 / amd64 | 1   | 2 GB | [Docker Desktop](https://www.docker.com/get-started) |

--- a/docs/site/content/docs/assets/prereq-unmanaged-windows.md
+++ b/docs/site/content/docs/assets/prereq-unmanaged-windows.md
@@ -1,0 +1,3 @@
+| Architecture   | CPU | RAM  | Required software |
+|:---------------|:----|:-----|:------------------|
+| x86_64 / amd64 | 1   | 2 GB | [Docker Desktop](https://www.docker.com/get-started) |

--- a/docs/site/content/docs/assets/unmanaged-desc.md
+++ b/docs/site/content/docs/assets/unmanaged-desc.md
@@ -1,3 +1,3 @@
 Unmanaged clusters offer Tanzu environments for **development** and
 **experimentation**. By default, they run locally via [kind](https://kind.sigs.k8s.io) with Tanzu components installed atop. If you're interested in running cluster(s) in a production-ready context, see
-our guidance around [managed-clusters](/getting-started).
+our guidance around [managed-clusters](../getting-started).

--- a/docs/site/content/docs/assets/unmanaged-desc.md
+++ b/docs/site/content/docs/assets/unmanaged-desc.md
@@ -1,0 +1,3 @@
+Unmanaged clusters offer Tanzu environments for **development** and
+**experimentation**. By default, they run locally via [kind](https://kind.sigs.k8s.io) with Tanzu components installed atop. If you're interested in running cluster(s) in a production-ready context, see
+our guidance around [managed-clusters](/getting-started).

--- a/docs/site/content/docs/latest/getting-started-unmanaged.md
+++ b/docs/site/content/docs/latest/getting-started-unmanaged.md
@@ -1,0 +1,85 @@
+# Getting Started with Unmanaged Clusters
+
+<!-- markdownlint-disable MD036 -->
+<!-- markdownlint-disable MD024 -->
+
+{{% include "/docs/assets/unmanaged-desc.md" %}}
+
+## Install Tanzu CLI
+
+The `tanzu` CLI is used for deploying and managing Tanzu Community Edition.
+Choose your operating system below for guidance on installation.
+
+{{< tabs tabTotal="3" tabID="1" tabName1="Linux" tabName2="Mac" tabName3="Windows">}}
+{{< tab tabNum="1" >}}
+
+### Linux System Requirements
+
+{{% include "/docs/assets/prereq-unmanaged-linux.md" %}}
+
+### Package Manager
+
+**Homebrew**
+
+{{% include "/docs/assets/install-homebrew.md" %}}
+
+### Direct Download
+
+{{% include "/docs/assets/direct-download.md" %}}
+
+{{< /tab >}}
+{{< tab tabNum="2" >}}
+
+### Mac System Requirements
+
+{{% include "/docs/assets/prereq-unmanaged-mac.md" %}}
+
+### Package Manager
+
+**Homebrew**
+
+{{% include "/docs/assets/install-homebrew.md" %}}
+
+### Direct Download
+
+{{% include "/docs/assets/direct-download.md" %}}
+
+{{< /tab >}}
+{{< tab tabNum="3" >}}
+
+### Windows System Requirements
+
+{{% include "/docs/assets/prereq-unmanaged-windows.md" %}}
+
+### Package Manager
+
+**Chocolatey**
+
+1. Install using [chocolatey](https://chocolatey.org/install), in **Powershell, as an administrator**.
+
+    ```sh
+    choco install tanzu-community-edition
+    ```
+
+### Direct Download
+
+{{% include "/docs/assets/direct-download.md" %}}
+
+{{< /tab >}}
+{{< /tabs >}}
+
+## Deploy a Cluster
+
+{{% include "/docs/assets/create-unmanaged-cluster.md" %}}
+
+## Deploy a Package
+
+{{% include "/docs/assets/install-package-to-cluster.md" %}}
+
+## Delete a Cluster
+
+{{% include "/docs/assets/delete-unmanaged-cluster.md" %}}
+
+## Next Steps
+
+* [Unmanaged Clusters Reference Documentation](/docs/latest/ref-unmanaged-cluster)

--- a/docs/site/content/docs/latest/ref-unmanaged-cluster.md
+++ b/docs/site/content/docs/latest/ref-unmanaged-cluster.md
@@ -1,0 +1,211 @@
+# Unmanaged Clusters Reference
+
+This is the reference documentation for the `unmanaged-cluster` plugin. If
+this is your first time deploying an unmanaged cluster, see
+[Getting Started with Unmanaged Clusters](getting-started-unmanaged/).
+
+## Command aliases
+
+As a Tanzu CLI plugin, unmanaged clusters can be interacted with using `tanzu
+unmanaged-cluster`. `uc`, `um`, and `unmanaged` are all valid aliases for the
+command. This means the following commands equate to the same:
+
+* `tanzu unmanaged-cluster create hello`
+* `tanzu uc create hello`
+* `tanzu um create hello`
+* `tanzu unmanaged create hello`
+
+## Creating clusters
+
+`create` is used to create a new cluster. By default, it:
+
+1. Installs a cluster using `kind`.
+1. Installs `kapp-controller`.
+1. Installs a core package repository.
+1. Installs a user-managed package repository.
+1. Installs a CNI package.
+    * defaults to `antrea`.
+1. Sets your kubeconfig context to the newly created cluster.
+
+To create a cluster, run:
+
+```sh
+tanzu unmanaged-cluster create ${CLUSTER_NAME}
+```
+
+## Listing clusters
+
+`list` or `ls` is used to list all known clusters. To list known clusters, run:
+
+```sh
+tanzu unmanaged-cluster list
+```
+
+## Deleting clusters
+
+`delete` or `rm` is used to delete a cluster. It will:
+
+1. Attempt to delete the cluster based on the provider.
+    * by default, clusters use `kind`, this will delete the `kind` cluster.
+1. Attempt to remove the cluster's directory.
+    * located at `~/.config/tanzu/tkg/unmanaged/${CLUSTER_NAME}/`.
+
+To delete a cluster, run:
+
+```sh
+tanzu unmanaged-cluster delete ${CLUSTER_NAME}
+```
+
+## Custom configuration
+
+To create a configuration file for cluster creation, run:
+
+```sh
+tanzu unmanaged-cluster config create ${CLUSTER_NAME}
+```
+
+This will create a configuration file, which you can modify to change how
+clusters are created. When creating a cluster, the `-f` flag can be used to
+specify this configuration file.
+
+Along with a configuration file, `unmanaged-cluster` respects settings from
+other settings such as flags. The order in which settings are resolved is:
+
+1. Defaults (lowest precedence)
+1. Configuration File
+1. Environment Variables
+1. Flags (highest precedence)
+
+As a result of rendering the above, a final configuration file is persisted to:
+
+`~/.config/tanzu/tkg/unmanaged/${CLUSTER_NAME}/config.yaml`
+
+Reviewing this file can help in troubleshooting issues during cluster
+bootstrapping.
+
+## Install to existing cluster
+
+If you wish to install the Tanzu components, such as `kapp-controller` and the
+package repositories into an **existing** cluster, you can do so with the
+`--existing-cluster-kubeconfig`/`e` flags or `existingClusterKubeconfig`
+configuration field. The following example demonstrates installing into an
+existing [minikube](https://minikube.sigs.k8s.io) cluster.
+
+1. Create a `minikube` cluster.
+
+    ```sh
+    $ minikube start
+
+    * minikube v1.24.0 on Arch rolling
+    * Automatically selected the docker driver. Other choices: kvm2, ssh
+    * Starting control plane node minikube in cluster minikube
+    * Pulling base image ...
+
+    * Preparing Kubernetes v1.22.3 on Docker 20.10.8 ...
+      - Generating certificates and keys ...
+      - Booting up control plane ...
+      - Configuring RBAC rules ...
+    * Verifying Kubernetes components...
+      - Using image gcr.io/k8s-minikube/storage-provisioner:v5
+    * Enabled addons: storage-provisioner, default-storageclass
+    * Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
+    ```
+
+1. Install the unmanaged cluster components
+
+    ```sh
+    tanzu unmanaged-cluster create -e ~/.kube/config --cni=none
+    ```
+
+    * `~/.kube/config` is the location of the kubeconfig used to access the
+      `minikube` cluster.
+    * `--cni=none` is set since `minikube` already sets up a network for pods.
+
+1. Now you can use the `tanzu` CLI to interact with the cluster.
+
+    ```sh
+    tanzu package list -A
+    ```
+
+## Disable CNI installation
+
+To create a cluster **without** a CNI installed, run:
+
+```sh
+tanzu unmanaged-cluster create --cni=none
+```
+
+This will skip CNI installation and prompt the following during the CNI
+installation step.
+
+```txt
+🌐 Installing CNI
+   No CNI installed: CNI was set to none.
+```
+
+The cluster creation will complete successfully. After that, you are free to
+install a CNI into the cluster.
+
+## Customize the distribution
+
+Unmanaged clusters gather details on how to create a cluster from a Tanzu
+Kubernetes Release (TKr) file. For each release of unmanaged clusters, a
+[default TKr is
+set](https://github.com/vmware-tanzu/community-edition/blob/d0a8622e164c1e345686470b7bcce0c6be9c58f5/cli/cmd/plugin/unmanaged-cluster/tkr/tkr.go#L14-L16).
+
+When creating clusters, you can point to a different TKr using the `--tkr` flag.
+The TCE project keeps TKrs for unmanaged clusters at
+`projects.registry.vmware.com/tce/tkr`. Using
+[imgpkg](https://carvel.dev/imgpkg), you can query available TKrs using:
+
+```sh
+$ imgpkg tag list -i projects.registry.vmware.com/tce/tkr
+Tags
+
+Name
+sha256-2fd337282cf17357c6329f441dc970ec900145faef9e2ec6122f98fa75d529c3.imgpkg
+sha256-33f63314fb72ead645715f6ac85128c0fe0fd380d14f0a79eddba3dd361b73dd.imgpkg
+sha256-ac6566268e0f113a4b91bab870a34353685e886f97e248633bb2c2fcf6490dc8.imgpkg
+v1.21.5
+v1.21.5-1
+v1.21.5-2
+v1.21.5-3
+v1.22.2
+```
+
+To create a cluster with an alternative TKr, you can run:
+
+```sh
+tanzu unmanaged-cluster create --tkr projects.registry.vmware.com/tce/tkr:v1.22.2
+```
+
+To customize a TKr, you can pull an existing one down using `imgpkg`:
+
+```sh
+$ imgpkg pull -i projects.registry.vmware.com/tce/tkr:v1.22.2 -o tkr
+Pulling image 'projects.registry.vmware.com/tce/tkr@sha256:7c1a241dc57fe94f02be4dd6d7e4b29f159415417164abc4b5ab6bb10cf4cbaa'
+Extracting layer 'sha256:e17e901811682a2c8c91c8865f3344a21fdf8f83f012de167c15d2ab06cc494a' (1/1)
+
+Succeeded
+```
+
+You can then edit the above TKr in the `tkr/tkr-bom-v1.22.2.yaml`. After
+modifying it, you may also wish to rename the YAML file. Once you have made your
+modifications, you can repush it using:
+
+```sh
+imgpkg push -f ./tkr/tkr-bom-CUSTOM.yaml -i ${YOUR_REGISTRY}:${YOUR_TAG}
+```
+
+Once pushed, you can reference this repo using the `--tkr` flag.
+
+## Limitations
+
+This section details known limitations of unmanaged clusters.
+
+### Can't Upgrade Kubernetes
+
+By design, `unmanaged-clusters` do not lifecycle-manage Kubernetes. They are not
+meant to be long-running with real workloads. To change Kubernetes versions,
+delete the existing cluster and create a new cluster with a different
+configuration.

--- a/docs/site/data/docs/latest-toc.yml
+++ b/docs/site/data/docs/latest-toc.yml
@@ -11,8 +11,8 @@ toc:
       subfolderitems:
         - page: Managed Clusters
           url: /getting-started
-        - page: Standalone Clusters
-          url: /getting-started-standalone
+        - page: Unmanaged Clusters
+          url: /getting-started-unmanaged
     - title: Installation
       subfolderitems:
         - page: Plan Your Installation
@@ -73,6 +73,8 @@ toc:
       subfolderitems:
         - page: Glossary
           url: /glossary
+        - page: Unmanaged Clusters
+          url: /ref-unmanaged-cluster
         - page: AWS Account Reference
           url: /ref-aws
         - page: AWS Workload Cluster Template


### PR DESCRIPTION


## What this PR does / why we need it

This commit introduces the getting started guide for unmanaged cluster.
This replaces (in the TOC) the existing standalone-cluster docs.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Getting started guide introduced for unmanaged-clusters 
```

## Which issue(s) this PR fixes

Fixes: #TODO

## Describe testing done for PR

Run `hugo serve`

![image](https://user-images.githubusercontent.com/6200057/149019389-94871b87-f935-4719-9e98-7adf5cb6ed4b.png)


## Special notes for your reviewer

Run hugo locally and review the docs.
