### PR TITLE
Doc - Update the pkg repo version in docs for 0.10.0 release

### DIFF
--- a/docs/site/config.yaml
+++ b/docs/site/config.yaml
@@ -51,9 +51,9 @@ params:
   docs_latest: latest
   docs_versions:
     - latest
-  release_latest: v0.9.1
-  release_latest_no_v: 0.9.1
-  pkg_repo_latest: 0.9.2
+  release_latest: v0.10.0
+  release_latest_no_v: 0.10.0
+  pkg_repo_latest: 0.10.0
   release_versions:
     - v0.9.1
     - v0.9.0


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
-Update the `pkg_repo_latest` version in docs for 0.10.0 release
-Update the `release_latest`  and `release_latest_no_v ` values in docs for 0.10.0 release. my understanding here is that this was supposed to be done with automation, but this decision is now reversed and a PR is required as per https://github.com/vmware-tanzu/community-edition/pull/3148

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
Run `hugo server `as per instructions in [readme](https://github.com/vmware-tanzu/community-edition/blob/main/docs/README.md)

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
