### PR TITLE
Use the Windows zip file when updating chocolatey

### DIFF
--- a/hack/choco/update-choco-package.sh
+++ b/hack/choco/update-choco-package.sh
@@ -18,14 +18,14 @@ pushd "${temp_dir}"
 
 TCE_REPO="https://github.com/vmware-tanzu/community-edition" 
 TCE_REPO_RELEASES_URL="https://github.com/vmware-tanzu/community-edition/releases"
-TCE_WINDOWS_TAR_BALL_FILE="tce-darwin-amd64-${version}.tar.gz"
+TCE_WINDOWS_ZIP_FILE="tce-windows-amd64-${version}.zip"
 TCE_CHECKSUMS_FILE="tce-checksums.txt"
  
 echo "Checking if the necessary files exist for the TCE ${version} release"
  
 wget --spider -q \
-   "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_WINDOWS_TAR_BALL_FILE}" || {
-       echo "${TCE_WINDOWS_TAR_BALL_FILE} is not accessible in TCE ${version} release"
+   "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_WINDOWS_ZIP_FILE}" || {
+       echo "${TCE_WINDOWS_ZIP_FILE} is not accessible in TCE ${version} release"
        exit 1
    }
  


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
The chocolatey update script downloads the Darwin tarball, and should actually download the Windows zip file.


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3156 
