### PR TITLE
Doc - Add windows binary download/install doc

### DIFF
--- a/docs/site/content/docs/assets/cli-install-windows.md
+++ b/docs/site/content/docs/assets/cli-install-windows.md
@@ -1,19 +1,34 @@
 ## Installation Procedure
 
-1. Make sure you have the [Chocolatey package manager installed](https://chocolatey.org/install).
+You can install Tanzu Community Edition using Chocolatey **or** you can download the binary and install.
+### Option 1: Use the Chocolatey installation method
 
-1. You must download and install the latest version of `kubectl`. For more information, see [Install and Set Up kubectl on Windows](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/) in the Kubernetes documentation.
+1. Make sure you have the [Chocolatey](https://chocolatey.org/install) package manager installed.
 
-1. You must download and install the latest version of `docker`. For more information, see [Install Docker Desktop on Windows](https://docs.docker.com/desktop/windows/install/) in the Docker documentation.
-
-1. Open PowerShell **as an administrator** and run the following:
+1. Open Windows PowerShell **as an administrator** and run the following:
 
     ```sh
     choco install tanzu-community-edition
     ```
 
-    > Both `docker` and `kubectl` are required to be present on the system, but are not explicit Chocolatey dependencies.
-    > Installing the Tanzu Community Edition package will extract the binaries and configure the plugin repositories. This might take a minute.
-
 1. The `tanzu` command will be added to your `$PATH` variable automatically by Chocolatey.
 
+### Option 2: Use the Binary download/installation method
+
+1. Download the release for [Windows](https://github.com/vmware-tanzu/community-edition/releases/download/{{< release_latest >}}/tce-windows-amd64-{{< release_latest >}}.zip).
+
+1. Open Windows PowerShell **as an administrator**, change to the download directory and unpack the release, for example,
+
+    ```sh
+    cd <DOWNLOAD-DIR>
+    Expand-Archive -Path 'tce-windows-amd64-{{< release_latest >}}.zip'
+    ```
+
+1. Change to the extracted directory and run `.\install.bat`.
+
+    ```sh
+    cd tce-windows-amd64-{{< release_latest >}}\tce-windows-amd64-{{< release_latest >}}
+    .\install.bat
+    ```
+
+1. Add `C:\Program Files\tanzu` to your PATH.

--- a/docs/site/content/docs/assets/prereq-windows.md
+++ b/docs/site/content/docs/assets/prereq-windows.md
@@ -9,4 +9,4 @@
 |Latest version of Chrome, Firefox, Safari, Internet Explorer, or  Edge|
 |Ensure your bootstrap machine is using [cgroup v1](https://man7.org/linux/man-pages/man7/cgroups.7.html). (Docker Desktop for Windows versions prior to 4.3.0 use cgroup1). For more information, see [Check and set the cgroup](../support-matrix/#check-and-set-the-cgroup).|
 
-Note: Bootstrapping a cluster to Docker from a Windows bootstrap machine is currently experimental.
+Note: Bootstrapping a cluster to Docker from a Windows bootstrap machine is currently experimental, for more information, see [Docker-based Clusters on Windows](../ref-windows-capd).

--- a/docs/site/content/docs/latest/cli-installation.md
+++ b/docs/site/content/docs/latest/cli-installation.md
@@ -1,8 +1,8 @@
 # Install Tanzu Community Edition
 
-Tanzu Community Edition consists of the Tanzu CLI and a select set of plugins. You will install
-Tanzu Community Edition on your local machine and then use the Tanzu CLI on your local machine
-to deploy a cluster to your chosen target platform. Your local machine is often referred to as your bootstrap machine, and the process of deploying a cluster is referred to as bootstrapping. For more information, see the [Glossary](glossary).
+Tanzu Community Edition consists of the Tanzu CLI and a select set of plugins. You will install Tanzu Community Edition on your local machine and then use the Tanzu CLI on your local machine to deploy ([bootstrap](../glossary/#bootstrap)) a cluster to your chosen target platform.
+
+Installing the Tanzu Community Edition extracts the binaries and configures the plugin repositories. The first time you run the `tanzu` command the installed plugins and plugin repositories are initialized. This action might take a minute.
 
 ## Procedure
 

--- a/docs/site/content/docs/latest/getting-started.md
+++ b/docs/site/content/docs/latest/getting-started.md
@@ -11,7 +11,9 @@ Tanzu Community Edition.
 
 ## Tanzu Community Edition Installation
 
-Tanzu Community Edition consists of the Tanzu CLI and a select set of plugins. You will install Tanzu Community Edition on your local machine and then use the Tanzu CLI on your local machine to deploy a cluster to your chosen target platform.
+Tanzu Community Edition consists of the Tanzu CLI and a select set of plugins. You will install Tanzu Community Edition on your local machine and then use the Tanzu CLI on your local machine to deploy ([bootstrap](../glossary/#bootstrap)) a cluster to your chosen target platform.
+
+Installing the Tanzu Community Edition extracts the binaries and configures the plugin repositories. The first time you run the `tanzu` command the installed plugins and plugin repositories are initialized. This action might take a minute.
 
 {{< tabs tabTotal="3" tabID="1" tabName1="Linux" tabName2="Mac" tabName3="Windows">}}
 {{< tab tabNum="1" >}}


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
* Instructions for installing TCE on Windows using binary download/install method were removed before launch in PR:
https://github.com/vmware-tanzu/community-edition/pull/1983. This PR adds those instructions back in.

* Removed repetition in prereqs - trying to avoid repeating prereqs in the actual install procedures. The prereq table above the install procedure should be the one source of truth. For example, the prereqs that were in the procedure had a different docker link to the prereq table. The prereq table has the correct one which links to the supported version 4.2.0

* Added an internal link to our 'Docker-based Clusters on Windows' topic 

* Made the intro text consistent across the Getting Started guide and the Install Tanzu Community Edition topic in the Installation doc

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```Add documentation that describes how to download and install the TCE binary for Windows (non Chocolately install method for Windows)

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2974 

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
