### PR TITLE
Add control plane tolerations for ako pod

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.4.3/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
@@ -203,3 +203,8 @@ spec:
               port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
@@ -106,3 +106,8 @@ spec:
               port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
Signed-off-by: Chen Lin <linch@vmware.com>

## What this PR does / why we need it
Missing control plane tolerations for ako pod will cause that ako pod get stuck in `Pending` stage when worker nodes are failed to create
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Details for the Release Notes (PLEASE PROVIDE)

<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
