### PR TITLE
Implements setting number of nodes for control-plane and workers

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -22,7 +22,8 @@ type createUnmanagedOpts struct {
 	podcidr                   string
 	servicecidr               string
 	portMapping               []string
-	numNodes                  string
+	numContPlanes             string
+	numWorkers                string
 }
 
 const createDesc = `
@@ -63,7 +64,8 @@ func init() {
 	CreateCmd.Flags().StringSliceVarP(&co.portMapping, "port-map", "p", []string{}, "Ports to map between container node and the host (format: '80:80/tcp' or just '80')")
 	CreateCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
 	CreateCmd.Flags().BoolVar(&co.skipPreflightChecks, "skip-preflight", false, "Skip the preflight checks; default is false")
-	CreateCmd.Flags().StringVarP(&co.numNodes, "nodes", "n", "", "The number of nodes to deploy; default is 1 control-plane")
+	CreateCmd.Flags().StringVar(&co.numContPlanes, "control-plane-node-count", "", "The number of control plane nodes to deploy; default is 1")
+	CreateCmd.Flags().StringVar(&co.numWorkers, "worker-node-count", "", "The number of worker nodes to deploy; default is 0")
 }
 
 func create(cmd *cobra.Command, args []string) error {
@@ -87,7 +89,8 @@ func create(cmd *cobra.Command, args []string) error {
 		config.Cni:                       co.cni,
 		config.PodCIDR:                   co.podcidr,
 		config.ServiceCIDR:               co.servicecidr,
-		config.NumberOfNodes:             co.numNodes,
+		config.ControlPlaneNodeCount:     co.numContPlanes,
+		config.WorkerNodeCount:           co.numWorkers,
 	}
 	clusterConfig, err := config.InitializeConfiguration(configArgs)
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/config/config.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config.go
@@ -35,17 +35,19 @@ const (
 	ProtocolTCP               = "tcp"
 	ProtocolUDP               = "udp"
 	ProtocolSCTP              = "sctp"
-	NumberOfNodes             = "NumberOfNodes"
+	ControlPlaneNodeCount     = "ControlPlaneNodeCount"
+	WorkerNodeCount           = "WorkerNodeCount"
 )
 
 var defaultConfigValues = map[string]string{
-	TKRLocation:   "projects.registry.vmware.com/tce/tkr:v1.21.5",
-	Provider:      "kind",
-	Cni:           "antrea",
-	PodCIDR:       "10.244.0.0/16",
-	ServiceCIDR:   "10.96.0.0/16",
-	Tty:           "true",
-	NumberOfNodes: "1",
+	TKRLocation:           "projects.registry.vmware.com/tce/tkr:v1.21.5",
+	Provider:              "kind",
+	Cni:                   "antrea",
+	PodCIDR:               "10.244.0.0/16",
+	ServiceCIDR:           "10.96.0.0/16",
+	Tty:                   "true",
+	ControlPlaneNodeCount: "1",
+	WorkerNodeCount:       "0",
 }
 
 // PortMap is the mapping between a host port and a container port.
@@ -94,9 +96,12 @@ type UnmanagedClusterConfig struct {
 	// SkipPreflightChecks determines whether preflight checks are performed prior
 	// to attempting to deploy the cluster.
 	SkipPreflightChecks bool `yaml:"SkipPreflight"`
-	// NumberOfNodes is the number of nodes to deploy for the cluster.
+	// ControlPlaneNodeCount is the number of control plane nodes to deploy for the cluster.
 	// Default is 1
-	NumberOfNodes string `yaml:"NumberOfNodes"`
+	ControlPlaneNodeCount string `yaml:"ControlPlaneNodeCount"`
+	// WorkerNodeCount is the number of worker nodes to deploy for the cluster.
+	// Default is 0
+	WorkerNodeCount string `yaml:"WorkerNodeCount"`
 }
 
 // KubeConfigPath gets the full path to the KubeConfig for this unmanaged cluster.

--- a/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
@@ -13,15 +13,16 @@ import (
 )
 
 var emptyConfig = map[string]string{
-	ClusterConfigFile: "",
-	ClusterName:       "",
-	Tty:               "",
-	TKRLocation:       "",
-	Provider:          "",
-	Cni:               "",
-	PodCIDR:           "",
-	ServiceCIDR:       "",
-	NumberOfNodes:     "",
+	ClusterConfigFile:     "",
+	ClusterName:           "",
+	Tty:                   "",
+	TKRLocation:           "",
+	Provider:              "",
+	Cni:                   "",
+	PodCIDR:               "",
+	ServiceCIDR:           "",
+	ControlPlaneNodeCount: "",
+	WorkerNodeCount:       "",
 }
 
 func TestInitializeConfigurationNoName(t *testing.T) {
@@ -62,8 +63,12 @@ func TestInitializeConfigurationDefaults(t *testing.T) {
 		t.Errorf("expected default ServiceCidr, was: %q", config.ServiceCidr)
 	}
 
-	if config.NumberOfNodes != defaultConfigValues[NumberOfNodes] {
-		t.Errorf("expected default NumberOfNodes, was: %q", config.NumberOfNodes)
+	if config.ControlPlaneNodeCount != defaultConfigValues[ControlPlaneNodeCount] {
+		t.Errorf("expected default ControlPlaneNodeCount, was: %q", config.ControlPlaneNodeCount)
+	}
+
+	if config.WorkerNodeCount != defaultConfigValues[WorkerNodeCount] {
+		t.Errorf("expected default WorkerNodeCount, was: %q", config.ControlPlaneNodeCount)
 	}
 }
 
@@ -99,8 +104,12 @@ func TestInitializeConfigurationEnvVariables(t *testing.T) {
 		t.Errorf("expected default ServiceCidr, was: %q", config.ServiceCidr)
 	}
 
-	if config.NumberOfNodes != defaultConfigValues[NumberOfNodes] {
-		t.Errorf("expected default NumberOfNodes value, was: %q", config.NumberOfNodes)
+	if config.ControlPlaneNodeCount != defaultConfigValues[ControlPlaneNodeCount] {
+		t.Errorf("expected default ControlPlaneNodeCount value, was: %q", config.ControlPlaneNodeCount)
+	}
+
+	if config.WorkerNodeCount != defaultConfigValues[WorkerNodeCount] {
+		t.Errorf("expected default WorkerNodeCount value, was: %q", config.WorkerNodeCount)
 	}
 }
 
@@ -137,8 +146,12 @@ func TestInitializeConfigurationArgsTakePrecedent(t *testing.T) {
 		t.Errorf("expected default ServiceCidr, was: %q", config.ServiceCidr)
 	}
 
-	if config.NumberOfNodes != defaultConfigValues[NumberOfNodes] {
-		t.Errorf("expected default NumberOfNodes value, was: %q", config.NumberOfNodes)
+	if config.ControlPlaneNodeCount != defaultConfigValues[ControlPlaneNodeCount] {
+		t.Errorf("expected default ControlPlaneNodeCount value, was: %q", config.ControlPlaneNodeCount)
+	}
+
+	if config.WorkerNodeCount != defaultConfigValues[WorkerNodeCount] {
+		t.Errorf("expected default WorkerNodeCount value, was: %q", config.WorkerNodeCount)
 	}
 }
 
@@ -150,13 +163,14 @@ func TestInitializeConfigurationFromConfigFile(t *testing.T) {
 	yamlEncoder.SetIndent(2)
 
 	if err := yamlEncoder.Encode(UnmanagedClusterConfig{
-		ClusterName:   "test3",
-		Provider:      "courteous",
-		Cni:           "bongos",
-		PodCidr:       "8.8.8.0/24",
-		ServiceCidr:   "9.9.9.0/24",
-		TkrLocation:   "here",
-		NumberOfNodes: "99",
+		ClusterName:           "test3",
+		Provider:              "courteous",
+		Cni:                   "bongos",
+		PodCidr:               "8.8.8.0/24",
+		ServiceCidr:           "9.9.9.0/24",
+		TkrLocation:           "here",
+		ControlPlaneNodeCount: "99",
+		WorkerNodeCount:       "25",
 	}); err != nil {
 		t.Errorf("failed setting up test data")
 		return
@@ -203,8 +217,12 @@ func TestInitializeConfigurationFromConfigFile(t *testing.T) {
 		t.Errorf("expected ServiceCidr to be set to '9.9.9.0/24', was: %q", config.ServiceCidr)
 	}
 
-	if config.NumberOfNodes != "99" {
-		t.Errorf("expected NumberOfNodes to be set to 'bongos', was: %q", config.NumberOfNodes)
+	if config.ControlPlaneNodeCount != "99" {
+		t.Errorf("expected ControlPlaneNodeCount to be set to '99', was: %q", config.ControlPlaneNodeCount)
+	}
+
+	if config.WorkerNodeCount != "25" {
+		t.Errorf("expected WorkerNodeCount to be set to '25', was: %q", config.WorkerNodeCount)
 	}
 }
 


### PR DESCRIPTION
## What this PR does / why we need it

This commit enables `unmanaged-clusters` to support _both_
setting control-plane nodes _and_ worker nodes, not just an
arbitrary number of nodes (where 1 automatically
is set to a control plane)

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
unmanaged-cluster can set both/either control-plane nodes and worker nodes
```

## Which issue(s) this PR fixes
Fixes: #3145

## Describe testing done for PR
```shell
# default behavior preserved ...
$ tanzu unmanaged-cluster create test1
...

$ kubectl get nodes
NAME                  STATUS   ROLES                  AGE     VERSION
test1-control-plane   Ready    control-plane,master   48s     v1.21.5

$ tanzu unmanaged-cluster delete test1
...

# can set any number of control plane and worker nodes
$ tanzu unmanaged-cluster create life --control-plane-node-count 2 --worker-node-count 2
...

$ kubectl get pods -A
NAMESPACE            NAME                                          READY   STATUS    RESTARTS   AGE
kube-system          antrea-agent-ft87c                            2/2     Running   0          3m40s
kube-system          antrea-agent-gpsbd                            2/2     Running   0          3m40s
kube-system          antrea-agent-qks7d                            2/2     Running   0          3m40s
kube-system          antrea-agent-szp6x                            2/2     Running   0          3m40s
kube-system          antrea-controller-67846968bb-5b5zq            1/1     Running   0          3m40s
kube-system          coredns-558bd4d5db-cgn4q                      1/1     Running   0          6m32s
kube-system          coredns-558bd4d5db-kwzg4                      1/1     Running   0          6m32s
kube-system          etcd-life-control-plane                       1/1     Running   0          6m31s
kube-system          etcd-life-control-plane2                      1/1     Running   0          6m16s
kube-system          kube-apiserver-life-control-plane             1/1     Running   0          6m31s
kube-system          kube-apiserver-life-control-plane2            1/1     Running   0          6m17s
kube-system          kube-controller-manager-life-control-plane    1/1     Running   1          6m31s
kube-system          kube-controller-manager-life-control-plane2   1/1     Running   0          6m18s
kube-system          kube-proxy-87wmg                              1/1     Running   0          5m25s
kube-system          kube-proxy-c5zbg                              1/1     Running   0          5m25s
kube-system          kube-proxy-dv5s7                              1/1     Running   0          6m33s
kube-system          kube-proxy-vpp4g                              1/1     Running   0          6m18s
kube-system          kube-scheduler-life-control-plane             1/1     Running   1          6m31s
kube-system          kube-scheduler-life-control-plane2            1/1     Running   0          6m17s
local-path-storage   local-path-provisioner-547f784dff-2qvs2       1/1     Running   0          6m32s
tkg-system           kapp-controller-f7dbbcb4f-szzlf               1/1     Running   0          5m4s


$ kubectl get nodes
NAME                  STATUS   ROLES                  AGE     VERSION
life-control-plane    Ready    control-plane,master   6m48s   v1.21.5
life-control-plane2   Ready    control-plane,master   6m22s   v1.21.5
life-worker           Ready    <none>                 5m29s   v1.21.5
life-worker2          Ready    <none>                 5m29s   v1.21.5

```

---

Note: Per Sean's comments, this does _not_ support users deploying multiple control planes with no worker nodes. It will error out. After this merges, I will create an issue to support removing the taint from the control plane nodes if there are no worker nodes present.
