### PR TITLE
Standalone plugin cobra command name should not have deprecation notice

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/main.go
+++ b/cli/cmd/plugin/standalone-cluster/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var descriptor = cliv1alpha1.PluginDescriptor{
-	Name:        "standalone-cluster (!!! deprecated - see unmanaged-cluster !!!)",
+	Name:        "standalone-cluster",
 	Description: `(!!! deprecated - see unmanaged-cluster !!!) Create clusters without a dedicated management cluster`,
 	Group:       cliv1alpha1.RunCmdGroup,
 


### PR DESCRIPTION
- The deprecation notice for standalone cluster should only be in the
  description. This removes the deprecation notice for standalone
  clusters from it's name in the cobra command. This is in support of
  `tanzu plugin list` and calling the command via the `tanzu` higher
  order command.

Signed-off-by: John McBride <jmcbride@vmware.com>

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
Built and `tanzu plugin list`:
```
❯ tanzu plugin list
  NAME                LATEST VERSION  DESCRIPTION                                                                                          REPOSITORY  VERSION         STATUS
  builder                             Build Tanzu components                                                                                           v0.10.0         installed
  cluster             v0.2.1          Kubernetes cluster operations                                                                        core        v0.10.0         installed
  codegen                             Tanzu code generation tool                                                                                       v0.10.0         installed
  conformance                         Run Sonobuoy conformance tests against clusters                                                                  v0.10.0-fake.4  installed
  diagnostics                         Cluster diagnostics                                                                                              v0.10.0-fake.4  installed
  kubernetes-release  v0.2.1          Kubernetes release operations                                                                        core        v0.10.0         installed
  login               v0.2.1          Login to the platform                                                                                core        v0.10.0         installed
  management-cluster  v0.2.1          Kubernetes management cluster operations                                                             core        v0.10.0         installed
  package             v0.2.1          Tanzu package management                                                                             core        v0.10.0         installed
  pinniped-auth       v0.2.1          Pinniped authentication operations (usually not directly invoked)                                    core        v0.10.0         installed
  secret                              Tanzu secret management                                                                              core        v0.10.0         installed
  standalone-cluster                  (!!! deprecated - see unmanaged-cluster !!!) Create clusters without a dedicated management cluster              v0.10.0         installed
  test                                Test the CLI                                                                                                     v0.10.0         installed
  unmanaged-cluster                   Deploy and manage single-node, static, Tanzu clusters.                                                           v0.10.0-fake.4  installed

```

tanzu help command:
```
❯ tanzu help
Tanzu CLI

Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components
    codegen                 Tanzu code generation tool
    test                    Test the CLI

  Run
    cluster                 Kubernetes cluster operations
    conformance             Run Sonobuoy conformance tests against clusters
    diagnostics             Cluster diagnostics
    kubernetes-release      Kubernetes release operations
    management-cluster      Kubernetes management cluster operations
    package                 Tanzu package management
    secret                  Tanzu secret management
    standalone-cluster      (!!! deprecated - see unmanaged-cluster !!!) Create clusters without a dedicated management cluster
    unmanaged-cluster       Deploy and manage single-node, static, Tanzu clusters.

  System
    completion              Output shell completion code
    config                  Configuration for the CLI
    init                    Initialize the CLI
    login                   Login to the platform
    plugin                  Manage CLI plugins
    update                  Update the CLI
    version                 Version information


Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.

Not logged in

```

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
