### PR TITLE
[E2E][vSphere] Fix vSphere E2E test failure when tce daily official tar ball is available

### DIFF
--- a/test/download-or-build-tce.sh
+++ b/test/download-or-build-tce.sh
@@ -34,7 +34,11 @@ fi
 
 rm -f tce-daily-build.tar.gz
 curl -L "${DOWNLOAD_GCP_URI}" -o tce-daily-build.tar.gz
+
+set +e
 IS_XML=$(file tce-daily-build.tar.gz | grep XML)
+set -e
+
 if [ "${IS_XML}" == "" ]; then
     # extract the daily
     tar -xvf tce-daily-build.tar.gz --one-top-level=tce-daily-build --strip-components 1


### PR DESCRIPTION
## What this PR does / why we need it

Fixes vSphere E2E test failure when tce daily official tar ball is available

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #3022

## Describe testing done for PR

Tried it manually in local dev machine

## Special notes for your reviewer

None