### PR TITLE
Fix build/install directive on clean system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,10 @@ OCI_REGISTRY := projects.registry.vmware.com/tce
 .PHONY: lint mdlint shellcheck check yamllint misspell actionlint urllint imagelint
 check: ensure-deps lint mdlint shellcheck yamllint misspell actionlint urllint imagelint
 
+.PHONY: check-deps-minimum-build
+check-deps-minimum-build:
+	hack/ensure-deps/check-zip.sh
+
 .PHONY: ensure-deps
 ensure-deps:
 	hack/ensure-deps/ensure-dependencies.sh
@@ -185,20 +189,20 @@ $(TOOLING_BINARIES):
 ##### Tooling Binaries
 
 ##### BUILD TARGETS #####
-build-tce-cli-plugins: version clean-plugin build-cli-plugins ## builds the CLI plugins that live in the TCE repo into the artifacts directory
+build-tce-cli-plugins: version clean-plugin check-deps-minimum-build build-cli-plugins ## builds the CLI plugins that live in the TCE repo into the artifacts directory
 	@printf "\n[COMPLETE] built TCE-specific plugins at $(ARTIFACTS_DIR)\n"
 	@printf "To install these plugins, run \`make install-tce-cli-plugins\`\n"
 
-install-tce-cli-plugins: version clean-plugin build-cli-plugins framework-set-unstable-versions install-plugins ## builds and installs CLI plugins found in artifacts directory @printf "\n[COMPLETE] built and installed TCE-specific plugins at $${XDG_DATA_HOME}/tanzu-cli/. "
+install-tce-cli-plugins: version clean-plugin check-deps-minimum-build build-cli-plugins framework-set-unstable-versions install-plugins ## builds and installs CLI plugins found in artifacts directory @printf "\n[COMPLETE] built and installed TCE-specific plugins at $${XDG_DATA_HOME}/tanzu-cli/. "
 	@printf "These plugins will be automatically detected by your tanzu CLI.\n"	
 
-build-all-tanzu-cli-plugins: version clean build-cli build-cli-plugins ## builds the Tanzu CLI and all CLI plugins that are used in TCE
+build-all-tanzu-cli-plugins: version clean check-deps-minimum-build build-cli build-cli-plugins ## builds the Tanzu CLI and all CLI plugins that are used in TCE
 	@printf "\n[COMPLETE] built plugins at $(ARTIFACTS_DIR)\n"
 	@printf "These plugins will be automatically detected by tanzu CLI.\n"
 	@printf "\n[COMPLETE] built tanzu CLI at $(TCE_RELEASE_DIR). "
 	@printf "Move this binary to a location in your path!\n"
 
-install-all-tanzu-cli-plugins: version clean build-cli install-cli build-cli-plugins install-plugins ## installs the Tanzu CLI and all CLI plugins that are used in TCE
+install-all-tanzu-cli-plugins: version clean check-deps-minimum-build build-cli install-cli build-cli-plugins install-plugins ## installs the Tanzu CLI and all CLI plugins that are used in TCE
 	@printf "\n[COMPLETE] built and installed TCE-specific plugins at $${XDG_DATA_HOME}/tanzu-cli/.\n"
 	@printf "These plugins will be automatically detected by your tanzu CLI.\n"
 	@printf "\n[COMPLETE] built and installed tanzu CLI at $(TANZU_CLI_INSTALL_PATH). "

--- a/hack/builder/build-tanzu.sh
+++ b/hack/builder/build-tanzu.sh
@@ -23,7 +23,9 @@ fi
 ROOT_REPO_DIR="${TCE_RELEASE_DIR}"
 rm -fr "${ROOT_REPO_DIR}"
 mkdir -p "${ROOT_REPO_DIR}"
-cd "${ROOT_REPO_DIR}" || exit 1
+
+# recreate the TF repo
+pushd "${ROOT_REPO_DIR}" || exit 1
 
 if [[ -z "${TCE_BUILD_VERSION}" ]]; then
     echo "TCE_BUILD_VERSION is not set"
@@ -37,6 +39,10 @@ if [[ -n "${TANZU_FRAMEWORK_REPO_HASH}" ]]; then
 fi
 git clone --depth 1 --branch "${TANZU_FRAMEWORK_REPO_BRANCH}" "${TANZU_FRAMEWORK_REPO}" "tanzu-framework"
 set -x
+
+popd || exit 1
+
+# now build TF
 pushd "${ROOT_REPO_DIR}/tanzu-framework" || exit 1
 git reset --hard
 if [[ -n "${TANZU_FRAMEWORK_REPO_HASH}" ]]; then

--- a/hack/builder/install-tanzu.sh
+++ b/hack/builder/install-tanzu.sh
@@ -20,11 +20,12 @@ if [ ! -d "${ROOT_REPO_DIR}" ] || [ ! -d "${ROOT_REPO_DIR}/tanzu-framework" ]; t
     echo "Please run \`make build-cli\` first to clone the repository"
 fi
 
-cd "${ROOT_REPO_DIR}/tanzu-framework" || exit 1
+pushd "${ROOT_REPO_DIR}/tanzu-framework" || exit 1
 
 BUILD_SHA="$(git describe --match="$(git rev-parse --short HEAD)" --always)"
 sed -i.bak -e "s/ --dirty//g" ./Makefile && rm ./Makefile.bak
 sed -i.bak -e "s|--artifacts artifacts/\${OS}/\${ARCH}/cli|--artifacts artifacts|g" ./Makefile && rm ./Makefile.bak
+sed -i.bak -e "s|--artifacts artifacts-admin/\${OS}/\${ARCH}/cli|--artifacts artifacts-admin|g" ./Makefile && rm ./Makefile.bak
 sed -i.bak -e "s|--artifacts artifacts-admin/\${GOHOSTOS}/\${GOHOSTARCH}/cli|--artifacts artifacts-admin|g" ./Makefile && rm ./Makefile.bak
 sed -i.bak -e "s|--local \$(ARTIFACTS_DIR)/\$(GOHOSTOS)/\$(GOHOSTARCH)/cli|--local \$(ARTIFACTS_DIR)|g" ./Makefile && rm ./Makefile.bak
 sed -i.bak -e "s|--local \$(ARTIFACTS_DIR)-admin/\$(GOHOSTOS)/\$(GOHOSTARCH)/cli|--local \$(ARTIFACTS_DIR)-admin|g" ./Makefile && rm ./Makefile.bak
@@ -34,5 +35,7 @@ sed -i.bak -e "s/\$(shell git describe --tags --abbrev=0 2>\$(NUL))/${FRAMEWORK_
  #The tanzu-framework `build-install-cli-all` target always uses the current host OS, and if that's not being built it will fail.
 GOHOSTOS=$(go env GOHOSTOS)
 if [[ "$ENVS" == *"${GOHOSTOS}"* ]]; then
-    BUILD_SHA=${BUILD_SHA} BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} TANZI_CLI_NO_INIT=true TANZU_CORE_BUCKET="tce-tanzu-cli-framework" make ENVS="${ENVS}" install-cli-plugins install-cli
+    BUILD_SHA=${BUILD_SHA} BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} TANZI_CLI_NO_INIT=true TANZU_CORE_BUCKET="tce-tanzu-cli-framework" make ENVS="${ENVS}" install-cli install-cli-plugins
 fi
+
+popd || exit 1

--- a/hack/ensure-deps/check-curl.sh
+++ b/hack/ensure-deps/check-curl.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script can be used to check your local development environment
+# for necessary dependencies used in TCE
+
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
+
+if [[ "${TCE_CI_BUILD}" != "true" ]]; then
+
+if [[ -z "$(command -v curl)" ]]; then
+  echo "**** Please install curl before proceeding *****"
+  exit 1
+fi
+
+fi

--- a/hack/ensure-deps/check-zip.sh
+++ b/hack/ensure-deps/check-zip.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script can be used to check your local development environment
+# for necessary dependencies used in TCE
+
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
+
+if [[ "${TCE_CI_BUILD}" != "true" ]]; then
+
+if [[ -z "$(command -v zip)" ]]; then
+  echo "**** Please install zip before proceeding *****"
+  exit 1
+fi
+if [[ -z "$(command -v unzip)" ]]; then
+    echo "**** Please install unzip before proceeding *****"
+    exit 1
+fi
+
+fi

--- a/hack/ensure-deps/ensure-curl.sh
+++ b/hack/ensure-deps/ensure-curl.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script can be used to check your local development environment
+# for necessary dependencies used in TCE
+
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
+
+SUDO_CMD="sudo"
+if [[ "${TCE_CI_BUILD}" == "true" ]]; then
+  SUDO_CMD=""
+fi
+
+if [[ -z "$(command -v curl)" ]]; then
+  if [[ -f "/etc/redhat-release" ]]; then
+    ${SUDO_CMD} yum -y install curl
+  elif [[ "$(grep Ubuntu /etc/os-release)" != "" ]]; then
+    ${SUDO_CMD} apt-get -y install curl
+  else
+    echo "**** Please install curl before proceeding *****"
+    exit 1
+  fi
+fi

--- a/hack/ensure-deps/ensure-dependencies.sh
+++ b/hack/ensure-deps/ensure-dependencies.sh
@@ -37,11 +37,6 @@ if [[ -z "$(command -v docker)" ]]; then
     echo "Missing docker"
     ((i=i+1))
 fi
-
-if [[ -z "$(command -v curl)" ]]; then
-    echo "Missing curl"
-    ((i=i+1))
-fi
 # these are must have dependencies to just get going
 
 if [[ $i -gt 0 ]]; then
@@ -50,6 +45,8 @@ if [[ $i -gt 0 ]]; then
     exit 1
 fi
 
+"${TCE_REPO_PATH}/hack/ensure-deps/ensure-curl.sh"
+"${TCE_REPO_PATH}/hack/ensure-deps/ensure-zip.sh"
 "${TCE_REPO_PATH}/hack/ensure-deps/ensure-imgpkg.sh"
 "${TCE_REPO_PATH}/hack/ensure-deps/ensure-kbld.sh"
 "${TCE_REPO_PATH}/hack/ensure-deps/ensure-ytt.sh"

--- a/hack/ensure-deps/ensure-zip.sh
+++ b/hack/ensure-deps/ensure-zip.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script can be used to check your local development environment
+# for necessary dependencies used in TCE
+
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
+
+SUDO_CMD="sudo"
+if [[ "${TCE_CI_BUILD}" == "true" ]]; then
+  SUDO_CMD=""
+fi
+
+if [[ -z "$(command -v zip)" ]]; then
+  if [[ -f "/etc/redhat-release" ]]; then
+    ${SUDO_CMD} yum -y install zip
+  elif [[ "$(grep Ubuntu /etc/os-release)" != "" ]]; then
+    ${SUDO_CMD} apt-get -y install zip
+  else
+    echo "**** Please install zip before proceeding *****"
+    exit 1
+  fi
+fi
+if [[ -z "$(command -v unzip)" ]]; then
+  if [[ -f "/etc/redhat-release" ]]; then
+    ${SUDO_CMD} yum -y install unzip
+  elif [[ "$(grep Ubuntu /etc/os-release)" != "" ]]; then
+    ${SUDO_CMD} apt-get -y install unzip
+  else
+    echo "**** Please install unzip before proceeding *****"
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This fixes an issue with the `make install-all-tanzu-cli-plugins` command on a fresh system or where tanzu CLI has never been installed.

There are two issues here:
1) There was a slight logic flaw where we `cd` into the TF folder to build but never reverted back to the TCE repo path to continue the build process from the correct path. In other words, we need to make sure we always do a `pushd`/`popd` to ensure we are consistently expecting to be in certain paths.
2) On Ubuntu-based systems, `zip` and `unzip` aren't installed by default which leads to the failure to unzip pinniped and thus building it. This causes the Tanzu Framework plugins to bomb out and not build any of those plugins (but doesn't bomb out) and thereby failing to install them. This checks to make sure that zip/unzip are installed and if they aren't, the build bombs out with an error.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix build/install directive on clean system
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/2787

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
`make release`
`make install-all-tanzu-cli-plugins`

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA
