### PR TITLE
Add GitHub Actions to dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
-# Dependabot config for go mod version updgrades
+# Dependabot config for go mod version upgrades
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "gomod"
     directory: "hack/builder"
     schedule:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This adds github-actions to our dependabot configuration so we are
notified of any needed updates for any of the dependencies used in our
GitHub Actions.