### PR TITLE
Introduce colors library for `unmanaged-cluster` logging

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/go.mod
+++ b/cli/cmd/plugin/unmanaged-cluster/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/cppforlife/go-cli-ui v0.0.0-20200716203538-1e47f820817f
+	github.com/fatih/color v1.13.0
 	github.com/k14s/imgpkg v0.6.0
 	github.com/k14s/ytt v0.37.0
 	github.com/spf13/cobra v1.2.1

--- a/cli/cmd/plugin/unmanaged-cluster/go.sum
+++ b/cli/cmd/plugin/unmanaged-cluster/go.sum
@@ -379,8 +379,9 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -847,8 +848,9 @@ github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcncea
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
-github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.9 h1:sqDoxXbdeALODt0DAeJCVp38ps9ZogZEAXjus69YV3U=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-ieproxy v0.0.1/go.mod h1:pYabZ6IHcRpFh7vIaLfK7rdcWgFEb3SFJ6/gNWuh88E=
@@ -857,8 +859,9 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
-github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
@@ -1556,6 +1559,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0 h1:xrCZDmdtoloIiooiA9q0OQb9r8HejIHYoHGhGCe1pGg=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=

--- a/cli/cmd/plugin/unmanaged-cluster/log/log.go
+++ b/cli/cmd/plugin/unmanaged-cluster/log/log.go
@@ -13,14 +13,11 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/fatih/color"
 )
 
 const (
-	ColorNone       = "\033[0m"
-	ColorRed        = "\033[31m"
-	ColorBlue       = "\033[34m"
-	ColorLightGreen = "\033[32m"
-
 	// The following are a set of emoji codes that can be used
 	// with the Event and Eventf logging methods in this package.
 	// They should all take up 2 terminal columns.
@@ -47,8 +44,8 @@ type CMDLogger struct {
 	logLevel int
 	// instances of indentation (" ") to prepend to a long message
 	indent int
-	// color to log the message as
-	color string
+	// logColor defines the color to log the message as define by fatih/color Attributes
+	logColor color.Attribute
 	// output controls where log messages are sent
 	output io.Writer
 }
@@ -103,7 +100,7 @@ type Logger interface {
 	V(level int) Logger
 	// Style provides indentation and colorization of log messages. The indent argument specifies the amount of " "
 	// characters to prepend to the message. The color should be specified using color constants in this package.
-	Style(indent int, color string) Logger
+	Style(indent int, c color.Attribute) Logger
 	// AddLogFile adds a file name to log all activity to.
 	AddLogFile(filePath string)
 }
@@ -198,13 +195,7 @@ func (l *CMDLogger) Error(message string) {
 		return
 	}
 
-	// default to red when color is not set
-	if l.color == "" {
-		l.color = ColorRed
-		message = processStyle(l, message)
-	} else {
-		message = processStyle(l, message)
-	}
+	message = processStyle(l, message)
 	fmt.Print(message)
 }
 
@@ -213,13 +204,6 @@ func (l *CMDLogger) Errorf(message string, args ...interface{}) {
 		return
 	}
 
-	// default to red when color is not set
-	if l.color == "" {
-		l.color = ColorRed
-		message = processStyle(l, message)
-	} else {
-		message = processStyle(l, message)
-	}
 	message = processStyle(l, message)
 	fmt.Fprintf(l.output, message, args...)
 }
@@ -359,7 +343,7 @@ func (l *CMDLogger) V(level int) Logger {
 	}
 }
 
-func (l *CMDLogger) Style(indent int, color string) Logger {
+func (l *CMDLogger) Style(indent int, c color.Attribute) Logger {
 	// if tty is disable, don't return a style-capable logger
 	if !l.tty {
 		return l
@@ -369,7 +353,7 @@ func (l *CMDLogger) Style(indent int, color string) Logger {
 		level:    l.level,
 		logLevel: l.logLevel,
 		indent:   indent,
-		color:    color,
+		logColor: c,
 		output:   l.output,
 	}
 }
@@ -394,9 +378,8 @@ func processStyle(l *CMDLogger, message string) string {
 	}
 
 	// apply color value to entire message
-	if l.color != "" {
-		message = l.color + message
-		message += ColorNone
+	if l.logColor != 0 {
+		message = color.New(l.logColor).Sprint(message)
 	}
 
 	return message

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/config"
 
 	v1 "k8s.io/api/apps/v1"
@@ -144,8 +145,8 @@ func (t *TanzuUnmanaged) Deploy(scConfig *config.UnmanagedClusterConfig) error {
 	if err != nil {
 		return err
 	}
-	log.Style(outputIndent, logger.ColorNone).Infof("Rendered Config: %s\n", configFp)
-	log.Style(outputIndent, logger.ColorNone).Infof("Bootstrap Logs: %s\n", bootstrapLogsFp)
+	log.Style(outputIndent, color.Faint).Infof("Rendered Config: %s\n", configFp)
+	log.Style(outputIndent, color.Faint).Infof("Bootstrap Logs: %s\n", bootstrapLogsFp)
 
 	log.Event(logger.WrenchEmoji, "Processing Tanzu Kubernetes Release\n")
 	t.bom, err = parseTKRBom(bomFileName)
@@ -156,16 +157,16 @@ func (t *TanzuUnmanaged) Deploy(scConfig *config.UnmanagedClusterConfig) error {
 	// 3. Resolve all required images
 	// base image
 	log.Event(logger.PictureEmoji, "Selected base image\n")
-	log.Style(outputIndent, logger.ColorNone).Infof("%s\n", t.bom.GetTKRNodeImage())
+	log.Style(outputIndent, color.Faint).Infof("%s\n", t.bom.GetTKRNodeImage())
 	scConfig.NodeImage = t.bom.GetTKRNodeImage()
 
 	// core package repository
 	log.Event(logger.PackageEmoji, "Selected core package repository\n")
-	log.Style(outputIndent, logger.ColorNone).Infof("%s\n", t.bom.GetTKRCoreRepoBundlePath())
+	log.Style(outputIndent, color.Faint).Infof("%s\n", t.bom.GetTKRCoreRepoBundlePath())
 	// core user package repositories
 	log.Event(logger.PackageEmoji, "Selected additional package repositories\n")
 	for _, additionalRepo := range t.bom.GetAdditionalRepoBundlesPaths() {
-		log.Style(outputIndent, logger.ColorNone).Infof("%s\n", additionalRepo)
+		log.Style(outputIndent, color.Faint).Infof("%s\n", additionalRepo)
 	}
 	// kapp-controller
 	err = resolveKappBundle(t)
@@ -173,7 +174,7 @@ func (t *TanzuUnmanaged) Deploy(scConfig *config.UnmanagedClusterConfig) error {
 		return fmt.Errorf("failed resolving kapp-controller bundle. Error: %s", err.Error())
 	}
 	log.Event(logger.PackageEmoji, "Selected kapp-controller image bundle\n")
-	log.Style(outputIndent, logger.ColorNone).Infof("%s\n", t.kappControllerBundle.GetRegistryURL())
+	log.Style(outputIndent, color.Faint).Infof("%s\n", t.kappControllerBundle.GetRegistryURL())
 
 	// 4. Create the cluster
 	log.Eventf(logger.RocketEmoji, "Creating cluster %s\n", scConfig.ClusterName)
@@ -183,8 +184,8 @@ func (t *TanzuUnmanaged) Deploy(scConfig *config.UnmanagedClusterConfig) error {
 	}
 
 	kcBytes := createdCluster.Kubeconfig
-	log.Style(outputIndent, logger.ColorNone).Info("To troubleshoot, use:\n")
-	log.Style(outputIndent, logger.ColorNone).Infof("kubectl ${COMMAND} --kubeconfig %s\n", scConfig.KubeconfigPath)
+	log.Style(outputIndent, color.Faint).Info("To troubleshoot, use:\n")
+	log.Style(outputIndent, color.Faint).Infof("kubectl ${COMMAND} --kubeconfig %s\n", scConfig.KubeconfigPath)
 
 	// 5. Install kapp-controller
 	kc, err := kapp.New(kcBytes)
@@ -220,7 +221,7 @@ func (t *TanzuUnmanaged) Deploy(scConfig *config.UnmanagedClusterConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to resolve a CNI package. Error: %s", err.Error())
 	}
-	log.Style(outputIndent, logger.ColorNone).Infof("%s:%s\n", t.selectedCNIPkg.fqPkgName, t.selectedCNIPkg.pkgVersion)
+	log.Style(outputIndent, color.Faint).Infof("%s:%s\n", t.selectedCNIPkg.fqPkgName, t.selectedCNIPkg.pkgVersion)
 	err = installCNI(pkgClient, t)
 	if err != nil {
 		return fmt.Errorf("failed to install the CNI package. Error: %s", err.Error())
@@ -237,12 +238,12 @@ func (t *TanzuUnmanaged) Deploy(scConfig *config.UnmanagedClusterConfig) error {
 	log.Event(logger.GreenCheckEmoji, "Cluster created\n")
 	log.Eventf(logger.ControllerEmoji, "kubectl context set to %s\n\n", scConfig.ClusterName)
 	// provide user example commands to run
-	log.Style(0, logger.ColorNone).Infof("View available packages:\n")
-	log.Style(outputIndent, logger.ColorLightGreen).Infof("tanzu package available list\n")
-	log.Style(0, logger.ColorNone).Infof("View running pods:\n")
-	log.Style(outputIndent, logger.ColorLightGreen).Infof("kubectl get po -A\n")
-	log.Style(0, logger.ColorNone).Infof("Delete this cluster:\n")
-	log.Style(outputIndent, logger.ColorLightGreen).Infof("tanzu unmanaged delete %s\n", scConfig.ClusterName)
+	log.Infof("View available packages:\n")
+	log.Style(outputIndent, color.FgGreen).Infof("tanzu package available list\n")
+	log.Infof("View running pods:\n")
+	log.Style(outputIndent, color.FgGreen).Infof("kubectl get po -A\n")
+	log.Infof("Delete this cluster:\n")
+	log.Style(outputIndent, color.FgGreen).Infof("tanzu unmanaged delete %s\n", scConfig.ClusterName)
 	return nil
 }
 
@@ -443,7 +444,7 @@ func createClusterDirectory(clusterName string) (string, error) {
 }
 
 func getTkrBom(registry string) (string, error) {
-	log.Style(outputIndent, logger.ColorNone).Infof("%s\n", registry)
+	log.Style(outputIndent, color.Faint).Infof("%s\n", registry)
 	expectedBomName := buildFilesystemSafeBomName(registry)
 
 	bomPath, err := getUnmanagedBomPath()
@@ -467,7 +468,7 @@ func getTkrBom(registry string) (string, error) {
 	// if the expected bom is already in the config directory, don't download it again. return early
 	for _, file := range items {
 		if file.Name() == expectedBomName {
-			log.Style(outputIndent, logger.ColorNone).Infof("TKR exists at %s\n", filepath.Join(bomPath, file.Name()))
+			log.Style(outputIndent, color.Faint).Infof("TKR exists at %s\n", filepath.Join(bomPath, file.Name()))
 			return file.Name(), nil
 		}
 	}
@@ -519,7 +520,7 @@ func blockForBomImage(b tkr.TkrImageReader, bomPath, expectedBomName string) err
 	// start a go routine to animate the downloading logs while the imgpkg libraries get the bom image
 	ctx, cancel := context.WithCancel(context.Background())
 	go func(ctx context.Context) {
-		log.Style(outputIndent, logger.ColorNone).AnimateProgressWithOptions(
+		log.Style(outputIndent, color.Reset).AnimateProgressWithOptions(
 			logger.AnimatorWithContext(ctx),
 			logger.AnimatorWithMaxLen(maxProgressLength),
 			logger.AnimatorWithMessagef("Downloading to: %s", f),
@@ -535,7 +536,7 @@ func blockForBomImage(b tkr.TkrImageReader, bomPath, expectedBomName string) err
 
 	// Once downloading is done, cancel the logging animation go routine and log completion
 	cancel()
-	log.Style(outputIndent, logger.ColorNone).ReplaceLinef("Downloaded to: %s", f)
+	log.Style(outputIndent, color.Faint).ReplaceLinef("Downloaded to: %s", f)
 
 	return nil
 }
@@ -592,7 +593,7 @@ func blockForPullingBaseImage(cm cluster.ClusterManager, scConfig *config.Unmana
 	// start a go routine to animate the downloading logs while the docker exec gets the image
 	ctx, cancel := context.WithCancel(context.Background())
 	go func(ctx context.Context) {
-		log.Style(outputIndent, logger.ColorNone).AnimateProgressWithOptions(
+		log.Style(outputIndent, color.Reset).AnimateProgressWithOptions(
 			logger.AnimatorWithContext(ctx),
 			logger.AnimatorWithMaxLen(maxProgressLength),
 			logger.AnimatorWithMessagef("Pulling base image"),
@@ -608,7 +609,7 @@ func blockForPullingBaseImage(cm cluster.ClusterManager, scConfig *config.Unmana
 
 	// once we're done, cancel the go routine animation and log final message
 	cancel()
-	log.Style(outputIndent, logger.ColorNone).ReplaceLinef("Base image downloaded")
+	log.Style(outputIndent, color.Faint).ReplaceLinef("Base image downloaded")
 
 	return nil
 }
@@ -617,7 +618,7 @@ func blockForClusterCreate(cm cluster.ClusterManager, scConfig *config.Unmanaged
 	// start a go routine to animate the downloading logs while the docker exec gets the image
 	ctx, cancel := context.WithCancel(context.Background())
 	go func(ctx context.Context) {
-		log.Style(outputIndent, logger.ColorNone).AnimateProgressWithOptions(
+		log.Style(outputIndent, color.Reset).AnimateProgressWithOptions(
 			logger.AnimatorWithContext(ctx),
 			logger.AnimatorWithMaxLen(maxProgressLength),
 			logger.AnimatorWithMessagef("Creating cluster"),
@@ -633,7 +634,7 @@ func blockForClusterCreate(cm cluster.ClusterManager, scConfig *config.Unmanaged
 
 	// Once done, cancel the go routine animations and log final message
 	cancel()
-	log.Style(outputIndent, logger.ColorNone).ReplaceLinef("Cluster created")
+	log.Style(outputIndent, color.Faint).ReplaceLinef("Cluster created")
 
 	return kc, nil
 }
@@ -667,7 +668,7 @@ func blockForKappStatus(kappDeployment *v1.Deployment, kc kapp.KappManager) {
 	ctx, cancel := context.WithCancel(context.Background())
 	status := make(chan string, 1)
 	go func(ctx context.Context) {
-		log.Style(outputIndent, logger.ColorNone).AnimateProgressWithOptions(
+		log.Style(outputIndent, color.Faint).AnimateProgressWithOptions(
 			logger.AnimatorWithContext(ctx),
 			logger.AnimatorWithMaxLen(maxProgressLength),
 			logger.AnimatorWithMessagef("kapp-controller status: %s"),
@@ -682,7 +683,7 @@ func blockForKappStatus(kappDeployment *v1.Deployment, kc kapp.KappManager) {
 		status <- kappState
 		if kappState == "Running" {
 			cancel()
-			log.Style(outputIndent, logger.ColorNone).ReplaceLinef("kapp-controller status: %s", kappState)
+			log.Style(outputIndent, color.Faint).ReplaceLinef("kapp-controller status: %s", kappState)
 			break
 		}
 		time.Sleep(1 * time.Second)
@@ -702,7 +703,7 @@ func blockForRepoStatus(repo *v1alpha1.PackageRepository, pkgClient packages.Pac
 	ctx, cancel := context.WithCancel(context.Background())
 	status := make(chan string, 1)
 	go func(ctx context.Context) {
-		log.Style(outputIndent, logger.ColorNone).AnimateProgressWithOptions(
+		log.Style(outputIndent, color.Reset).AnimateProgressWithOptions(
 			logger.AnimatorWithContext(ctx),
 			logger.AnimatorWithMaxLen(maxProgressLength),
 			logger.AnimatorWithMessagef("Core package repo status: %s"),
@@ -722,7 +723,7 @@ func blockForRepoStatus(repo *v1alpha1.PackageRepository, pkgClient packages.Pac
 		}
 		if pkgStatus == "Reconcile succeeded" {
 			cancel()
-			log.Style(outputIndent, logger.ColorNone).ReplaceLinef("Core package repo status: %s", pkgStatus)
+			log.Style(outputIndent, color.Faint).ReplaceLinef("Core package repo status: %s", pkgStatus)
 			break
 		}
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
- Added default colors to warn, error, info, etc. If a color is already set (aka, it's not the `color.Reset` attribute) it will use that color instead.

- This keeps us from having to manage escape codes ourselves and also gives us the advantage of bailing out on the use of colors when `NO_COLOR` is set in the env.

- This also replaces "successful" info messages with the `Faded` attribute. So during the progress animation, when the reconciliation or status is done, it replaces those messages with faded messages indicating success to the user.

A few screen-shots (notice the green towards the bottom and the faded text):

iTerm Dark theme
![Screen Shot 2022-01-13 at 10 38 39 AM](https://user-images.githubusercontent.com/23109390/149381495-4249a080-7bf9-483d-9f30-7cd10d214218.png)

iTerm Lite theme
![Screen Shot 2022-01-13 at 10 39 55 AM](https://user-images.githubusercontent.com/23109390/149381499-9b046264-aa59-4c32-bb28-daf931e51a73.png)

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
See screenshots

## Special notes for your reviewer
Happy to test this with more themes etc.

The dependencies introduced here are also very minimal.
