### PR TITLE
Update external-dns test e2e README to reference getting started guide

### DIFF
--- a/addons/packages/external-dns/0.10.0/test/README.md
+++ b/addons/packages/external-dns/0.10.0/test/README.md
@@ -8,23 +8,17 @@ End-to-End tests for `external-dns` are located in the `./e2e` directory.
 
 To run the `external-dns` end-to-end tests you need:
 
-* A Tanzu Community Edition cluster and the cluster needs to be the current-context.
+* A Tanzu Community Edition cluster and the cluster needs to be the
+  current-context. See the [Getting Started
+  Guide](https://tanzucommunityedition.io/docs/latest/getting-started/) for
+  instuctions on how to create a cluster.
 * The cluster supports Service type `LoadBalancer`.
 * The `external-dns.community.tanzu.vmware.com` Package must exist on the
   cluster so it can be installed by the test.
 
-From the root of this repo, you can run the following to setup a local cluster:
-
-```bash
-$ ./test/docker/run-tce-docker-standalone-cluster.sh
-STANDALONE INIT YO YO YO...
-...
-Standalone cluster created!
-...
-```
-
-Docker clusters do not support Service type `LoadBalancer` by default, one
-method of supporting Service type `LoadBalancer` is to install MetalLB.
+Clusters built with `docker` or `kind` providers do not support Service type
+`LoadBalancer` by default, one method of supporting Service type `LoadBalancer`
+is to install MetalLB.
 
 To install MetalLB run:
 

--- a/addons/packages/external-dns/0.8.0/test/README.md
+++ b/addons/packages/external-dns/0.8.0/test/README.md
@@ -6,25 +6,17 @@ End-to-End tests for `external-dns` are located in the `./e2e` directory.
 
 ### Prerequisites
 
-To run the `external-dns` end-to-end tests you need:
-
-* A Tanzu Community Edition cluster and the cluster needs to be the current-context.
+* A Tanzu Community Edition cluster and the cluster needs to be the
+  current-context. See the [Getting Started
+  Guide](https://tanzucommunityedition.io/docs/latest/getting-started/) for
+  instuctions on how to create a cluster.
 * The cluster supports Service type `LoadBalancer`.
 * The `external-dns.community.tanzu.vmware.com` Package must exist on the
   cluster so it can be installed by the test.
 
-From the root of this repo, you can run the following to setup a local cluster:
-
-```bash
-$ ./test/docker/run-tce-docker-standalone-cluster.sh
-STANDALONE INIT YO YO YO...
-...
-Standalone cluster created!
-...
-```
-
-Docker clusters do not support Service type `LoadBalancer` by default, one
-method of supporting Service type `LoadBalancer` is to install MetalLB.
+Clusters built with `docker` or `kind` providers do not support Service type
+`LoadBalancer` by default, one method of supporting Service type `LoadBalancer`
+is to install MetalLB.
 
 To install MetalLB run:
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This removes the command to deploy a cluster in the external-dns e2e test readme and replaces it with a link to the getting started guide so it stays up-to-date with how to deploy a tanzu cluster.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3008

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Readme change.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
