### PR TITLE
Update kpack capacity requirements

### DIFF
--- a/addons/packages/kpack/0.5.0/package.yaml
+++ b/addons/packages/kpack/0.5.0/package.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   refName: kpack.community.tanzu.vmware.com
   version: 0.5.0
-  capacityRequirementsDescription: Cluster with nodes > 50GB ephemeral storage, Registry > 5GB available space
+  capacityRequirementsDescription: Registry with > 1GB available space
   releaseNotes: https://github.com/pivotal/kpack/releases/tag/v0.5.0
   valuesSchema:
     openAPIv3:

--- a/addons/packages/kpack/vendir.lock.yml
+++ b/addons/packages/kpack/vendir.lock.yml
@@ -2,7 +2,7 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - githubRelease:
-      url: https://api.github.com/repos/vmware-tanzu/package-for-kpack/releases/57710993
+      url: https://api.github.com/repos/vmware-tanzu/package-for-kpack/releases/57955795
     path: .
   path: 0.5.0
 kind: LockConfig


### PR DESCRIPTION
## What this PR does / why we need it
This pr updates the kpack requirements to be less since they do not need to be as high as they are currently set.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Reduce kpack capacity requirement to 1GB of registry space
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: No current issue exists

## Describe testing done for PR
Ran package-for-kpack tests

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
