### PR TITLE
Remove reference to standalone cluster

### DIFF
--- a/cli/cmd/plugin/diagnostics/pkg/collect_cmd.go
+++ b/cli/cmd/plugin/diagnostics/pkg/collect_cmd.go
@@ -42,7 +42,6 @@ var (
 	}
 
 	workloadArgs = collectWorkloadArgs{
-		standalone: false,
 		infra:      "docker",
 	}
 )
@@ -56,7 +55,6 @@ func CollectCmd(fs embed.FS) *cobra.Command {
 		mgmtArgs.clusterName = mgmtSvr.name
 		mgmtArgs.contextName = mgmtSvr.kubecontext
 	} else {
-		workloadArgs.standalone = true
 		workloadArgs.kubeconfig = getDefaultKubeconfig()
 	}
 
@@ -81,7 +79,6 @@ func CollectCmd(fs embed.FS) *cobra.Command {
 	cmd.Flags().StringVar(&mgmtArgs.contextName, "management-cluster-context", mgmtArgs.contextName, "The context name of the management cluster (required)")
 
 	// workload
-	cmd.Flags().BoolVar(&workloadArgs.standalone, "workload-cluster-standalone", workloadArgs.standalone, "If true, workload cluster is treated as standalone")
 	cmd.Flags().StringVar(&workloadArgs.infra, "workload-cluster-infra", workloadArgs.infra, "Overrides the infrastructure type for the managed cluster (i.e. aws, azure, vsphere, etc)")
 	cmd.Flags().StringVar(&workloadArgs.clusterName, "workload-cluster-name", workloadArgs.clusterName, "The name of the managed cluster for which to collect diagnostics (required)")
 	cmd.Flags().StringVar(&workloadArgs.namespace, "workload-cluster-namespace", workloadArgs.namespace, "The namespace where managed workload resources are stored (required)")
@@ -264,11 +261,6 @@ func collectWorkloadDiags() error {
 	}
 
 	scriptName := wcScriptPath
-	if workloadArgs.standalone {
-		argsMap["workload_kubeconfig"] = getDefaultKubeconfig()
-		argsMap["workload_context"] = getDefaultClusterContext(workloadArgs.clusterName)
-	}
-
 	libScript := libScriptPath
 	libData, err := scriptFS.ReadFile(libScript)
 	if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it
This PR removes reference to `standalone-cluster` as it is being phased out.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Diagnostics plugin does removes support for stand-alone cluster
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2864 

## Describe testing done for PR
Run the plugins e2e test suite

## Special notes for your reviewer
This PR simply deprecate reference to the old standalone cluster. It does not provide support for the new unmanaged cluster mode.  As mentioned in #2864 , that feature is alpha and true support can come later.
