### PR TITLE
Fix hourly cleanup of self hosted runners

### DIFF
--- a/hack/runner/webhook/server.go
+++ b/hack/runner/webhook/server.go
@@ -373,14 +373,13 @@ func backgroundClean() {
 		for _, runner := range runners.Runners {
 			runnerName := *runner.Name
 			runnerStatus := *runner.Status
-			klog.Infof("Runner: %s\n", runnerName)
+			klog.Infof("Runner %s Status: %s\n", runnerName, runnerStatus)
 
-			if !strings.Contains(selfhostedRunnerPrefix, runnerName) {
+			if !strings.Contains(runnerName, selfhostedRunnerPrefix) {
 				klog.Infof("Skipping Runner: %s\n", runnerName)
 				continue
 			}
 
-			klog.V(4).Infof("Runner %s Status: %s\n", runnerName, runnerStatus)
 			switch runnerStatus {
 			case runnerIdle:
 				err := ghClient.DeleteGitHubRunnerByName(runnerName)


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Had an oops... `if !strings.Contains(selfhostedRunnerPrefix, runnerName)` -> `if !strings.Contains(runnerName, selfhostedRunnerPrefix)`. Wasn't cleaning up, but is now.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA