### PR TITLE
Don't error if unable to read unmanaged clusters

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -254,7 +254,13 @@ func (t *UnmanagedCluster) List() ([]Cluster, error) {
 
 	dirs, err := os.ReadDir(configDir)
 	if err != nil {
-		return nil, err
+		// If the config dir can't be read, it's possible no clusters have been
+		// created yet. Or they don't have permissions to something in their own
+		// home directory, which could indicate the config was copied in from
+		// elsewhere. In either case, if we can't read the unmanaged cluster
+		// info, we can just assume there are no clusters for them to see and
+		// just return an empty list.
+		return clusters, nil
 	}
 
 	// 1. enter each directory in the tanzu unmanaged config directory,


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

If we attempt to list unmanaged clusters before any have been created,
the config directory does not exist yet and the command errors out
stating that the directory does not exist.

Rather than erroring, we can safely assume that if the directory can't
be read, there just aren't any clusters to list. This updates the list
logic to return an empty list in this case rather than an error.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2905 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Cleaned up config dir, attempted to list clusters, verified no error was given and an empty list was returned.

```sh
tanzu unmanaged-cluster ls 
  NAME  PROVIDER
```