### PR TITLE
Enable misspell checks on docs

### DIFF
--- a/docs/site/content/docs/assets/aws-clusters.md
+++ b/docs/site/content/docs/assets/aws-clusters.md
@@ -36,7 +36,7 @@ There are some prerequisites the installation process will assume.  Refer to the
 
     * `A`: Whether to create a new Virtual Private Cloud in AWS or use an existing
       one. If using an existing one, you must provide its VPC ID. For initial
-      deployments, it is recomended to create a new Virtual Private Cloud. This will
+      deployments, it is recommended to create a new Virtual Private Cloud. This will
       ensure the installer takes care of all networking creation and configuration.
     * `B`: If creating a new VPC, the CIDR range or IPs to use for hosts (EC2
       VMs).

--- a/docs/site/content/docs/assets/aws-standalone-clusters.md
+++ b/docs/site/content/docs/assets/aws-standalone-clusters.md
@@ -33,7 +33,7 @@ Refer to the [Prepare to Deploy a Management or Standalone Cluster to AWS](../aw
 
     * `A`: Whether to create a new Virtual Private Cloud in AWS or use an existing
       one. If using an existing one, you must provide its VPC ID. For initial
-      deployments, it is recomended to create a new Virtual Private Cloud. This will
+      deployments, it is recommended to create a new Virtual Private Cloud. This will
       ensure the installer takes care of all networking creation and configuration.
     * `B`: If creating a new VPC, the CIDR range or IPs to use for hosts (EC2
       VMs).

--- a/docs/site/content/docs/assets/azure-clusters.md
+++ b/docs/site/content/docs/assets/azure-clusters.md
@@ -47,7 +47,7 @@ accepting image licenses and preparing your Azure account.
       [Virtual Network in Azure](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview)
       or use an existing one.
       If using an existing one, you must provide its VNET name. For initial
-      deployments, it is recomended to create a new Virtual Network. This will
+      deployments, it is recommended to create a new Virtual Network. This will
       ensure the installer takes care of all networking creation and configuration.
     * `B`: The Resource Group under which to create the VNET.
     * `C`: The name to use when creating a new VNET.
@@ -219,7 +219,7 @@ Kubernetes.
 
    * If you did not specify a name for your management cluster, the installer generated a random unique name. In this case, you must manually add the CLUSTER_NAME parameter and assign a workload cluster name. The workload cluster names must be must be 42 characters or less and must comply with DNS hostname requirements as described here: [RFC 1123](https://tools.ietf.org/html/rfc1123)
    * If you specified a name for your management cluster, the CLUSTER_NAME parameter is present and needs to be changed to the new workload cluster name.
-   * The other parameters in ``workload1.yaml`` are likely fine as-is. Validation is performed on the file prior to applying it, so the `tanzu` command will return a message if something necessary is omitted. However, you can change paramaters as required. Reference an example configuration template here:  [Azure Workload Cluster Template](../azure-wl-template).
+   * The other parameters in ``workload1.yaml`` are likely fine as-is. Validation is performed on the file prior to applying it, so the `tanzu` command will return a message if something necessary is omitted. However, you can change parameters as required. Reference an example configuration template here:  [Azure Workload Cluster Template](../azure-wl-template).
 
 1. Create your workload cluster.
 

--- a/docs/site/content/docs/assets/azure-standalone-clusters.md
+++ b/docs/site/content/docs/assets/azure-standalone-clusters.md
@@ -45,7 +45,7 @@ accepting image licenses and preparing your Azure account.
       [Virtual Network in Azure](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview)
       or use an existing one.
       If using an existing one, you must provide its VNET name. For initial
-      deployments, it is recomended to create a new Virtual Network. This will
+      deployments, it is recommended to create a new Virtual Network. This will
       ensure the installer takes care of all networking creation and configuration.
     * `B`: The Resource Group under which to create the VNET.
     * `C`: The name to use when creating a new VNET.

--- a/docs/site/content/docs/assets/cli-install-linux.md
+++ b/docs/site/content/docs/assets/cli-install-linux.md
@@ -40,7 +40,7 @@
     > - For example, to download {{< release_latest >}} for Linux, provide:  <br>`bash -s {{< release_latest >}} linux`
     > - This script requires `curl`, `grep`, `sed`, `tr`, and `jq` in order to work
     > - The release will be downloaded to the local directory as `tce-linux-amd64-{{< release_latest >}}.tar.gz`
-    > - *_Note:_* A GitHub personal access token may be provided to the script as the `GITHUB_TOKEN` environment variable. This bypasses GitHub API rate limiting but is _not_ required. Follow [the GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to aquire and use a personal access token.
+    > - *_Note:_* A GitHub personal access token may be provided to the script as the `GITHUB_TOKEN` environment variable. This bypasses GitHub API rate limiting but is _not_ required. Follow [the GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to acquire and use a personal access token.
 
 1. Unpack the release.
 

--- a/docs/site/content/docs/latest/_index.md
+++ b/docs/site/content/docs/latest/_index.md
@@ -32,5 +32,5 @@ With Tanzu Community Edition, it is easy for experienced and aspiring cloud nati
 
 - Aspiring and experienced **cloud native practitioners** (including **operators**, **DevOps**, and **developers**) looking to build new cloud native skills
 - Skilled **cloud native practitioners** looking for a free Kubernetes-based application platform to use in their self-supported environment
-- **Platform and IT infrastructure operators** as well as **Site Reliabilty Engineers** looking to provide and manage container infrastructure for their internal users or customers in self-supported environments
+- **Platform and IT infrastructure operators** as well as **Site Reliability Engineers** looking to provide and manage container infrastructure for their internal users or customers in self-supported environments
 - **Cloud native ecosystem participants**, for example, **independent software vendors** looking to build their businesses around platform-adjacent opportunities

--- a/docs/site/content/docs/latest/designs/package-process.md
+++ b/docs/site/content/docs/latest/designs/package-process.md
@@ -118,7 +118,7 @@ directories:
         newRootPath: deploy
 ```
 
-> There are multiple sources you can use. Ideally, packages use either `git` or `githubReleases` such that we can lock in the version. Using the `http` source does not give us the same guarentee as the aforementioned sources.
+> There are multiple sources you can use. Ideally, packages use either `git` or `githubReleases` such that we can lock in the version. Using the `http` source does not give us the same guarantee as the aforementioned sources.
 
 This configuration means vendir will manage the `config/upstream` directory. To
 download the assets and produce a lock file, run the following.

--- a/docs/site/content/docs/latest/docker-monitoring-stack.md
+++ b/docs/site/content/docs/latest/docker-monitoring-stack.md
@@ -310,7 +310,14 @@ Note the stats/prometheus link. This will be useful to reference when testing Pr
 
 ## Deploy local-path-storage
 
-Both Prometheus and Grafana have a requirement for persistent storage, so both have Persistent Volume Claims. By default, there is no storage provider available in Tanzu Community Edition standalone, and thus no default Storage Class. To accomodate this request for persistent storage, another community package called `local-path-storage` must be deployed in the Tanzu Comunity Edition standalone cluster. Once the package has been successfully installed and reconciled, there should be a new default StorageClass called `local-path` created on the cluster.
+Both Prometheus and Grafana have a requirement for persistent storage, so both
+have Persistent Volume Claims. By default, there is no storage provider
+available in Tanzu Community Edition standalone, and thus no default Storage
+Class. To accommodate this request for persistent storage, another community
+package called `local-path-storage` must be deployed in the Tanzu Comunity
+Edition standalone cluster. Once the package has been successfully installed and
+reconciled, there should be a new default StorageClass called `local-path`
+created on the cluster.
 
 Begin by installing the required version of the package. In this guide, we are installed version 0.0.20.
 

--- a/docs/site/content/docs/latest/package-management.md
+++ b/docs/site/content/docs/latest/package-management.md
@@ -283,7 +283,7 @@ tanzu package install ${NAME} \
     a. Retrieve the list of possible values using the `--values-schema` flag.
 
     ```text
-    tanzu pacakage available get contour.community.tanzu.vmware.com/1.17.1 --values-schema
+    tanzu package available get contour.community.tanzu.vmware.com/1.17.1 --values-schema
 
     | Retrieving package details for contour.community.tanzu.vmware.com/1.17.1...
       KEY                                  DEFAULT         TYPE     DESCRIPTION

--- a/docs/site/content/docs/latest/packages-create-example.md
+++ b/docs/site/content/docs/latest/packages-create-example.md
@@ -9,7 +9,7 @@ While most common use cases will reuse an existing package, this example explore
 * A full description of the package creation process is available [here](package-creation-step-by-step).  
 * A description of the Tanzu Community Edition packages architecture is available [here](architecture/#package-management).  
 * A description of how to work with existing packages and package repositories is available [here](package-management).  
-* Descriptions of a package and a package repository are availabe [here](glossary/#p)
+* Descriptions of a package and a package repository are available [here](glossary/#p)
 
 ## Prerequisites
 

--- a/docs/site/content/docs/latest/tanzu-debugging-tips.md
+++ b/docs/site/content/docs/latest/tanzu-debugging-tips.md
@@ -116,9 +116,9 @@ management cluster.
    ## Minimal output
    tanzu cluster get <CLUSTER NAME> --show-all-conditions all
 
-   ## Summarized Output - helpful when infra related issues are occuring
+   ## Summarized Output - helpful when infra related issues are occurring
    tanzu cluster get <CLUSTER NAME> --show-all-conditions all --show-group-members
 
-   ## Very Detailed output - helpful when kubernetes bootstrapping issues are occuring
+   ## Very Detailed output - helpful when kubernetes bootstrapping issues are occurring
    tanzu cluster get <CLUSTER NAME> --show-all-conditions all --show-details --show-group-members
    ```

--- a/docs/site/themes/template/assets/scss/_footer.scss
+++ b/docs/site/themes/template/assets/scss/_footer.scss
@@ -32,7 +32,7 @@ footer {
         p {
             margin: 0px;
         }
-        .copywrite {
+        .copyright {
             font-size: 12px;
             padding-right: 10px;
             a {
@@ -78,7 +78,7 @@ footer {
                 .mobile {
                     display: inline;
                 }
-                .copywrite {
+                .copyright {
                     display: block;
                     margin-top:20px;
                 }

--- a/docs/site/themes/template/layouts/_default/download.html
+++ b/docs/site/themes/template/layouts/_default/download.html
@@ -13,7 +13,7 @@
             
             {{ partial "download-table.html" . }}
 
-            <p>You can download older versions of Tanzu Community Edition from <a href="https://github.com/vmware-tanzu/community-edition/releases/">Github</a>.</p>
+            <p>You can download older versions of Tanzu Community Edition from <a href="https://github.com/vmware-tanzu/community-edition/releases/">GitHub</a>.</p>
         </div>
     </main>
 {{ end }}

--- a/docs/site/themes/template/layouts/partials/footer.html
+++ b/docs/site/themes/template/layouts/partials/footer.html
@@ -19,7 +19,7 @@
 				<a href="https://www.vmware.com//help/privacy/california-privacy-rights.html">Your California Privacy Rights</a> | 
 				<a class='ot-sdk-show-settings'>Cookie Settings</a>
 			</div>
-			<p class="copywrite">&copy; {{ now.Year }} VMware Tanzu Community Edition Authors. <a href="http://vmware.github.io/">A VMware-backed project. <img src="/img/vmware-logo.svg" alt="VMware logo" /></a></p>
+			<p class="copyright">&copy; {{ now.Year }} VMware Tanzu Community Edition Authors. <a href="http://vmware.github.io/">A VMware-backed project. <img src="/img/vmware-logo.svg" alt="VMware logo" /></a></p>
 		</div>
 	</div>
 </footer>

--- a/docs/site/themes/template/layouts/partials/header.html
+++ b/docs/site/themes/template/layouts/partials/header.html
@@ -27,7 +27,7 @@
 			</ul>
 			<div class="social">
 				<li><a href="{{ .Site.Params.twitter_url }}"><img src="/img/twitter.svg" alt="Twitter logo" height="21" /><span class="sr-only">Twitter</span></a></li>
-				<li><a href="{{ .Site.Params.github_url }}"><img src="/img/github.svg" alt="GitHub logo" /><span class="sr-only">Github</a></li>
+				<li><a href="{{ .Site.Params.github_url }}"><img src="/img/github.svg" alt="GitHub logo" /><span class="sr-only">GitHub</a></li>
 				<!--<li><a href="{{ .Site.Params.slack_url }}"><img src="/img/slack.svg" alt="Slack logo" height="21" /><span class="sr-only">Slack</span></a></li>-->
 				<li><a href="{{ .Site.Params.google_group_url }}"><img src="/img/google-groups.png" alt="Google Groups logo" height="21" /><span class="sr-only">Google Groups</span></a></li>
 			</div>

--- a/docs/site/themes/template/static/fonts/README.md
+++ b/docs/site/themes/template/static/fonts/README.md
@@ -4,7 +4,7 @@
 
 The Vision
 ---
-To create a modern, geometric typeface. Open sourced, and openly available. Influenced by other popular geometric, minimalist sans-serif typefaces of the new millenium. Designed for optimal readability at small point sizes while beautiful at large point sizes.
+To create a modern, geometric typeface. Open sourced, and openly available. Influenced by other popular geometric, minimalist sans-serif typefaces of the new millennium. Designed for optimal readability at small point sizes while beautiful at large point sizes.
 
 December 2017 update
 ---

--- a/hack/check/.misspellignore
+++ b/hack/check/.misspellignore
@@ -1,3 +1,2 @@
-docs/site/
 go.mod
 go.sum


### PR DESCRIPTION
We had been skipping the docs source files in our `misspell` checks,
presumably because the site had a lot of active churn as we were
preparing for launch. Now that the site has stabilized, it would be good
to run these checks to catch spelling errors in our documentation.

This removes the docs tree from the list of ignored paths for the check
and addresses the spelling errors that uncovered.