### PR TITLE
Doc - Add doc note on namespaces.

### DIFF
--- a/docs/site/content/docs/assets/package-installation.md
+++ b/docs/site/content/docs/assets/package-installation.md
@@ -35,12 +35,10 @@ For more information, see [Planning Your Installation](https://tanzucommunityedi
     tanzu package repository add tce-repo --url projects.registry.vmware.com/tce/main:0.9.1 --namespace tanzu-package-repo-global
     ```
 
-    > Package repositories installed into the `tanzu-package-repo-global` namespace are available to the entire cluster.  
-    > Use the `--namespace` argument in the `tanzu package repository add` command to install a package repository into a specific namespace. If you install a package repository into another namespace, you must specify that namespace as an argument in the `tanzu package install` command  when you install a package from that repository.  
-    > A `tanzu-core` repository is also installed in the `tkg-system` namespace
-    > clusters. This repository holds lower-level components that are **not**
-    > meant to be installed by the user! These packages are used during cluster
-    > boostrapping.
+    > * Package repositories are installed into the `default` namespace by default.  
+    > * Packages are installed in the same namespace where the PackageRepository is installed. If you install a package repository into another non-default namespace, you must specify that same namespace as an argument in the `tanzu package install` command when you install a package from that repository.  
+    > * Package repositories installed into the `tanzu-package-repo-global` namespace are available to the entire cluster. In this case, the packages can be installed in a different namespace to the PackageRepository, they don't need to be installed into the `tanzu-package-repo-global` namespace.  
+    > * A `tanzu-core` repository is also installed in the `tkg-system` namespace clusters. This repository holds lower-level components that are **not** meant to be installed by the user. These packages are used during cluster boostrapping.  
 
 1. Verify the package repository has reconciled.
 
@@ -124,8 +122,8 @@ For more information, see [Planning Your Installation](https://tanzucommunityedi
 
     ```
 
-    **NOTE**: Use one of the available package versions, since the one described
-    in this guide might no longer be available.
+    **Note**: Use one of the available package versions, since the one described in this guide might no longer be available.
+    **Note**: While the underlying resources associated with cert-manager are installed in the cert-manager namespace, the actual cert-manager package is installed to the `default` namespace as per the installation output message. For an explanation of this behavior, see 2 above and the [Package Repositories](../package-management/#package-repositories) topic.
 
 1. Verify cert-manager is installed in the cluster.
 

--- a/docs/site/content/docs/latest/package-management.md
+++ b/docs/site/content/docs/latest/package-management.md
@@ -8,19 +8,17 @@ package` to interact with packages.
 
 ## Package Repositories
 
-A package repository holds references to package(s). By installing a package
-repository into a cluster, packages become available for installation. A look
-at this relationship is as follows.
+A package repository holds references to package(s). By installing a package repository into a cluster, packages become available for installation. A look at this relationship is as follows.
 
 ![tanzu packaging flow](/docs/img/pkg-mgmt-repo.png)
 
-Packages are available in the same namespace where the PackageRepository has been installed.
-There is however, a namespace that provides packages globally to the cluster if the PackageRepository
-providing them is installed in it. This namespace is `tanzu-package-repo-global`.
+ The PackageRepository is installed in the `default` namespace by default.
 
-The `tanzu-core` package repository will pre-exist on every cluster in the
-`tkg-system` namespace. Packages in this repository are exclusively for cluster
-bootstrapping. They should **not** be reinstalled by users.
+ Packages are installed in the same namespace where the PackageRepository is installed. If you install the PackageRepository into another non-default namespace, you must specify that same namespace as an argument in the `tanzu package install` command when you install a package from that repository.
+
+If you install the PackageRepository into the `tanzu-package-repo-global` namespace, then all packages are available globally to the cluster. In this case, the packages can be installed in a different namespace to the PackageRepository, they don't need to be installed into the `tanzu-package-repo-global`  namespace.  
+
+The `tanzu-core` package repository will pre-exist on every cluster in the `tkg-system` namespace. Packages in this repository are exclusively for cluster bootstrapping. They should **not** be reinstalled by users.
 
 ### Adding a Package Repository
 


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
To explain why packages go into default namespace:


- Added note to step 6 in Installing a Package in Getting Started
- Updated and added to text on step 2  in Installing a Package in Getting Started
- Updated text  in Package Repositories section of Work with Packages topic

(related to #1937)

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2147

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
I'm not sure how to explain the **why is the package installed in the default namespace**?, I could add a link to [Adding a Package Repository](https://tanzucommunityedition.io/docs/latest/package-management/#adding-a-package-repository) which might help
or 
what else do you suggest?

