### PR TITLE
Dump daily build changelog for debug purposes

### DIFF
--- a/hack/dailybuild/publish-daily-build.sh
+++ b/hack/dailybuild/publish-daily-build.sh
@@ -50,6 +50,10 @@ GITHUB_TOKEN="${GITHUB_TOKEN}" release-notes \
   --required-author "" --go-template go-template:./daily.template --output daily-notes.txt
 set -x
 
+echo "********* changelog dump for debugging *********"
+cat daily-notes.txt
+echo "********* changelog dump for debugging *********"
+
 echo "${ACTUAL_COMMIT_SHA}" | tee ./PREVIOUS_DAILY_HASH
 
 make run


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
We should dump the changelog in the GH action log for debug purposes. Last night 2/10, the GH Discussion post did not get created and I suspect that it was because the changelog had a special character that was messing up the JSON. We should dump the changelog for debugging and even just for visibility purposes.

Good news is that we anticipated failures would happen and the hash was updated and committed to the repo; therefore won't mess up tonight's (or future) daily build because it can just advance to the next delta.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Dump daily build changelog for debug purposes
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA