### PR TITLE
[E2E] Use self hosted AWS EC2 runners for Azure and AWS E2E tests

### DIFF
--- a/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
@@ -14,11 +14,27 @@ on:
       - "**"
 
 jobs:
+  setup-runner:
+    name: Start self-hosted EC2 runner
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    runs-on: ubuntu-latest
+    outputs:
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        shell: bash
+        run: |
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "INSTANCE_NAME: ${INSTANCE_NAME}"
+          echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   e2e-aws-managed-test:
     # Only run this job if we're in the main repo, not a fork.
     if: github.repository == 'vmware-tanzu/community-edition'
     name: E2E AWS Management and Workload Cluster Test
-    runs-on: ubuntu-latest
+    needs: setup-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.setup-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -60,3 +76,18 @@ jobs:
             bootstrap.*.diagnostics.tar.gz
             management-cluster.*.diagnostics.tar.gz
             workload-cluster.*.diagnostics.tar.gz
+  teardown-runner:
+    name: Stop self-hosted EC2 runner
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    needs:
+      - setup-runner # required to get output from the setup-runner job
+      - e2e-aws-managed-test # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stop EC2 runner
+        id: stop-ec2-runner
+        shell: bash
+        run: |
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/.github/workflows/e2e-aws-standalone-cluster.yaml
+++ b/.github/workflows/e2e-aws-standalone-cluster.yaml
@@ -14,11 +14,27 @@ on:
       - "**"
 
 jobs:
+  setup-runner:
+    name: Start self-hosted EC2 runner
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    runs-on: ubuntu-latest
+    outputs:
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        shell: bash
+        run: |
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "INSTANCE_NAME: ${INSTANCE_NAME}"
+          echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   e2e-aws-standalone-test:
     # Only run this job if we're in the main repo, not a fork.
     if: github.repository == 'vmware-tanzu/community-edition'
     name: E2E AWS Standalone Cluster Test
-    runs-on: ubuntu-latest
+    needs: setup-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.setup-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -60,3 +76,18 @@ jobs:
             bootstrap.*.diagnostics.tar.gz
             management-cluster.*.diagnostics.tar.gz
             workload-cluster.*.diagnostics.tar.gz
+  teardown-runner:
+    name: Stop self-hosted EC2 runner
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    needs:
+      - setup-runner # required to get output from the setup-runner job
+      - e2e-aws-standalone-test # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stop EC2 runner
+        id: stop-ec2-runner
+        shell: bash
+        run: |
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
@@ -14,6 +14,21 @@ on:
       - "**"
 
 jobs:
+  setup-runner:
+    name: Start self-hosted EC2 runner
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    runs-on: ubuntu-latest
+    outputs:
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        shell: bash
+        run: |
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "INSTANCE_NAME: ${INSTANCE_NAME}"
+          echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   e2e-azure-management-and-workload-test:
     # Only run this job if we're in the main repo, not a fork.
     if: github.repository == 'vmware-tanzu/community-edition'
@@ -59,3 +74,19 @@ jobs:
             bootstrap.*.diagnostics.tar.gz
             management-cluster.*.diagnostics.tar.gz
             workload-cluster.*.diagnostics.tar.gz
+
+  teardown-runner:
+    name: Stop self-hosted EC2 runner
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    needs:
+      - setup-runner # required to get output from the setup-runner job
+      - e2e-azure-management-and-workload-test # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stop EC2 runner
+        id: stop-ec2-runner
+        shell: bash
+        run: |
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/.github/workflows/e2e-azure-standalone-cluster.yaml
+++ b/.github/workflows/e2e-azure-standalone-cluster.yaml
@@ -14,11 +14,27 @@ on:
       - "**"
 
 jobs:
+  setup-runner:
+    name: Start self-hosted EC2 runner
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    runs-on: ubuntu-latest
+    outputs:
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        shell: bash
+        run: |
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "INSTANCE_NAME: ${INSTANCE_NAME}"
+          echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   e2e-azure-standalone-test:
     # Only run this job if we're in the main repo, not a fork.
     if: github.repository == 'vmware-tanzu/community-edition'
     name: E2E Azure Standalone Cluster Test
-    runs-on: ubuntu-latest
+    needs: setup-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.setup-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -59,3 +75,18 @@ jobs:
             bootstrap.*.diagnostics.tar.gz
             management-cluster.*.diagnostics.tar.gz
             workload-cluster.*.diagnostics.tar.gz
+  teardown-runner:
+    name: Stop self-hosted EC2 runner
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    needs:
+      - setup-runner # required to get output from the setup-runner job
+      - e2e-azure-standalone-test # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stop EC2 runner
+        id: stop-ec2-runner
+        shell: bash
+        run: |
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "INSTANCE_NAME: ${INSTANCE_NAME}"


### PR DESCRIPTION
## What this PR does / why we need it

Use self hosted AWS EC2 runners for Azure and AWS E2E tests

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
NONE
```

## Which issue(s) this PR fixes

Fixes: #3203 

## Describe testing done for PR

Skipping as I'm yet to get the AMI image (or way to produce it) we need to run the self hosted runners. I would need the AMI image in my AWS account and then have to run the AWS service (available in TCE repo) with my AWS account credentials in it's config and with webhooks settings setup in my fork repo

## Special notes for your reviewer

-