### PR TITLE
[E2E] add `BUILD_VERSION` to vSphere E2E test script invocations and allow manual trigger of E2E test workflows

### DIFF
--- a/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
@@ -1,6 +1,7 @@
 name: E2E Test - AWS Management and Workload Cluster
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/e2e-aws-standalone-cluster.yaml
+++ b/.github/workflows/e2e-aws-standalone-cluster.yaml
@@ -1,6 +1,7 @@
 name: E2E Test - AWS Standalone Cluster
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
@@ -1,6 +1,7 @@
 name: E2E Test - Azure Management and Workload Cluster
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/e2e-azure-standalone-cluster.yaml
+++ b/.github/workflows/e2e-azure-standalone-cluster.yaml
@@ -1,6 +1,7 @@
 name: E2E Test - Azure Standalone Cluster
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/e2e-diagnostics-plugin.yaml
+++ b/.github/workflows/e2e-diagnostics-plugin.yaml
@@ -1,6 +1,7 @@
 name: E2E Test - Diagnostics Plugin
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/e2e-vsphere-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-vsphere-management-and-workload-cluster.yaml
@@ -1,6 +1,7 @@
 name: E2E Test - vSphere Management and Workload Cluster
 
 on:
+  workflow_dispatch:
   repository_dispatch:
     types: [daily-build]
 

--- a/.github/workflows/e2e-vsphere-standalone-cluster.yaml
+++ b/.github/workflows/e2e-vsphere-standalone-cluster.yaml
@@ -1,6 +1,7 @@
 name: E2E Test - vSphere Standalone Cluster
 
 on:
+  workflow_dispatch:
   repository_dispatch:
     types: [daily-build]
 

--- a/Makefile
+++ b/Makefile
@@ -427,10 +427,10 @@ docker-standalone-cluster-e2e-test:
 
 # vSphere Management + Workload Cluster E2E Test
 vsphere-management-and-workload-cluster-e2e-test:
-	test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
+	BUILD_VERSION=$(BUILD_VERSION) test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
 
 # vSphere Standalone Cluster E2E Test
 vsphere-standalone-cluster-e2e-test:
-	test/vsphere/run-tce-vsphere-standalone-cluster.sh
+	BUILD_VERSION=$(BUILD_VERSION) test/vsphere/run-tce-vsphere-standalone-cluster.sh
 
 ##### E2E TESTS #####


### PR DESCRIPTION
## What this PR does / why we need it

Adds `BUILD_VERSION` to vSphere E2E test script invocations, and allow manual trigger of E2E test workflows for cluster deployment tests and also diagnostics plugin E2E test

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #2883 

## Describe testing done for PR

None

## Special notes for your reviewer

None