### PR TITLE
Change tty control flag to `--tty-disable`

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -34,7 +34,7 @@ func init() {
 	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'antrea'")
 	ConfigureCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR to use for Pod IP addresses. Default and format is '10.244.0.0/16'")
 	ConfigureCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR to use for Service IP addresses. Default and format is '10.96.0.0/16'")
-	ConfigureCmd.Flags().BoolVar(&co.tty, "tty", true, "Specify whether terminal is tty; set to false to disable styled output.")
+	ConfigureCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
 }
 
 func configure(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
@@ -32,7 +32,7 @@ var DeleteCmd = &cobra.Command{
 }
 
 func init() {
-	DeleteCmd.Flags().BoolVar(&co.tty, "tty", true, "Specify whether terminal is tty; set to false to disable styled output.")
+	DeleteCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
 }
 
 func destroy(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
@@ -35,7 +35,7 @@ var ListCmd = &cobra.Command{
 }
 
 func init() {
-	ListCmd.Flags().BoolVar(&co.tty, "tty", true, "Specify whether terminal is tty; set to false to disable styled output.")
+	ListCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
 	ListCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table); default is table")
 }
 

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
@@ -31,14 +31,17 @@ func TtySetting(flags *pflag.FlagSet) bool {
 		result = (fileInfo.Mode() & os.ModeCharDevice) != 0
 	}
 
-	if flags.Changed("tty") {
+	if flags.Changed("tty-disable") {
 		// User has explicitly set the flag, use that value
-		result, _ = flags.GetBool("tty")
-	} else if tty := os.Getenv("TANZU_TTY"); tty != "" {
-		// Not explicitly provided, but there is an env setting
-		val, err := strconv.ParseBool(tty)
+		disableTTY, err := flags.GetBool("tty-disable")
 		if err == nil {
-			result = val
+			result = !disableTTY
+		}
+	} else if tty := os.Getenv("TANZU_TTY_DISABLE"); tty != "" {
+		// Not explicitly provided, but there is an env setting
+		disableTTY, err := strconv.ParseBool(tty)
+		if err == nil {
+			result = !disableTTY
 		}
 	}
 	return result

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -16,12 +16,11 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/config"
-
 	v1 "k8s.io/api/apps/v1"
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/cluster"
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/config"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/kapp"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/kubeconfig"
 	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/log"


### PR DESCRIPTION
Bool flags for cobra commands are defaulted to true when present, and
the syntax of needing an = to set the value to something other than that
isn't the most intuitive.

Rather than have our tty control flag default to true, requiring the
user to explicitly set the value to switch it to false, this simplifies
things by changing the flag to `--tty-disable`. That makes its usage a
little simpler in that when it is actually used, the intent of using it
is to disable the TTY formatting in our output. So now it can just be
used as a simple flag.