### PR TITLE
Doc - Add links to Cluster API infrastructure providers

### DIFF
--- a/docs/site/content/docs/latest/support-matrix.md
+++ b/docs/site/content/docs/latest/support-matrix.md
@@ -18,9 +18,9 @@ hardware/software configurations is required on your local machine.
 After you install Tanzu Community Edition on your local machine, you can use the Tanzu CLI to deploy a cluster to **one** of the following infrastructure providers:
 | Cloud Infrastructure Provider    |Local Infrastructure Provider|
 |:------------------------ |:------------------------ |
-|Amazon Web Services (AWS) |Docker |
-|Microsoft Azure| |
-|vSphere| |
+|[Amazon Web Services (AWS)](https://github.com/kubernetes-sigs/cluster-api-provider-aws) |[Docker](https://github.com/kubernetes-sigs/cluster-api/tree/main/test/infrastructure/docker) |
+|[Microsoft Azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure)| |
+|[vSphere](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/)| |
 
 The Cloud Infrastructure providers support the following infrastructure platforms and operating systems (OSs):
 


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
Add links to Cluster API Providers in Support Matrix in doc

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```none

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2990 

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
Is this the best way to link these or do we need to elaborate further somewhere else in doc, we don't mention cluster api anywhere else in doc We could add a [glossary ](http://localhost:1313/docs/latest/glossary/#c) entry with a description and links  and then link to this glossary item from support matrix - probably over thinking this!
