### PR TITLE
Implements allowing users to set number of nodes for unmanaged-clusters

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -22,6 +22,7 @@ type createUnmanagedOpts struct {
 	podcidr                   string
 	servicecidr               string
 	portMapping               []string
+	numNodes                  string
 }
 
 const createDesc = `
@@ -62,6 +63,7 @@ func init() {
 	CreateCmd.Flags().StringSliceVarP(&co.portMapping, "port-map", "p", []string{}, "Ports to map between container node and the host (format: '80:80/tcp' or just '80')")
 	CreateCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
 	CreateCmd.Flags().BoolVar(&co.skipPreflightChecks, "skip-preflight", false, "Skip the preflight checks; default is false")
+	CreateCmd.Flags().StringVarP(&co.numNodes, "nodes", "n", "", "The number of nodes to deploy; default is 1 control-plane")
 }
 
 func create(cmd *cobra.Command, args []string) error {
@@ -85,6 +87,7 @@ func create(cmd *cobra.Command, args []string) error {
 		config.Cni:                       co.cni,
 		config.PodCIDR:                   co.podcidr,
 		config.ServiceCIDR:               co.servicecidr,
+		config.NumberOfNodes:             co.numNodes,
 	}
 	clusterConfig, err := config.InitializeConfiguration(configArgs)
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/config/config.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config.go
@@ -35,15 +35,17 @@ const (
 	ProtocolTCP               = "tcp"
 	ProtocolUDP               = "udp"
 	ProtocolSCTP              = "sctp"
+	NumberOfNodes             = "NumberOfNodes"
 )
 
 var defaultConfigValues = map[string]string{
-	TKRLocation: "projects.registry.vmware.com/tce/tkr:v1.21.5",
-	Provider:    "kind",
-	Cni:         "antrea",
-	PodCIDR:     "10.244.0.0/16",
-	ServiceCIDR: "10.96.0.0/16",
-	Tty:         "true",
+	TKRLocation:   "projects.registry.vmware.com/tce/tkr:v1.21.5",
+	Provider:      "kind",
+	Cni:           "antrea",
+	PodCIDR:       "10.244.0.0/16",
+	ServiceCIDR:   "10.96.0.0/16",
+	Tty:           "true",
+	NumberOfNodes: "1",
 }
 
 // PortMap is the mapping between a host port and a container port.
@@ -92,6 +94,9 @@ type UnmanagedClusterConfig struct {
 	// SkipPreflightChecks determines whether preflight checks are performed prior
 	// to attempting to deploy the cluster.
 	SkipPreflightChecks bool `yaml:"SkipPreflight"`
+	// NumberOfNodes is the number of nodes to deploy for the cluster.
+	// Default is 1
+	NumberOfNodes string `yaml:"NumberOfNodes"`
 }
 
 // KubeConfigPath gets the full path to the KubeConfig for this unmanaged cluster.

--- a/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
@@ -21,6 +21,7 @@ var emptyConfig = map[string]string{
 	Cni:               "",
 	PodCIDR:           "",
 	ServiceCIDR:       "",
+	NumberOfNodes:     "",
 }
 
 func TestInitializeConfigurationNoName(t *testing.T) {
@@ -60,6 +61,10 @@ func TestInitializeConfigurationDefaults(t *testing.T) {
 	if config.ServiceCidr != defaultConfigValues[ServiceCIDR] {
 		t.Errorf("expected default ServiceCidr, was: %q", config.ServiceCidr)
 	}
+
+	if config.NumberOfNodes != defaultConfigValues[NumberOfNodes] {
+		t.Errorf("expected default NumberOfNodes, was: %q", config.NumberOfNodes)
+	}
 }
 
 func TestInitializeConfigurationEnvVariables(t *testing.T) {
@@ -92,6 +97,10 @@ func TestInitializeConfigurationEnvVariables(t *testing.T) {
 
 	if config.ServiceCidr != defaultConfigValues[ServiceCIDR] {
 		t.Errorf("expected default ServiceCidr, was: %q", config.ServiceCidr)
+	}
+
+	if config.NumberOfNodes != defaultConfigValues[NumberOfNodes] {
+		t.Errorf("expected default NumberOfNodes value, was: %q", config.NumberOfNodes)
 	}
 }
 
@@ -127,6 +136,10 @@ func TestInitializeConfigurationArgsTakePrecedent(t *testing.T) {
 	if config.ServiceCidr != defaultConfigValues[ServiceCIDR] {
 		t.Errorf("expected default ServiceCidr, was: %q", config.ServiceCidr)
 	}
+
+	if config.NumberOfNodes != defaultConfigValues[NumberOfNodes] {
+		t.Errorf("expected default NumberOfNodes value, was: %q", config.NumberOfNodes)
+	}
 }
 
 func TestInitializeConfigurationFromConfigFile(t *testing.T) {
@@ -137,12 +150,13 @@ func TestInitializeConfigurationFromConfigFile(t *testing.T) {
 	yamlEncoder.SetIndent(2)
 
 	if err := yamlEncoder.Encode(UnmanagedClusterConfig{
-		ClusterName: "test3",
-		Provider:    "courteous",
-		Cni:         "bongos",
-		PodCidr:     "8.8.8.0/24",
-		ServiceCidr: "9.9.9.0/24",
-		TkrLocation: "here",
+		ClusterName:   "test3",
+		Provider:      "courteous",
+		Cni:           "bongos",
+		PodCidr:       "8.8.8.0/24",
+		ServiceCidr:   "9.9.9.0/24",
+		TkrLocation:   "here",
+		NumberOfNodes: "99",
 	}); err != nil {
 		t.Errorf("failed setting up test data")
 		return
@@ -187,6 +201,10 @@ func TestInitializeConfigurationFromConfigFile(t *testing.T) {
 
 	if config.ServiceCidr != "9.9.9.0/24" {
 		t.Errorf("expected ServiceCidr to be set to '9.9.9.0/24', was: %q", config.ServiceCidr)
+	}
+
+	if config.NumberOfNodes != "99" {
+		t.Errorf("expected NumberOfNodes to be set to 'bongos', was: %q", config.NumberOfNodes)
 	}
 }
 


### PR DESCRIPTION
## What this PR does / why we need it
Users can now provide `nodes` in configuration,or  the `--nodes` / `-n` flag to set the number of nodes.

The first node is always a control plane. Other nodes are automatically set to works for the `kind` provider.

_Note:_ This does not support scaling.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Can set number of nodes for unmanaged-cluster
```

## Which issue(s) this PR fixes
Fixes: #3121

## Describe testing done for PR
```
$ tanzu unmanaged-cluster create -n 3 meow
...

$ kubectl get pods -A
❯ k get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
kube-system          antrea-agent-7dcdm                           2/2     Running   0          43s
kube-system          antrea-agent-gvkqg                           2/2     Running   0          43s
kube-system          antrea-agent-vt86x                           2/2     Running   0          43s
kube-system          antrea-controller-c9cc8588b-4rsr9            1/1     Running   0          42s
kube-system          coredns-558bd4d5db-6nsz7                     1/1     Running   0          2m14s
kube-system          coredns-558bd4d5db-lrx2x                     1/1     Running   0          2m14s
kube-system          etcd-meow-control-plane                      1/1     Running   0          2m18s
kube-system          kube-apiserver-meow-control-plane            1/1     Running   0          2m18s
kube-system          kube-controller-manager-meow-control-plane   1/1     Running   0          2m18s
kube-system          kube-proxy-j6lcx                             1/1     Running   0          2m2s
kube-system          kube-proxy-m8rwg                             1/1     Running   0          2m15s
kube-system          kube-proxy-ntcbp                             1/1     Running   0          2m2s
kube-system          kube-scheduler-meow-control-plane            1/1     Running   0          2m18s
local-path-storage   local-path-provisioner-547f784dff-7hs8w      1/1     Running   0          2m14s
tkg-system           kapp-controller-f7dbbcb4f-jvzq5              1/1     Running   0          104s

$ kubectl get ndoes
NAME                 STATUS   ROLES                  AGE     VERSION
meow-control-plane   Ready    control-plane,master   2m39s   v1.21.5
meow-worker          Ready    <none>                 2m9s    v1.21.5
meow-worker2         Ready    <none>                 2m9s    v1.21.5

```
