### PR TITLE
Fix the type of several boolean flags in CPI 1.22.4 and 1.22.3-alpha1

### DIFF
--- a/addons/packages/vsphere-cpi/1.22.5/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-cpi/1.22.5/bundle/config/vsphereconf.lib.txt
@@ -48,14 +48,14 @@ router-path = "(@=values.vsphereCPI.nsxt.routes.routerPath @)"
 [NSXT]
 host = "(@=values.vsphereCPI.nsxt.host @)"
 (@ if values.vsphereCPI.nsxt.insecureFlag: -@)
-insecure-flag = "true"
+insecure-flag = true
 (@ else: -@)
-insecure-flag = "false"
+insecure-flag = false
 (@ end -@)
 (@ if values.vsphereCPI.nsxt.remoteAuth: -@)
-remote-auth = "true"
+remote-auth = true
 (@ else: -@)
-remote-auth = "false"
+remote-auth = false
 (@ end -@)
 (@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace and values.vsphereCPI.nsxt.username and values.vsphereCPI.nsxt.password  : -@)
 secret-name = "(@=values.vsphereCPI.nsxt.secretName @)"

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/vsphereconf.lib.txt
@@ -48,14 +48,14 @@ router-path = "(@=values.vsphereCPI.nsxt.routes.routerPath @)"
 [NSXT]
 host = "(@=values.vsphereCPI.nsxt.host @)"
 (@ if values.vsphereCPI.nsxt.insecureFlag: -@)
-insecure-flag = "true"
+insecure-flag = true
 (@ else: -@)
-insecure-flag = "false"
+insecure-flag = false
 (@ end -@)
 (@ if values.vsphereCPI.nsxt.remoteAuth: -@)
-remote-auth = "true"
+remote-auth = true
 (@ else: -@)
-remote-auth = "false"
+remote-auth = false
 (@ end -@)
 (@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace and values.vsphereCPI.nsxt.username and values.vsphereCPI.nsxt.password  : -@)
 secret-name = "(@=values.vsphereCPI.nsxt.secretName @)"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Schema of `insecure-flag` of `remote-auth` in `/vsphereconf.lib.txt` has wrong type
## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
