### PR TITLE
Notify community with daily developer build downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ or existing pull requests. If an issue does not exist, please create one for
 your feedback! If one exists, please feel free to comment and add any
 additional context you may have!
 
+## Latest Daily Build
+
+Here are quick pointers to the latest **unsigned development** builds for:
+
+* [Linux AMD64 - YY/YY/YY](XXXX)
+* [Darwin AMD64 - YY/YY/YY](XXXXX)
+* [Windows AMD64 - YY/YY/YY](XXXXX)
+
 ## Repository Layout
 
 The following describes the key directories that make up this repository.

--- a/hack/dailybuild/dailybuild.go
+++ b/hack/dailybuild/dailybuild.go
@@ -4,26 +4,35 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/gorilla/feeds"
 )
 
 const (
-	projectID  string = "vmware-cna"
-	bucketName string = "tce-cli-plugins-staging"
-	gcpFile    string = "gcptokenfile.json"
-	rssFile    string = "../../rss.xml"
+	regexReadmeLinuxAmd64   string = "\\[Linux AMD64.*\\]\\(.*\\)"
+	regexReadmeDarwinAmd64  string = "\\[Darwin AMD64.*\\]\\(.*\\)"
+	regexReadmeWindowsAmd64 string = "\\[Windows AMD64.*\\]\\(.*\\)"
+
+	projectID      string = "vmware-cna"
+	bucketName     string = "tce-cli-plugins-staging"
+	gcpFile        string = "gcptokenfile.json"
+	fullPathReadme string = "../../README.md"
 )
 
 type Builds struct {
+	BuildDate    string
 	DarwinAmd64  string
 	DarwinArm64  string
 	WindowsAmd64 string
@@ -40,7 +49,6 @@ type ClientUploader struct {
 // UploadFile uploads an object
 func (c *ClientUploader) UploadFile(filename string) error {
 	ctx := context.Background()
-
 	ctx, cancel := context.WithTimeout(ctx, time.Second*1200)
 	defer cancel()
 
@@ -65,7 +73,7 @@ func (c *ClientUploader) UploadFile(filename string) error {
 	return nil
 }
 
-func uploadTarball(platform, arch, tag, extension string) (string, error) {
+func uploadTarball(buildDate, platform, arch, tag, extension string) (string, error) {
 	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", gcpFile)
 
 	client, err := storage.NewClient(context.Background())
@@ -75,7 +83,7 @@ func uploadTarball(platform, arch, tag, extension string) (string, error) {
 	}
 
 	assetFilename := fmt.Sprintf("tce-%s-%s-%s.%s", platform, arch, tag, extension)
-	uploadPathTmp := filepath.Join("build-daily", time.Now().Format("2006-01-02"))
+	uploadPathTmp := filepath.Join("build-daily", buildDate)
 	uploadPath := fmt.Sprintf("%s/", uploadPathTmp)
 
 	uploader := &ClientUploader{
@@ -96,14 +104,15 @@ func uploadTarball(platform, arch, tag, extension string) (string, error) {
 }
 
 func uploadAll(tag, gcpToken string) (*Builds, error) {
-	// upload
 	err := os.WriteFile(gcpFile, []byte(gcpToken), 0644)
 	if err != nil {
 		fmt.Printf("WriteFile failed: %v\n", err)
 		return nil, err
 	}
 
-	urlLinuxAmd64, err := uploadTarball("linux", "amd64", tag, "tar.gz")
+	buildDate := time.Now().Format("2006-01-02")
+
+	urlLinuxAmd64, err := uploadTarball(buildDate, "linux", "amd64", tag, "tar.gz")
 	if err != nil {
 		fmt.Printf("uploadLinux failed: %v\n", err)
 
@@ -115,7 +124,7 @@ func uploadAll(tag, gcpToken string) (*Builds, error) {
 		return nil, err
 	}
 
-	urlWindowsAmd64, err := uploadTarball("windows", "amd64", tag, "zip")
+	urlWindowsAmd64, err := uploadTarball(buildDate, "windows", "amd64", tag, "zip")
 	if err != nil {
 		fmt.Printf("uploadWindows failed: %v\n", err)
 
@@ -127,7 +136,7 @@ func uploadAll(tag, gcpToken string) (*Builds, error) {
 		return nil, err
 	}
 
-	urlDarwinAmd64, err := uploadTarball("darwin", "amd64", tag, "tar.gz")
+	urlDarwinAmd64, err := uploadTarball(buildDate, "darwin", "amd64", tag, "tar.gz")
 	if err != nil {
 		fmt.Printf("uploadDarwinAmd64 failed: %v\n", err)
 
@@ -139,7 +148,7 @@ func uploadAll(tag, gcpToken string) (*Builds, error) {
 		return nil, err
 	}
 
-	_, err = uploadTarball("darwin", "arm64", tag, "tar.gz")
+	_, err = uploadTarball(buildDate, "darwin", "arm64", tag, "tar.gz")
 	if err != nil {
 		fmt.Printf("uploadDarwinArm64 failed: %v\n", err)
 
@@ -157,6 +166,7 @@ func uploadAll(tag, gcpToken string) (*Builds, error) {
 	}
 
 	builds := &Builds{
+		BuildDate:    buildDate,
 		LinuxAmd64:   urlLinuxAmd64,
 		WindowsAmd64: urlWindowsAmd64,
 		DarwinAmd64:  urlDarwinAmd64,
@@ -165,51 +175,31 @@ func uploadAll(tag, gcpToken string) (*Builds, error) {
 	return builds, nil
 }
 
-func createRssFeed(builds *Builds) error {
-	// update rss
-	now, err := time.Parse(time.RFC3339, "2013-01-16T21:52:35-05:00")
+func updateReadme(builds *Builds) error {
+	readme, err := os.ReadFile(fullPathReadme)
 	if err != nil {
-		fmt.Printf("time.Parse failed: %v\n", err)
-		return err
-	}
-	tz := time.FixedZone("PST", -8*60*60)
-	now = now.In(tz)
-
-	dateDailyBuild := fmt.Sprintf("Daily Build %s", time.Now().Format("2006-01-02"))
-	buildMessage := fmt.Sprintf("<p>You can find the daily build here:<br><a href=%q>%s</a><br><a href=%q>%s</a><br><a href=%q>%s</a></p>",
-		builds.LinuxAmd64, builds.LinuxAmd64, builds.WindowsAmd64, builds.WindowsAmd64, builds.DarwinAmd64, builds.DarwinAmd64)
-
-	feed := &feeds.Feed{
-		Title:       "Tanzu Community Edition daily build",
-		Link:        &feeds.Link{Href: "https://github.com/vmware-tanzu/community-edition"},
-		Description: "Tanzu Community Edition daily build",
-		Author:      &feeds.Author{Name: "tce-automation", Email: "tce-core-eng@vmware.com"},
-		Created:     now,
-		Copyright:   "This work is copyright © VMware",
-	}
-
-	feed.Items = []*feeds.Item{
-		{
-			Title:       dateDailyBuild,
-			Link:        &feeds.Link{Href: "https://github.com/vmware-tanzu/community-edition"},
-			Description: dateDailyBuild,
-			Author:      &feeds.Author{Name: "tce-automation", Email: "tce-core-eng@vmware.com"},
-			Created:     now,
-			Content:     buildMessage,
-		},
-	}
-
-	rss, err := feed.ToRss()
-	if err != nil {
-		fmt.Printf("unexpected error encoding RSS: %v", err)
+		fmt.Printf("ReadFile returned error: %v\n", err)
 		return err
 	}
 
-	errFile := os.Remove(rssFile)
+	replaceLinuxAmd64 := fmt.Sprintf("[Linux AMD64 - %s](%s)", builds.BuildDate, builds.LinuxAmd64)
+	var expLinuxAmd64 = regexp.MustCompile(regexReadmeLinuxAmd64)
+	replace1 := expLinuxAmd64.ReplaceAllString(string(readme), replaceLinuxAmd64)
+
+	replaceDarwinAmd64 := fmt.Sprintf("[Darwin AMD64 - %s](%s)", builds.BuildDate, builds.DarwinAmd64)
+	var expDarwinAmd64 = regexp.MustCompile(regexReadmeDarwinAmd64)
+	replace2 := expDarwinAmd64.ReplaceAllString(replace1, replaceDarwinAmd64)
+
+	replaceWindowsAmd64 := fmt.Sprintf("[Windows AMD64 - %s](%s)", builds.BuildDate, builds.WindowsAmd64)
+	var expWindowsAmd64 = regexp.MustCompile(regexReadmeWindowsAmd64)
+	replaceFinal := expWindowsAmd64.ReplaceAllString(replace2, replaceWindowsAmd64)
+
+	err = os.Remove(fullPathReadme)
 	if err != nil {
-		fmt.Printf("Remove failed: %v\n", errFile)
+		fmt.Printf("Remove failed: %v\n", err)
+		return err
 	}
-	err = os.WriteFile(rssFile, []byte(rss), 0666)
+	err = os.WriteFile(fullPathReadme, []byte(replaceFinal), 0644)
 	if err != nil {
 		fmt.Printf("WriteFile failed: %v\n", err)
 		return err
@@ -218,16 +208,72 @@ func createRssFeed(builds *Builds) error {
 	return nil
 }
 
-func uploadAndUpdateRss(tag, gcpToken string) error {
+func postDiscussion(token string, builds *Builds) error {
+	titleTemplate := "Daily Development Build for %s"
+	bodyTemplate := "Downloadable assets:\\n\\n" +
+		"Linux AMD64 - %s\\n" +
+		"Darwin AMD64 - %s\\n" +
+		"Windows AMD64 - %s\\n"
+	jsonTemplate := "{\n" +
+		"\"query\": \"mutation {   createDiscussion(input: {repositoryId: \\\"MDEwOlJlcG9zaXRvcnkzMDM4MDIzMzI\\\", categoryId: \\\"DIC_kwDOEhun3M4CA9pd\\\", body: \\\"%s\\\", title: \\\"%s\\\"}) {     discussion {       id     }   } }\"\n" +
+		"}\n"
+
+	url := "https://api.github.com/graphql"
+	titleStr := fmt.Sprintf(titleTemplate, builds.BuildDate)
+	bodyStr := fmt.Sprintf(bodyTemplate, builds.LinuxAmd64, builds.DarwinAmd64, builds.WindowsAmd64)
+	authStr := fmt.Sprintf("token %s", token)
+	jsonStr := fmt.Sprintf(jsonTemplate, bodyStr, titleStr)
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*1200)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer([]byte(jsonStr)))
+	if err != nil {
+		fmt.Printf("http.NewRequest failed. Err: %v\n", err)
+		return err
+	}
+	req.Header.Set("Authorization", authStr)
+	req.Header.Set("Content-Type", "application/json")
+
+	/* #nosec G402 */
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("client.Do failed. Err: %v\n", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	fmt.Printf("StatusCode: %d\n", resp.StatusCode)
+	fmt.Printf("Status: %s\n", resp.Status)
+	if resp.StatusCode != http.StatusOK {
+		fmt.Printf("resp.StatusCode failed: %d\n", resp.StatusCode)
+		return errors.New(resp.Status)
+	}
+
+	return nil
+}
+
+func uploadAndUpdateRss(tag, ghToken, gcpToken string) error {
 	builds, err := uploadAll(tag, gcpToken)
 	if err != nil {
 		fmt.Printf("uploadAll failed: %v\n", err)
 		return err
 	}
 
-	err = createRssFeed(builds)
+	err = updateReadme(builds)
 	if err != nil {
-		fmt.Printf("createRssFeed failed: %v\n", err)
+		fmt.Printf("updateReadme failed: %v\n", err)
+		return err
+	}
+
+	err = postDiscussion(ghToken, builds)
+	if err != nil {
+		fmt.Printf("postDiscussion failed: %v\n", err)
 		return err
 	}
 
@@ -242,6 +288,10 @@ func main() {
 	if v := os.Getenv("GCP_BUCKET_SA"); v != "" {
 		gcpToken = v
 	}
+	var ghToken string
+	if v := os.Getenv("GITHUB_TOKEN"); v != "" {
+		ghToken = v
+	}
 
 	flag.Parse()
 
@@ -250,11 +300,15 @@ func main() {
 		os.Exit(1)
 	}
 	if gcpToken == "" {
-		fmt.Printf("A token must be provided\n")
+		fmt.Printf("A GCP token must be provided\n")
+		os.Exit(1)
+	}
+	if ghToken == "" {
+		fmt.Printf("A GitHub token must be provided\n")
 		os.Exit(1)
 	}
 
-	err := uploadAndUpdateRss(tag, gcpToken)
+	err := uploadAndUpdateRss(tag, ghToken, gcpToken)
 	if err != nil {
 		fmt.Printf("uploadAndUpdateRss failed: %v\n", err)
 		os.Exit(1)

--- a/hack/dailybuild/go.mod
+++ b/hack/dailybuild/go.mod
@@ -2,7 +2,4 @@ module dailybuild
 
 go 1.16
 
-require (
-	cloud.google.com/go/storage v1.18.2
-	github.com/gorilla/feeds v1.1.1
-)
+require cloud.google.com/go/storage v1.18.2

--- a/hack/dailybuild/go.sum
+++ b/hack/dailybuild/go.sum
@@ -148,8 +148,6 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1 h1:dp3bWCh+PPO1zjRRiCSczJav13sBvG4UhNyVTa1KqdU=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
-github.com/gorilla/feeds v1.1.1 h1:HwKXxqzcRNg9to+BbvJog4+f3s/xzvtZXICcQGutYfY=
-github.com/gorilla/feeds v1.1.1/go.mod h1:Nk0jZrvPFZX1OBe5NPiddPw7CfwF6Q9eqzaBbaightA=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -158,10 +156,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/hack/dailybuild/publish-daily-build.sh
+++ b/hack/dailybuild/publish-daily-build.sh
@@ -59,8 +59,8 @@ fi
 
 git stash pop
 
-git add rss.xml
-git commit -s -m "auto-generated - update daily build rss"
+git add README.md
+git commit -s -m "auto-generated - update daily build in README"
 git push origin "dailybuild-${DATE}"
-gh pr create --title "auto-generated - update daily build rss" --body "auto-generated - update daily build rss"
+gh pr create --title "auto-generated - update daily build in README" --body "auto-generated - update daily build in README"
 gh pr merge "dailybuild-${DATE}" --delete-branch --squash --admin


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Since we can't publish a message in the #`#tanzu-community-edition` slack channel, we have deleted the failed method to publish an RSS feed and instead replaced it with:

- dynamically modifying the README.md with the links for the latest daily build on all supported platforms
- post a thread in a newly created category in the repo's Discussion tab found here: https://github.com/vmware-tanzu/community-edition/discussions/categories/daily-development-builds

Note that on the next successful build, the placeholder text will be updated with each subsequent build's links.

Future TODO: Something that could be cool.... taking that Discussions thread that gets created and maybe using the release tool to provide a commit history between daily builds. Just saying...

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Notify community with daily developer build downloads
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Performed local testing of scripts

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA
