### PR TITLE
Doc - Add doc link for windows bootstrap machine workaround 

### DIFF
--- a/docs/site/content/docs/assets/aws-clusters.md
+++ b/docs/site/content/docs/assets/aws-clusters.md
@@ -11,6 +11,8 @@ There are some prerequisites the installation process will assume.  Refer to the
     tanzu management-cluster create --ui
     ```
 
+    Note: If you are bootstrapping from a Windows machine and encounter an `unable to ensure prerequisites` error, see the following  [troubleshooting topic](../faq-cluster-bootstrapping/#x509-certificate-signed-by-unknown-authority-when-deploying-management-cluster-from-windows).
+
 1. Choose Amazon from the provider tiles.
 
     ![kickstart amazon tile](/docs/img/kickstart-amazon-tile.png)

--- a/docs/site/content/docs/assets/azure-clusters.md
+++ b/docs/site/content/docs/assets/azure-clusters.md
@@ -13,6 +13,8 @@ accepting image licenses and preparing your Azure account.
     tanzu management-cluster create --ui
     ```
 
+    Note: If you are bootstrapping from a Windows machine and encounter an `unable to ensure prerequisites` error, see the following  [troubleshooting topic](../faq-cluster-bootstrapping/#x509-certificate-signed-by-unknown-authority-when-deploying-management-cluster-from-windows).
+
 1. Choose Azure from the provider tiles.
 
     ![kickstart azure tile](/docs/img/kickstart-azure-tile.png)

--- a/docs/site/content/docs/assets/capd-clusters.md
+++ b/docs/site/content/docs/assets/capd-clusters.md
@@ -58,6 +58,8 @@ To optimise your Docker system and ensure a successful deployment, you may wish 
    tanzu management-cluster create --ui
    ```
 
+    Note: If you are bootstrapping from a Windows machine and encounter an `unable to ensure prerequisites` error, see the following [troubleshooting topic](../faq-cluster-bootstrapping/#x509-certificate-signed-by-unknown-authority-when-deploying-management-cluster-from-windows).
+
 1. Complete the configuration steps in the installer interface for Docker and create the management cluster. The following configuration settings are recommended:
 
    * The Kubernetes Network Settings are auto-filled with a default CNI Provider and Cluster Service CIDR.

--- a/docs/site/content/docs/assets/step1.md
+++ b/docs/site/content/docs/assets/step1.md
@@ -37,4 +37,10 @@ tanzu management-cluster create --ui --bind 192.168.1.87:5555 --browser none
 
 The Tanzu Installer opens, click the **Deploy** button for **VMware vSphere**, **AWS**, **Azure**, or **Docker**.
 
+**Note**: If you are bootstrapping from a Windows machine and you encounter the following error, see this [troubleshooting entry](../faq-cluster-bootstrapping/#x509-certificate-signed-by-unknown-authority-when-deploying-management-cluster-from-windows) for a workaround.
+
+```sh
+Error: unable to ensure prerequisites: unable to ensure tkg BOM file: failed to download TKG compatibility file from the registry: failed to list TKG compatibility image tags: Get "https://projects.registry.vmware.com/v2/": x509: certificate signed by unknown authority
+```
+
 Complete the Installer steps as follows:

--- a/docs/site/content/docs/assets/vsphere-clusters.md
+++ b/docs/site/content/docs/assets/vsphere-clusters.md
@@ -47,6 +47,8 @@ VMware Customer Connect.
     tanzu management-cluster create --ui
     ```
 
+    **Note**: If you are bootstrapping from a Windows machine and encounter an `unable to ensure prerequisites` error, see the following[troubleshooting topic](../faq-cluster-bootstrapping/#x509-certificate-signed-by-unknown-authority-when-deploying-management-cluster-from-windows).
+
 1. Choose VMware vSphere from the provider tiles.
 
     ![kickstart vsphere tile](/docs/img/kickstart-vsphere-tile.png)


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it

Adds a link in the following relevant sections to point those using a windows bootstrap machine to a [common error ](https://tanzucommunityedition.io/docs/latest/faq-cluster-bootstrapping/#x509-certificate-signed-by-unknown-authority-when-deploying-management-cluster-from-windows) that can occur:

-AWS, Azure, Docker, vSphere tab in the Getting Started guide
-Install topics for AWS, Azure, Docker, vsphere

related to: #1398 

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2984 

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

Review here

https://deploy-preview-2989--quirky-franklin-8969be.netlify.app/docs/latest/getting-started/

https://deploy-preview-2989--quirky-franklin-8969be.netlify.app/docs/latest/aws-install-mgmt/

https://deploy-preview-2989--quirky-franklin-8969be.netlify.app/docs/latest/azure-install-mgmt/

https://deploy-preview-2989--quirky-franklin-8969be.netlify.app/docs/latest/docker-install-mgmt/

https://deploy-preview-2989--quirky-franklin-8969be.netlify.app/docs/latest/vsphere-install-mgmt/

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
