### PR TITLE
Add rebase rule to ako statefulset to prevent kapp-controller from removing its annotations.

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/kapp-config.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/kapp-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ako-kapp-config
+  labels:
+    kapp.k14s.io/config: ""
+data:
+  config.yml: |
+    apiVersion: kapp.k14s.io/v1alpha1
+    kind: Config
+    rebaseRules:
+    - paths:
+      - [metadata, annotations, AviObjectDeletionStatus]
+      type: copy
+      sources: [existing]
+      resourceMatchers:
+      - kindNamespaceNameMatcher: {kind: StatefulSet, namespace: avi-system, name: ako}

--- a/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/overlays/overlay-statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/overlays/overlay-statefulset.yaml
@@ -91,7 +91,7 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
-    kapp.k14s.io/update-strategy: always-replace
+    kapp.k14s.io/update-strategy: fallback-on-replace
 spec:
   replicas: #@ values.loadBalancerAndIngressService.config.replica_count
   selector:

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/kapp-config.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/kapp-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ako-kapp-config
+  labels:
+    kapp.k14s.io/config: ""
+data:
+  config.yml: |
+    apiVersion: kapp.k14s.io/v1alpha1
+    kind: Config
+    rebaseRules:
+    - paths:
+      - [metadata, annotations, AviObjectDeletionStatus]
+      type: copy
+      sources: [existing]
+      resourceMatchers:
+      - kindNamespaceNameMatcher: {kind: StatefulSet, namespace: avi-system, name: ako}

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/overlays/overlay-statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/overlays/overlay-statefulset.yaml
@@ -21,7 +21,7 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
-    kapp.k14s.io/update-strategy: always-replace
+    kapp.k14s.io/update-strategy: fallback-on-replace
 spec:
   replicas: #@ values.loadBalancerAndIngressService.config.replica_count
   selector:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

AKO uses annotation to pass "cleanup finished" signal to the AKO-operator. We don't want this annotation to be override (removed) by the kapp-controller during its reconcilation.


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add rebase rule to ako statefulset to prevent kapp-controller from removing its annotations.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
