### PR TITLE
Doc -  note that cgroup1 is req on mac bootstrap

### DIFF
--- a/docs/site/content/docs/assets/prereq-linux.md
+++ b/docs/site/content/docs/assets/prereq-linux.md
@@ -4,29 +4,8 @@
 |Arch: x86; ARM is currently unsupported|
 |RAM: 6 GB|
 |CPU: 2|
-|[Docker](https://docs.docker.com/engine/install/) <BR> In Docker, you must create the docker group and add your user before you attempt to create a standalone or management cluster. Complete steps 1 to 4 in the [Manage Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) procedure in the Docker documentation.|
+|[Docker](https://docs.docker.com/engine/install/) <BR> Add your non-root user account to the docker user group. Create the group if it does not already exist. This lets the Tanzu CLI access the Docker socket, which is owned by the root user. For more information, see steps 1 to 4 in the [Manage Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) procedure in the Docker documentation.|
 |[Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/) |
 |Latest version of Chrome, Firefox, Safari, Internet Explorer, or  Edge|
 |System time is synchronized with a Network Time Protocol (NTP) server.|
-|Ensure your Linux bootstrap machine is using cgroup v1, for more information, see **Check and set the cgroup** below.|
-
-#### Check and set the cgroup 
-
-1. Check the cgroup by running the following command:
-
-    ```sh
-    docker info | grep -i cgroup 
-    ```
-
-    You should see the following output:
-
-    ```sh
-    Cgroup Driver: cgroupfs
-    Cgroup Version: 1
-    ```
-
-2. If your Linux distribution is configured to use cgroups v2, you will need to set the `systemd.unified_cgroup_hierarchy=0` kernel parameter to restore cgroups v1. See the instructions for setting kernel parameters for your Linux distribution, including:
-
-    [Fedora 32+](https://fedoramagazine.org/docker-and-fedora-32/)  
-    [Arch Linux](https://wiki.archlinux.org/title/Kernel_parameters)  
-    [OpenSUSE](https://doc.opensuse.org/documentation/leap/reference/html/book-reference/cha-grub2.html)
+|Ensure your bootstrap machine is using [cgroup v1](https://man7.org/linux/man-pages/man7/cgroups.7.html). For more information, see [Check and set the cgroup](../support-matrix/#check-and-set-the-cgroup).|

--- a/docs/site/content/docs/assets/prereq-mac.md
+++ b/docs/site/content/docs/assets/prereq-mac.md
@@ -8,28 +8,4 @@
 |[Docker Desktop for Mac; Version <= 4.2.0](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-420)|
 |[Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/) |
 |Latest version of Chrome, Firefox, Safari, Internet Explorer, or  Edge|
-
-#### Check the cgroup version 
-
-1. Check the cgroup by running the following command:
-
-    ```sh
-    docker info | grep -i cgroup 
-    ```
-
-    You should see the following output:
-
-    ```sh
-    Cgroup Driver: cgroupfs
-    Cgroup Version: 1
-    ```
-
-2. If you see cgroup version 2, you are running an incompatible version of
-   Docker Desktop. To resolve this, we recommend running [Docker Desktop
-   4.2.0](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-420).
-
-    > In a future release, we'll support cgroupsv2 which will resolve this issue.
-    > Please follow [issue
-    > 2798](https://github.com/vmware-tanzu/community-edition/issues/2798) for
-    > progress.
-
+|Ensure your bootstrap machine is using [cgroup v1](https://man7.org/linux/man-pages/man7/cgroups.7.html). (Docker Desktop for Mac versions prior to 4.3.0 use cgroup1). For more information, see [Check and set the cgroup](../support-matrix/#check-and-set-the-cgroup).|

--- a/docs/site/content/docs/assets/prereq-windows.md
+++ b/docs/site/content/docs/assets/prereq-windows.md
@@ -7,30 +7,6 @@
 |[Docker Desktop for Windows](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-420)|
 |[Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/) |
 |Latest version of Chrome, Firefox, Safari, Internet Explorer, or  Edge|
+|Ensure your bootstrap machine is using [cgroup v1](https://man7.org/linux/man-pages/man7/cgroups.7.html). (Docker Desktop for Windows versions prior to 4.3.0 use cgroup1). For more information, see [Check and set the cgroup](../support-matrix/#check-and-set-the-cgroup).|
 
 Note: Bootstrapping a cluster to Docker from a Windows bootstrap machine is currently experimental.
-
-#### Check the cgroup version 
-
-1. Check the cgroup by running the following command:
-
-    ```sh
-    docker info | grep -i cgroup 
-    ```
-
-    You should see the following output:
-
-    ```sh
-    Cgroup Driver: cgroupfs
-    Cgroup Version: 1
-    ```
-
-2. If you see cgroup version 2, you are running an incompatible version of
-   Docker Desktop. To resolve this, we recommend running [Docker Desktop
-   4.2.0](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-420).
-
-    > In a future release, we'll support cgroupsv2 which will resolve this issue.
-    > Please follow [issue
-    > 2798](https://github.com/vmware-tanzu/community-edition/issues/2798) for
-    > progress.
-

--- a/docs/site/content/docs/latest/support-matrix.md
+++ b/docs/site/content/docs/latest/support-matrix.md
@@ -49,3 +49,35 @@ Mac and Windows: In Docker Desktop, select Preferences > Resources > Advanced
 ## Supported Kubernetes Versions
 
 Tanzu Community Edition supports the following Kubernetes versions: `1.21.2, 1.20.8, 1.19.12`
+
+## Check and set the cgroup
+
+1. Check the cgroup by running the following command:
+
+    ```sh
+    docker info | grep -i cgroup
+    ```
+
+    You should see the following output:
+
+    ```sh
+    Cgroup Driver: cgroupfs
+    Cgroup Version: 1
+    ```
+
+1. If you see cgroup version 2,  we recommend the following:
+   * **Mac**: Run the following compatible version of
+   Docker Desktop: [Docker Desktop
+   4.2.0](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-420).
+   * **Windows**: Run the following compatible version of [Docker Desktop
+   4.2.0](https://docs.docker.com/desktop/windows/release-notes/#docker-desktop-420)
+   * **Linux**: Set the `systemd.unified_cgroup_hierarchy=0` kernel parameter to restore cgroups v1. See the instructions for setting kernel parameters for your Linux distribution, including:
+
+        [Fedora 32+](https://fedoramagazine.org/docker-and-fedora-32/)  
+        [Arch Linux](https://wiki.archlinux.org/title/Kernel_parameters)  
+        [OpenSUSE](https://doc.opensuse.org/documentation/leap/reference/html/book-reference/cha-grub2.html)
+
+    > In a future release, we'll support cgroupsv2 which will resolve this issue.
+    > Please follow [issue
+    > 2798](https://github.com/vmware-tanzu/community-edition/issues/2798) for
+    > progress.


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
-Improved wording on the note about docker group in the Support Matrix
-Added note to Mac & Windows  support matrix about cgroup1
-to avoid repetition and help to streamline the Support Matrix and Getting Started Guide - moved steps for 'Check and set the cgroup1' to the bottom of the Support matrix topic and restructured so that they are applicable to all OS
-Fixed fixed merge conflict with  #2806


Update support matrix to indicate that cgroup1 is also required on mac bootstrap as per #2828 

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2828 

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
