### PR TITLE
Declare hostNetwork field for kapp-controller to boolean type

### DIFF
--- a/addons/packages/kapp-controller/0.30.0/bundle/config/schema.yaml
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/schema.yaml
@@ -18,9 +18,8 @@ kappController:
     #@schema/desc "The coreDNSIP will be injected into /etc/resolv.conf of kapp-controller pod"
     #@schema/nullable
     coreDNSIP: ""
-    #@schema/desc "Host network of kapp-controller deployment"
-    #@schema/nullable
-    hostNetwork: ""
+    #@schema/desc "Whether to enable host networking for kapp-controller deployment"
+    hostNetwork: false
     #@schema/desc "The priority value that various system components use to find the priority of the kapp-controller pod"
     #@schema/nullable
     priorityClassName: ""

--- a/addons/packages/kapp-controller/0.30.0/bundle/config/values.yaml
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/values.yaml
@@ -9,7 +9,7 @@ kappController:
   deployment:
     #! The coreDNSIP will be injected into /etc/resolv.conf of kapp-controller pod
     coreDNSIP: null
-    hostNetwork: null
+    hostNetwork: false
     priorityClassName: null
     concurrency: 4
     tolerations: []

--- a/addons/packages/kapp-controller/0.30.0/package.yaml
+++ b/addons/packages/kapp-controller/0.30.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/kapp-controller@sha256:713530834c0849526b95dfa48027aa510c5fc1ec29a585a817a0918a542ce135
+          image: projects.registry.vmware.com/tce/kapp-controller@sha256:35b9945059bd1ba989edf130ae244419db75638c89b843e336a6ee15af34b883
       template:
       - ytt:
           paths:
@@ -61,10 +61,9 @@ spec:
                   nullable: true
                   description: The coreDNSIP will be injected into /etc/resolv.conf of kapp-controller pod
                 hostNetwork:
-                  type: string
-                  default: null
-                  nullable: true
-                  description: Host network of kapp-controller deployment
+                  type: boolean
+                  default: false
+                  description: Whether to enable host networking for kapp-controller deployment
                 priorityClassName:
                   type: string
                   default: null

--- a/hack/packages/check-sample-values-and-render-ytt.sh
+++ b/hack/packages/check-sample-values-and-render-ytt.sh
@@ -44,7 +44,12 @@ check_sample_values_and_render_ytt() {
 	${yttCmd} > /dev/null
 	status=$?
 
-	[ $status -eq 0 ] && echo -e "${GREEN}===> ytt manifests successfully rendered for ${PACKAGE}/${VERSION}${NC}" || echo -e "${RED}===> $yttCmd failed. ytt manifests could not be generated!!${NC}"
+	if [ $status -eq 0 ]; then
+	  echo -e "${GREEN}===> ytt manifests successfully rendered for ${PACKAGE}/${VERSION}${NC}"
+	else
+	  echo -e "${RED}===> $yttCmd failed. ytt manifests could not be generated!!${NC}"
+	  exit 1
+	fi
 
 }
 


### PR DESCRIPTION
Signed-off-by: Shivaani Gupta <gshivaani@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Declare hostNetwork field for kapp-controller to boolean type

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Declare hostNetwork field as type bool 
```

## Describe testing done for PR
Tested with following ytt commands locally:

make generate-openapischema-package PACKAGE=kapp-controller VERSION=0.30.0
make push-package PACKAGE=kapp-controller VERSION=0.30.0 TAG=0.30.0


