### PR TITLE
Create OpenAPIV3 schema for vsphere-csi package and generate package with the schema

### DIFF
--- a/addons/packages/vsphere-csi/2.3.0/README.md
+++ b/addons/packages/vsphere-csi/2.3.0/README.md
@@ -16,7 +16,7 @@ None
 
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
-| `vsphereCSI.namespace` | Required | The namespace of the Kubernetes cluster in cluster ID. Default value is `null`. |
+| `vsphereCSI.namespace` | Required | The namespace in which vsphere-csi is deployed. Default value is `null`. |
 | `vsphereCSI.clusterName` | Required | The name of the Kubernetes cluster in cluster ID. Default value is `null`. |
 | `vsphereCSI.server` | Required | The IP address or FQDN of the vCenter endpoint. Default value is `null`. |
 | `vsphereCSI.datacenter` | Required | The Datacenter in which VMs are located. Default value is `null`. |

--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/schema.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/schema.yaml
@@ -1,0 +1,45 @@
+#! schema.yaml
+
+#@data/values-schema
+#@schema/desc "OpenAPIv3 Schema for vsphere-csi"
+---
+#@schema/desc "Configuration for vsphere-csi"
+vsphereCSI:
+  #@schema/desc "The cryptographic thumbprint of the vSphere endpoint's certificate, must be provided if `insecureFlag` is False"
+  tlsThumbprint: ""
+  #@schema/desc "The namespace in which vsphere-csi is deployed"
+  namespace: kube-system
+  #@schema/desc "The name of the Kubernetes cluster in cluster ID"
+  clusterName: ""
+  #@schema/desc "The IP address or FQDN of the vCenter endpoint"
+  server: ""
+  #@schema/desc "The Datacenter in which VMs are located"
+  datacenter: ""
+  #@schema/desc "The public network to be used"
+  publicNetwork: ""
+  #@schema/desc "vCenter username in clear text"
+  username: ""
+  #@schema/desc "vCenter password in clear text"
+  password: ""
+  #@schema/desc " The region used by multi-AZ feature"
+  #@schema/nullable
+  region: ""
+  #@schema/desc "The zone used by multi-AZ feature"
+  #@schema/nullable
+  zone: ""
+  #@schema/desc "The flag that disables TLS peer verification"
+  insecureFlag: False
+  #@schema/desc "The timeout period for csi-provisioner container"
+  provisionTimeout: 300s
+  #@schema/desc "The timeout period for csi-attacher container"
+  attachTimeout: 300s
+  #@schema/desc "The timeout period for csi-resizer container"
+  resizerTimeout: 300s
+  #@schema/desc "The vSphere version used"
+  vSphereVersion: 6.7.0
+  #@schema/desc "The HTTP_PROXY env var passed to csi-attacher container"
+  http_proxy: ""
+  #@schema/desc "The HTTPS_PROXY env var passed to csi-attacher container"
+  https_proxy: ""
+  #@schema/desc "The NO_PROXY env var passed to csi-attacher container"
+  no_proxy: ""

--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/values.star
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/values.star
@@ -2,15 +2,15 @@ load("@ytt:data", "data")
 load("@ytt:assert", "assert")
 
 def validate_vsphereCSI():
-   data.values.vsphereCSI.namespace or assert.fail("vsphereCSI namespace should be provided")
-   data.values.vsphereCSI.clusterName or assert.fail("vsphereCSI clusterName should be provided")
-   data.values.vsphereCSI.server or assert.fail("vsphereCSI server should be provided")
-   data.values.vsphereCSI.datacenter or assert.fail("vsphereCSI datacenter should be provided")
-   data.values.vsphereCSI.publicNetwork or assert.fail("vsphereCSI publicNetwork should be provided")
-   data.values.vsphereCSI.username or assert.fail("vsphereCSI username should be provided")
-   data.values.vsphereCSI.password or assert.fail("vsphereCSI password should be provided")
+   data.values.vsphereCSI.namespace != "" or assert.fail("vsphereCSI namespace should be provided")
+   data.values.vsphereCSI.clusterName != "" or assert.fail("vsphereCSI clusterName should be provided")
+   data.values.vsphereCSI.server != "" or assert.fail("vsphereCSI server should be provided")
+   data.values.vsphereCSI.datacenter != "" or assert.fail("vsphereCSI datacenter should be provided")
+   data.values.vsphereCSI.publicNetwork != "" or assert.fail("vsphereCSI publicNetwork should be provided")
+   data.values.vsphereCSI.username != "" or assert.fail("vsphereCSI username should be provided")
+   data.values.vsphereCSI.password != "" or assert.fail("vsphereCSI password should be provided")
    if not data.values.vsphereCSI.insecureFlag:
-     data.values.vsphereCSI.tlsThumbprint or assert.fail("vsphereCSI tlsThumbprint should be provided when insecureFlag is False")
+     data.values.vsphereCSI.tlsThumbprint != "" or assert.fail("vsphereCSI tlsThumbprint should be provided when insecureFlag is False")
    end
 end
 

--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/values.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/values.yaml
@@ -5,15 +5,15 @@
 vsphereCSI:
   tlsThumbprint: ""
   namespace: kube-system
-  clusterName: null
-  server: null
-  datacenter: null
-  publicNetwork: null
-  username: null
-  password: null
+  clusterName: ""
+  server: ""
+  datacenter: ""
+  publicNetwork: ""
+  username: ""
+  password: ""
   region: null
   zone: null
-  insecureFlag: True
+  insecureFlag: False
   provisionTimeout: 300s
   attachTimeout: 300s
   resizerTimeout: 300s

--- a/addons/packages/vsphere-csi/2.3.0/package.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/package.yaml
@@ -5,21 +5,106 @@ metadata:
 spec:
   refName: vsphere-csi.community.tanzu.vmware.com
   version: 2.3.0
-  releaseNotes: "vsphere-csi 2.3.0 https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.3.0"
+  releaseNotes: vsphere-csi 2.3.0 https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.3.0
   licenses:
-    - "Apache 2.0"
+  - Apache 2.0
   template:
     spec:
       fetch:
-        - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:a2814538e00b6a875ead5cbc3bfd43335b5fa981c2d6c5ead42058eab79edf4e
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/vsphere-csi@sha256:069990d21488f6ffea7fe5cc33e074297294a52f3f202fbe346745e8fbc55aef
       template:
-        - ytt:
-            paths:
-              - config/
-        - kbld:
-            paths:
-              - "-"
-              - .imgpkg/images.yml
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
       deploy:
-        - kapp: {}
+      - kapp: {}
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      description: OpenAPIv3 Schema for vsphere-csi
+      properties:
+        vsphereCSI:
+          type: object
+          additionalProperties: false
+          description: Configuration for vsphere-csi
+          properties:
+            tlsThumbprint:
+              type: string
+              default: ""
+              description: The cryptographic thumbprint of the vSphere endpoint's certificate, must be provided if `insecureFlag` is False
+            namespace:
+              type: string
+              default: kube-system
+              description: The namespace in which vsphere-csi is deployed
+            clusterName:
+              type: string
+              default: ""
+              description: The name of the Kubernetes cluster in cluster ID
+            server:
+              type: string
+              default: ""
+              description: The IP address or FQDN of the vCenter endpoint
+            datacenter:
+              type: string
+              default: ""
+              description: The Datacenter in which VMs are located
+            publicNetwork:
+              type: string
+              default: ""
+              description: The public network to be used
+            username:
+              type: string
+              default: ""
+              description: vCenter username in clear text
+            password:
+              type: string
+              default: ""
+              description: vCenter password in clear text
+            region:
+              type: string
+              default: null
+              nullable: true
+              description: ' The region used by multi-AZ feature'
+            zone:
+              type: string
+              default: null
+              nullable: true
+              description: The zone used by multi-AZ feature
+            insecureFlag:
+              type: boolean
+              default: false
+              description: The flag that disables TLS peer verification
+            provisionTimeout:
+              type: string
+              default: 300s
+              description: The timeout period for csi-provisioner container
+            attachTimeout:
+              type: string
+              default: 300s
+              description: The timeout period for csi-attacher container
+            resizerTimeout:
+              type: string
+              default: 300s
+              description: The timeout period for csi-resizer container
+            vSphereVersion:
+              type: string
+              default: 6.7.0
+              description: The vSphere version used
+            http_proxy:
+              type: string
+              default: ""
+              description: The HTTP_PROXY env var passed to csi-attacher container
+            https_proxy:
+              type: string
+              default: ""
+              description: The HTTPS_PROXY env var passed to csi-attacher container
+            no_proxy:
+              type: string
+              default: ""
+              description: The NO_PROXY env var passed to csi-attacher container

--- a/addons/packages/vsphere-csi/2.3.0/sample-values/vsphere_csi.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/sample-values/vsphere_csi.yaml
@@ -1,0 +1,16 @@
+#@data/values
+#@overlay/match-child-defaults missing_ok=True
+
+---
+vsphereCSI:
+  tlsThumbprint: "testThumbprint"
+  namespace: kube-system
+  clusterName: cluster-test
+  server: 10.1.1.1
+  datacenter: ds-test
+  publicNetwork: test
+  username: test
+  password: test
+  provisionTimeout: 300s
+  attachTimeout: 3000s
+  vSphereVersion: 7.0.0

--- a/addons/packages/vsphere-csi/2.4.1/README.md
+++ b/addons/packages/vsphere-csi/2.4.1/README.md
@@ -16,7 +16,7 @@ None
 
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
-| `vsphereCSI.namespace` | Required | The namespace of the Kubernetes cluster in cluster ID. Default value is `null`. |
+| `vsphereCSI.namespace` | Required | The namespace in which vsphere-csi is deployed. Default value is `null`. |
 | `vsphereCSI.clusterName` | Required | The name of the Kubernetes cluster in cluster ID. Default value is `null`. |
 | `vsphereCSI.server` | Required | The IP address or FQDN of the vCenter endpoint. Default value is `null`. |
 | `vsphereCSI.datacenter` | Required | The Datacenter in which VMs are located. Default value is `null`. |
@@ -35,7 +35,7 @@ None
 | `vsphereCSI.https_proxy` | Optional | The HTTPS_PROXY env var passed to csi-attacher container. Default value is `null`. |
 | `vsphereCSI.no_proxy` | Optional | The NO_PROXY env var passed to csi-attacher container. Default value is `null`. |
 | `vsphereCSI.deployment_replicas` | Optional | The number of replicas of vsphere-csi-controller deployment. Default: `3`. |
-| `vsphereCSI.windows_support` | Optional | Enables CSI Windows support. Default: `false`. |
+| `vsphereCSI.windows_support` | Optional | Whether to enables CSI Windows support. Default: `false`. |
 
 ## Usage Example
 

--- a/addons/packages/vsphere-csi/2.4.1/bundle/config/schema.yaml
+++ b/addons/packages/vsphere-csi/2.4.1/bundle/config/schema.yaml
@@ -1,0 +1,51 @@
+#! schema.yaml
+
+#@data/values-schema
+#@schema/desc "OpenAPIv3 Schema for vsphere-csi"
+---
+#@schema/desc "Configuration for vsphere-csi"
+vsphereCSI:
+  #@schema/desc "The cryptographic thumbprint of the vSphere endpoint's certificate, must be provided if `insecureFlag` is False"
+  tlsThumbprint: ""
+  #@schema/desc "The namespace in which vsphere-csi is deployed"
+  namespace: kube-system
+  #@schema/desc "The name of the Kubernetes cluster in cluster ID"
+  clusterName: ""
+  #@schema/desc "The IP address or FQDN of the vCenter endpoint"
+  server: ""
+  #@schema/desc "The Datacenter in which VMs are located"
+  datacenter: ""
+  #@schema/desc "The public network to be used"
+  publicNetwork: ""
+  #@schema/desc "vCenter username in clear text"
+  username: ""
+  #@schema/desc "vCenter password in clear text"
+  password: ""
+  #@schema/desc " The region used by multi-AZ feature"
+  #@schema/nullable
+  region: ""
+  #@schema/desc "The zone used by multi-AZ feature"
+  #@schema/nullable
+  zone: ""
+  #@schema/desc "The flag that disables TLS peer verification"
+  insecureFlag: False
+  #@schema/desc "Whether to use topology-categories label in vSphere config"
+  useTopologyCategories: false
+  #@schema/desc "The timeout period for csi-provisioner container"
+  provisionTimeout: 300s
+  #@schema/desc "The timeout period for csi-attacher container"
+  attachTimeout: 300s
+  #@schema/desc "The timeout period for csi-resizer container"
+  resizerTimeout: 300s
+  #@schema/desc "The vSphere version used"
+  vSphereVersion: 6.7.0
+  #@schema/desc "The HTTP_PROXY env var passed to csi-attacher container"
+  http_proxy: ""
+  #@schema/desc "The HTTPS_PROXY env var passed to csi-attacher container"
+  https_proxy: ""
+  #@schema/desc "The NO_PROXY env var passed to csi-attacher container"
+  no_proxy: ""
+  #@schema/desc "The number of replicas of vsphere-csi-controller deployment"
+  deployment_replicas: 3
+  #@schema/desc "Whether to enables CSI Windows support"
+  windows_support: false

--- a/addons/packages/vsphere-csi/2.4.1/bundle/config/values.star
+++ b/addons/packages/vsphere-csi/2.4.1/bundle/config/values.star
@@ -2,15 +2,15 @@ load("@ytt:data", "data")
 load("@ytt:assert", "assert")
 
 def validate_vsphereCSI():
-   data.values.vsphereCSI.namespace or assert.fail("vsphereCSI namespace should be provided")
-   data.values.vsphereCSI.clusterName or assert.fail("vsphereCSI clusterName should be provided")
-   data.values.vsphereCSI.server or assert.fail("vsphereCSI server should be provided")
-   data.values.vsphereCSI.datacenter or assert.fail("vsphereCSI datacenter should be provided")
-   data.values.vsphereCSI.publicNetwork or assert.fail("vsphereCSI publicNetwork should be provided")
-   data.values.vsphereCSI.username or assert.fail("vsphereCSI username should be provided")
-   data.values.vsphereCSI.password or assert.fail("vsphereCSI password should be provided")
+   data.values.vsphereCSI.namespace != "" or assert.fail("vsphereCSI namespace should be provided")
+   data.values.vsphereCSI.clusterName != "" or assert.fail("vsphereCSI clusterName should be provided")
+   data.values.vsphereCSI.server != "" or assert.fail("vsphereCSI server should be provided")
+   data.values.vsphereCSI.datacenter != "" or assert.fail("vsphereCSI datacenter should be provided")
+   data.values.vsphereCSI.publicNetwork != "" or assert.fail("vsphereCSI publicNetwork should be provided")
+   data.values.vsphereCSI.username != "" or assert.fail("vsphereCSI username should be provided")
+   data.values.vsphereCSI.password != "" or assert.fail("vsphereCSI password should be provided")
    if not data.values.vsphereCSI.insecureFlag:
-     data.values.vsphereCSI.tlsThumbprint or assert.fail("vsphereCSI tlsThumbprint should be provided when insecureFlag is False")
+     data.values.vsphereCSI.tlsThumbprint != "" or assert.fail("vsphereCSI tlsThumbprint should be provided when insecureFlag is False")
    end
 end
 

--- a/addons/packages/vsphere-csi/2.4.1/package.yaml
+++ b/addons/packages/vsphere-csi/2.4.1/package.yaml
@@ -5,21 +5,118 @@ metadata:
 spec:
   refName: vsphere-csi.community.tanzu.vmware.com
   version: 2.4.1
-  releaseNotes: "vsphere-csi 2.4.1-rc.1 https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.4.1-rc.1"
+  releaseNotes: vsphere-csi 2.4.1-rc.1 https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.4.1-rc.1
   licenses:
-    - "Apache 2.0"
+  - Apache 2.0
   template:
     spec:
       fetch:
-        - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:c615f4a95de0161f244f644cfb512449ef8b2c233e63541d16fa44bcd7bd28b6
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/vsphere-csi@sha256:ffb6731278dc157d75ff56e8a4e8f6b5f8f08cc108a86e42c0cb8204ae7203ef
       template:
-        - ytt:
-            paths:
-              - config/
-        - kbld:
-            paths:
-              - "-"
-              - .imgpkg/images.yml
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
       deploy:
-        - kapp: {}
+      - kapp: {}
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      description: OpenAPIv3 Schema for vsphere-csi
+      properties:
+        vsphereCSI:
+          type: object
+          additionalProperties: false
+          description: Configuration for vsphere-csi
+          properties:
+            tlsThumbprint:
+              type: string
+              default: ""
+              description: The cryptographic thumbprint of the vSphere endpoint's certificate, must be provided if `insecureFlag` is False
+            namespace:
+              type: string
+              default: kube-system
+              description: The namespace in which vsphere-csi is deployed
+            clusterName:
+              type: string
+              default: ""
+              description: The name of the Kubernetes cluster in cluster ID
+            server:
+              type: string
+              default: ""
+              description: The IP address or FQDN of the vCenter endpoint
+            datacenter:
+              type: string
+              default: ""
+              description: The Datacenter in which VMs are located
+            publicNetwork:
+              type: string
+              default: ""
+              description: The public network to be used
+            username:
+              type: string
+              default: ""
+              description: vCenter username in clear text
+            password:
+              type: string
+              default: ""
+              description: vCenter password in clear text
+            region:
+              type: string
+              default: null
+              nullable: true
+              description: ' The region used by multi-AZ feature'
+            zone:
+              type: string
+              default: null
+              nullable: true
+              description: The zone used by multi-AZ feature
+            insecureFlag:
+              type: boolean
+              default: false
+              description: The flag that disables TLS peer verification
+            useTopologyCategories:
+              type: boolean
+              default: false
+              description: Whether to use topology-categories label in vSphere config
+            provisionTimeout:
+              type: string
+              default: 300s
+              description: The timeout period for csi-provisioner container
+            attachTimeout:
+              type: string
+              default: 300s
+              description: The timeout period for csi-attacher container
+            resizerTimeout:
+              type: string
+              default: 300s
+              description: The timeout period for csi-resizer container
+            vSphereVersion:
+              type: string
+              default: 6.7.0
+              description: The vSphere version used
+            http_proxy:
+              type: string
+              default: ""
+              description: The HTTP_PROXY env var passed to csi-attacher container
+            https_proxy:
+              type: string
+              default: ""
+              description: The HTTPS_PROXY env var passed to csi-attacher container
+            no_proxy:
+              type: string
+              default: ""
+              description: The NO_PROXY env var passed to csi-attacher container
+            deployment_replicas:
+              type: integer
+              default: 3
+              description: The number of replicas of vsphere-csi-controller deployment
+            windows_support:
+              type: boolean
+              default: false
+              description: Whether to enables CSI Windows support

--- a/addons/packages/vsphere-csi/2.4.1/sample-values/vsphere_csi.yaml
+++ b/addons/packages/vsphere-csi/2.4.1/sample-values/vsphere_csi.yaml
@@ -3,22 +3,21 @@
 
 ---
 vsphereCSI:
-  tlsThumbprint: ""
+  tlsThumbprint: "testThumbprint"
   namespace: kube-system
-  clusterName: ""
-  server: ""
-  datacenter: ""
-  publicNetwork: ""
-  username: ""
-  password: ""
-  region: null
-  zone: null
-  insecureFlag: False
-  useTopologyCategories: false
+  clusterName: cluster-test
+  server: 10.1.1.1
+  datacenter: ds-test
+  publicNetwork: test
+  username: test
+  password: test
+  region: region1
+  zone: zone1
+  useTopologyCategories: true
   provisionTimeout: 300s
   attachTimeout: 300s
   resizerTimeout: 300s
-  vSphereVersion: 6.7.0
+  vSphereVersion: 7.0.0
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Create OpenAPIV3 schema for vsphere-csi package and generate package with the schema

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Create OpenAPIV3 schema for vsphere-csi package and generate package with the schema
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2831 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested with ytt commands and ran make generate-openapischema-package locally

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
YTT version needs to be bumped to latest (0.38.0)