### PR TITLE
Correct casing of /etc/kubernetes path

### DIFF
--- a/docs/site/content/docs/latest/tsg-bootstrap.md
+++ b/docs/site/content/docs/latest/tsg-bootstrap.md
@@ -102,7 +102,7 @@ If the steps above are not enough, or you want complete control over your troubl
 1. Before you can proceed to run ``kubectl`` commands against the pods inside the bootstrap cluster container, copy the `admin.conf` file to the default kubeconfig location:
 
    ```sh
-   cp -v /etc/Kubernetes/admin.conf ~/.kube/config
+   cp -v /etc/kubernetes/admin.conf ~/.kube/config
    ```
 
 1. Now you are inside the bootstrap cluster container that is going to bootstrap your cluster to the target provider, you can run ``kubectl`` commands against this container. By watching the status of the pods, you can understand what might go wrong in the bootstrap process. Run the following command to see the pods being created inside the container:


### PR DESCRIPTION
Our troubleshooting docs walk through how to exec into a pod in order to
run kubectl commands. As part of this, we have the user copy the
admin.conf file over so it doesn't need to be specified as the
`--kubeconfig` when running commands. The example command we give for
them to copy and paste had a type where "Kuberenetes" was capitalized in
that path, so just pasting that command would fail to find the file.
This changes that path to the correct all-lowercase
`/etc/kubernetes/admin.conf`.