### PR TITLE
Doc - Add mac binary download/install install steps to doc

### DIFF
--- a/docs/site/content/docs/assets/cli-install-mac.md
+++ b/docs/site/content/docs/assets/cli-install-mac.md
@@ -1,10 +1,10 @@
 ## Installation Procedure
 
-1. Make sure you have the [Homebrew package manager installed](https://brew.sh/)
+You can install Tanzu Community Edition using Homebrew **or** you can download the binary and install.
 
-1. You must download and install the latest version of `kubectl`. For more information, see [Install and Set Up kubectl on MacOS](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/) in the Kubernetes documentation.
+### Option 1: Use the Homebrew install method
 
-1. You must download and install the latest version of `docker`. For more information, see [Install Docker Desktop on MacOS](https://docs.docker.com/desktop/mac/install/) in the Docker documentation.
+1. Make sure you have the [Homebrew](https://brew.sh/) package manager installed.
 
 1. Run the following in your terminal:
 
@@ -15,8 +15,24 @@
 1. Run the post install configuration script. Note the output of the `brew install` step for the correct location of the configure script:
 
     ```sh
-    {HOMEBREW-INSTALL-LOCATION}/{{< release_latest >}}/libexec/configure-tce.sh
+    <HOMEBREW-INSTALL-LOCATION>/{{< release_latest >}}/libexec/configure-tce.sh
     ```
 
-    > This puts all the Tanzu plugins in the correct location.
-    > The first time you run the `tanzu` command the installed plugins and plugin repositories are initialized. This action might take a minute.
+## Option 2: Use the binary download/install  method
+
+1. Download the release for [macOS](https://github.com/vmware-tanzu/community-edition/releases/download/{{< release_latest >}}/tce-darwin-amd64-{{< release_latest >}}.tar.gz).
+
+1. Change to the download directory and unpack the release. Run the following in your terminal:
+
+    ```sh
+    cd <DOWNLOAD-DIR>
+    tar xzvf ~/<DOWNLOAD-DIR>/tce-darwin-amd64-{{< release_latest >}}.tar.gz
+
+    ```
+
+1. Change to the extracted directory and run the install script.
+
+    ```sh
+    cd tce-darwin-amd64-{{< release_latest >}}
+    ./install.sh
+    ```


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
* Instructions for installing TCE on Mac using binary download/install method were removed before launch in: https://github.com/vmware-tanzu/community-edition/pull/2032.  This PR adds those instructions back in.

* Removed repetition in prereqs - trying to avoid repeating prereqs in the actual install procedures. The prereq table above the install procedure should be the one source of truth.

* Apply consistent way to refer to variable paths as per [style guide](https://tanzucommunityedition.io/docs/latest/contribute/style-guide/#use-angle-brackets-for-placeholders)  


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```Add documentation that describes how to download and install the TCE binary for Mac (non Homebrew install method for Mac)

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2976 

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
