### PR TITLE
Move misspell to common location

### DIFF
--- a/hack/check/check-misspell.sh
+++ b/hack/check/check-misspell.sh
@@ -9,17 +9,17 @@ set -o nounset
 set -o pipefail
 
 
-MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CHECK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"; pwd )"
+HACK_DIR="$( cd "${CHECK_DIR}/.."; pwd )"
 
 # Install tools we need if it is not present
-if [[ ! -f "${MY_DIR}/tools/bin/misspell" ]]; then
-  curl -L https://git.io/misspell | bash
-  mkdir -p "${MY_DIR}/tools/bin"
-  mv ./bin/misspell "${MY_DIR}/tools/bin/misspell"
+if [[ ! -f "${HACK_DIR}/tools/bin/misspell" ]]; then
+  mkdir -p "${HACK_DIR}/tools/bin"
+  curl -L https://git.io/misspell | BINDIR="${HACK_DIR}/tools/bin" bash
 fi
 
 # Spell checking
 # misspell check Project - https://github.com/client9/misspell
-misspellignore_files="${MY_DIR}/.misspellignore"
+misspellignore_files="${CHECK_DIR}/.misspellignore"
 ignore_files=$(cat "${misspellignore_files}")
-git ls-files | grep -v "${ignore_files}" | xargs "${MY_DIR}/tools/bin/misspell" | grep "misspelling" && echo "Please fix the listed misspell errors and verify using 'make misspell'" && exit 1 || echo "misspell check passed!"
+git ls-files | grep -v "${ignore_files}" | xargs "${HACK_DIR}/tools/bin/misspell" | grep "misspelling" && echo "Please fix the listed misspell errors and verify using 'make misspell'" && exit 1 || echo "misspell check passed!"


### PR DESCRIPTION
Our testing and check binaries have a standard path of `hack/tools/bin`.
The misspell check was installing the misspell binary in
`hack/checks/tools/bin`. This cleans up the script and changes the
binary path so it is consistent with our other tools.