### PR TITLE
Add script to update choco package TCE version after every release

### DIFF
--- a/.github/workflows/release-choco-package.yaml
+++ b/.github/workflows/release-choco-package.yaml
@@ -1,0 +1,33 @@
+name: Release - Choco Package
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  update-choco-package:
+    name: Update Choco Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Config credentials
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
+        run: |
+          git config --global pull.rebase true
+          git config --global url."https://git:${GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global user.name github-actions
+          git config --global user.email github-actions@github.com
+
+
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Update Choco Package
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
+        shell: bash
+        run: |
+          GITHUB_REF="${{ github.ref }}"
+          version=${GITHUB_REF/refs\/tags\//}
+          ./hack/choco/update-choco-package.sh ${version}

--- a/hack/choco/update-choco-package.sh
+++ b/hack/choco/update-choco-package.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+ 
+# Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+ 
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+ 
+version="${1:?TCE version argument empty. Example usage: ./hack/choco/update-choco-package.sh v0.10.0}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is not set}"
+ 
+ 
+temp_dir=$(mktemp -d)
+ 
+pushd "${temp_dir}"
+
+TCE_REPO="https://github.com/vmware-tanzu/community-edition" 
+TCE_REPO_RELEASES_URL="https://github.com/vmware-tanzu/community-edition/releases"
+TCE_WINDOWS_TAR_BALL_FILE="tce-darwin-amd64-${version}.tar.gz"
+TCE_CHECKSUMS_FILE="tce-checksums.txt"
+ 
+echo "Checking if the necessary files exist for the TCE ${version} release"
+ 
+wget --spider -q \
+   "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_WINDOWS_TAR_BALL_FILE}" || {
+       echo "${TCE_WINDOWS_TAR_BALL_FILE} is not accessible in TCE ${version} release"
+       exit 1
+   }
+ 
+wget --spider -q "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_CHECKSUMS_FILE}" || {
+   echo "${TCE_CHECKSUMS_FILE} is not accessible in TCE ${version} release"
+   exit 1
+}
+ 
+# Use --depth 1 once https://github.com/cli/cli/issues/2979#issuecomment-780490392 get resolve
+git clone "${TCE_REPO}"
+
+cd community-edition
+ 
+PR_BRANCH="update-tce-to-${version}-${RANDOM}"
+ 
+# Random number in branch name in case there's already some branch for the version update,
+# though there shouldn't be one. There could be one if the other branch's PR tests failed and didn't merge
+git checkout -b "${PR_BRANCH}"
+
+
+# Replacing old version with the latest stable released version.
+# Using -i so that it works on Mac and Linux OS, so that it's useful for local development.
+sed -i -e "s/\(\$releaseVersion =\).*/\$releaseVersion = ""'${version}'""/g" hack/choco/tools/chocolateyinstall.ps1 
+rm -fv hack/choco/tools/chocolateyinstall.ps1-e
+
+version="${version:1}"
+sed -i -e "s/\(<version>\).*\(<\/version>\)/<version>""${version}""\<\/version>/g" hack/choco/tanzu-community-edition.nuspec
+rm -fv hack/choco/tanzu-community-edition.nuspec-e
+ 
+git add hack/choco/tools/chocolateyinstall.ps1
+git add hack/choco/tanzu-community-edition.nuspec
+ 
+git commit -m "auto-generated - update tce choco install scripts for version ${version}"
+ 
+git push origin "${PR_BRANCH}"
+ 
+gh pr create --repo ${TCE_REPO} --title "auto-generated - update tce choco install scripts for version ${version}" --body "auto-generated - update tce choco install scripts for version ${version}"
+ 
+gh pr merge --repo ${TCE_REPO} "${PR_BRANCH}" --squash --delete-branch --auto
+ 
+popd


### PR DESCRIPTION
Signed-off-by: Aman Sharma <amansh@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR adds a script which will update the version of TCE in choco package after ever release.

Files in which TCE version is updating are:
- [hack/choco/tce-community-edition.nuspec](https://github.com/vmware-tanzu/community-edition/blob/main/hack/choco/tanzu-community-edition.nuspec)
- [hack/choco/tools/chocolateyinstall.ps1](https://github.com/vmware-tanzu/community-edition/blob/main/hack/choco/tools/chocolateyinstall.ps1)
## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: [#2228](https://github.com/vmware-tanzu/community-edition/issues/2228)

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Publish a release in forked branch after which GitHub workflow ran and update the TCE version in choco package files.
Action logs for release-choco-package workflow: [logs](https://github.com/aman556/community-edition/runs/5092964616?check_suite_focus=true) 
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
Please have a look on the above logs. 