### PR TITLE
`unmanaged-cluster` log package: Non-format log methods print new-line

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -105,7 +105,7 @@ func create(cmd *cobra.Command, args []string) error {
 	tm := tanzu.New(log)
 	err = tm.Deploy(clusterConfig)
 	if err != nil {
-		log.Errorf("%s\n", err.Error())
+		log.Error(err.Error())
 		return nil
 	}
 

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
@@ -53,7 +53,6 @@ func list(cmd *cobra.Command, args []string) error {
 		t.AddRow(c.Name, c.Provider)
 	}
 	t.Render()
-	log.Info("")
 
 	return nil
 }

--- a/cli/cmd/plugin/unmanaged-cluster/log/log.go
+++ b/cli/cmd/plugin/unmanaged-cluster/log/log.go
@@ -51,7 +51,7 @@ type CMDLogger struct {
 
 // Logger provides the logging interaction for the application.
 type Logger interface {
-	// Event takes an emoji codepoint (e.g. "\U0001F609") and presents a log message.
+	// Event takes an emoji codepoint (e.g. "\U0001F609") and presents a log message on it's own line.
 	// This package provides several standard emoji codepoints as string constants. I.e: logger.HammerEmoji
 	// Warning: Emojis may have variable width and this method assumes 2 width emojis, adding a space between the emoji and message.
 	// Emojis provided in this package as string consts have 2 width and work with this method.
@@ -64,20 +64,20 @@ type Logger interface {
 	// If you wish for additional space, add it at the beginning of the message (string) argument.
 	Eventf(emoji, message string, args ...interface{})
 	// Info prints a standard log message.
-	// Line breaks are not automatically added to the end.
+	// Line breaks are automatically added to the end.
 	Info(message string)
 	// Infof takes a format string, arguments, and prints it as a standard log message.
 	// Line breaks are not automatically added to the end.
 	Infof(message string, args ...interface{})
 	// Warn prints a warning message. When TTY is enabled (default), it will be stylized as yellow.
-	// Line breaks are not automatically added to the end.
+	// Line breaks are automatically added to the end.
 	Warn(message string)
 	// Warnf takes a format string, arguments, and prints it as a warning message.
 	// When TTY is enabled (default), it will be stylized as yellow.
 	// Line breaks are not automatically added to the end.
 	Warnf(message string, args ...interface{})
 	// Error prints an error message. When TTY is enabled (default), it will be stylized as red.
-	// Line breaks are not automatically added to the end.
+	// Line breaks are automatically added to the end.
 	Error(message string)
 	// Errorf takes a format string, arguments, and prints it as an error message.
 	// When TTY is enabled (default), it will be stylized as yellow.
@@ -139,8 +139,8 @@ func (l *CMDLogger) Event(emoji, message string) {
 	// so that each event is within it's own "block"
 	fmt.Print("\n")
 
-	// process indentation and ensure a space after the emoji
-	message = "%s " + message
+	// process indentation and ensure a space after the emoji and a new line after message
+	message = "%s " + message + "\n"
 	message = processStyle(l, message)
 	fmt.Fprintf(l.output, message, emoji)
 }
@@ -173,7 +173,7 @@ func (l *CMDLogger) Warn(message string) {
 	}
 
 	message = processStyle(l, message)
-	fmt.Print(message)
+	fmt.Println(message)
 }
 
 func (l *CMDLogger) Warnf(message string, args ...interface{}) {
@@ -191,7 +191,7 @@ func (l *CMDLogger) Error(message string) {
 	}
 
 	message = processStyle(l, message)
-	fmt.Print(message)
+	fmt.Println(message)
 }
 
 func (l *CMDLogger) Errorf(message string, args ...interface{}) {
@@ -209,7 +209,7 @@ func (l *CMDLogger) Info(message string) {
 	}
 
 	message = processStyle(l, message)
-	fmt.Print(message)
+	fmt.Println(message)
 }
 
 func (l *CMDLogger) Infof(message string, args ...interface{}) {

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -128,10 +128,10 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 	// Configure the logger to capture all bootstrap activity
 	bootstrapLogsFp := filepath.Join(t.clusterDirectory, "bootstrap.log")
 	log.AddLogFile(bootstrapLogsFp)
-	log.Event(logger.FolderEmoji, "Created cluster directory\n")
+	log.Event(logger.FolderEmoji, "Created cluster directory")
 
 	// 2. Download and Read the TKR
-	log.Event(logger.WrenchEmoji, "Resolving Tanzu Kubernetes Release (TKR)\n")
+	log.Event(logger.WrenchEmoji, "Resolving Tanzu Kubernetes Release (TKR)")
 	bomFileName, err := getTkrBom(scConfig.TkrLocation)
 	if err != nil {
 		return fmt.Errorf("failed getting TKR BOM. Error: %s", err.Error())
@@ -144,7 +144,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 	log.Style(outputIndent, color.Faint).Infof("Rendered Config: %s\n", configFp)
 	log.Style(outputIndent, color.Faint).Infof("Bootstrap Logs: %s\n", bootstrapLogsFp)
 
-	log.Event(logger.WrenchEmoji, "Processing Tanzu Kubernetes Release\n")
+	log.Event(logger.WrenchEmoji, "Processing Tanzu Kubernetes Release")
 	t.bom, err = parseTKRBom(bomFileName)
 	if err != nil {
 		return fmt.Errorf("failed parsing TKR BOM. Error: %s", err.Error())
@@ -152,15 +152,15 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 
 	// 3. Resolve all required images
 	// base image
-	log.Event(logger.PictureEmoji, "Selected base image\n")
+	log.Event(logger.PictureEmoji, "Selected base image")
 	log.Style(outputIndent, color.Faint).Infof("%s\n", t.bom.GetTKRNodeImage())
 	scConfig.NodeImage = t.bom.GetTKRNodeImage()
 
 	// core package repository
-	log.Event(logger.PackageEmoji, "Selected core package repository\n")
+	log.Event(logger.PackageEmoji, "Selected core package repository")
 	log.Style(outputIndent, color.Faint).Infof("%s\n", t.bom.GetTKRCoreRepoBundlePath())
 	// core user package repositories
-	log.Event(logger.PackageEmoji, "Selected additional package repositories\n")
+	log.Event(logger.PackageEmoji, "Selected additional package repositories")
 	for _, additionalRepo := range t.bom.GetAdditionalRepoBundlesPaths() {
 		log.Style(outputIndent, color.Faint).Infof("%s\n", additionalRepo)
 	}
@@ -169,7 +169,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 	if err != nil {
 		return fmt.Errorf("failed resolving kapp-controller bundle. Error: %s", err.Error())
 	}
-	log.Event(logger.PackageEmoji, "Selected kapp-controller image bundle\n")
+	log.Event(logger.PackageEmoji, "Selected kapp-controller image bundle")
 	log.Style(outputIndent, color.Faint).Infof("%s\n", t.kappControllerBundle.GetRegistryURL())
 
 	// 4. Create the cluster
@@ -189,7 +189,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 		return fmt.Errorf("failed to create kapp-controller manager, Error: %s", err.Error())
 	}
 
-	log.Event(logger.EnvelopeEmoji, "Installing kapp-controller\n")
+	log.Event(logger.EnvelopeEmoji, "Installing kapp-controller")
 	kappDeployment, err := installKappController(t, kc)
 	if err != nil {
 		return fmt.Errorf("failed to install kapp-controller, Error: %s", err.Error())
@@ -198,7 +198,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 
 	// 6. Install package repositories
 	pkgClient := packages.NewClient(kcBytes)
-	log.Event(logger.EnvelopeEmoji, "Installing package repositories\n")
+	log.Event(logger.EnvelopeEmoji, "Installing package repositories")
 	createdCoreRepo, err := createPackageRepo(pkgClient, tkgSysNamespace, tkgCoreRepoName, t.bom.GetTKRCoreRepoBundlePath())
 	if err != nil {
 		return fmt.Errorf("failed to install core package repo. Error: %s", err.Error())
@@ -212,7 +212,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 	blockForRepoStatus(createdCoreRepo, pkgClient)
 
 	// 7. Install CNI
-	log.Event(logger.GlobeEmoji, "Installing CNI\n")
+	log.Event(logger.GlobeEmoji, "Installing CNI")
 	t.selectedCNIPkg, err = resolveCNI(pkgClient, t.config.Cni)
 	if err != nil {
 		return fmt.Errorf("failed to resolve a CNI package. Error: %s", err.Error())
@@ -231,7 +231,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 	}
 
 	// 8. Return
-	log.Event(logger.GreenCheckEmoji, "Cluster created\n")
+	log.Event(logger.GreenCheckEmoji, "Cluster created")
 	log.Eventf(logger.ControllerEmoji, "kubectl context set to %s\n\n", scConfig.ClusterName)
 	// provide user example commands to run
 	log.Infof("View available packages:\n")
@@ -720,7 +720,7 @@ func blockForRepoStatus(repo *v1alpha1.PackageRepository, pkgClient packages.Pac
 		status <- pkgStatus
 		if err != nil {
 			cancel()
-			log.Errorf("failed to check package repository status: %s", err.Error())
+			log.Errorf("failed to check package repository status: %s\n", err.Error())
 			return
 		}
 		if pkgStatus == "Reconcile succeeded" {


### PR DESCRIPTION
Refactors the non-format style methods in the logging package
to print a newline at the end of their message.

This simplifies the logging API where before, code lines like:
```go
log.Errorf("%s\n", myError)
```

can now be simplified to:
```go
log.Error(myError)
```

Users can still use the format style alternatives
to provide a format string and a newline at the end if they prefer.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
unmanaged-cluster log package non-format methods now print newline
```

## Which issue(s) this PR fixes
Fixes: #2873

## Describe testing done for PR
Built the plugin binaries and all still looks good!

![image](https://user-images.githubusercontent.com/23109390/150577010-11dc3ed3-b05e-404b-add1-3747418f8f0f.png)

## Special notes for your reviewer
@stmcginnis I also removed this line in the `cmd/list.go`:
```diff
t.Render()
-log.Info("")
```
and I couldn't for the life of me figure out what it was supposed to be doing since new lines were not added before this PR. So my assumption is it was something left over
