### PR TITLE
Fix the type for tolerations key in schema for kapp-controller deployment

### DIFF
--- a/addons/packages/kapp-controller/0.30.0/bundle/config/schema.yaml
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/schema.yaml
@@ -26,7 +26,8 @@ kappController:
     #@schema/desc "Concurrency of kapp-controller deployment"
     concurrency: 4
     #@schema/desc "kapp-controller deployment tolerations"
-    tolerations: ["toleration1"]
+    #@schema/type any=True
+    tolerations: []
     #@schema/desc "Bind port for kapp-controller API"
     apiPort: 10350
     #@schema/desc "Address for metrics server"

--- a/addons/packages/kapp-controller/0.30.0/package.yaml
+++ b/addons/packages/kapp-controller/0.30.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/kapp-controller@sha256:35b9945059bd1ba989edf130ae244419db75638c89b843e336a6ee15af34b883
+          image: projects.registry.vmware.com/tce/kapp-controller@sha256:c496bc7d583eb5f4273d4b31f37c89d35b4d41b78d703727c6d344edb07276a0
       template:
       - ytt:
           paths:
@@ -74,12 +74,9 @@ spec:
                   default: 4
                   description: Concurrency of kapp-controller deployment
                 tolerations:
-                  type: array
-                  description: kapp-controller deployment tolerations
-                  items:
-                    type: string
-                    default: toleration1
+                  nullable: true
                   default: []
+                  description: kapp-controller deployment tolerations
                 apiPort:
                   type: integer
                   default: 10350


### PR DESCRIPTION

## What this PR does / why we need it
Fix the type for tolerations key in schema for kapp-controller deployment

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix the type for tolerations key in schema for kapp-controller deployment
```

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested with following value for tolerations key :
```
      tolerations:
      - key: CriticalAddonsOnly
        operator: Exists
      - effect: NoSchedule
        key: node-role.kubernetes.io/master
      - effect: NoSchedule
        key: node.kubernetes.io/not-ready
      - effect: NoSchedule
        key: node.cloudprovider.kubernetes.io/uninitialized
        value: "true"
```
