### PR TITLE
Add clarification about squashing commits

### DIFF
--- a/docs/site/content/docs/latest/contribute/contributing.md
+++ b/docs/site/content/docs/latest/contribute/contributing.md
@@ -93,11 +93,12 @@ Depending on the size of the feature you may be expected to first write a design
 - Use the imperative mood (ie "If applied, this commit will (subject)" should make sense).
 - Put a summary of the main area affected by the commit at the start,
   with a colon as delimiter. For example 'docs:', 'extensions/(extensionname):', 'design:' or something similar.
-- Do not merge commits that don't relate to the affected issue (e.g. "Updating from PR comments", etc). Should
-  the need to cherrypick a commit or rollback arise, it should be clear what a specific commit's purpose is.
 - If the main branch has moved on, you'll need to rebase before we can merge,
   so merging upstream main or rebasing from upstream before opening your
   PR will probably save you some time.
+- Before merging commits, squash them to the minimal number of logical commits. Should
+  the need to cherrypick a commit or rollback arise, it should be clear what a specific commit's purpose is.
+  Do not merge commits that don't relate to the affected issue (e.g. "Updating from PR comments", etc). Should
 
 Pull requests *must* include a `Fixes #NNNN` or `Updates #NNNN` comment.
 Remember that `Fixes` will close the associated issue, and `Updates` will link the PR to it.
@@ -118,8 +119,8 @@ Signed-off-by: Your Name <you@youremail.com>
 
 ### Merging commits
 
-Maintainers should prefer to merge pull requests with the [Squash and merge](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits) option.
-This option is preferred for a number of reasons.
+Maintainers should prefer to merge pull requests with the [Squash and merge](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits) option and maintainers may still ask contributors to squash commits themselves manually prior to merging.
+The "Squash and merge" option is preferred for a number of reasons.
 First, it causes GitHub to insert the pull request number in the commit subject which makes it easier to track which PR changes landed in.
 Second, it gives maintainers an opportunity to edit the commit message to conform to Tanzu Community Edition standards and general [good practice](https://chris.beams.io/posts/git-commit/).
 Finally, a one-to-one correspondence between pull requests and commits makes it easier to manage reverting changes and increases the reliability of bisecting the tree (since CI runs at a pull request granularity).

--- a/docs/site/content/docs/latest/contribute/contributing.md
+++ b/docs/site/content/docs/latest/contribute/contributing.md
@@ -98,7 +98,7 @@ Depending on the size of the feature you may be expected to first write a design
   PR will probably save you some time.
 - Before merging commits, squash them to the minimal number of logical commits. Should
   the need to cherrypick a commit or rollback arise, it should be clear what a specific commit's purpose is.
-  Do not merge commits that don't relate to the affected issue (e.g. "Updating from PR comments", etc). Should
+  Do not merge commits that don't relate to the affected issue (e.g. "Updating from PR comments", etc).
 
 Pull requests *must* include a `Fixes #NNNN` or `Updates #NNNN` comment.
 Remember that `Fixes` will close the associated issue, and `Updates` will link the PR to it.


### PR DESCRIPTION
Per discussion with @jpmcb on https://github.com/vmware-tanzu/community-edition/pull/2924, maintainers may ask contributors to squash commits manually:

> But it's not a strict requirement that the contributor squash their own commits. Admittedly, it's my personal preference since I can't always anticipate and write the best commit message when squashing a number of commits using the "Squash and merge" button. For me, it's almost always easier to merge something that is one commit already with a single cohesive commit message. But that's more philosophical than anything. Feel free to ask us to just "squash and merge" when needed

```release-note
NONE
```

