### PR TITLE
Introduces `ExistingClusterKubeconfig` option to `unmanaged-cluster`

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -13,14 +13,15 @@ import (
 )
 
 type createUnmanagedOpts struct {
-	skipPreflightChecks    bool
-	clusterConfigFile      string
-	infrastructureProvider string
-	tkrLocation            string
-	cni                    string
-	podcidr                string
-	servicecidr            string
-	portMapping            []string
+	skipPreflightChecks       bool
+	clusterConfigFile         string
+	existingClusterKubeconfig string
+	infrastructureProvider    string
+	tkrLocation               string
+	cni                       string
+	podcidr                   string
+	servicecidr               string
+	portMapping               []string
 }
 
 const createDesc = `
@@ -52,6 +53,7 @@ var co = createUnmanagedOpts{}
 
 func init() {
 	CreateCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "A config file describing how to create the Tanzu environment")
+	CreateCmd.Flags().StringVarP(&co.existingClusterKubeconfig, "existing-cluster-kubeconfig", "e", "", "Use an existing kubeconfg to tanzu-ify a clsuter")
 	CreateCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider for cluster creation; default is kind")
 	CreateCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The URL to the image containing a Tanzu Kubernetes release")
 	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy; default is antrea")
@@ -75,13 +77,14 @@ func create(cmd *cobra.Command, args []string) error {
 
 	// Determine our configuration to use
 	configArgs := map[string]string{
-		config.ClusterConfigFile: co.clusterConfigFile,
-		config.ClusterName:       clusterName,
-		config.Provider:          co.infrastructureProvider,
-		config.TKRLocation:       co.tkrLocation,
-		config.Cni:               co.cni,
-		config.PodCIDR:           co.podcidr,
-		config.ServiceCIDR:       co.servicecidr,
+		config.ClusterConfigFile:         co.clusterConfigFile,
+		config.ExistingClusterKubeconfig: co.existingClusterKubeconfig,
+		config.ClusterName:               clusterName,
+		config.Provider:                  co.infrastructureProvider,
+		config.TKRLocation:               co.tkrLocation,
+		config.Cni:                       co.cni,
+		config.PodCIDR:                   co.podcidr,
+		config.ServiceCIDR:               co.servicecidr,
 	}
 	clusterConfig, err := config.InitializeConfiguration(configArgs)
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/config/config.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config.go
@@ -20,20 +20,21 @@ import (
 )
 
 const (
-	ClusterConfigFile = "ClusterConfigFile"
-	ClusterName       = "ClusterName"
-	Tty               = "Tty"
-	TKRLocation       = "TkrLocation"
-	Provider          = "Provider"
-	Cni               = "Cni"
-	PodCIDR           = "PodCidr"
-	ServiceCIDR       = "ServiceCidr"
-	configDir         = ".config"
-	tanzuConfigDir    = "tanzu"
-	yamlIndent        = 2
-	ProtocolTCP       = "tcp"
-	ProtocolUDP       = "udp"
-	ProtocolSCTP      = "sctp"
+	ClusterConfigFile         = "ClusterConfigFile"
+	ExistingClusterKubeconfig = "ExistingClusterKubeconfig"
+	ClusterName               = "ClusterName"
+	Tty                       = "Tty"
+	TKRLocation               = "TkrLocation"
+	Provider                  = "Provider"
+	Cni                       = "Cni"
+	PodCIDR                   = "PodCidr"
+	ServiceCIDR               = "ServiceCidr"
+	configDir                 = ".config"
+	tanzuConfigDir            = "tanzu"
+	yamlIndent                = 2
+	ProtocolTCP               = "tcp"
+	ProtocolUDP               = "udp"
+	ProtocolSCTP              = "sctp"
 )
 
 var defaultConfigValues = map[string]string{
@@ -60,8 +61,11 @@ type PortMap struct {
 type UnmanagedClusterConfig struct {
 	// ClusterName is the name of the cluster.
 	ClusterName string `yaml:"ClusterName"`
-	// KubeconfigPath is the serialized path to the kubeconfig to use.
+	// KubeconfigPath is the location where the Kubeconfig will be persisted
+	// after the cluster is created.
 	KubeconfigPath string `yaml:"KubeconfigPath"`
+	// ExistingClusterKubeconfig is the serialized path to the kubeconfig to use of an existing cluster.
+	ExistingClusterKubeconfig string `yaml:"ExistingClusterKubeconfig"`
 	// NodeImage is the host OS image to use for Kubernetes nodes.
 	// It is typically resolved, automatically, in the Taznu Kubernetes Release (TKR) BOM,
 	// but also can be overridden in configuration.
@@ -161,7 +165,7 @@ func InitializeConfiguration(commandArgs map[string]string) (*UnmanagedClusterCo
 	}
 
 	// Sanatize the filepath for the provided kubeconfig
-	config.KubeconfigPath = sanatizeKubeconfigPath(config.KubeconfigPath)
+	config.ExistingClusterKubeconfig = sanatizeKubeconfigPath(config.ExistingClusterKubeconfig)
 
 	return config, nil
 }


### PR DESCRIPTION
## What this PR does / why we need it
This PR introduces the `ExistingClusterKubeconfig` config option which is supported by the `--existing-cluster-kubeconfig` flag during `create`.

This enables users to bring their own clusters that already exist and already have a kubeconfig on the filesystem.

#### Why not just use `KubeconfigPath`?

This would have required a greater refactor since the `config.KubeconfigPath` is used to create and set the context of _new_ created kind clusters:

```go
clusterConfig := kindcluster.CreateWithkubeconfigPath(c.KubeconfigPath)

...

err = kindProvider.Create(c.ClusterName, clusterConfig, kindConfig)
```

This means that we would have been _overloading_ the use of `KubeconfigPath`: it would both be the path to the kubeconfig for some arbitrary created cluster or used in logic to determine if a user is attempting to provide an existing cluster.

Instead, introducing a _new option_ allows us to keep `Kubeconfig` just as it is: the file path to a kubeconfig.

Deeper in the implementation, we actually take advantage of this by setting the `Kubeconfig` to the what is provided by a user when using `ExistingClusterKubeconfig`. This enables existing program flow to stay in place without creating extra logic around a separate kubeconfig.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
introduce ExistingclusterKubeconfig option for unmanaged-cluster
```

## Which issue(s) this PR fixes
Fixes: #2890

## Describe testing done for PR

Existing functionality intact, still able to create cluster and target it:

![Screen Shot 2022-01-24 at 11 09 30 AM](https://user-images.githubusercontent.com/23109390/150839733-20ee93bc-c730-490f-8cf1-cf5c795af714.png)

- create some arbitrary cluster. Used kind for this example:
```
$ kind create cluster --name already-exists
...
```
- Get the cluster's kubeconfig:
```
$ kind get kubeconfig --name already-exists > /tmp/kubeconfig.yaml
```

- Give `unmanaged-cluster` the kubeconfig as an option:

![Screen Shot 2022-01-24 at 1 34 56 PM](https://user-images.githubusercontent.com/23109390/150860417-4d4b5e54-ef60-4351-be35-f86170fc9408.png)


Check the stats of the cluster:
```
❯ k get pods -A --kubeconfig kubeconfig.yaml
NAMESPACE            NAME                                                   READY   STATUS    RESTARTS   AGE
kube-system          coredns-558bd4d5db-j72jw                               1/1     Running   0          2m52s
kube-system          coredns-558bd4d5db-psrm9                               1/1     Running   0          2m52s
kube-system          etcd-already-exists-control-plane                      1/1     Running   0          2m55s
kube-system          kindnet-gx8v4                                          1/1     Running   0          2m52s
kube-system          kube-apiserver-already-exists-control-plane            1/1     Running   0          2m55s
kube-system          kube-controller-manager-already-exists-control-plane   1/1     Running   0          2m54s
kube-system          kube-proxy-8lgm2                                       1/1     Running   0          2m52s
kube-system          kube-scheduler-already-exists-control-plane            1/1     Running   0          2m55s
local-path-storage   local-path-provisioner-547f784dff-rfhv8                1/1     Running   0          2m52s
tkg-system           kapp-controller-f7dbbcb4f-nrpbz                        1/1     Running   0          89s

```

## Special notes for your reviewer
N/a
