### PR TITLE
Resolve auto merge failing issue in choco and brew and adding check in update-brew script

### DIFF
--- a/.github/workflows/release-choco-package.yaml
+++ b/.github/workflows/release-choco-package.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-choco-package:
     name: Update Choco Package
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
     runs-on: ubuntu-latest
     steps:
       - name: Config credentials

--- a/hack/choco/update-choco-package.sh
+++ b/hack/choco/update-choco-package.sh
@@ -44,8 +44,17 @@ cd community-edition
 PR_BRANCH="update-tce-to-${version}-${RANDOM}"
  
 # Random number in branch name in case there's already some branch for the version update,
-# though there shouldn't be one. There could be one if the other branch's PR tests failed and didn't merge
-git checkout -b "${PR_BRANCH}"
+# though there shouldn't be one. There could be one if the other branch's PR tests failed and 
+# didn't merge then we are adding another random value for that but as we are testing the brew 
+# formula so no PR will raise if it fails.
+DOES_NEW_BRANCH_EXIST=$(git branch -a | grep remotes | grep "${PR_BRANCH}" || true)
+echo "does branch exist: ${DOES_NEW_BRANCH_EXIST}"
+if [[ "${DOES_NEW_BRANCH_EXIST}" == "" ]]; then
+    git checkout -b "${PR_BRANCH}"
+else
+    PR_BRANCH="${PR_BRANCH}-${RANDOM}"
+    git checkout -b "${PR_BRANCH}"
+fi
 
 # setup
 git config user.name github-actions
@@ -53,14 +62,14 @@ git config user.email github-actions@github.com
 
 # Replacing old version with the latest stable released version.
 # Using -i so that it works on Mac and Linux OS, so that it's useful for local development.
-sed -i -e "s/\(\$releaseVersion =\).*/\$releaseVersion = ""'${version}'""/g" hack/choco/tools/chocolateyinstall.ps1 
+sed -i -e "s/\(\$releaseVersion =\).*/\$releaseVersion = \'${version}\'/g" hack/choco/tools/chocolateyinstall.ps1 
 rm -fv hack/choco/tools/chocolateyinstall.ps1-e
 
 version="${version:1}"
 sed -i -e "s/\(<version>\).*\(<\/version>\)/<version>""${version}""\<\/version>/g" hack/choco/tanzu-community-edition.nuspec
 rm -fv hack/choco/tanzu-community-edition.nuspec-e
 
-sed -i -e "s/\(\$checksum64 =\).*/\$checksum64 = ""'${windows_amd64_shasum}'""/g" hack/choco/tools/chocolateyinstall.ps1 
+sed -i -e "s/\(\$checksum64 =\).*/\$checksum64 = \'${windows_amd64_shasum}\'/g" hack/choco/tools/chocolateyinstall.ps1 
 rm -fv hack/choco/tools/chocolateyinstall.ps1-e
 
 git add hack/choco/tools/chocolateyinstall.ps1

--- a/hack/choco/update-choco-package.sh
+++ b/hack/choco/update-choco-package.sh
@@ -60,7 +60,7 @@ version="${version:1}"
 sed -i -e "s/\(<version>\).*\(<\/version>\)/<version>""${version}""\<\/version>/g" hack/choco/tanzu-community-edition.nuspec
 rm -fv hack/choco/tanzu-community-edition.nuspec-e
 
-sed -i -e "s/\(\$checksum64 =\).*/\$releaseVersion = ""'${windows_amd64_shasum}'""/g" hack/choco/tools/chocolateyinstall.ps1 
+sed -i -e "s/\(\$checksum64 =\).*/\$checksum64 = ""'${windows_amd64_shasum}'""/g" hack/choco/tools/chocolateyinstall.ps1 
 rm -fv hack/choco/tools/chocolateyinstall.ps1-e
 
 git add hack/choco/tools/chocolateyinstall.ps1

--- a/hack/homebrew/update-homebrew-package.sh
+++ b/hack/homebrew/update-homebrew-package.sh
@@ -57,6 +57,10 @@ PR_BRANCH="update-tce-to-${version}-${RANDOM}"
 # though there shouldn't be one. There could be one if the other branch's PR tests failed and didn't merge
 git checkout -b "${PR_BRANCH}"
 
+# setup
+git config user.name github-actions
+git config user.email github-actions@github.com
+
 # Replacing old version with the latest stable released version.
 # Using -i so that it works on Mac and Linux OS, so that it's useful for local development.
 sed -i.bak "s/version \"v.*/version \"${version}\"/" tanzu-community-edition.rb
@@ -72,7 +76,7 @@ mv tanzu-community-edition-updated.rb tanzu-community-edition.rb
 
 git add tanzu-community-edition.rb
 
-git commit -m "auto-generated - update tce homebrew formula for version ${version}"
+git commit -s -m "auto-generated - update tce homebrew formula for version ${version}"
 
 git push origin "${PR_BRANCH}"
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

- This PR is resolving the failing of auto-merge which required human intervention in choco and brew update scripts.
- Also it adding a part to update checksum value for choco package.
- It is adding a check in [update-homebrew-package.sh](https://github.com/vmware-tanzu/community-edition/blob/main/hack/homebrew/update-homebrew-package.sh) before merging in main.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: [#3179](https://github.com/vmware-tanzu/community-edition/issues/3179)

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Did release on my fork branch.
[Logs for above test](https://github.com/aman556/community-edition/runs/5283471379?check_suite_focus=true)
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
