### PR TITLE
Only build platforms needed in action checks

### DIFF
--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -51,7 +51,7 @@ jobs:
         shell: bash
         run: |
           make ensure-deps
-          make release
+          make release ENVS=linux-amd64
       - name: Install
         shell: bash
         run: |

--- a/.github/workflows/check-pr-diagnostics-plugin.yaml
+++ b/.github/workflows/check-pr-diagnostics-plugin.yaml
@@ -59,7 +59,7 @@ jobs:
         shell: bash
         run: |
           make ensure-deps
-          make release
+          make release ENVS=linux-amd64
       - name: Install
         shell: bash
         run: |

--- a/.github/workflows/check-pr-docker-management.yaml
+++ b/.github/workflows/check-pr-docker-management.yaml
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         run: |
           make ensure-deps
-          make release
+          make release ENVS=linux-amd64
       - name: Install
         shell: bash
         run: |

--- a/.github/workflows/check-pr-docker-standalone.yaml
+++ b/.github/workflows/check-pr-docker-standalone.yaml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
         run: |
           make ensure-deps
-          make release
+          make release ENVS=linux-amd64
       - name: Install
         shell: bash
         run: |


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We have several "check" jobs that run on new PRs. These jobs are
currently running `make release` to get the binary to use to perform
those checks.

The GitHub Actions run on a Linux AMD64 platform, but by default the
`make release` target builds for all supported platforms. We end up
waiting a long time while these unnecessary platform targets are built,
to then just pull out the linux-amd64 binary to perform our tests.

This updates the `make release` targets called in these actions to only
build the linux-amd64 binary that we need, saving some time by not
waiting on platform targets we just throw away.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```