### PR TITLE
Introduce "never-stale" label exemption to stalebot

### DIFF
--- a/.github/workflows/stale-bot.yaml
+++ b/.github/workflows/stale-bot.yaml
@@ -19,3 +19,5 @@ jobs:
           days-before-pr-close: 30
           # Don't add stale label to PRs / issues with milestones "upcoming" attached.
           exempt-milestones: "upcoming"
+          # Don't add stale label to PRs / issues with this label
+          exempt-issue-labels: "never-stale"


### PR DESCRIPTION
Since stalebot will try to make stale and close issues/prs
that correlate with tanzu-framework tracking issues,
this introduces the use of "never-stale" to ignore those issues.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
stale-bot now ignores issues tracking tanzu-framework issues
```

## Which issue(s) this PR fixes
N/a - followup to https://github.com/vmware-tanzu/community-edition/pull/2877

## Describe testing done for PR
N/a wait and see what the action does

## Special notes for your reviewer
N/a
