### PR TITLE
unmanaged-cluster: add line break after error output

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -69,7 +69,7 @@ func configure(cmd *cobra.Command, args []string) error {
 
 	err = config.RenderConfigToFile(fileName, scConfig)
 	if err != nil {
-		log.Errorf("Failed to write configuration file: %s", err.Error())
+		log.Errorf("Failed to write configuration file: %s\n", err.Error())
 		return nil
 	}
 	log.Infof("Wrote configuration file to: %s\n", fileName)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -106,7 +106,7 @@ func create(cmd *cobra.Command, args []string) error {
 	tm := tanzu.New(log)
 	err = tm.Deploy(clusterConfig)
 	if err != nil {
-		log.Error(err.Error())
+		log.Errorf("%s\n", err.Error())
 		return nil
 	}
 

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
@@ -42,7 +42,7 @@ func list(cmd *cobra.Command, args []string) error {
 	tClient := tanzu.New(log)
 	clusters, err := tClient.List()
 	if err != nil {
-		return fmt.Errorf("unable to list clusters. Error: %s", err.Error())
+		return fmt.Errorf("unable to list clusters. Error: %s\n", err.Error())
 	}
 
 	t := component.NewOutputWriter(cmd.OutOrStdout(), "table", "NAME", "PROVIDER")


### PR DESCRIPTION
## What this PR does / why we need it

This inserts a line break when an error is returned to the calling
client (cmd packag). It improves readability as PS1 of the terminal will
not start at the end of the error message.

## Describe testing done for PR

Prior to this change, outputs like the following occurred.

![image](https://user-images.githubusercontent.com/6200057/149366361-7c5e5eae-1f9e-44f1-a54f-b0114667f2d3.png)

![image](https://user-images.githubusercontent.com/6200057/149366396-dee6d273-8b4e-473f-8594-bdd430742f32.png)

With these changes, we now see an appropriate break, improving readability.

![image](https://user-images.githubusercontent.com/6200057/149366458-6d49980b-80f7-4c7b-91f8-cc55cc5cacc3.png)



## Special notes for your reviewer

This is a minor enough change where-in if @jpmcb or @stmcginnis do not have any suggestions, it can be approved and merged.
