### PR TITLE
[E2E] Increase wait timeout for waiting for pods in cluster

### DIFF
--- a/test/check-tce-cluster-creation.sh
+++ b/test/check-tce-cluster-creation.sh
@@ -23,7 +23,7 @@ kubectl config use-context "$kube_context" || {
     exit 1
 }
 
-kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=600s || {
+kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=900s || {
     error "TIMED OUT WAITING FOR ALL PODS TO BE UP!"
     exit 1
 }


### PR DESCRIPTION
## What this PR does / why we need it

Increase wait timeout for waiting for pods in cluster in E2E tests. Previously timeout time was 10 minutes, now it's 15 minutes. Seems like 10 minutes is not enough at times 😅 

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #2488 

## Describe testing done for PR

None

## Special notes for your reviewer

None