### PR TITLE
Create OpenAPIV3 schema for antrea versions ( 1.2.3, 0.13.3, 0.11.3 ) and generate package with the schema

### DIFF
--- a/addons/packages/antrea/0.11.3/bundle/config/schema.yaml
+++ b/addons/packages/antrea/0.11.3/bundle/config/schema.yaml
@@ -1,0 +1,33 @@
+#! schema.yaml
+
+#@data/values-schema
+#@schema/desc "OpenAPIv3 Schema for antrea"
+---
+#@schema/desc "The namespace in which to deploy antrea"
+namespace: kube-system
+#@schema/desc "The cloud provider in use. One of the following options => aws, azure, vsphere, docker"
+infraProvider: vsphere
+antrea:
+  #@schema/desc "Configuration for antrea"
+  config:
+    #@schema/desc "ClusterIP CIDR range for IPv4 Services"
+    serviceCIDR: 10.96.0.0/12
+    #@schema/desc "The traffic encapsulation mode. One of the following options => encap, noEncap, hybrid, networkPolicyOnly"
+    trafficEncapMode: encap
+    #@schema/desc "Flag to enable/disable SNAT for the egress traffic from a Pod to the external network"
+    noSNAT: false
+    #@schema/desc "Default MTU to use for the host gateway interface and the network interface of each Pod"
+    #@schema/nullable
+    defaultMTU: ""
+    #@schema/desc "FeatureGates is a map of feature names to flags that enable or disable experimental features"
+    featureGates:
+      #@schema/desc "Flag to enable/disable antrea proxy"
+      AntreaProxy: false
+      #@schema/desc "Flag to enable/disable antrea policy"
+      AntreaPolicy: true
+      #@schema/desc "Flag to enable/disable flow exporter"
+      FlowExporter: false
+      #@schema/desc "Flag to enable/disable antrea traceflow"
+      AntreaTraceflow: false
+      #@schema/desc "Flag to enable/disable network policy stats"
+      NetworkPolicyStats: false

--- a/addons/packages/antrea/0.11.3/package.yaml
+++ b/addons/packages/antrea/0.11.3/package.yaml
@@ -5,24 +5,89 @@ metadata:
 spec:
   refName: antrea.community.tanzu.vmware.com
   version: 0.11.3
-  releaseNotes: "antrea 0.11.3 https://github.com/antrea-io/antrea/releases/tag/v0.11.3"
+  releaseNotes: antrea 0.11.3 https://github.com/antrea-io/antrea/releases/tag/v0.11.3
   licenses:
-    - "Apache 2.0"
+  - Apache 2.0
   template:
     spec:
       syncPeriod: 5m
       fetch:
-        - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/antrea@sha256:35a2848a2e6cb317f40776e16b2511b226d11930a5245747b655678e5b9a65a1
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/antrea@sha256:26404f38371f0e38c8997c302d5442387763346965f6d1d112535c8bd44fd4da
       template:
-        - ytt:
-            paths:
-              - config/
-        - kbld:
-            paths:
-              - "-"
-              - .imgpkg/images.yml
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
       deploy:
       - kapp:
           rawOptions:
-            - --wait-timeout=30s
+          - --wait-timeout=30s
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      description: OpenAPIv3 Schema for antrea
+      properties:
+        namespace:
+          type: string
+          default: kube-system
+          description: The namespace in which to deploy antrea
+        infraProvider:
+          type: string
+          default: vsphere
+          description: The cloud provider in use. One of the following options => aws, azure, vsphere, docker
+        antrea:
+          type: object
+          additionalProperties: false
+          properties:
+            config:
+              type: object
+              additionalProperties: false
+              description: Configuration for antrea
+              properties:
+                serviceCIDR:
+                  type: string
+                  default: 10.96.0.0/12
+                  description: ClusterIP CIDR range for IPv4 Services
+                trafficEncapMode:
+                  type: string
+                  default: encap
+                  description: The traffic encapsulation mode. One of the following options => encap, noEncap, hybrid, networkPolicyOnly
+                noSNAT:
+                  type: boolean
+                  default: false
+                  description: Flag to enable/disable SNAT for the egress traffic from a Pod to the external network
+                defaultMTU:
+                  type: string
+                  default: null
+                  nullable: true
+                  description: Default MTU to use for the host gateway interface and the network interface of each Pod
+                featureGates:
+                  type: object
+                  additionalProperties: false
+                  description: FeatureGates is a map of feature names to flags that enable or disable experimental features
+                  properties:
+                    AntreaProxy:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable antrea proxy
+                    AntreaPolicy:
+                      type: boolean
+                      default: true
+                      description: Flag to enable/disable antrea policy
+                    FlowExporter:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable flow exporter
+                    AntreaTraceflow:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable antrea traceflow
+                    NetworkPolicyStats:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable network policy stats

--- a/addons/packages/antrea/0.13.3/README.md
+++ b/addons/packages/antrea/0.13.3/README.md
@@ -12,7 +12,6 @@ The following configuration values can be set to customize the antrea installati
 
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
-| `namespace` | Optional | The namespace in which to deploy antrea. |
 | `infraProvider` | Required | The cloud provider in use. One of: `aws`, `azure`, `vsphere`, `docker`. |
 
 ### antrea Configuration
@@ -23,9 +22,12 @@ The following configuration values can be set to customize the antrea installati
 | `antrea.config.trafficEncapMode` | Optional | The traffic encapsulation mode. Default: `encap` |
 | `antrea.config.noSNAT` | Optional | Boolean flag to enable/disable SNAT. Default: `false`. |
 | `antrea.config.defaultMTU` | Optional | MTU to use. Default: `null` (Antrea will autodetect). |
+| `antrea.config.tlsCipherSuites` | Optional | List of allowed cipher suites  |
 | `antrea.config.featureGates.AntreaProxy` | Optional | Boolean flag to enable/disable antrea proxy. Default: `false`. |
+| `antrea.config.featureGates.EndpointSlice` | Optional | Boolean flag to enable/disable EndpointSlice support in AntreaProxy. Default: `false` |
 | `antrea.config.featureGates.AntreaPolicy` | Optional | Boolean flag to enable/disable antrea policy. Default: `true`. |
 | `antrea.config.featureGates.AntreaTraceFlow` | Optional | Boolean flag to enable/disable antrea traceflow. Default: `false`. |
+| `antrea.config.featureGates.NodePortLocal` | Optional | Boolean flag to enable/disable NodePortLocal feature to make the pods reachable externally through NodePort |
 | `antrea.config.featureGates.FlowExporter`| Optional | Boolean flag to enable/disable flow exporter. Default: `false`. |
 | `antrea.config.featureGates.NetworkPolicyStats` | Optional | Boolean flag to enable/disable network policy stats. Default: `false`. |
 

--- a/addons/packages/antrea/0.13.3/bundle/config/schema.yaml
+++ b/addons/packages/antrea/0.13.3/bundle/config/schema.yaml
@@ -1,0 +1,37 @@
+#! schema.yaml
+
+#@data/values-schema
+#@schema/desc "OpenAPIv3 Schema for antrea"
+---
+#@schema/desc "The cloud provider in use. One of the following options => aws, azure, vsphere, docker"
+infraProvider: vsphere
+antrea:
+  #@schema/desc "Configuration for antrea"
+  config:
+    #@schema/desc "ClusterIP CIDR range for IPv4 Services"
+    serviceCIDR: 10.96.0.0/12
+    #@schema/desc "The traffic encapsulation mode. One of the following options => encap, noEncap, hybrid, networkPolicyOnly"
+    trafficEncapMode: encap
+    #@schema/desc "Flag to enable/disable SNAT for the egress traffic from a Pod to the external network"
+    noSNAT: false
+    #@schema/desc "Default MTU to use for the host gateway interface and the network interface of each Pod"
+    #@schema/nullable
+    defaultMTU: ""
+    #@schema/desc "List of allowed cipher suites. If omitted, the default Go Cipher Suites will be used"
+    tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+    #@schema/desc "FeatureGates is a map of feature names to flags that enable or disable experimental features"
+    featureGates:
+      #@schema/desc "Flag to enable/disable antrea proxy"
+      AntreaProxy: false
+      #@schema/desc "Flag to enable/disable EndpointSlice support in AntreaProxy. If AntreaProxy is not enabled, this flag will not take effect"
+      EndpointSlice: false
+      #@schema/desc "Flag to enable/disable antrea policy"
+      AntreaPolicy: true
+      #@schema/desc "Flag to enable/disable flow exporter"
+      FlowExporter: false
+      #@schema/desc "Flag to enable/disable NodePortLocal feature to make the pods reachable externally through NodePort"
+      NodePortLocal: false
+      #@schema/desc "Flag to enable/disable antrea traceflow"
+      AntreaTraceflow: false
+      #@schema/desc "Flag to enable/disable network policy stats"
+      NetworkPolicyStats: false

--- a/addons/packages/antrea/0.13.3/package.yaml
+++ b/addons/packages/antrea/0.13.3/package.yaml
@@ -5,24 +5,97 @@ metadata:
 spec:
   refName: antrea.community.tanzu.vmware.com
   version: 0.13.3
-  releaseNotes: "antrea 0.13.3 https://github.com/antrea-io/antrea/releases/tag/v0.13.3"
+  releaseNotes: antrea 0.13.3 https://github.com/antrea-io/antrea/releases/tag/v0.13.3
   licenses:
-    - "Apache 2.0"
+  - Apache 2.0
   template:
     spec:
       syncPeriod: 5m
       fetch:
-        - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/antrea@sha256:bf80a1114ac0dda12753ac4d7d34e1ff34052f9228636df823a5852480bf0be2
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/antrea@sha256:6aa4936d63d5e4a3dbe6a370a67ff7ae57cca883197401b717998befbf608c08
       template:
-        - ytt:
-            paths:
-              - config/
-        - kbld:
-            paths:
-              - "-"
-              - .imgpkg/images.yml
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
       deploy:
       - kapp:
           rawOptions:
-            - --wait-timeout=30s
+          - --wait-timeout=30s
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      description: OpenAPIv3 Schema for antrea
+      properties:
+        infraProvider:
+          type: string
+          default: vsphere
+          description: The cloud provider in use. One of the following options => aws, azure, vsphere, docker
+        antrea:
+          type: object
+          additionalProperties: false
+          properties:
+            config:
+              type: object
+              additionalProperties: false
+              description: Configuration for antrea
+              properties:
+                serviceCIDR:
+                  type: string
+                  default: 10.96.0.0/12
+                  description: ClusterIP CIDR range for IPv4 Services
+                trafficEncapMode:
+                  type: string
+                  default: encap
+                  description: The traffic encapsulation mode. One of the following options => encap, noEncap, hybrid, networkPolicyOnly
+                noSNAT:
+                  type: boolean
+                  default: false
+                  description: Flag to enable/disable SNAT for the egress traffic from a Pod to the external network
+                defaultMTU:
+                  type: string
+                  default: null
+                  nullable: true
+                  description: Default MTU to use for the host gateway interface and the network interface of each Pod
+                tlsCipherSuites:
+                  type: string
+                  default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+                  description: List of allowed cipher suites. If omitted, the default Go Cipher Suites will be used
+                featureGates:
+                  type: object
+                  additionalProperties: false
+                  description: FeatureGates is a map of feature names to flags that enable or disable experimental features
+                  properties:
+                    AntreaProxy:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable antrea proxy
+                    EndpointSlice:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable EndpointSlice support in AntreaProxy. If AntreaProxy is not enabled, this flag will not take effect
+                    AntreaPolicy:
+                      type: boolean
+                      default: true
+                      description: Flag to enable/disable antrea policy
+                    FlowExporter:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable flow exporter
+                    NodePortLocal:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable NodePortLocal feature to make the pods reachable externally through NodePort
+                    AntreaTraceflow:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable antrea traceflow
+                    NetworkPolicyStats:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable network policy stats

--- a/addons/packages/antrea/1.2.3/README.md
+++ b/addons/packages/antrea/1.2.3/README.md
@@ -12,7 +12,6 @@ The following configuration values can be set to customize the antrea installati
 
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
-| `namespace` | Optional | The namespace in which to deploy antrea. |
 | `infraProvider` | Required | The cloud provider in use. One of: `aws`, `azure`, `vsphere`, `docker`. |
 
 ### antrea Configuration
@@ -22,15 +21,18 @@ The following configuration values can be set to customize the antrea installati
 | `antrea.config.serviceCIDR` | Optional | The service IPv4 CIDR to use. Default: `10.96.0.0/12` |
 | `antrea.config.serviceCIDRv6` | Optional | The service IPv6 CIDR to use. Default: nil |
 | `antrea.config.trafficEncapMode` | Optional | The traffic encapsulation mode. Default: `encap` |
-| `antrea.config.noSNAT` | Optional | Boolean flag to enable/disable SNAT. Default: `false`. |
-| `antrea.config.defaultMTU` | Optional | MTU to use. Default: `null` (Antrea will autodetect). |
+| `antrea.config.noSNAT` | Optional | Boolean flag to enable/disable SNAT. Default: `false` |
+| `antrea.config.defaultMTU` | Optional | MTU to use. Default: `null` (Antrea will autodetect) |
+| `antrea.config.tlsCipherSuites` | Optional | List of allowed cipher suites  |
 | `antrea.config.disableUdpTunnelOffload` | Optional | Disable UDP tunnel offload feature on default NIC. Default: `false` |
-| `antrea.config.featureGates.AntreaProxy` | Optional | Boolean flag to enable/disable antrea proxy. Default: `false`. |
-| `antrea.config.featureGates.AntreaPolicy` | Optional | Boolean flag to enable/disable antrea policy. Default: `true`. |
-| `antrea.config.featureGates.AntreaTraceFlow` | Optional | Boolean flag to enable/disable antrea traceflow. Default: `false`. |
-| `antrea.config.featureGates.Egress` | Optional | Boolean flag to enable/disable SNAT IPs of Pod egress traffic. Default: `false`. |
-| `antrea.config.featureGates.FlowExporter`| Optional | Boolean flag to enable/disable flow exporter. Default: `false`. |
-| `antrea.config.featureGates.NetworkPolicyStats` | Optional | Boolean flag to enable/disable network policy stats. Default: `false`. |
+| `antrea.config.featureGates.AntreaProxy` | Optional | Boolean flag to enable/disable antrea proxy. Default: `false` |
+| `antrea.config.featureGates.EndpointSlice` | Optional | Boolean flag to enable/disable EndpointSlice support in AntreaProxy. Default: `false` |
+| `antrea.config.featureGates.AntreaPolicy` | Optional | Boolean flag to enable/disable antrea policy. Default: `true` |
+| `antrea.config.featureGates.AntreaTraceFlow` | Optional | Boolean flag to enable/disable antrea traceflow. Default: `false` |
+| `antrea.config.featureGates.Egress` | Optional | Boolean flag to enable/disable SNAT IPs of Pod egress traffic. Default: `false` |
+| `antrea.config.featureGates.NodePortLocal` | Optional | Boolean flag to enable/disable NodePortLocal feature to make the pods reachable externally through NodePort |
+| `antrea.config.featureGates.FlowExporter`| Optional | Boolean flag to enable/disable flow exporter. Default: `false` |
+| `antrea.config.featureGates.NetworkPolicyStats` | Optional | Boolean flag to enable/disable network policy stats. Default: `false` |
 
 ## Usage Example
 

--- a/addons/packages/antrea/1.2.3/bundle/config/schema.yaml
+++ b/addons/packages/antrea/1.2.3/bundle/config/schema.yaml
@@ -1,0 +1,44 @@
+#! schema.yaml
+
+#@data/values-schema
+#@schema/desc "OpenAPIv3 Schema for antrea"
+---
+#@schema/desc "The cloud provider in use. One of the following options => aws, azure, vsphere, docker"
+infraProvider: vsphere
+antrea:
+  #@schema/desc "Configuration for antrea"
+  config:
+    #@schema/desc "ClusterIP CIDR range for IPv4 Services"
+    serviceCIDR: 10.96.0.0/12
+    #@schema/desc "ClusterIP CIDR range for IPv6 Services"
+    #@schema/nullable
+    serviceCIDRv6: ""
+    #@schema/desc "The traffic encapsulation mode. One of the following options => encap, noEncap, hybrid, networkPolicyOnly"
+    trafficEncapMode: encap
+    #@schema/desc "Flag to enable/disable SNAT for the egress traffic from a Pod to the external network"
+    noSNAT: false
+    #@schema/desc "Disable UDP tunnel offload feature on default NIC"
+    disableUdpTunnelOffload: false
+    #@schema/desc "Default MTU to use for the host gateway interface and the network interface of each Pod"
+    #@schema/nullable
+    defaultMTU: ""
+    #@schema/desc "List of allowed cipher suites. If omitted, the default Go Cipher Suites will be used"
+    tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+    #@schema/desc "FeatureGates is a map of feature names to flags that enable or disable experimental features"
+    featureGates:
+      #@schema/desc "Flag to enable/disable antrea proxy"
+      AntreaProxy: false
+      #@schema/desc "Flag to enable/disable EndpointSlice support in AntreaProxy. If AntreaProxy is not enabled, this flag will not take effect"
+      EndpointSlice: false
+      #@schema/desc "Flag to enable/disable antrea policy"
+      AntreaPolicy: true
+      #@schema/desc "Flag to enable/disable flow exporter"
+      FlowExporter: false
+      #@schema/desc "Flag to enable/disable SNAT IPs of Pod egress traffic"
+      Egress: false
+      #@schema/desc "Flag to enable/disable NodePortLocal feature to make the pods reachable externally through NodePort"
+      NodePortLocal: false
+      #@schema/desc "Flag to enable/disable antrea traceflow"
+      AntreaTraceflow: false
+      #@schema/desc "Flag to enable/disable network policy stats"
+      NetworkPolicyStats: false

--- a/addons/packages/antrea/1.2.3/package.yaml
+++ b/addons/packages/antrea/1.2.3/package.yaml
@@ -5,24 +5,110 @@ metadata:
 spec:
   refName: antrea.community.tanzu.vmware.com
   version: 1.2.3
-  releaseNotes: "antrea 1.2.3 https://github.com/antrea-io/antrea/releases/tag/v1.2.3"
+  releaseNotes: antrea 1.2.3 https://github.com/antrea-io/antrea/releases/tag/v1.2.3
   licenses:
-    - "Apache 2.0"
+  - Apache 2.0
   template:
     spec:
       syncPeriod: 5m
       fetch:
-        - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/antrea@sha256:6bc659b8f1bcd90208bf90be5f3e1085252bb8b9655cc5a3f1c9a2bcc6ab1ffb
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/antrea@sha256:b5772748c5df17dbf3bc14a435b1609f7ef81623dbef1443904d8b8a4767972e
       template:
-        - ytt:
-            paths:
-              - config/
-        - kbld:
-            paths:
-              - "-"
-              - .imgpkg/images.yml
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
       deploy:
-        - kapp:
-            rawOptions:
-              - --wait-timeout=30s
+      - kapp:
+          rawOptions:
+          - --wait-timeout=30s
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      description: OpenAPIv3 Schema for antrea
+      properties:
+        infraProvider:
+          type: string
+          default: vsphere
+          description: The cloud provider in use. One of the following options => aws, azure, vsphere, docker
+        antrea:
+          type: object
+          additionalProperties: false
+          properties:
+            config:
+              type: object
+              additionalProperties: false
+              description: Configuration for antrea
+              properties:
+                serviceCIDR:
+                  type: string
+                  default: 10.96.0.0/12
+                  description: ClusterIP CIDR range for IPv4 Services
+                serviceCIDRv6:
+                  type: string
+                  default: null
+                  nullable: true
+                  description: ClusterIP CIDR range for IPv6 Services
+                trafficEncapMode:
+                  type: string
+                  default: encap
+                  description: The traffic encapsulation mode. One of the following options => encap, noEncap, hybrid, networkPolicyOnly
+                noSNAT:
+                  type: boolean
+                  default: false
+                  description: Flag to enable/disable SNAT for the egress traffic from a Pod to the external network
+                disableUdpTunnelOffload:
+                  type: boolean
+                  default: false
+                  description: Disable UDP tunnel offload feature on default NIC
+                defaultMTU:
+                  type: string
+                  default: null
+                  nullable: true
+                  description: Default MTU to use for the host gateway interface and the network interface of each Pod
+                tlsCipherSuites:
+                  type: string
+                  default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+                  description: List of allowed cipher suites. If omitted, the default Go Cipher Suites will be used
+                featureGates:
+                  type: object
+                  additionalProperties: false
+                  description: FeatureGates is a map of feature names to flags that enable or disable experimental features
+                  properties:
+                    AntreaProxy:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable antrea proxy
+                    EndpointSlice:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable EndpointSlice support in AntreaProxy. If AntreaProxy is not enabled, this flag will not take effect
+                    AntreaPolicy:
+                      type: boolean
+                      default: true
+                      description: Flag to enable/disable antrea policy
+                    FlowExporter:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable flow exporter
+                    Egress:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable SNAT IPs of Pod egress traffic
+                    NodePortLocal:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable NodePortLocal feature to make the pods reachable externally through NodePort
+                    AntreaTraceflow:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable antrea traceflow
+                    NetworkPolicyStats:
+                      type: boolean
+                      default: false
+                      description: Flag to enable/disable network policy stats


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
- [x] Create OpenAPIV3 schema for antrea versions ( 1.2.3, 0.13.3, 0.11.3 ) and generate package with the schema

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Create OpenAPIV3 schema for antrea package and generate package with the schema
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2842 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested with following ytt commands locally:
<version> below can be substituted with each item from the list: ( 1.2.3, 0.13.3, 0.11.3 )
* make generate-openapischema-package PACKAGE=antrea VERSION=1.2.3
* make push-package PACKAGE=antrea VERSION=1.2.3 TAG=1.2.3

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
ytt version => 0.38.0
kapp version => 0.37.0
yq version => 4.11.1

Also, I would be adding github workflow in the same PR which I am currently working on