### PR TITLE
Add OVA download link to release downloads

### DIFF
--- a/docs/site/data/downloads/0-9-1.yml
+++ b/docs/site/data/downloads/0-9-1.yml
@@ -30,3 +30,5 @@ source:
     file_name: v0.9.1.zip
     checksum: ''
     size: ''
+ova:
+  ova_page_link: 'https://customerconnect.vmware.com/downloads/details?downloadGroup=TCE-090&productId=1202&download=true&fileId=b1d59dca8908173f7441bb4d77d7e1d6&uuId=8283159f-927e-417d-9902-f26c5c0cf13d'

--- a/docs/site/themes/template/layouts/partials/download-table.html
+++ b/docs/site/themes/template/layouts/partials/download-table.html
@@ -52,4 +52,9 @@
             </tbody>
         </table>
     {{ end }}
+    {{ if .ova }}
+        <p>The vSphere Open Virtual Appliance (OVA) files for this release of Tanzu Community Edition can be
+        <a href="{{ .ova.ova_page_link }}">downloaded here</a>.
+        </p>
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This adds a link to the Customer Connect page for the OVAs needed when
deploying to a vSphere environment.

Originally submitted by @qnetter in https://github.com/vmware-tanzu/community-edition/pull/3115

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3114 
Fixes: #3113 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `hugo server --disableFastRender` and verified rendered output.