### PR TITLE
Enables dependabot version upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,210 @@
+# Dependabot config for go mod version updgrades
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "hack/builder"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "test/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "hack/asset"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "hack/tools"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "hack/tagger"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "hack/builder"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "hack/packages"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "hack/dailybuild"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "hack/imagelinter"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "hack/runner/webhook"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "hack/release/release"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "hack/workflows/packages"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/test/pkg"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "cli/cmd/plugin/conformance"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "cli/cmd/plugin/diagnostics"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/pinniped/hack"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "cli/cmd/plugin/unmanaged-cluster"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/antrea/1.2.3/test"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/harbor/2.3.3/test"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/harbor/2.2.3/test"
+    schedule:
+
+  - package-ecosystem: "gomod"
+    directory: "cli/cmd/plugin/standalone-cluster"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/calico/3.11.3/test"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/calico/3.19.1/test"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/multus-cni/3.7.1/test"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/whereabouts/0.5.0/test"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/external-dns/0.8.0/test"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/vsphere-cpi/1.22.4/test"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/external-dns/0.10.0/test"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/vsphere-cpi/1.23.0-alpha.1/test"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/packages/sriov-network-device-plugin/3.3.2/test"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "tanzu-framework"


### PR DESCRIPTION
## What this PR does / why we need it
This yaml config should enable dependabot version upgrades for our many go modules. This will open bot PRs for upgradeable dependencies in our go mods.

As documented here: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-dependabot-version-updates

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Enables dependabot PRs
```

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
Will have to wait and see it work in GitHub 👀 

## Special notes for your reviewer
N/a