### PR TITLE
Docs: Mobile docs side navigation toggle

### DIFF
--- a/docs/site/themes/template/assets/js/main.js
+++ b/docs/site/themes/template/assets/js/main.js
@@ -24,13 +24,15 @@ window.onclick = function(event) {
 
 }
 
-function toggleAccordion(el) {
+function toggleAriaAttribute(el) {
     var state = el.getAttribute('aria-expanded');
-            
     // toggle state
     state = (state === 'true') ? 'false' : 'true';
     el.setAttribute('aria-expanded', state);
+}
 
+function toggleAccordion(el) {
+    toggleAriaAttribute(el)
     // show/hide list
     el.nextElementSibling.classList.toggle('show');
 }
@@ -92,8 +94,17 @@ function createCopyButtons() {
 document.addEventListener('DOMContentLoaded', function(){
     // hamburger
     var hamburger = document.getElementById('mobileNavToggle');
+    var docsMobileButton = document.getElementById('mobileDocsNavToggle');
+    var docsNav = document.getElementById('docsNav');
+
     hamburger.addEventListener('click', function() {
         mobileNavToggle();
+    });
+
+    docsMobileButton.addEventListener('click', function() {
+      toggleAriaAttribute(docsMobileButton);
+      docsMobileButton.classList.toggle('side-nav-visible');
+      docsNav.classList.toggle('show');
     });
 
     // accordion

--- a/docs/site/themes/template/assets/scss/_docs.scss
+++ b/docs/site/themes/template/assets/scss/_docs.scss
@@ -8,15 +8,69 @@
         display: block;
     }
 
+    .mobile {
+      display: none;
+      border: 1px solid $blue;
+      cursor: pointer;
+      font-family: $metropolis-medium;
+      letter-spacing: 1.2px;
+      margin-bottom: 30px;
+      position: relative;
+      width: 100%;
+
+      @include breakpoint(small) {
+        display: block;
+      }
+
+      &:after {
+        content: '';
+        position: absolute;
+        display: block;
+        background-image: url(/img/down-arrow.svg);
+        background-repeat: no-repeat;
+        background-position: center;
+        width: 11px;
+        height: 20px;
+        top: calc(50% - 10px);
+        left: calc(95% - 10px);
+      }
+
+      &:focus,
+      &:hover {
+        background-color: $lightblue;
+      }
+
+      &:focus {
+        outline: 5px auto $blue;
+      }
+
+      &:active {
+        box-shadow: 0 3px 0 0 darken($lightblue, 8%) inset;
+      }
+
+      &.side-nav-visible {
+        &:after {
+          transform: rotate(180deg);
+          transform-origin: center;
+        }
+      }
+    }
+
     .side-nav {
         width: 25%;
         float: left;
         position: relative;
 
         @include breakpoint(small) {
+            display: none;
             float: none;
             margin-bottom: 50px;
             width: 100%;
+            border-bottom: 1px solid $grey;
+        }
+
+        &.show {
+          display: block;
         }
 
         button.h4, h5 {

--- a/docs/site/themes/template/layouts/partials/docs-sidebar.html
+++ b/docs/site/themes/template/layouts/partials/docs-sidebar.html
@@ -1,4 +1,6 @@
-<div class="side-nav">
+<button class="button mobile" id="mobileDocsNavToggle" aria-expanded="false" aria-controls="docsNav">Table of contents</button>
+<noscript>Please enable javascript to use dropdown navigation</noscript>
+<div class="side-nav" id="docsNav">
     {{ if .Site.Params.use_advanced_docs }}
         <noscript>Please enable javascript to use dropdown navigation</noscript>
         {{ $version := .CurrentSection.Params.version }}


### PR DESCRIPTION
## What this PR does / why we need it
This introduces a button to toggle side navigation visibility in `/docs` at smaller viewports. The button and side navigation toggling is only applied to the `small` breakpoint.

| Before      | After |
| ----------- | ----------- |
| ![tanzucommunityedition io_docs_latest_(iPhone XR)](https://user-images.githubusercontent.com/227587/149583358-6cd1b0bd-1f66-4b93-b294-540a2e3d3f4b.png) | ![localhost_1313_docs_latest_(iPhone XR)](https://user-images.githubusercontent.com/227587/149583372-8d94e3fc-45a9-46f5-a656-0d231dbfed4c.png) |


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
Fixes: #2119

## Describe testing done for PR
- `hugo server`
- Navigate to `/docs`
- Reduce viewport width to smaller than `767px` or visit on a mobile browser

## Special notes for your reviewer
The button label is currently `Table of contents`. Open to suggestions on different label name and styling.
