### PR TITLE
Perform full release build for check-main

### DIFF
--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -51,7 +51,7 @@ jobs:
         shell: bash
         run: |
           make ensure-deps
-          make release ENVS=linux-amd64
+          make release
       - name: Install
         shell: bash
         run: |


### PR DESCRIPTION
2956d4aaa9aa95cd2df2afca4b3c7d8607047c4f updated several PR GitHub
Actions to only build the linux-amd64 target since that is all we test
with on the test runners.

The check-main job only runs on merges to main. To have a safety to make
sure there are no build failures introduced for non-Linux amd64 build
targets, we should still do a full release as part of this check so we
can catch those issues early.