### PR TITLE
Add multus mtu test

### DIFF
--- a/addons/packages/multus-cni/3.7.1/test/e2e/multihomed-testfiles/simple-macvlan.yaml
+++ b/addons/packages/multus-cni/3.7.1/test/e2e/multihomed-testfiles/simple-macvlan.yaml
@@ -12,6 +12,7 @@ spec:
                     "capabilities": { "ips": true },
                     "master": "eth0",
                     "mode": "bridge",
+                    "mtu": 1450,
                     "ipam": {
                         "type": "static"
                     }

--- a/addons/packages/multus-cni/3.7.1/test/e2e/multuscni_test.go
+++ b/addons/packages/multus-cni/3.7.1/test/e2e/multuscni_test.go
@@ -18,6 +18,7 @@ var (
 	// The net1 is the default iface name when not appointed.
 	checkMacVlanIFaceExistence = "ip a show dev net1"
 	checkIFaceStatus           = "ip -j a show net1 | jq -r '.[]|.operstate'"
+	checkMTUValue              = "ip -j a show net1 | jq -r '.[]|.mtu'"
 	getMacVlanIP               = "ip -j a show | jq -r '.[]|select(.ifname ==\"net1\")|.addr_info[]|select(.family==\"inet\").local'"
 )
 
@@ -51,7 +52,10 @@ var _ = Describe("Multus CNI Addon E2E Test", func() {
 
 	JustBeforeEach(func() {
 		By("Should install jq command")
-		_, err := utils.Kubectl(nil, "exec", "macvlan-worker", "--", "yum", "install", "-y", "jq")
+		updateCentOSRepo := "cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*"
+		_, err := utils.Kubectl(nil, "exec", "macvlan-worker", "--", "bash", "-c", updateCentOSRepo)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = utils.Kubectl(nil, "exec", "macvlan-worker", "--", "yum", "install", "-y", "jq")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -101,6 +105,12 @@ var _ = Describe("Multus CNI Addon E2E Test", func() {
 			"bash", "-c", checkIFaceStatus)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strings.Replace(ifstatus, "\n", "", -1)).To(Equal("UP"))
+
+		By("check pod interface mtu: net1")
+		ifmtu, err := utils.Kubectl(nil, "exec", "macvlan-worker", "--",
+			"bash", "-c", checkMTUValue)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Replace(ifmtu, "\n", "", -1)).To(Equal("1450"))
 
 		By("get pod interface address: net1")
 		ip, err := utils.Kubectl(nil, "exec", "macvlan-worker", "--",


### PR DESCRIPTION
Add mtu setting on macvlan interface
Fix package list on CentOS

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Add mtu test for multus based interfaces and fix CentOS package list change since Jan. 2022.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Passed multus-cni package e2e test: ginkgo -v -- --packages="multus-cni" --version="3.7.1" --guest-cluster-name="tce-mycluster1" 

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
