### PR TITLE
Introduce terminal-width aware animated logging for `unmanaged-cluster`

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/go.mod
+++ b/cli/cmd/plugin/unmanaged-cluster/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/vmware-tanzu/carvel-kapp-controller v0.28.0
 	github.com/vmware-tanzu/carvel-vendir v0.23.0
 	github.com/vmware-tanzu/tanzu-framework v0.10.0
+	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.22.2


### PR DESCRIPTION
## What this PR does / why we need it
Introduces "terminal-width" aware progress logging.

Using the file descriptor of the attached terminal, we can determine the width of the terminal using Go's standard library. There is a bug ([described in depth here](https://github.com/vmware-tanzu/community-edition/issues/2852#issuecomment-1020427005)) that keeps long lines in small terminals from being replaced.

So, if the progress line is too long, we rebuild a truncated version of it. While this does cut off some information, the next "success" log line is still full length giving the user all the necessary details. 

Shout out to @stmcginnis for finding a solution to this in the go std library!!

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
fixed unmanaged-cluster animated logging wrapping during progress logging incorrectly
```

## Which issue(s) this PR fixes
Fixes: #2852

## Describe testing done for PR
Normal terminal size still works great:

![Screen Shot 2022-01-25 at 9 32 35 AM](https://user-images.githubusercontent.com/23109390/151019489-d4d51e50-b2b1-4ed0-bf5c-ff9c05ddb6bc.png)

Small terminal now won't have the wrapping issue. Lines get replaced as expected:

![Screen Shot 2022-01-25 at 9 33 16 AM](https://user-images.githubusercontent.com/23109390/151019498-cc7d7f1c-0ad7-4842-9a02-6f0c7fa91793.png)

_*note*_: even though the full path here is getting truncated, the "success" line is still full length and replaces that line successfully giving all the necessary details to the user. Example:

![Screen Shot 2022-01-25 at 9 41 11 AM](https://user-images.githubusercontent.com/23109390/151020267-b11b38a9-c3fc-4e58-a198-652e1ce7b250.png)



## Special notes for your reviewer
N/a
