### PR TITLE
TCE UI - Use Go embed to include and serve UI static files in plugin

### DIFF
--- a/cli/cmd/plugin/ui/Makefile
+++ b/cli/cmd/plugin/ui/Makefile
@@ -8,7 +8,6 @@ GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 
 # Directories
 UI_DIR := web/tanzu-ui
-GOBINDATA := $(TOOLS_BIN_DIR)/gobindata
 
 .DEFAULT_GOAL:=help
 
@@ -34,12 +33,8 @@ e2e-test: ## Run e2e testing suite
 build: ## Build the executable
 	echo "N/A: Implement building"
 
-ui-dependencies: ## install UI dependencies (node modules)
+ui-dependencies: ## Install UI dependencies (node modules)
 	cd $(UI_DIR); npm ci
 
 ui-build: ui-dependencies ## Install dependencies, then compile client UI for production
 	cd $(UI_DIR); npm run build:prod
-	$(MAKE) generate-ui-bindata
-
-generate-ui-bindata: $(GOBINDATA) ## Generate go-bindata for ui files
-	$(GOBINDATA) -mode=420 -modtime=1 -o=web/zz_generated.bindata.go -pkg=main $(UI_DIR)/build/...

--- a/cli/cmd/plugin/ui/main.go
+++ b/cli/cmd/plugin/ui/main.go
@@ -4,17 +4,20 @@
 package main
 
 import (
+	"embed"
 	"fmt"
+	"github.com/spf13/cobra"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
-	"path/filepath"
-
-	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/ui/api"
 )
+
+//go:embed web/tanzu-ui/build
+var content embed.FS
 
 var descriptor = plugin.PluginDescriptor{
 	Name:        "ui",
@@ -36,16 +39,14 @@ func main() {
 
 	bindAddress := "0.0.0.0:8080"
 	browser := ""
-	staticFiles := "web"
 
 	// Add our command line options
 	p.Cmd.Flags().StringVarP(&bindAddress, "bind", "b", bindAddress, "Specify the IP and port to bind the Kickstart UI against (e.g. 127.0.0.1:8080).")
 	p.Cmd.Flags().StringVar(&browser, "browser", "", "Specify the browser to open the Kickstart UI on. Use 'none' for no browser. Defaults to OS default browser. Supported: ['chrome', 'firefox', 'safari', 'ie', 'edge', 'none']")
-	p.Cmd.Flags().StringVarP(&staticFiles, "web-files", "f", staticFiles, "Specify the directory path for static HTML files to serve.")
 	p.Cmd.PersistentFlags().Int32VarP(&logLevel, "verbose", "v", 0, "Number for the log level verbosity (0-9)")
 
 	p.Cmd.Run = func(cmd *cobra.Command, args []string) {
-		launch(bindAddress, browser, staticFiles)
+		launch(bindAddress, browser)
 	}
 
 	if err := p.Execute(); err != nil {
@@ -53,16 +54,13 @@ func main() {
 	}
 }
 
-func launch(bindAddress, browser, staticFiles string) {
-	workingDir, _ := os.Getwd()
-	staticFiles, err := filepath.Abs(filepath.Join(workingDir, staticFiles))
-	if err != nil {
-		fmt.Printf("Error getting static directory path: %s\n", err.Error())
-		os.Exit(1)
-	}
+func launch(bindAddress, browser string) {
+	// get static content from go embed
+	fsys := fs.FS(content)
+	staticContent, _ := fs.Sub(fsys, "web/tanzu-ui/build")
 
 	router := api.NewRouter()
-	router.PathPrefix("/ui").Handler(http.StripPrefix("/ui", api.Logger(http.FileServer(http.Dir(staticFiles)), "ui")))
+	router.PathPrefix("/ui").Handler(http.StripPrefix("/ui", api.Logger(http.FileServer(http.FS(staticContent)), "ui")))
 
 	if logLevel > 3 {
 		if err := api.PrintRoutes(router); err != nil {
@@ -70,7 +68,6 @@ func launch(bindAddress, browser, staticFiles string) {
 		}
 	}
 
-	fmt.Printf("Serving from %s\n", staticFiles)
 	fmt.Printf("http://%s/ui/ browser: %s\n", bindAddress, browser)
 	if err := http.ListenAndServe(bindAddress, router); err != nil {
 		fmt.Printf("Error starting web server: %v", err)

--- a/cli/cmd/plugin/ui/web/index.html
+++ b/cli/cmd/plugin/ui/web/index.html
@@ -1,6 +1,0 @@
-<html>
-    <head><title>Test</title></head>
-    <body>
-        This is a test.
-    </body>
-</html>

--- a/cli/cmd/plugin/ui/web/tanzu-ui/.env
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/.env
@@ -1,0 +1,1 @@
+PUBLIC_URL=/ui

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/App.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/App.tsx
@@ -29,7 +29,7 @@ function App() {
                         <div cds-layout="vertical gap:md p:lg">
                             <Routes>
                                 <Route path="/" element={<Home />} />
-                                <Route path="about" element={<About />} />
+                                <Route path="/about" element={<About />} />
                             </Routes>
                         </div>
                     </div>

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/index.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/index.tsx
@@ -11,7 +11,7 @@ import App from './App';
 
 ReactDOM.render(
     <React.StrictMode>
-        <BrowserRouter>
+        <BrowserRouter basename="/ui">
             <App />
         </BrowserRouter>
     </React.StrictMode>,

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -21,7 +21,6 @@ export GO111MODULE := on
 # Directories.
 BIN_DIR := bin
 SRCS := go.mod go.sum
-GOBINDATA := $(BIN_DIR)/gobindata
 
 # Host information.
 HOST_OS=$(shell go env GOOS)
@@ -59,11 +58,6 @@ help: ## Display this help
 golangci-lint: $(GOLANGCI_LINT) $(SRCS) ## Build golangci-lint
 $(GOLANGCI_LINT): go.mod
 	go build -tags=tools -o $@ github.com/golangci/golangci-lint/cmd/golangci-lint
-
-gobindata: $(GOBINDATA)
-$(GOBINDATA): go.mod # Build go-bindata
-	mkdir -p $(BIN_DIR)
-	go build -tags=tools -o $(BIN_DIR) github.com/shuLhan/go-bindata/...; mv $(BIN_DIR)/go-bindata $(GOBINDATA)
 
 ## --------------------------------------
 ## Cleanup

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,4 @@ module github.com/vmware-tanzu/community-edition/hack/tools
 
 go 1.16
 
-require (
-	github.com/golangci/golangci-lint v1.43.0
-	github.com/shuLhan/go-bindata v4.0.0+incompatible
-)
+require github.com/golangci/golangci-lint v1.43.0

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -697,8 +697,6 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c h1:W65qqJCIOVP4jpqPQ0YvHYKwcMEMVWIzWC5iNQQfBTU=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
 github.com/shirou/gopsutil/v3 v3.21.10/go.mod h1:t75NhzCZ/dYyPQjyQmrAYP6c8+LCdFANeBMdLPCNnew=
-github.com/shuLhan/go-bindata v4.0.0+incompatible h1:xD8LkuVZLV5OOn/IEuFdt6EEAW7deWiqgwaaSGhjAJc=
-github.com/shuLhan/go-bindata v4.0.0+incompatible/go.mod h1:pkcPAATLBDD2+SpAPnX5vEM90F7fcwHCvvLCMXcmw3g=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // Copyright 2021 VMware, Inc. All Rights Reserved.
@@ -8,5 +9,4 @@ package tools
 
 import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
-	_ "github.com/shuLhan/go-bindata" // Force load of go-bindata
 )


### PR DESCRIPTION
Uses Go embed to include and serve contents of the /web/tanzu-ui/build folder, containing all static UI assets
Removes any previous Go bindata implementation

Note: router implementation requires that static Javascript/CSS files included by index.html have a path prefix of 'ui.' I was able to work around this by setting PUBLIC_URL=/ui in the react app but we should find a better implementation

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3066 


## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
To test running the UI, you must first build the UI with the makefile target `ui-build` found in `community-edition/cli/cmd/plugin/ui/Makefile`

Once you have built the UI you can run `go run main.go` from `community-edition/cli/cmd/plugin/ui`
