### PR TITLE
Create OpenAPIV3 schema for vsphere-cpi package and generate package with the schema, but for version 1.23.0-alpha.1

### DIFF
--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/README.md
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/README.md
@@ -17,22 +17,24 @@ None
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
 | `vsphereCPI.mode`    | Optional | The vSphere mode. Either `vsphereCPI` or `vsphereParavirtualCPI`. Default value is `vsphereCPI` |
-| `vsphereCPI.server` | Required | The IP address or FQDN of the vSphere endpoint. Default value is `null`. |
-| `vsphereCPI.datacenter` | Required | The datacenter in which VMs are created/located. Default value is `null`. |
-| `vsphereCPI.username` | Required | Username used to access a vSphere endpoint. Default value is `null`. |
-| `vsphereCPI.password` | Required | Password used to access a vSphere endpoint. Default value is `null`. |
+| `vsphereCPI.server` | Required | The IP address or FQDN of the vSphere endpoint. Default value is `""`. |
+| `vsphereCPI.datacenter` | Required | The datacenter in which VMs are created/located. Default value is `""`. |
+| `vsphereCPI.username` | Required | Username used to access a vSphere endpoint. Default value is `""`. |
+| `vsphereCPI.password` | Required | Password used to access a vSphere endpoint. Default value is `""`. |
 | `vsphereCPI.tlsThumbprint` | Optional | The cryptographic thumbprint of the vSphere endpoint's certificate. Default value is `""`. |
 | `vsphereCPI.insecureFlag` | Optional | The flag that disables TLS peer verification. Default value is `False`. |
-| `vsphereCPI.ipFamily` | Optional | IP family. Default value is `null`. |
-| `vsphereCPI.vmInternalNetwork` | Optional | Internal VM network name. Default value is `null`. |
-| `vsphereCPI.vmExternalNetwork` | Optional | External VM network name. Default value is `null`. |
+| `vsphereCPI.ipFamily` | Optional | IP family. Default value is `""`. |
+| `vsphereCPI.vmInternalNetwork` | Optional | Internal VM network name. Default value is `""`. |
+| `vsphereCPI.vmExternalNetwork` | Optional | External VM network name. Default value is `""`. |
+| `vsphereCPI.vmExcludeInternalNetworkSubnetCidr` | Optional | External VM network name. Default value is `""`. |
+| `vsphereCPI.vmExcludeExternalNetworkSubnetCidr` | Optional | Internal VM network name. Default value is `""`. |
 | `vsphereCPI.cloudProviderExtraArgs.tls-cipher-suites` | Optional | External arguments for cloud provider. Default: `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384` |
 | `vsphereCPI.nsxt.podRoutingEnabled` | Optional | A flag that enables pod routing. Default: `false`. |
 | `vsphereCPI.nsxt.routes.routerPath` | Optional | NSX-T T0/T1 logical router path. Default: `""`. |
 | `vsphereCPI.nsxt.routes.clusterCidr` | Optional | Cluster CIDR. Default: `""` . |
 | `vsphereCPI.nsxt.username` | Optional | The username used to access NSX-T. Default: `""`. |
 | `vsphereCPI.nsxt.password` | Optional | The password used to access NSX-T. Default: `""`. |
-| `vsphereCPI.nsxt.host`| Optional | The NSX-T server. Default: `null`. |
+| `vsphereCPI.nsxt.host`| Optional | The NSX-T server. Default: `""`. |
 | `vsphereCPI.nsxt.insecureFlag` | Optional | InsecureFlag is to be set to true if NSX-T uses self-signed cert. Default: `false`. |
 | `vsphereCPI.nsxt.remoteAuth` | Optional | RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM). Default: `false`. |
 | `vsphereCPI.nsxt.vmcAccessToken`| Optional | VMCAccessToken is VMC access token for token based authentification. Default: `""`. |
@@ -42,7 +44,7 @@ None
 |`vsphereCPI.nsxt.rootCAData` | Optional | The certificate authority for the server certificate for locally signed certificates. Default: `""`. |
 | `vsphereCPI.nsxt.secretName` | Optional | The name of secret that stores CPI configuration. Default: `cloud-provider-vsphere-nsxt-credentials`. |
 | `vsphereCPI.nsxt.secretNamespace`| Optional | The namespace of secret that stores CPI configuration. Default: `True`. |
-| `vsphereCPI.clusterAPIVersion`| Optional for `vsphereParavirtual` | Used in `vsphereParavirtual` mode, defines the Cluster API versions. Default: `run.tanzu.vmware.com/v1alpha2` |
+| `vsphereCPI.clusterAPIVersion`| Optional for `vsphereParavirtual` | Used in `vsphereParavirtual` mode, defines the Cluster API versions. Default: `cluster.x-k8s.io/v1beta1` |
 | `vsphereCPI.clusterKind`| Optional for `vsphereParavirtual` | Used in `vsphereParavirtual` mode, defines the Cluster kind. Default: `Cluster` |
 | `vsphereCPI.clusterName`| Required for `vsphereParavirtual` | Used in `vsphereParavirtual` mode, defines the Cluster name. Default: `test-cluster` |
 | `vsphereCPI.clusterUID`| Required for `vsphereParavirtual` | Used in `vsphereParavirtual` mode, defines the Cluster UID. Default: `""` |

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/schema.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/schema.yaml
@@ -1,0 +1,97 @@
+#! schema.yaml
+
+#@data/values-schema
+#@schema/desc "OpenAPIv3 Schema for vsphere-cpi"
+---
+#@schema/desc "Configurations for vsphere-cpi"
+vsphereCPI:
+  #@schema/desc "The vSphere mode. Either vsphereCPI or vsphereParavirtualCPI. Default value is vsphereCPI"
+  mode: vsphereCPI
+  #@schema/desc "The cryptographic thumbprint of the vSphere endpoint's certificate"
+  tlsThumbprint: ""
+  #@schema/desc "The IP address or FQDN of the vSphere endpoint"
+  server: ""
+  #@schema/desc "The datacenter in which VMs are created/located"
+  datacenter: ""
+  #@schema/desc "Username used to access a vSphere endpoint"
+  username: ""
+  #@schema/desc "Password used to access a vSphere endpoint"
+  password: ""
+  #@schema/desc "The region used by vSphere multi-AZ feature"
+  #@schema/nullable
+  region: ""
+  #@schema/desc "The zone used by vSphere multi-AZ feature"
+  #@schema/nullable
+  zone: ""
+  #@schema/desc "The flag that disables TLS peer verification"
+  insecureFlag: False
+  #@schema/desc "The IP family configuration"
+  #@schema/nullable
+  ipFamily: ""
+  #@schema/desc "Internal VM network name"
+  #@schema/nullable
+  vmInternalNetwork: ""
+  #@schema/desc "External VM network name"
+  #@schema/nullable
+  vmExternalNetwork: ""
+  #@schema/desc "Internal VM network cidr to be excluded."
+  #@schema/nullable
+  vmExcludeInternalNetworkSubnetCidr: ""
+  #@schema/desc "External VM network cidr to be excluded."
+  #@schema/nullable
+  vmExcludeExternalNetworkSubnetCidr: ""
+  #@schema/desc "Extra arguments for the cloud-provider-vsphere."
+  cloudProviderExtraArgs:
+    #@schema/desc "External arguments for cloud provider"
+    tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+  nsxt:
+    #@schema/desc "A flag that enables pod routing"
+    podRoutingEnabled: false
+    routes:
+      #@schema/desc "NSX-T T0/T1 logical router path"
+      routerPath: ""
+      #@schema/desc "Cluster CIDR"
+      clusterCidr: ""
+    #@schema/desc "The username used to access NSX-T"
+    username: ""
+    #@schema/desc "The password used to access NSX-T"
+    password: ""
+    #@schema/desc "The NSX-T server"
+    #@schema/nullable
+    host: ""
+    #@schema/desc "InsecureFlag is to be set to true if NSX-T uses self-signed cert"
+    insecureFlag: false
+    #@schema/desc "RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)"
+    remoteAuth: false
+    #@schema/desc "VMCAccessToken is VMC access token for token based authentification"
+    vmcAccessToken: ""
+    #@schema/desc "VMCAuthHost is VMC verification host for token based authentification"
+    vmcAuthHost: ""
+    #@schema/desc "Client certificate key for NSX-T"
+    clientCertKeyData: ""
+    #@schema/desc "Client certificate data for NSX-T"
+    clientCertData: ""
+    #@schema/desc "The certificate authority for the server certificate for locally signed certificates"
+    rootCAData: ""
+    #@schema/desc "The name of secret that stores CPI configuration"
+    secretName: "cloud-provider-vsphere-nsxt-credentials"
+    #@schema/desc "The namespace of secret that stores CPI configuration"
+    secretNamespace: "kube-system"
+  #@schema/desc "HTTP proxy setting"
+  http_proxy: ""
+  #@schema/desc "HTTPS proxy setting"
+  https_proxy: ""
+  #@schema/desc "No-proxy setting"
+  no_proxy: ""
+  #@schema/desc "Used in vsphereParavirtual mode, defines the Cluster API versions. Default: cluster.x-k8s.io/v1beta1."
+  clusterAPIVersion: "cluster.x-k8s.io/v1beta1"
+  #@schema/desc "Used in vsphereParavirtual mode, defines the Cluster kind. Default: Cluster."
+  clusterKind: "Cluster"
+  #@schema/desc "Used in vsphereParavirtual mode, defines the Cluster name. Default: ''."
+  clusterName: ""
+  #@schema/desc "Used in vsphereParavirtual mode, defines the Cluster UID. Default: ''"
+  clusterUID: ""
+  #@schema/desc "Used in vsphereParavirtual mode, the endpoint IP of supervisor cluster's API server. Default: ''"
+  supervisorMasterEndpointIP: ""
+  #@schema/desc "Used in vsphereParavirtual mode, the endpoint port of supervisor cluster's API server port. Default: ''"
+  supervisorMasterPort: ""

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/upstream/vsphere-paravirtual-cpi/03-deployment.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/upstream/vsphere-paravirtual-cpi/03-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - args:
             - --controllers=service
             - --controllers=cloud-node
-            # TODO(fhan): add field AntreaNSXRouted to support routable pod with AntreaNSX
+            #! TODO(fhan): add field AntreaNSXRouted to support routable pod with AntreaNSX
             - --cloud-config=/config/cloud-config
             #@yaml/text-templated-strings
             - --cluster-name=(@= values.vsphereCPI.clusterName @)

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/values.star
@@ -2,10 +2,10 @@ load("@ytt:data", "data")
 load("@ytt:assert", "assert")
 
 def validate_vsphereCPI():
-   data.values.vsphereCPI.server or assert.fail("vsphereCPI server should be provided")
-   data.values.vsphereCPI.datacenter or assert.fail("vsphereCPI datacenter should be provided")
-   data.values.vsphereCPI.username or assert.fail("vsphereCPI username should be provided")
-   data.values.vsphereCPI.password or assert.fail("vsphereCPI password should be provided")
+   data.values.vsphereCPI.server != "" or assert.fail("vsphereCPI server should be provided")
+   data.values.vsphereCPI.datacenter != "" or assert.fail("vsphereCPI datacenter should be provided")
+   data.values.vsphereCPI.username != "" or assert.fail("vsphereCPI username should be provided")
+   data.values.vsphereCPI.password != "" or assert.fail("vsphereCPI password should be provided")
    if not data.values.vsphereCPI.insecureFlag:
      data.values.vsphereCPI.tlsThumbprint or assert.fail("vsphereCPI tlsThumbprint should be provided when insecureFlag is False")
    end
@@ -19,6 +19,8 @@ def validate_vsphereParavirtualCPI():
    data.values.vsphereCPI.clusterUID or assert.fail("vsphereParavirtualCPI UID of cluster should be provided")
    data.values.vsphereCPI.supervisorMasterEndpointIP or assert.fail("vsphereParavirtualCPI supervisorMasterEndpointIP of cluster should be provided")
    data.values.vsphereCPI.supervisorMasterPort or assert.fail("vsphereParavirtualCPI supervisorMasterPort of cluster should be provided")
+   data.values.vsphereCPI.clusterName != "" or assert.fail("vsphereParavirtualCPI cluster name should be provided")
+   data.values.vsphereCPI.clusterUID != "" or assert.fail("vsphereParavirtualCPI cluster UID should be provided")
 end
 
 def validate_nsxt_config():

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/vsphereconf.lib.txt
@@ -47,8 +47,16 @@ exclude-external-network-subnet-cidr = "(@=values.vsphereCPI.vmExcludeExternalNe
 router-path = "(@=values.vsphereCPI.nsxt.routes.routerPath @)"
 [NSXT]
 host = "(@=values.vsphereCPI.nsxt.host @)"
-insecure-flag = "(@=str(values.vsphereCPI.nsxt.insecureFlag).lower() @)"
-remote-auth = "(@=str(values.vsphereCPI.nsxt.remoteAuth).lower() @)"
+(@ if values.vsphereCPI.nsxt.insecureFlag: -@)
+insecure-flag = "true"
+(@ else: -@)
+insecure-flag = "false"
+(@ end -@)
+(@ if values.vsphereCPI.nsxt.remoteAuth: -@)
+remote-auth = "true"
+(@ else: -@)
+remote-auth = "false"
+(@ end -@)
 (@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace and values.vsphereCPI.nsxt.username and values.vsphereCPI.nsxt.password  : -@)
 secret-name = "(@=values.vsphereCPI.nsxt.secretName @)"
 secret-namespace = "(@=values.vsphereCPI.nsxt.secretNamespace @)"

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/package.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/package.yaml
@@ -5,21 +5,209 @@ metadata:
 spec:
   refName: vsphere-cpi.community.tanzu.vmware.com
   version: 1.23.0-alpha.1
-  releaseNotes: "vsphere-cpi 1.23.0-alpha.1 https://github.com/kubernetes/cloud-provider-vsphere"
+  releaseNotes: vsphere-cpi 1.23.0-alpha.1 https://github.com/kubernetes/cloud-provider-vsphere
   licenses:
-    - "Apache 2.0"
+  - Apache 2.0
   template:
     spec:
       fetch:
-        - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:7894ffd9b9fca6a53f2277159304b5966fa9bd1dcc1f416f74dfb7ebfe95d96c
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:7894ffd9b9fca6a53f2277159304b5966fa9bd1dcc1f416f74dfb7ebfe95d96c
       template:
-        - ytt:
-            paths:
-              - config/
-        - kbld:
-            paths:
-              - "-"
-              - .imgpkg/images.yml
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
       deploy:
-        - kapp: {}
+      - kapp: {}
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      description: OpenAPIv3 Schema for vsphere-cpi
+      properties:
+        vsphereCPI:
+          type: object
+          additionalProperties: false
+          description: Configurations for vsphere-cpi
+          properties:
+            mode:
+              type: string
+              default: vsphereCPI
+              description: The vSphere mode. Either vsphereCPI or vsphereParavirtualCPI. Default value is vsphereCPI
+            tlsThumbprint:
+              type: string
+              default: ""
+              description: The cryptographic thumbprint of the vSphere endpoint's certificate
+            server:
+              type: string
+              default: ""
+              description: The IP address or FQDN of the vSphere endpoint
+            datacenter:
+              type: string
+              default: ""
+              description: The datacenter in which VMs are created/located
+            username:
+              type: string
+              default: ""
+              description: Username used to access a vSphere endpoint
+            password:
+              type: string
+              default: ""
+              description: Password used to access a vSphere endpoint
+            region:
+              type: string
+              default: null
+              nullable: true
+              description: The region used by vSphere multi-AZ feature
+            zone:
+              type: string
+              default: null
+              nullable: true
+              description: The zone used by vSphere multi-AZ feature
+            insecureFlag:
+              type: boolean
+              default: false
+              description: The flag that disables TLS peer verification
+            ipFamily:
+              type: string
+              default: null
+              nullable: true
+              description: The IP family configuration
+            vmInternalNetwork:
+              type: string
+              default: null
+              nullable: true
+              description: Internal VM network name
+            vmExternalNetwork:
+              type: string
+              default: null
+              nullable: true
+              description: External VM network name
+            vmExcludeInternalNetworkSubnetCidr:
+              type: string
+              default: null
+              nullable: true
+              description: Internal VM network cidr to be excluded.
+            vmExcludeExternalNetworkSubnetCidr:
+              type: string
+              default: null
+              nullable: true
+              description: External VM network cidr to be excluded.
+            cloudProviderExtraArgs:
+              type: object
+              additionalProperties: false
+              description: Extra arguments for the cloud-provider-vsphere.
+              properties:
+                tls-cipher-suites:
+                  type: string
+                  default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+                  description: External arguments for cloud provider
+            nsxt:
+              type: object
+              additionalProperties: false
+              properties:
+                podRoutingEnabled:
+                  type: boolean
+                  default: false
+                  description: A flag that enables pod routing
+                routes:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    routerPath:
+                      type: string
+                      default: ""
+                      description: NSX-T T0/T1 logical router path
+                    clusterCidr:
+                      type: string
+                      default: ""
+                      description: Cluster CIDR
+                username:
+                  type: string
+                  default: ""
+                  description: The username used to access NSX-T
+                password:
+                  type: string
+                  default: ""
+                  description: The password used to access NSX-T
+                host:
+                  type: string
+                  default: null
+                  nullable: true
+                  description: The NSX-T server
+                insecureFlag:
+                  type: boolean
+                  default: false
+                  description: InsecureFlag is to be set to true if NSX-T uses self-signed cert
+                remoteAuth:
+                  type: boolean
+                  default: false
+                  description: RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)
+                vmcAccessToken:
+                  type: string
+                  default: ""
+                  description: VMCAccessToken is VMC access token for token based authentification
+                vmcAuthHost:
+                  type: string
+                  default: ""
+                  description: VMCAuthHost is VMC verification host for token based authentification
+                clientCertKeyData:
+                  type: string
+                  default: ""
+                  description: Client certificate key for NSX-T
+                clientCertData:
+                  type: string
+                  default: ""
+                  description: Client certificate data for NSX-T
+                rootCAData:
+                  type: string
+                  default: ""
+                  description: The certificate authority for the server certificate for locally signed certificates
+                secretName:
+                  type: string
+                  default: cloud-provider-vsphere-nsxt-credentials
+                  description: The name of secret that stores CPI configuration
+                secretNamespace:
+                  type: string
+                  default: kube-system
+                  description: The namespace of secret that stores CPI configuration
+            http_proxy:
+              type: string
+              default: ""
+              description: HTTP proxy setting
+            https_proxy:
+              type: string
+              default: ""
+              description: HTTPS proxy setting
+            no_proxy:
+              type: string
+              default: ""
+              description: No-proxy setting
+            clusterAPIVersion:
+              type: string
+              default: cluster.x-k8s.io/v1beta1
+              description: 'Used in vsphereParavirtual mode, defines the Cluster API versions. Default: cluster.x-k8s.io/v1beta1.'
+            clusterKind:
+              type: string
+              default: Cluster
+              description: 'Used in vsphereParavirtual mode, defines the Cluster kind. Default: Cluster.'
+            clusterName:
+              type: string
+              default: ""
+              description: 'Used in vsphereParavirtual mode, defines the Cluster name. Default: ''''.'
+            clusterUID:
+              type: string
+              default: ""
+              description: 'Used in vsphereParavirtual mode, defines the Cluster UID. Default: '''''
+            supervisorMasterEndpointIP:
+              type: string
+              default: ""
+              description: 'Used in vsphereParavirtual mode, the endpoint IP of supervisor cluster''s API server. Default: '''''
+            supervisorMasterPort:
+              type: string
+              default: ""
+              description: 'Used in vsphereParavirtual mode, the endpoint port of supervisor cluster''s API server port. Default: '''''

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/sample-values/vsphere-cpi.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/sample-values/vsphere-cpi.yaml
@@ -4,26 +4,20 @@
 ---
 vsphereCPI:
   mode: vsphereCPI
-  tlsThumbprint: ""
-  server: ""
-  datacenter: ""
-  username: ""
-  password: ""
-  region: null
-  zone: null
+  tlsThumbprint: "test"
+  server: 10.1.1.1
+  datacenter: ds-test
+  username: test
+  password: test
   insecureFlag: False
-  ipFamily: null
   vmInternalNetwork: null
   vmExternalNetwork: null
-  vmExcludeInternalNetworkSubnetCidr: null
-  vmExcludeExternalNetworkSubnetCidr: null
   cloudProviderExtraArgs:
     tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
   nsxt:
     podRoutingEnabled: false
     routes:
       routerPath: ""
-      clusterCidr: ""
     username: ""
     password: ""
     host: null
@@ -36,12 +30,3 @@ vsphereCPI:
     rootCAData: ""
     secretName: "cloud-provider-vsphere-nsxt-credentials"
     secretNamespace: "kube-system"
-  http_proxy: ""
-  https_proxy: ""
-  no_proxy: ""
-  clusterAPIVersion: "cluster.x-k8s.io/v1beta1"
-  clusterKind: "Cluster"
-  clusterName: ""
-  clusterUID: ""
-  supervisorMasterEndpointIP: ""
-  supervisorMasterPort: ""

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/test/vsphere_cpi_test.go
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/test/vsphere_cpi_test.go
@@ -165,7 +165,7 @@ vsphereCPI:
 				ownerRefConfigMap := findConfigMapByName(configMaps, "ccm-owner-reference")
 				ownerRef, exists := ownerRefConfigMap.Data["owner-reference"]
 				Expect(exists).To(BeTrue())
-				Expect(ownerRef).To(Equal("{\"apiVersion\": \"run.tanzu.vmware.com/v1alpha2\",\n\"kind\": \"Cluster\",\n\"name\": \"tkg-cluster\",\n\"uid\": \"57341fa8-0983-472f-b744-00cf724dd307\"}\n"))
+				Expect(ownerRef).To(Equal("{\"apiVersion\": \"cluster.x-k8s.io/v1beta1\",\n\"kind\": \"Cluster\",\n\"name\": \"tkg-cluster\",\n\"uid\": \"57341fa8-0983-472f-b744-00cf724dd307\"}\n"))
 			})
 		})
 	})


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This is a follow-up PR of https://github.com/vmware-tanzu/community-edition/pull/2805. 

It adds the schema.yaml to the latest version vsphere-cpi and updates the package manifest.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Create OpenAPIV3 schema for vsphere-cpi package and generate package with the schema, but for version 1.23.0-alpha.1
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
vsphere-cpi unit test.


## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
