### PR TITLE
[vsphere-cpi] Add new flags `insecure` and `remoteAuthEnabled`

### DIFF
--- a/addons/packages/vsphere-cpi/1.18.1/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.18.1/bundle/config/values.star
@@ -37,7 +37,7 @@ def validate_nsxt_cert():
 end
 
 def validate_nsxt_secret():
-   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "" or validate_nsxt_username_password() == False:
+   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "":
      return False
    end
    return True

--- a/addons/packages/vsphere-cpi/1.18.1/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-cpi/1.18.1/bundle/config/vsphereconf.lib.txt
@@ -43,7 +43,7 @@ router-path = "(@=values.vsphereCPI.nsxt.routes.routerPath @)"
 host = "(@=values.vsphereCPI.nsxt.host @)"
 insecure-flag = "(@=str(values.vsphereCPI.nsxt.insecureFlag).lower() @)"
 remote-auth = "(@=str(values.vsphereCPI.nsxt.remoteAuth).lower() @)"
-(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace and values.vsphereCPI.nsxt.username and values.vsphereCPI.nsxt.password  : -@)
+(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace: -@)
 secret-name = "(@=values.vsphereCPI.nsxt.secretName @)"
 secret-namespace = "(@=values.vsphereCPI.nsxt.secretNamespace @)"
 (@ end -@)

--- a/addons/packages/vsphere-cpi/1.19.1/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.19.1/bundle/config/values.star
@@ -37,7 +37,7 @@ def validate_nsxt_cert():
 end
 
 def validate_nsxt_secret():
-   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "" or validate_nsxt_username_password() == False:
+   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "":
      return False
    end
    return True

--- a/addons/packages/vsphere-cpi/1.19.1/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-cpi/1.19.1/bundle/config/vsphereconf.lib.txt
@@ -43,7 +43,7 @@ router-path = "(@=values.vsphereCPI.nsxt.routes.routerPath @)"
 host = "(@=values.vsphereCPI.nsxt.host @)"
 insecure-flag = "(@=str(values.vsphereCPI.nsxt.insecureFlag).lower() @)"
 remote-auth = "(@=str(values.vsphereCPI.nsxt.remoteAuth).lower() @)"
-(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace and values.vsphereCPI.nsxt.username and values.vsphereCPI.nsxt.password  : -@)
+(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace: -@)
 secret-name = "(@=values.vsphereCPI.nsxt.secretName @)"
 secret-namespace = "(@=values.vsphereCPI.nsxt.secretNamespace @)"
 (@ end -@)

--- a/addons/packages/vsphere-cpi/1.20.0/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.20.0/bundle/config/values.star
@@ -37,7 +37,7 @@ def validate_nsxt_cert():
 end
 
 def validate_nsxt_secret():
-   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "" or validate_nsxt_username_password() == False:
+   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "":
      return False
    end
    return True

--- a/addons/packages/vsphere-cpi/1.20.0/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-cpi/1.20.0/bundle/config/vsphereconf.lib.txt
@@ -51,7 +51,7 @@ remote-auth = "true"
 (@ else: -@)
 remote-auth = "false"
 (@ end -@)
-(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace and values.vsphereCPI.nsxt.username and values.vsphereCPI.nsxt.password  : -@)
+(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace: -@)
 secret-name = "(@=values.vsphereCPI.nsxt.secretName @)"
 secret-namespace = "(@=values.vsphereCPI.nsxt.secretNamespace @)"
 (@ end -@)

--- a/addons/packages/vsphere-cpi/1.21.0/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.21.0/bundle/config/values.star
@@ -37,7 +37,7 @@ def validate_nsxt_cert():
 end
 
 def validate_nsxt_secret():
-   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "" or validate_nsxt_username_password() == False:
+   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "":
      return False
    end
    return True

--- a/addons/packages/vsphere-cpi/1.21.0/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-cpi/1.21.0/bundle/config/vsphereconf.lib.txt
@@ -51,7 +51,7 @@ remote-auth = "true"
 (@ else: -@)
 remote-auth = "false"
 (@ end -@)
-(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace and values.vsphereCPI.nsxt.username and values.vsphereCPI.nsxt.password  : -@)
+(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace: -@)
 secret-name = "(@=values.vsphereCPI.nsxt.secretName @)"
 secret-namespace = "(@=values.vsphereCPI.nsxt.secretNamespace @)"
 (@ end -@)

--- a/addons/packages/vsphere-cpi/1.22.4/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.22.4/bundle/config/values.star
@@ -37,7 +37,7 @@ def validate_nsxt_cert():
 end
 
 def validate_nsxt_secret():
-   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "" or validate_nsxt_username_password() == False:
+   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "":
      return False
    end
    return True

--- a/addons/packages/vsphere-cpi/1.22.4/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-cpi/1.22.4/bundle/config/vsphereconf.lib.txt
@@ -51,7 +51,7 @@ remote-auth = "true"
 (@ else: -@)
 remote-auth = "false"
 (@ end -@)
-(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace and values.vsphereCPI.nsxt.username and values.vsphereCPI.nsxt.password  : -@)
+(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace: -@)
 secret-name = "(@=values.vsphereCPI.nsxt.secretName @)"
 secret-namespace = "(@=values.vsphereCPI.nsxt.secretNamespace @)"
 (@ end -@)

--- a/addons/packages/vsphere-cpi/1.22.5/README.md
+++ b/addons/packages/vsphere-cpi/1.22.5/README.md
@@ -34,8 +34,10 @@ None
 | `vsphereCPI.nsxt.username` | Optional | The username used to access NSX-T. Default: `""`. |
 | `vsphereCPI.nsxt.password` | Optional | The password used to access NSX-T. Default: `""`. |
 | `vsphereCPI.nsxt.host`| Optional | The NSX-T server. Default: `null`. |
-| `vsphereCPI.nsxt.insecureFlag` | Optional | InsecureFlag is to be set to true if NSX-T uses self-signed cert. Default: `false`. |
-| `vsphereCPI.nsxt.remoteAuth` | Optional | RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM). Default: `false`. |
+| `vsphereCPI.nsxt.insecureFlag` | Optional | (Deprecated. For backward compatibiility. Will be replaced by insecure. If both set, result is insecureFlag || insecure) InsecureFlag is to be set to true if NSX-T uses self-signed cert. Default: `"false"`. |
+| `vsphereCPI.nsxt.insecure` | Optional | Insecure is to be set to true if NSX-T uses self-signed cert. Default is `false`. |
+| `vsphereCPI.nsxt.remoteAuth` | Optional | (Deprecated. For backward compatibiility. Will be replaced by removeAuthEnabled. If both set, result is remoteAuth || remoteAuthEnabled). RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM). Default: `"false"`. |
+| `vsphereCPI.nsxt.RemoteAuthEnabled` | Optional | RemoteAuthEnabled is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM). Default: `false`. |
 | `vsphereCPI.nsxt.vmcAccessToken`| Optional | VMCAccessToken is VMC access token for token based authentification. Default: `""`. |
 | `vsphereCPI.nsxt.vmcAuthHost` | Optional | VMCAuthHost is VMC verification host for token based authentification. Default: `""`. |
 | `vsphereCPI.nsxt.clientCertKeyData` | Optional | Client certificate key. Default: `""`. |

--- a/addons/packages/vsphere-cpi/1.22.5/bundle/config/schema.yaml
+++ b/addons/packages/vsphere-cpi/1.22.5/bundle/config/schema.yaml
@@ -56,10 +56,14 @@ vsphereCPI:
     #@schema/desc "The NSX-T server"
     #@schema/nullable
     host: ""
-    #@schema/desc "InsecureFlag is to be set to true if NSX-T uses self-signed cert"
-    insecureFlag: false
-    #@schema/desc "RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)"
-    remoteAuth: false
+    #@schema/desc "(Deprecated. For backward compatibiility. Will be replaced by insecure. If both set, result is insecureFlag || insecure) InsecureFlag is to be set to true if NSX-T uses self-signed cert"
+    insecureFlag: "false"
+    #@schema/desc "(Deprecated. For backward compatibiility. Will be replaced by removeAuthEnabled. If both set, result is remoteAuth || remoteAuthEnabled). RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)"
+    remoteAuth: "false"
+    #@schema/desc "Insecure is to be set to true if NSX-T uses self-signed cert"
+    insecure: false
+    #@schema/desc "RemoteAuthEnabled is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)"
+    remoteAuthEnabled: false
     #@schema/desc "VMCAccessToken is VMC access token for token based authentification"
     vmcAccessToken: ""
     #@schema/desc "VMCAuthHost is VMC verification host for token based authentification"
@@ -80,3 +84,13 @@ vsphereCPI:
   https_proxy: ""
   #@schema/desc "No-proxy setting"
   no_proxy: ""
+  #! Deprecated. Kept for backward compatibility
+  image:
+    #@schema/desc "The repository of CPI image"
+    repository: ""
+    #@schema/desc "The path of image"
+    path: ""
+    #@schema/desc "The image tag"
+    tag: ""
+    #@schema/desc "The pull policy of image"
+    pullPolicy: IfNotPresent

--- a/addons/packages/vsphere-cpi/1.22.5/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.22.5/bundle/config/values.star
@@ -37,7 +37,7 @@ def validate_nsxt_cert():
 end
 
 def validate_nsxt_secret():
-   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "" or validate_nsxt_username_password() == False:
+   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "":
      return False
    end
    return True

--- a/addons/packages/vsphere-cpi/1.22.5/bundle/config/values.yaml
+++ b/addons/packages/vsphere-cpi/1.22.5/bundle/config/values.yaml
@@ -26,8 +26,10 @@ vsphereCPI:
     username: ""
     password: ""
     host: null
-    insecureFlag: false
-    remoteAuth: false
+    insecureFlag: "false"
+    insecure: false
+    remoteAuth: "false"
+    remoteAuthEnabled: false
     vmcAccessToken: ""
     vmcAuthHost: ""
     clientCertKeyData: ""

--- a/addons/packages/vsphere-cpi/1.22.5/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-cpi/1.22.5/bundle/config/vsphereconf.lib.txt
@@ -47,17 +47,17 @@ exclude-external-network-subnet-cidr = "(@=values.vsphereCPI.vmExcludeExternalNe
 router-path = "(@=values.vsphereCPI.nsxt.routes.routerPath @)"
 [NSXT]
 host = "(@=values.vsphereCPI.nsxt.host @)"
-(@ if values.vsphereCPI.nsxt.insecureFlag: -@)
+(@ if values.vsphereCPI.nsxt.insecure or str(values.vsphereCPI.nsxt.insecureFlag).lower() == "true" : -@)
 insecure-flag = true
 (@ else: -@)
 insecure-flag = false
 (@ end -@)
-(@ if values.vsphereCPI.nsxt.remoteAuth: -@)
+(@ if values.vsphereCPI.nsxt.remoteAuthEnabled or str(values.vsphereCPI.nsxt.remoteAuth).lower() == "true" : -@)
 remote-auth = true
 (@ else: -@)
 remote-auth = false
 (@ end -@)
-(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace and values.vsphereCPI.nsxt.username and values.vsphereCPI.nsxt.password  : -@)
+(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace : -@)
 secret-name = "(@=values.vsphereCPI.nsxt.secretName @)"
 secret-namespace = "(@=values.vsphereCPI.nsxt.secretNamespace @)"
 (@ end -@)

--- a/addons/packages/vsphere-cpi/1.22.5/package.yaml
+++ b/addons/packages/vsphere-cpi/1.22.5/package.yaml
@@ -135,13 +135,21 @@ spec:
                   nullable: true
                   description: The NSX-T server
                 insecureFlag:
-                  type: boolean
-                  default: false
-                  description: InsecureFlag is to be set to true if NSX-T uses self-signed cert
+                  type: string
+                  default: "false"
+                  description: (Deprecated. For backward compatibiility. Will be replaced by insecure. If both set, result is insecureFlag || insecure) InsecureFlag is to be set to true if NSX-T uses self-signed cert
                 remoteAuth:
+                  type: string
+                  default: "false"
+                  description: (Deprecated. For backward compatibiility. Will be replaced by removeAuthEnabled. If both set, result is remoteAuth || remoteAuthEnabled). RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)
+                insecure:
                   type: boolean
                   default: false
-                  description: RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)
+                  description: Insecure is to be set to true if NSX-T uses self-signed cert
+                remoteAuthEnabled:
+                  type: boolean
+                  default: false
+                  description: RemoteAuthEnabled is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)
                 vmcAccessToken:
                   type: string
                   default: ""
@@ -182,3 +190,23 @@ spec:
               type: string
               default: ""
               description: No-proxy setting
+            image:
+              type: object
+              additionalProperties: false
+              properties:
+                repository:
+                  type: string
+                  default: ""
+                  description: The repository of CPI image
+                path:
+                  type: string
+                  default: ""
+                  description: The path of image
+                tag:
+                  type: string
+                  default: ""
+                  description: The image tag
+                pullPolicy:
+                  type: string
+                  default: IfNotPresent
+                  description: The pull policy of image

--- a/addons/packages/vsphere-cpi/1.22.5/sample-values/vsphere-cpi.yaml
+++ b/addons/packages/vsphere-cpi/1.22.5/sample-values/vsphere-cpi.yaml
@@ -22,8 +22,10 @@ vsphereCPI:
     username: ""
     password: ""
     host: null
-    insecureFlag: false
-    remoteAuth: false
+    insecureFlag: "false"
+    insecure: false
+    remoteAuth: "false"
+    remoteAuthEnabled: false
     vmcAccessToken: ""
     vmcAuthHost: ""
     clientCertKeyData: ""

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/README.md
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/README.md
@@ -35,8 +35,10 @@ None
 | `vsphereCPI.nsxt.username` | Optional | The username used to access NSX-T. Default: `""`. |
 | `vsphereCPI.nsxt.password` | Optional | The password used to access NSX-T. Default: `""`. |
 | `vsphereCPI.nsxt.host`| Optional | The NSX-T server. Default: `""`. |
-| `vsphereCPI.nsxt.insecureFlag` | Optional | InsecureFlag is to be set to true if NSX-T uses self-signed cert. Default: `false`. |
-| `vsphereCPI.nsxt.remoteAuth` | Optional | RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM). Default: `false`. |
+| `vsphereCPI.nsxt.insecureFlag` | Optional | (Deprecated. For backward compatibiility. Will be replaced by insecure. If both set, result is insecureFlag || insecure) InsecureFlag is to be set to true if NSX-T uses self-signed cert. Default: `"false"`. |
+| `vsphereCPI.nsxt.insecure` | Optional | Insecure is to be set to true if NSX-T uses self-signed cert. Default is `false`. |
+| `vsphereCPI.nsxt.remoteAuth` | Optional | (Deprecated. For backward compatibiility. Will be replaced by removeAuthEnabled. If both set, result is remoteAuth || remoteAuthEnabled). RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM). Default: `"false"`. |
+| `vsphereCPI.nsxt.RemoteAuthEnabled` | Optional | RemoteAuthEnabled is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM). Default: `false`. |
 | `vsphereCPI.nsxt.vmcAccessToken`| Optional | VMCAccessToken is VMC access token for token based authentification. Default: `""`. |
 | `vsphereCPI.nsxt.vmcAuthHost` | Optional | VMCAuthHost is VMC verification host for token based authentification. Default: `""`. |
 | `vsphereCPI.nsxt.clientCertKeyData` | Optional | Client certificate key. Default: `""`. |

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/schema.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/schema.yaml
@@ -34,10 +34,10 @@ vsphereCPI:
   #@schema/desc "External VM network name"
   #@schema/nullable
   vmExternalNetwork: ""
-  #@schema/desc "Internal VM network cidr to be excluded."
+  #@schema/desc "Comma separated list of internal network subnets to exclude from node IP selection."
   #@schema/nullable
   vmExcludeInternalNetworkSubnetCidr: ""
-  #@schema/desc "External VM network cidr to be excluded."
+  #@schema/desc "Comma separated list of external network subnets to exclude from node IP selection."
   #@schema/nullable
   vmExcludeExternalNetworkSubnetCidr: ""
   #@schema/desc "Extra arguments for the cloud-provider-vsphere."
@@ -59,10 +59,14 @@ vsphereCPI:
     #@schema/desc "The NSX-T server"
     #@schema/nullable
     host: ""
-    #@schema/desc "InsecureFlag is to be set to true if NSX-T uses self-signed cert"
-    insecureFlag: false
-    #@schema/desc "RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)"
-    remoteAuth: false
+    #@schema/desc "(Deprecated. For backward compatibiility. Will be replaced by insecure. If both set, result is insecureFlag || insecure) InsecureFlag is to be set to true if NSX-T uses self-signed cert"
+    insecureFlag: "false"
+    #@schema/desc "(Deprecated. For backward compatibiility. Will be replaced by removeAuthEnabled. If both set, result is remoteAuth || remoteAuthEnabled). RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)"
+    remoteAuth: "false"
+    #@schema/desc "Insecure is to be set to true if NSX-T uses self-signed cert"
+    insecure: false
+    #@schema/desc "RemoteAuthEnabled is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)"
+    remoteAuthEnabled: false
     #@schema/desc "VMCAccessToken is VMC access token for token based authentification"
     vmcAccessToken: ""
     #@schema/desc "VMCAuthHost is VMC verification host for token based authentification"
@@ -97,3 +101,13 @@ vsphereCPI:
   supervisorMasterPort: ""
   #@schema/desc "Enable pod routing with Antrea NSX"
   antreaNSXPodRoutingEnabled: false
+  #! Deprecated. Kept for backward compatibility
+  image:
+    #@schema/desc "The repository of CPI image"
+    repository: ""
+    #@schema/desc "The path of image"
+    path: ""
+    #@schema/desc "The image tag"
+    tag: ""
+    #@schema/desc "The pull policy of image"
+    pullPolicy: ""

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/values.star
@@ -46,7 +46,7 @@ def validate_nsxt_cert():
 end
 
 def validate_nsxt_secret():
-   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "" or validate_nsxt_username_password() == False:
+   if data.values.vsphereCPI.nsxt.secretName == "" or data.values.vsphereCPI.nsxt.secretNamespace == "":
      return False
    end
    return True

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/values.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/values.yaml
@@ -27,8 +27,10 @@ vsphereCPI:
     username: ""
     password: ""
     host: null
-    insecureFlag: false
-    remoteAuth: false
+    insecureFlag: "false"
+    insecure: false
+    remoteAuth: "false"
+    remoteAuthEnabled: false
     vmcAccessToken: ""
     vmcAuthHost: ""
     clientCertKeyData: ""

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/vsphereconf.lib.txt
@@ -47,17 +47,17 @@ exclude-external-network-subnet-cidr = "(@=values.vsphereCPI.vmExcludeExternalNe
 router-path = "(@=values.vsphereCPI.nsxt.routes.routerPath @)"
 [NSXT]
 host = "(@=values.vsphereCPI.nsxt.host @)"
-(@ if values.vsphereCPI.nsxt.insecureFlag: -@)
+(@ if values.vsphereCPI.nsxt.insecure or str(values.vsphereCPI.nsxt.insecureFlag).lower() == "true" : -@)
 insecure-flag = true
 (@ else: -@)
 insecure-flag = false
 (@ end -@)
-(@ if values.vsphereCPI.nsxt.remoteAuth: -@)
+(@ if values.vsphereCPI.nsxt.remoteAuthEnabled or str(values.vsphereCPI.nsxt.remoteAuth).lower() == "true" : -@)
 remote-auth = true
 (@ else: -@)
 remote-auth = false
 (@ end -@)
-(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace and values.vsphereCPI.nsxt.username and values.vsphereCPI.nsxt.password  : -@)
+(@ if values.vsphereCPI.nsxt.secretName and values.vsphereCPI.nsxt.secretNamespace : -@)
 secret-name = "(@=values.vsphereCPI.nsxt.secretName @)"
 secret-namespace = "(@=values.vsphereCPI.nsxt.secretNamespace @)"
 (@ end -@)

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/package.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/package.yaml
@@ -91,12 +91,12 @@ spec:
               type: string
               default: null
               nullable: true
-              description: Internal VM network cidr to be excluded.
+              description: Comma separated list of internal network subnets to exclude from node IP selection.
             vmExcludeExternalNetworkSubnetCidr:
               type: string
               default: null
               nullable: true
-              description: External VM network cidr to be excluded.
+              description: Comma separated list of external network subnets to exclude from node IP selection.
             cloudProviderExtraArgs:
               type: object
               additionalProperties: false
@@ -140,13 +140,21 @@ spec:
                   nullable: true
                   description: The NSX-T server
                 insecureFlag:
-                  type: boolean
-                  default: false
-                  description: InsecureFlag is to be set to true if NSX-T uses self-signed cert
+                  type: string
+                  default: "false"
+                  description: (Deprecated. For backward compatibiility. Will be replaced by insecure. If both set, result is insecureFlag || insecure) InsecureFlag is to be set to true if NSX-T uses self-signed cert
                 remoteAuth:
+                  type: string
+                  default: "false"
+                  description: (Deprecated. For backward compatibiility. Will be replaced by removeAuthEnabled. If both set, result is remoteAuth || remoteAuthEnabled). RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)
+                insecure:
                   type: boolean
                   default: false
-                  description: RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)
+                  description: Insecure is to be set to true if NSX-T uses self-signed cert
+                remoteAuthEnabled:
+                  type: boolean
+                  default: false
+                  description: RemoteAuthEnabled is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)
                 vmcAccessToken:
                   type: string
                   default: ""
@@ -215,3 +223,23 @@ spec:
               type: boolean
               default: false
               description: Enable pod routing with Antrea NSX
+            image:
+              type: object
+              additionalProperties: false
+              properties:
+                repository:
+                  type: string
+                  default: ""
+                  description: The repository of CPI image
+                path:
+                  type: string
+                  default: ""
+                  description: The path of image
+                tag:
+                  type: string
+                  default: ""
+                  description: The image tag
+                pullPolicy:
+                  type: string
+                  default: ""
+                  description: The pull policy of image

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/sample-values/vsphere-cpi.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/sample-values/vsphere-cpi.yaml
@@ -21,8 +21,10 @@ vsphereCPI:
     username: ""
     password: ""
     host: null
-    insecureFlag: false
-    remoteAuth: false
+    insecureFlag: "false"
+    insecure: false
+    remoteAuth: "false"
+    remoteAuthEnabled: false
     vmcAccessToken: ""
     vmcAuthHost: ""
     clientCertKeyData: ""

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/test/vsphere_cpi_test.go
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/test/vsphere_cpi_test.go
@@ -8,17 +8,17 @@ import (
 	"path/filepath"
 	"strings"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/config"
+	nsxconfig "k8s.io/cloud-provider-vsphere/pkg/nsxt/config"
 	"sigs.k8s.io/yaml"
 
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/repo"
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/ytt"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/providers/tests/unit/matchers"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("vSphere CPI Ytt Templates", func() {
@@ -581,6 +581,39 @@ vsphereCPI:
 				})
 			})
 		})
+
+		Context("Deprecate insecureFlag and remoteAuth", func() {
+			When("insecureFlag and remoteAuth are set", func() {
+				BeforeEach(func() {
+					values = `#@data/values
+#@overlay/match-child-defaults missing_ok=True
+---
+vsphereCPI:
+server: fake-server.com
+datacenter: dc0
+username: my-user
+password: my-password
+insecureFlag: True
+nsxt:
+podRoutingEnabled: true
+host: "test"
+routes:
+routerPath: ""
+clusterCidr: "10.0.0.0/12"
+secretName: "cloud-provider-vsphere-nsxt-credentials"
+secretNamespace: "kube-system"
+insecureFlag: "true"
+# remoteAuth: "true"`
+				})
+
+				It("correctly sets the value in the INI", func() {
+					Expect(yttRenderErr).NotTo(HaveOccurred())
+					Expect(nsxtConfiguration(output).InsecureFlag).To(Equal(true), "InsecureFlag should be true")
+					// TODO: enable this with new CPI version once the cloud provider vsphere has the fix https://github.com/kubernetes/cloud-provider-vsphere/issues/588
+					// Expect(nsxtConfiguration(output).RemoteAuth).To(Equal(true), "RemoteAuth should be true")
+				})
+			})
+		})
 	})
 })
 
@@ -769,6 +802,22 @@ func vsphereParavirtualDocuments(output string) {
 	}))
 }
 
+func nsxtConfig(output string) *nsxconfig.Config {
+	configMaps := unmarshalConfigMaps(output)
+	Expect(configMaps).NotTo(BeEmpty())
+	vsphereConf := findConfigMapByName(configMaps, "vsphere-cloud-config")
+	Expect(vsphereConf).NotTo(BeNil())
+	rawConfigINI := []byte(vsphereConf.Data["vsphere.conf"])
+	Expect(rawConfigINI).NotTo(BeNil())
+	nsxConfig, err := nsxconfig.ReadConfigINI(rawConfigINI)
+	Expect(err).NotTo(HaveOccurred())
+	return nsxConfig
+}
+
 func tlsThumbprint(output string) string {
 	return cpiConfig(output).Global.Thumbprint
+}
+
+func nsxtConfiguration(output string) *nsxconfig.Config {
+	return nsxtConfig(output)
 }


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
`remoteAuth` and `insecureFlag` is still needed for backward compatibility. 
We introduce new flag `remoteAuthEnable` and `insecure` with boolean type to replace these two

At the same time, fix some NSXT credentials parsing logic
Found an upstream CPI issue: https://github.com/kubernetes/cloud-provider-vsphere/issues/588

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add field `insecure` `remoteAuthEnabled ` with boolean type. `remoteAuth` and `insecureFlag` were kept for backward compatibility. `Image` field is added for the same reason.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: # 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
