### PR TITLE
Ajust makefile for a line commented by mistake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,8 @@ build-tce-cli-plugins: version clean-plugin check-deps-minimum-build build-cli-p
 	@printf "\n[COMPLETE] built TCE-specific plugins at $(ARTIFACTS_DIR)\n"
 	@printf "To install these plugins, run \`make install-tce-cli-plugins\`\n"
 
-install-tce-cli-plugins: version clean-plugin check-deps-minimum-build build-cli-plugins framework-set-unstable-versions install-plugins ## builds and installs CLI plugins found in artifacts directory @printf "\n[COMPLETE] built and installed TCE-specific plugins at $${XDG_DATA_HOME}/tanzu-cli/. "
+install-tce-cli-plugins: version clean-plugin check-deps-minimum-build build-cli-plugins framework-set-unstable-versions install-plugins ## builds and installs CLI plugins found in artifacts directory
+	@printf "\n[COMPLETE] built and installed TCE-specific plugins at $${XDG_DATA_HOME}/tanzu-cli/. "
 	@printf "These plugins will be automatically detected by your tanzu CLI.\n"	
 
 build-all-tanzu-cli-plugins: version clean check-deps-minimum-build build-cli build-cli-plugins ## builds the Tanzu CLI and all CLI plugins that are used in TCE


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Adjust a typo in the makefile.

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Before the PR**:
```
 $make

Targets:
  help            display help

  Build targets
  Targets for building and/or installing CLI plugins on the system.
  Append "ENVS=<os-arch>" to the end of these targets to limit the binaries built.
  e.g.: make build-all-tanzu-cli-plugins ENVS=linux-amd64
  List available at https://github.com/golang/go/blob/master/src/go/build/syslist.go

  build-tce-cli-plugins builds the CLI plugins that live in the TCE repo into the artifacts directory
  install-tce-cli-plugins builds and installs CLI plugins found in artifacts directory @printf "\n[COMPLETE] built and installed TCE-specific plugins at $${XDG_DATA_HOME}/tanzu-cli/. "
[...]
```
Notice the last line has a `printf` command in it.

**After the PR**
```
$ make

Targets:
  help            display help

  Build targets
  Targets for building and/or installing CLI plugins on the system.
  Append "ENVS=<os-arch>" to the end of these targets to limit the binaries built.
  e.g.: make build-all-tanzu-cli-plugins ENVS=linux-amd64
  List available at https://github.com/golang/go/blob/master/src/go/build/syslist.go

  build-tce-cli-plugins builds the CLI plugins that live in the TCE repo into the artifacts directory
  install-tce-cli-plugins builds and installs CLI plugins found in artifacts directory
```
I've also checked that `make install-tce-cli-plugins` now has the missing line of output coming from that `printf`.

## Special notes for your reviewer
I did not open an issue as this was just a typo.
I also didn't sign the CLA just yet as the documentation said it was not needed for obvious fixes:
https://tanzucommunityedition.io/docs/latest/contribute/contributing/#contributor-license-agreement