### PR TITLE
Docs: Add missing separator in glossary section

### DIFF
--- a/docs/site/content/docs/latest/glossary.md
+++ b/docs/site/content/docs/latest/glossary.md
@@ -43,6 +43,8 @@ Same as packages (see below).
 
 ## I
 
+---
+
 ### imgpkg
 
 {{% include "/docs/assets/imgpkg-desc.md" %}}


### PR DESCRIPTION
Signed-off-by: Garry Ing <ging@vmware.com>

## What this PR does / why we need it
- Adds a separator element for the `I` section

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: n/a

## Describe testing done for PR
- `hugo serve`
- Visit `/docs/latest/glossary`

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
