### PR TITLE
Add an overlay antreaNSXPodRoutingEnabled to enable pod routing with Antrea NSX

### DIFF
--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/overlays/vsphere-paravirtual-cpi/update-deployment.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/overlays/vsphere-paravirtual-cpi/update-deployment.yaml
@@ -1,0 +1,27 @@
+#@ load("/values.star", "values")
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:struct", "struct")
+#@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:sha256", "sha256")
+
+#@ if values.vsphereCPI.mode == "vsphereParavirtualCPI":
+#@ if values.vsphereCPI.antreaNSXPodRoutingEnabled:
+
+#@overlay/match by=overlay.subset({"kind": "Deployment", "metadata": {"name": "guest-cluster-cloud-provider"}})
+---
+spec:
+  template:
+    spec:
+      containers:
+        #@overlay/match by=overlay.all
+        - args:
+          - --controllers=route
+          - --configure-cloud-routes=true
+          - --allocate-node-cidrs=true
+          #! Note: This 'cluster-cidr' value is a workaround for RoutablePod feature.
+          #! Route controller needs to verify whether deleted route is within its authority.
+          #! But Cluster CIDR value is assigned by NCP after the cloud provider is deployed.
+          #! So use this wide range to make sure NCP allocated CIDR is covered in this.
+          - --cluster-cidr=0.0.0.0/0
+#@ end
+#@ end

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/schema.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/schema.yaml
@@ -95,3 +95,5 @@ vsphereCPI:
   supervisorMasterEndpointIP: ""
   #@schema/desc "Used in vsphereParavirtual mode, the endpoint port of supervisor cluster's API server port. Default: ''"
   supervisorMasterPort: ""
+  #@schema/desc "Enable pod routing with Antrea NSX"
+  antreaNSXPodRoutingEnabled: false

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/upstream/vsphere-paravirtual-cpi/03-deployment.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/upstream/vsphere-paravirtual-cpi/03-deployment.yaml
@@ -23,7 +23,6 @@ spec:
         - args:
             - --controllers=service
             - --controllers=cloud-node
-            #! TODO(fhan): add field AntreaNSXRouted to support routable pod with AntreaNSX
             - --cloud-config=/config/cloud-config
             #@yaml/text-templated-strings
             - --cluster-name=(@= values.vsphereCPI.clusterName @)

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/values.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/values.yaml
@@ -45,3 +45,4 @@ vsphereCPI:
   clusterUID: ""
   supervisorMasterEndpointIP: ""
   supervisorMasterPort: ""
+  antreaNSXPodRoutingEnabled: false

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/package.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/package.yaml
@@ -211,3 +211,7 @@ spec:
               type: string
               default: ""
               description: 'Used in vsphereParavirtual mode, the endpoint port of supervisor cluster''s API server port. Default: '''''
+            antreaNSXPodRoutingEnabled:
+              type: boolean
+              default: false
+              description: Enable pod routing with Antrea NSX


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
It allows user to enable pod routing with Antrea NSX, by changing the data value field `antreaNSXPodRoutingEnabled` to `true`


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add an overlay antreaNSXPodRoutingEnabled to enable pod routing with Antrea NSX
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
ytt unit tests for the vsphere-cpi package 


## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
