### PR TITLE
Add note to use global gitignore for IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+# NOTE: do not add IDE, editor, or OS-specific patterns here.
+# Individuals should add these to their global gitignore.
+#
+# Example:
+# git config --global core.excludesfile ~/.gitignore
+#
+# cat ~/.gitignore
+#   .idea
+#   .vscode
+#   *~
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a
@@ -38,13 +49,9 @@ debug
 Tiltfile
 
 .container-*
-.vimrc
 .go
-.DS_Store
 .push-*
-.vscode
 *.diff
-.idea
 
 cover.out
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Follow-on from a conversation in the `tanzu-framework` directory.

Rather than adding ignore patterns for everyone's preferred IDE, it's
better practice for developers to keep their own global gitignore for
their specific environments.

This adds a comment to the top of the .gitignore file to note this
policy and give hints for setting that up.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Removed entries from repo's gitignore and made sure global config worked.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
N/A
