### PR TITLE
Fix goheader year regex

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,9 +9,9 @@ linters-settings:
       const:
        - LICENSE: Apache-2.0
       regexp:
-       YEAR: (?:20\d{2} |20\d{2}-2\d{3})
+       YEAR: (?:20\d{2} |20\d{2}-2\d{3} )
     template: |-
-      Copyright {{ YEAR }} VMware Tanzu Community Edition contributors. All Rights Reserved.
+      Copyright {{ YEAR }}VMware Tanzu Community Edition contributors. All Rights Reserved.
       SPDX-License-Identifier: {{ LICENSE }}
   goconst:
     min-len: 2


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

A space was added after the single year regex so it wouldn't match
something like "2021-9000", but it was not accounted for in the
resulting template.

This updates the regex to capture that space after the single year
(2022) or multi-year (2021-2022) values and updates the template so it
does not end up expecting two spaces after the year match.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```