### PR TITLE
Adds tlsThumbprint and insecureFlag to vsphereCSI

### DIFF
--- a/addons/packages/vsphere-csi/2.3.0/README.md
+++ b/addons/packages/vsphere-csi/2.3.0/README.md
@@ -12,7 +12,7 @@ The following configuration values can be set to customize the vsphere CSI insta
 
 None
 
-### vSphere CPI Configuration
+### vSphere CSI Configuration
 
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
@@ -23,6 +23,7 @@ None
 | `vsphereCSI.publicNetwork` | Required | The public network to be used. Default value is `null`. |
 | `vsphereCSI.username` | Required | vCenter username in clear text. Default value is `null`. |
 | `vsphereCSI.password` | Required | vCenter password in clear text. Default value is `null`. |
+| `vsphereCSI.tlsThumbprint` | Optional | The cryptographic thumbprint of the vSphere endpoint's certificate. Default value is `""`. |
 | `vsphereCSI.provisionTimeout` | Optional | The timeout period for csi-provisioner container. Default value is `300s`. |
 | `vsphereCSI.attachTimeout` | Optional | The timeout period for csi-attacher container. Default value is `300s`. |
 | `vsphereCSI.resizerTimeout` | Optional | The timeout period for csi-resizer container. Default: `300s` |

--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/values.star
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/values.star
@@ -9,6 +9,9 @@ def validate_vsphereCSI():
    data.values.vsphereCSI.publicNetwork or assert.fail("vsphereCSI publicNetwork should be provided")
    data.values.vsphereCSI.username or assert.fail("vsphereCSI username should be provided")
    data.values.vsphereCSI.password or assert.fail("vsphereCSI password should be provided")
+   if not data.values.vsphereCSI.insecureFlag:
+     data.values.vsphereCSI.tlsThumbprint or assert.fail("vsphereCSI tlsThumbprint should be provided when insecureFlag is False")
+   end
 end
 
 #export

--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/values.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/values.yaml
@@ -3,6 +3,7 @@
 
 ---
 vsphereCSI:
+  tlsThumbprint: ""
   namespace: kube-system
   clusterName: null
   server: null
@@ -12,6 +13,7 @@ vsphereCSI:
   password: null
   region: null
   zone: null
+  insecureFlag: True
   provisionTimeout: 300s
   attachTimeout: 300s
   resizerTimeout: 300s

--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/vsphereconf.lib.txt
@@ -1,13 +1,22 @@
 
 (@ def vsphere_conf(values): -@)
 [Global]
+(@ if values.vsphereCSI.insecureFlag: -@)
 insecure-flag = true
+(@ else: -@)
+thumbprint = "(@=values.vsphereCSI.tlsThumbprint @)"
+(@ end -@)
 cluster-id = (@=values.vsphereCSI.namespace @)/(@=values.vsphereCSI.clusterName @)
 
 [VirtualCenter "(@=values.vsphereCSI.server @)"]
 user = "(@=values.vsphereCSI.username.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t","\\t") @)"
 password = "(@=values.vsphereCSI.password.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t","\\t") @)"
 datacenters = "(@=values.vsphereCSI.datacenter @)"
+(@ if values.vsphereCSI.insecureFlag: -@)
+insecure-flag = true
+(@ else: -@)
+thumbprint = "(@=values.vsphereCSI.tlsThumbprint @)"
+(@ end -@)
 
 [Network]
 public-network = "(@=values.vsphereCSI.publicNetwork @)"

--- a/addons/packages/vsphere-csi/2.4.1/README.md
+++ b/addons/packages/vsphere-csi/2.4.1/README.md
@@ -12,7 +12,7 @@ The following configuration values can be set to customize the vsphere CSI insta
 
 None
 
-### vSphere CPI Configuration
+### vSphere CSI Configuration
 
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
@@ -23,6 +23,7 @@ None
 | `vsphereCSI.publicNetwork` | Required | The public network to be used. Default value is `null`. |
 | `vsphereCSI.username` | Required | vCenter username in clear text. Default value is `null`. |
 | `vsphereCSI.password` | Required | vCenter password in clear text. Default value is `null`. |
+| `vsphereCSI.tlsThumbprint` | Optional | The cryptographic thumbprint of the vSphere endpoint's certificate. Default value is `""`. |
 | `vsphereCSI.region` | Optional | The region used by multi-AZ feature. Default value is `null`. |
 | `vsphereCSI.zone` | Optional | The zone used by multi-AZ feature. Default value is `null`. |
 | `vsphereCSI.useTopologyCategories` | Optional | Use topology-categories label in vSphere config. Default value is `false`. |

--- a/addons/packages/vsphere-csi/2.4.1/bundle/config/values.star
+++ b/addons/packages/vsphere-csi/2.4.1/bundle/config/values.star
@@ -9,6 +9,9 @@ def validate_vsphereCSI():
    data.values.vsphereCSI.publicNetwork or assert.fail("vsphereCSI publicNetwork should be provided")
    data.values.vsphereCSI.username or assert.fail("vsphereCSI username should be provided")
    data.values.vsphereCSI.password or assert.fail("vsphereCSI password should be provided")
+   if not data.values.vsphereCSI.insecureFlag:
+     data.values.vsphereCSI.tlsThumbprint or assert.fail("vsphereCSI tlsThumbprint should be provided when insecureFlag is False")
+   end
 end
 
 #export

--- a/addons/packages/vsphere-csi/2.4.1/bundle/config/values.yaml
+++ b/addons/packages/vsphere-csi/2.4.1/bundle/config/values.yaml
@@ -3,6 +3,7 @@
 
 ---
 vsphereCSI:
+  tlsThumbprint: ""
   namespace: kube-system
   clusterName: null
   server: null
@@ -12,6 +13,7 @@ vsphereCSI:
   password: null
   region: null
   zone: null
+  insecureFlag: True
   useTopologyCategories: false
   provisionTimeout: 300s
   attachTimeout: 300s

--- a/addons/packages/vsphere-csi/2.4.1/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-csi/2.4.1/bundle/config/vsphereconf.lib.txt
@@ -1,13 +1,22 @@
 
 (@ def vsphere_conf(values): -@)
 [Global]
+(@ if values.vsphereCSI.insecureFlag: -@)
 insecure-flag = true
+(@ else: -@)
+thumbprint = "(@=values.vsphereCSI.tlsThumbprint @)"
+(@ end -@)
 cluster-id = (@=values.vsphereCSI.namespace @)/(@=values.vsphereCSI.clusterName @)
 
 [VirtualCenter "(@=values.vsphereCSI.server @)"]
 user = "(@=values.vsphereCSI.username.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t","\\t") @)"
 password = "(@=values.vsphereCSI.password.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t","\\t") @)"
 datacenters = "(@=values.vsphereCSI.datacenter @)"
+(@ if values.vsphereCSI.insecureFlag: -@)
+insecure-flag = true
+(@ else: -@)
+thumbprint = "(@=values.vsphereCSI.tlsThumbprint @)"
+(@ end -@)
 
 [Network]
 public-network = "(@=values.vsphereCSI.publicNetwork @)"


### PR DESCRIPTION
If insecureFlag is not true a tlsThumbprint is exposed as a template variable.
tlsThumbprint in conjunction with insecureFlag=true may be used for securing connections.
Default value of insecureFlag is true for backwards compatibility.

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
tlsThumbprint is now exposed in the package templates. 
If insecureFlag=false, tlsThumbprint must be provided. 
The default is set to insecureFlag=true and tlsThumbprint="" for backwards compatibility
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
Tested on tkg cluster build. 

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
