### PR TITLE
Add start of basic server

### DIFF
--- a/cli/cmd/plugin/ui/api/base.go
+++ b/cli/cmd/plugin/ui/api/base.go
@@ -1,0 +1,19 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// SupportedAPIVersions handles requests to get the supported API versions by the server.
+func SupportedAPIVersions(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+
+	response := []string{"v1"}
+
+	_ = json.NewEncoder(w).Encode(response)
+}

--- a/cli/cmd/plugin/ui/api/logger.go
+++ b/cli/cmd/plugin/ui/api/logger.go
@@ -1,0 +1,26 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+func Logger(inner http.Handler, name string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		inner.ServeHTTP(w, r)
+
+		log.Printf(
+			"%s %s %s %s",
+			r.Method,
+			r.RequestURI,
+			name,
+			time.Since(start),
+		)
+	})
+}

--- a/cli/cmd/plugin/ui/api/router.go
+++ b/cli/cmd/plugin/ui/api/router.go
@@ -1,0 +1,108 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+
+	v1 "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/ui/api/v1"
+)
+
+type Route struct {
+	Name        string
+	Method      string
+	Pattern     string
+	HandlerFunc http.HandlerFunc
+}
+
+type Routes []Route
+
+func NewRouter() *mux.Router {
+	router := mux.NewRouter().StrictSlash(true)
+	for _, route := range routes {
+		var handler http.Handler
+		handler = route.HandlerFunc
+		handler = Logger(handler, route.Name)
+
+		router.
+			Methods(route.Method).
+			Path(route.Pattern).
+			Name(route.Name).
+			Handler(handler)
+	}
+
+	return router
+}
+
+func PrintRoutes(r *mux.Router) error {
+	err := r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		pathTemplate, err := route.GetPathTemplate()
+		if err == nil {
+			fmt.Println("ROUTE:", pathTemplate)
+		}
+		pathRegexp, err := route.GetPathRegexp()
+		if err == nil {
+			fmt.Println("Path regexp:", pathRegexp)
+		}
+		queriesTemplates, err := route.GetQueriesTemplates()
+		if err == nil {
+			fmt.Println("Queries templates:", strings.Join(queriesTemplates, ","))
+		}
+		queriesRegexps, err := route.GetQueriesRegexp()
+		if err == nil {
+			fmt.Println("Queries regexps:", strings.Join(queriesRegexps, ","))
+		}
+		methods, err := route.GetMethods()
+		if err == nil {
+			fmt.Println("Methods:", strings.Join(methods, ","))
+		}
+		fmt.Println()
+		return nil
+	})
+
+	return err
+}
+
+func Index(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, "/ui/", http.StatusPermanentRedirect)
+}
+
+var routes = Routes{
+	Route{
+		"Index",
+		"GET",
+		"/",
+		Index,
+	},
+	Route{
+		"Headers",
+		"GET",
+		"/headers",
+		headers,
+	},
+	Route{
+		"FindSupportAPIVersions",
+		"GET",
+		"/api",
+		SupportedAPIVersions,
+	},
+	Route{
+		"ContainerRuntimeInfo",
+		"GET",
+		"/api/v1/runtime",
+		v1.GetContainerRuntime,
+	},
+}
+
+func headers(w http.ResponseWriter, req *http.Request) {
+	for name, headers := range req.Header {
+		for _, h := range headers {
+			fmt.Fprintf(w, "%v: %v\n", name, h)
+		}
+	}
+}

--- a/cli/cmd/plugin/ui/api/v1/runtime.go
+++ b/cli/cmd/plugin/ui/api/v1/runtime.go
@@ -1,0 +1,29 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/ui/objects"
+)
+
+// GetContainerRuntime gets information about the container runtime. An empty
+// response indicates there is no runtime available (not installed or not running).
+func GetContainerRuntime(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+
+	response := objects.Runtime{
+		Name:       "test",
+		OSType:     "linux",
+		OSVersion:  "20.04",
+		CPU:        4,
+		Memory:     6235168768,
+		Containers: 1,
+	}
+
+	_ = json.NewEncoder(w).Encode(response)
+}

--- a/cli/cmd/plugin/ui/go.mod
+++ b/cli/cmd/plugin/ui/go.mod
@@ -7,6 +7,7 @@ go 1.16
 replace github.com/vmware-tanzu/community-edition => ../../../../
 
 require (
+	github.com/gorilla/mux v1.8.0
 	github.com/spf13/cobra v1.2.1
 	github.com/vmware-tanzu/community-edition v0.9.1
 )

--- a/cli/cmd/plugin/ui/go.sum
+++ b/cli/cmd/plugin/ui/go.sum
@@ -137,6 +137,8 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=

--- a/cli/cmd/plugin/ui/main.go
+++ b/cli/cmd/plugin/ui/main.go
@@ -8,10 +8,12 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin"
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/ui/api"
 )
 
 var descriptor = plugin.PluginDescriptor{
@@ -32,16 +34,18 @@ func main() {
 		log.Fatal(err, "unable to initialize new plugin")
 	}
 
-	bindAddress := "127.0.0.0:8080"
+	bindAddress := "0.0.0.0:8080"
 	browser := ""
+	staticFiles := "web"
 
 	// Add our command line options
-	p.Cmd.Flags().StringVarP(&bindAddress, "bind", "b", "127.0.0.1:8080", "Specify the IP and port to bind the Kickstart UI against (e.g. 127.0.0.1:8080).")
-	p.Cmd.Flags().StringVarP(&browser, "browser", "", "", "Specify the browser to open the Kickstart UI on. Use 'none' for no browser. Defaults to OS default browser. Supported: ['chrome', 'firefox', 'safari', 'ie', 'edge', 'none']")
+	p.Cmd.Flags().StringVarP(&bindAddress, "bind", "b", bindAddress, "Specify the IP and port to bind the Kickstart UI against (e.g. 127.0.0.1:8080).")
+	p.Cmd.Flags().StringVar(&browser, "browser", "", "Specify the browser to open the Kickstart UI on. Use 'none' for no browser. Defaults to OS default browser. Supported: ['chrome', 'firefox', 'safari', 'ie', 'edge', 'none']")
+	p.Cmd.Flags().StringVarP(&staticFiles, "web-files", "f", staticFiles, "Specify the directory path for static HTML files to serve.")
 	p.Cmd.PersistentFlags().Int32VarP(&logLevel, "verbose", "v", 0, "Number for the log level verbosity (0-9)")
 
 	p.Cmd.Run = func(cmd *cobra.Command, args []string) {
-		launch(bindAddress, browser)
+		launch(bindAddress, browser, staticFiles)
 	}
 
 	if err := p.Execute(); err != nil {
@@ -49,26 +53,26 @@ func main() {
 	}
 }
 
-func launch(bindAddress, browser string) {
-	fmt.Printf("http://%s browser: %s\n", bindAddress, browser)
-
-	http.HandleFunc("/", hello)
-	http.HandleFunc("/headers", headers)
-
-	err := http.ListenAndServe(bindAddress, nil)
+func launch(bindAddress, browser, staticFiles string) {
+	workingDir, _ := os.Getwd()
+	staticFiles, err := filepath.Abs(filepath.Join(workingDir, staticFiles))
 	if err != nil {
-		fmt.Printf("Error starting web server: %v", err)
+		fmt.Printf("Error getting static directory path: %s\n", err.Error())
+		os.Exit(1)
 	}
-}
 
-func hello(w http.ResponseWriter, req *http.Request) {
-	fmt.Fprintf(w, "hello\n")
-}
+	router := api.NewRouter()
+	router.PathPrefix("/ui").Handler(http.StripPrefix("/ui", api.Logger(http.FileServer(http.Dir(staticFiles)), "ui")))
 
-func headers(w http.ResponseWriter, req *http.Request) {
-	for name, headers := range req.Header {
-		for _, h := range headers {
-			fmt.Fprintf(w, "%v: %v\n", name, h)
+	if logLevel > 3 {
+		if err := api.PrintRoutes(router); err != nil {
+			fmt.Printf("Failed to print registered routes: %s\n", err.Error())
 		}
+	}
+
+	fmt.Printf("Serving from %s\n", staticFiles)
+	fmt.Printf("http://%s/ui/ browser: %s\n", bindAddress, browser)
+	if err := http.ListenAndServe(bindAddress, router); err != nil {
+		fmt.Printf("Error starting web server: %v", err)
 	}
 }

--- a/cli/cmd/plugin/ui/objects/runtime.go
+++ b/cli/cmd/plugin/ui/objects/runtime.go
@@ -1,0 +1,18 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package objects
+
+type Runtime struct {
+	Name string `json:"name,omitempty"`
+
+	OSType string `json:"ostype,omitempty"`
+
+	OSVersion string `json:"osversion,omitempty"`
+
+	CPU int32 `json:"cpu,omitempty"`
+
+	Memory int64 `json:"memory,omitempty"`
+
+	Containers int32 `json:"containers,omitempty"`
+}

--- a/cli/cmd/plugin/ui/web/index.html
+++ b/cli/cmd/plugin/ui/web/index.html
@@ -1,0 +1,6 @@
+<html>
+    <head><title>Test</title></head>
+    <body>
+        This is a test.
+    </body>
+</html>


### PR DESCRIPTION
This adds basic HTTP serving for static files and the start of an API
for the UI to interact with the system.

This is exploratory for now. May want to see if we want to reuse/refactor
the existing code in https://github.com/vmware-tanzu/tanzu-framework/tree/main/pkg/v1/tkg/web/server
for our purposes.