### PR TITLE
Remove doc version automation

### DIFF
--- a/docs/site/config.yaml
+++ b/docs/site/config.yaml
@@ -51,11 +51,10 @@ params:
   docs_latest: latest
   docs_versions:
     - latest
-  release_latest: v0.10.0
-  release_latest_no_v: 0.10.0
+  release_latest: v0.9.1
+  release_latest_no_v: 0.9.1
   pkg_repo_latest: 0.9.2
   release_versions:
-    - v0.10.0
     - v0.9.1
     - v0.9.0
     - v0.8.0

--- a/hack/release/cut-release.sh
+++ b/hack/release/cut-release.sh
@@ -83,18 +83,6 @@ fi
 rm ./release-notes.txt
 popd || exit 1
 
-# update the current version for the dynamic versions in the docs when cutting GA only
-if [[ "${BUILD_VERSION}" != *"-"* ]]; then
-    pushd "./docs/site" || exit 1
-    echo "Update dynamic doc version..."
-
-    sed -i.bak -E "s/release_latest: v[0-9]+\.[0-9]+\.[0-9]+/release_latest: ${BUILD_VERSION}/g" ./config.yaml && rm ./config.yaml.bak
-    sed -i.bak -E "s/release_latest_no_v: [0-9]+\.[0-9]+\.[0-9]+/release_latest_no_v: ${BUILD_VERSION#"v"}/g" ./config.yaml && rm ./config.yaml.bak
-    sed -i.bak -E "s/release_versions:/release_versions:\n    - ${BUILD_VERSION}/g" ./config.yaml && rm ./config.yaml.bak
-
-    popd || exit 1
-fi
-
 NEW_BUILD_VERSION=""
 if [[ -f "./hack/NEW_BUILD_VERSION" ]]; then
     NEW_BUILD_VERSION=$(cat ./hack/NEW_BUILD_VERSION)
@@ -163,7 +151,6 @@ git add hack/DEV_BUILD_VERSION.yaml
 if [[ "${BUILD_VERSION}" != *"-"* ]]; then
     echo "${ACTUAL_COMMIT_SHA}" | tee ./hack/PREVIOUS_RELEASE_HASH
     git add hack/PREVIOUS_RELEASE_HASH
-    git add docs/site/config.yaml
 fi
 git commit -s -m "auto-generated - update dev version"
 git push origin "${WHICH_BRANCH}-update-${NEW_DEV_BUILD_VERSION}"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This removes the automation that updates/bumps the documentation version when a new GA release is posted.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Remove doc version automation
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/vmware-tanzu/community-edition/issues/3143

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA