### PR TITLE
Fix self hosted runner Action field behavior change

### DIFF
--- a/hack/runner/webhook/main.go
+++ b/hack/runner/webhook/main.go
@@ -137,10 +137,7 @@ func checkAndDumpSettings() {
 	}
 }
 
-func main() {
-	initLogging()
-	checkAndDumpSettings()
-
+func initServer() {
 	// envvars
 	var port string
 	if v := os.Getenv("LISTEN_PORT"); v != "" {
@@ -190,6 +187,11 @@ func main() {
 		}
 	})
 
+	// clean up
+	go func() {
+		backgroundClean()
+	}()
+
 	// generic version check
 	http.HandleFunc(versionPath, func(w http.ResponseWriter, r *http.Request) {
 		version := Version{
@@ -210,4 +212,10 @@ func main() {
 	if err != nil {
 		klog.Errorf("ListenAndServe failed. Err: %v\n", err)
 	}
+}
+
+func main() {
+	initLogging()
+	checkAndDumpSettings()
+	initServer()
 }


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
There were two issues:
- pushing multiple commits to the same job could have lead to the deletion of the running after the first run was complete. We now check to make sure the runner is idle before deleting: https://github.com/vmware-tanzu/community-edition/pull/2881/files#diff-210090a2d26e86b33d3cc35058efd559b9e3764511cc6da7474d403f5819094eR162
- there seems to have been a behavior change recently in which a job would not correctly fire off the in_progress status. So will key off the completed status instead: https://github.com/vmware-tanzu/community-edition/pull/2881/files#diff-210090a2d26e86b33d3cc35058efd559b9e3764511cc6da7474d403f5819094eR293

Additional changes:
- Added some debugging for tracing
- Put GitHub and EC2 clients into respective structs
- Added an "all else fails" clean up thread that checks for github clients that are idle and attempts to clean them up

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix self hosted runner Action field behavior change
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/2870

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
It's currently running on the webhook instances and fielding jobs

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA
