### PR TITLE
package/external-dns: Remove empty serviceaccount value from e2e fixture

### DIFF
--- a/addons/packages/external-dns/0.10.0/test/e2e/fixtures/external-dns-values-fixture.yaml
+++ b/addons/packages/external-dns/0.10.0/test/e2e/fixtures/external-dns-values-fixture.yaml
@@ -20,6 +20,3 @@ deployment:
   securityContext: {}
   volumeMounts: []
   volumes: []
-
-serviceaccount:
-  annotations: {}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This removes the empty serviceaccount from the external-dns e2e fixture. This is causing some downstream tests to fail because it picks up upstream tests immediately, but not the package. This won't cause any issues for current e2e test runs because no assertions were made for the service account. We intend to add this back once downstream is more robust.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: n/a

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Manually ran the e2e tests locally.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
