### PR TITLE
Fix the upload of GCP artifacts to bucket

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -54,7 +54,9 @@ jobs:
           make get-deps
       - name: Build
         shell: bash
-        run: make build-tce-cli-plugins
+        run: |
+          make prep-gcp-tce-bucket
+          make build-tce-cli-plugins
       - name: Upload Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main

--- a/.github/workflows/release-ga-bucket.yaml
+++ b/.github/workflows/release-ga-bucket.yaml
@@ -64,7 +64,7 @@ jobs:
         shell: bash
         run: |
           make ensure-deps
-          make release-bucket
+          make release-buckets
       - name: Upload TCE Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main

--- a/.github/workflows/release-nonga-bucket.yaml
+++ b/.github/workflows/release-nonga-bucket.yaml
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         run: |
           make ensure-deps
-          make release-bucket
+          make release-buckets
       - name: Upload TCE Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main

--- a/Makefile
+++ b/Makefile
@@ -267,9 +267,27 @@ cut-release: version
 	hack/release/cut-release.sh
 	echo "$(BUILD_VERSION)" | tee -a ./cayman_trigger.txt
 
+.PHONY: prep-gcp-tanzu-bucket
+prep-gcp-tanzu-bucket:
+	TCE_SCRATCH_DIR=${TCE_SCRATCH_DIR} \
+	TANZU_FRAMEWORK_REPO=${TANZU_FRAMEWORK_REPO} \
+	TKG_DEFAULT_IMAGE_REPOSITORY=${TKG_DEFAULT_IMAGE_REPOSITORY} \
+	TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH=${TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH} \
+	TANZU_FRAMEWORK_REPO_BRANCH=${TANZU_FRAMEWORK_REPO_BRANCH} \
+	TANZU_FRAMEWORK_REPO_HASH=${TANZU_FRAMEWORK_REPO_HASH} \
+	BUILD_EDITION=tce TCE_BUILD_VERSION=$(BUILD_VERSION) \
+	FRAMEWORK_BUILD_VERSION=${FRAMEWORK_BUILD_VERSION} ENVS="${ENVS}" hack/builder/prep-gcp-tanzu.sh
+
+.PHONY: prep-gcp-tce-bucket
+prep-gcp-tce-bucket:
+	hack/builder/prep-gcp-tce.sh
+
 .PHONY: prune-buckets
-prune-buckets: version
+prune-buckets:
 	TCE_SCRATCH_DIR=${TCE_SCRATCH_DIR} hack/release/prune-buckets.sh
+
+.PHONY: release-buckets
+release-buckets: version prep-gcp-tanzu-bucket prep-gcp-tce-bucket build-cli-plugins prune-buckets
 
 .PHONY: upload-signed-assets
 upload-signed-assets:

--- a/hack/builder/Makefile
+++ b/hack/builder/Makefile
@@ -102,12 +102,12 @@ compile: check ## Compiles the TCE plugins using the Tanzu Framework builder
 	--version $(BUILD_VERSION) --ldflags "$(LD_FLAGS)" --path ../../cli/cmd/plugin \
 	--ldflags "$(LD_FLAGS) -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/config.DefaultStandaloneDiscoveryType=local'" \
 	--artifacts ../../${ARTIFACTS_DIR}/${OS}/${ARCH}/cli --target ${OS}_${ARCH}
+
+install-plugins: check ## Installs the compiled TCE plugins
 	$(GO) run github.com/vmware-tanzu/tanzu-framework/cmd/cli/plugin-admin/builder publish \
 	--type local --plugins "$(PLUGINS)" --version $(BUILD_VERSION) --os-arch "${OS}-${ARCH}" \
 	--local-output-discovery-dir "../../build/${OS}-${ARCH}-$(DISCOVERY_NAME)/discovery/$(DISCOVERY_NAME)" \
 	--local-output-distribution-dir "../../build/${OS}-${ARCH}-$(DISCOVERY_NAME)/distribution" \
 	--input-artifact-dir ../../${ARTIFACTS_DIR}
-
-install-plugins: check ## Installs the compiled TCE plugins
 	TANZU_CLI_NO_INIT=true $(GO) run -ldflags "$(LD_FLAGS)" github.com/vmware-tanzu/tanzu-framework/cmd/cli/tanzu \
 		plugin install all --local ../../build/${OS}-${ARCH}-default

--- a/hack/builder/prep-gcp-tce.sh
+++ b/hack/builder/prep-gcp-tce.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# fix the Makefile for the plugins before building
+pushd "${MY_DIR}" || exit 1
+
+sed -i.bak -e "s|--artifacts[ ]\+../../\${ARTIFACTS_DIR}/\${OS}/\${ARCH}/cli|--artifacts ../../\${ARTIFACTS_DIR}|g" ./Makefile && rm ./Makefile.bak
+sed -i.bak -e "s|--artifacts[ ]\+../../\${ARTIFACTS_DIR}/\${GOHOSTOS}/\${ARCH}/cli|--artifacts ../../\${ARTIFACTS_DIR}|g" ./Makefile && rm ./Makefile.bak
+
+popd || exit 1

--- a/hack/release/prune-buckets.sh
+++ b/hack/release/prune-buckets.sh
@@ -10,16 +10,11 @@ set -o xtrace
 
 TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
 TCE_SCRATCH_DIR="${TCE_SCRATCH_DIR:-""}"
-GITHUB_WORKSPACE="${GITHUB_WORKSPACE:-""}"
 
 # required input
 if [[ -z "${TCE_SCRATCH_DIR}" ]]; then
     echo "TCE_SCRATCH_DIR is not set"
     exit 1
-fi
-if [[ -z "${GITHUB_WORKSPACE}" ]]; then
-    echo "Use current working directory..."
-    GITHUB_WORKSPACE=$(pwd)
 fi
 
 # we only allow this to run from GitHub CI/Action
@@ -34,7 +29,7 @@ fi
 # this needs to be done for both tce and tanzu framework
 
 # do this on TCE
-pushd "${GITHUB_WORKSPACE}/artifacts" || exit 1
+pushd "./artifacts" || exit 1
 
 find ./ -type f | grep -v "yaml" | xargs rm 
 find ./ -type d | grep "test" | xargs rm -rf


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
After refactoring of TCE to use v0.16.0 a number of things relating to the upload of TF and TCE artifacts needed to be updated and fixed.

Probably the most significant change in this PR is relocation of the build of the distribution and discovery from `compile` to `install-plugins` step. The reason why is we don't need to create the distribution/discovery until we plan on installing the components.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix the upload of GCP artifacts to bucket
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Made sure the new workflow `make release-buckets` works. Along with:
`make release`
`make install-all-tanzu-cli-plugins`

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA