### PR TITLE
unmanaged-cluster: support no CNI and failed CNI

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -50,6 +50,10 @@ const (
 // TODO(joshrosso): global logger for the package. This is kind gross, but really convenient.
 var log logger.Logger
 
+// value for CNI configuration which represents creating a cluster without a
+// CNI.
+const cniNoneName = "none"
+
 // Cluster contains information about a cluster.
 type Cluster struct {
 	Name     string
@@ -212,15 +216,21 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 	blockForRepoStatus(createdCoreRepo, pkgClient)
 
 	// 7. Install CNI
+	// CNI plugins are installed as best effort. If no plugin is resolved in the
+	// repository, no CNI is installed, yet the cluster will still run.
 	log.Event(logger.GlobeEmoji, "Installing CNI")
 	t.selectedCNIPkg, err = resolveCNI(pkgClient, t.config.Cni)
+
+	// No CNI package was resolved to install
 	if err != nil {
-		return fmt.Errorf("failed to resolve a CNI package. Error: %s", err.Error())
-	}
-	log.Style(outputIndent, color.Faint).Infof("%s:%s\n", t.selectedCNIPkg.fqPkgName, t.selectedCNIPkg.pkgVersion)
-	err = installCNI(pkgClient, t)
-	if err != nil {
-		return fmt.Errorf("failed to install the CNI package. Error: %s", err.Error())
+		log.Style(outputIndent, color.FgYellow).Warnf("No CNI installed: %s.\n", err)
+	} else {
+		// CNI package resolved, do install
+		log.Style(outputIndent, color.Faint).Infof("%s:%s\n", t.selectedCNIPkg.fqPkgName, t.selectedCNIPkg.pkgVersion)
+		err = installCNI(pkgClient, t)
+		if err != nil {
+			return fmt.Errorf("failed to install the CNI package. Error: %s", err.Error())
+		}
 	}
 
 	// 8. Update kubeconfig and context
@@ -738,8 +748,14 @@ func blockForRepoStatus(repo *v1alpha1.PackageRepository, pkgClient packages.Pac
 	}
 }
 
-// TODO(joshrosso) this function is a mess, but waiting on some stuff to happen in other packages
+// installCNI installs the CNI package to be satisfied via kapp-controller. If
+// the selected CNI package is nil, it returns as a noop.
+// TODO(joshrosso): this function is a mess, but waiting on some stuff to
+// happen in other packages
 func installCNI(pkgClient packages.PackageManager, t *UnmanagedCluster) error {
+	if t.selectedCNIPkg == nil {
+		return fmt.Errorf("cannot install CNI when value is nil")
+	}
 	// install CNI (TODO(joshrosso): needs to support multiple CNIs
 	rootSvcAcct, err := pkgClient.CreateRootServiceAccount(tkgSysNamespace, tkgSvcAcctName)
 	if err != nil {
@@ -788,9 +804,13 @@ func mergeKubeconfigAndSetContext(mgr kubeconfig.Manager, kcPath, clusterName st
 	return nil
 }
 
-// resolveCNI determines which CNI package to use. It expects to be passed a fully qualified package name
-// except for special known CNI values such as antrea or calico.
+// resolveCNI determines which CNI package to use. It expects to be passed a
+// fully qualified package name except for special known CNI values such as
+// antrea or calico.
 func resolveCNI(mgr packages.PackageManager, cniName string) (*CNIPackage, error) {
+	if cniName == cniNoneName {
+		return nil, fmt.Errorf("CNI was set to %s", cniName)
+	}
 	pkgs, err := mgr.ListPackagesInNamespace(tkgSysNamespace)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What this PR does / why we need it

This commit adds support for creating clusters without installing CNI. It
also enables cluster creation to complete successfully when a CNI
package fails to resolve.

For creating clusters without CNI, a user may set the CNI configuration
value to "none". For example, cluster creation can occur as follows:

tanzu uc create testme --cni=none

Users will receive a warning message that no CNI was installed, and the
installation will complete.

For when a CNI is specified but is invalid, for example:

tanzu uc create testme --cni=beepboopnotreal

Users will receive a warning message that no CNI package was found, but
the install will still complete. This is because the cluster is still
successfully started and the user could choose to remedy or troubleshoot
after bootstrapping.

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
unmanaged-clusters support none for CNI value, preventing an install of CNI after cluster creation.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/2939
Fixes: https://github.com/vmware-tanzu/community-edition/issues/2940

## Describe testing done for PR

### CNI does not install when set to `none` :heavy_check_mark:.

![image](https://user-images.githubusercontent.com/6200057/151091358-70b17ebc-368c-4aaa-96e2-a87c82d4e780.png)

### CNI skipped when cannot resolve package (rather than fail) :heavy_check_mark: 

![image](https://user-images.githubusercontent.com/6200057/151091406-ea2e9ee1-07d8-460b-9a96-dd48cbc6dda4.png)


### CNI Selection still works as expected :heavy_check_mark: 

![image](https://user-images.githubusercontent.com/6200057/151091450-0b3660ed-c324-466f-a76a-db457bfdec3a.png)

## Special notes for your reviewer

None