### PR TITLE
Adds GitHub action stale bot

### DIFF
--- a/.github/workflows/stale-bot.yaml
+++ b/.github/workflows/stale-bot.yaml
@@ -1,0 +1,21 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue is being marked stale due to a period of inactivity. If this issue is still relevant, please comment or remove the stale label. Otherwise, this issue will close in 30 days.'
+          stale-pr-message: 'This PR is being marked stale due to a period of inactivty. If this PR is still relevant, please comment or remove the stale label. Otherwise, this PR will close in 30 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity. If this issue is still relevant, please re-open a new issue.'
+          close-pr-message: 'This PR was closed because it has been stalled for 30 days with no activity. If this PR is still relevant, please re-open a new PR against main.'
+          days-before-issue-stale: 60
+          days-before-pr-stale: 60
+          days-before-issue-close: 30
+          days-before-pr-close: 30
+          # Don't add stale label to PRs / issues with milestones "upcoming" attached.
+          exempt-milestones: "upcoming"


### PR DESCRIPTION
## What this PR does / why we need it
Adds `stale` label to PRs and issues after 30 days
and closes them after 15 days.

Avoids the stale label for PRs with milestones attached.

Ref GitHub stale action: https://github.com/actions/stale

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Added github actions stale bot to label / close stale issues and PRs
```

## Which issue(s) this PR fixes
Fixes: #2876

## Describe testing done for PR
N/a

## Special notes for your reviewer
n/a
