### PR TITLE
Document changing editions at the CLI

### DIFF
--- a/docs/site/content/docs/latest/change-edition.md
+++ b/docs/site/content/docs/latest/change-edition.md
@@ -1,0 +1,16 @@
+# Changing Editions for Existing Binaries
+
+If you have an existing set of `tanzu` binaries on your system, you can change between Tanzu Community Edition (TCE) and Tanzu Kubernetes Grid (TKG) modes without uninstalling anything.
+
+To do so, run the following command:
+
+```shell
+tanzu config set cli.edition (tce or tkg)
+```
+
+Doing this will have the following implications:
+
+* All binaries, including plugins, on your local system will remain the same. However, some plugins may not be exposed depending on the edition you are using.
+* Using the `tce` edition will _not_ install a user package repository into the management clusters; this will have to be added.
+  Using the `tkg` edition _will_ install a user package repository into the management clusters, which is the default package repository for TKG users.
+* Packages for the `tkg` edition will include VMware-built and validated components, some of which may not be open source.


### PR DESCRIPTION
Signed-off-by: Nolan Brubaker <brubakern@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Documents the behavior of changing the `cli.edition` configuration option on the `tanzu` CLI. This option is useful for users who which to use the same set of binaries, but interact with both TCE and TKG clusters.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2716 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Running the `tanzu config set cli.edition (tce|tkg)` command and observing differences in behavior.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->