### PR TITLE
Use `stg` image repo for `v0.16.0`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ TANZU_FRAMEWORK_REPO_BRANCH ?= v0.16.0
 TANZU_FRAMEWORK_REPO_HASH ?=
 # TKG_DEFAULT_IMAGE_REPOSITORY override for using a different image repo
 ifndef TKG_DEFAULT_IMAGE_REPOSITORY
-TKG_DEFAULT_IMAGE_REPOSITORY ?= projects.registry.vmware.com/tkg
+TKG_DEFAULT_IMAGE_REPOSITORY ?= projects-stg.registry.vmware.com/tkg
 endif
 # TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH override for using a different image path
 ifndef TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH


### PR DESCRIPTION


## What this PR does / why we need it
Uses the staging harbor image repo until images can get promoted. This change will need to be reverted before `v0.11.0` release.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
N/a - related to the v0.16.0 bump

## Describe testing done for PR
`make release` and then `./tce-linux-amd64-v0.11.0-dev.1/install.sh`

All plugins available:
```
❯ tanzu plugin list
unable to list plugin from discovery 'default-local': error while reading local plugin manifest directory: open /home/jmcb/.config/tanzu-plugins/discovery/standalone: no such file or directory
  NAME                DESCRIPTION                                                        SCOPE       DISCOVERY  VERSION        STATUS
  cluster             Kubernetes cluster operations                                      Standalone             v0.16.0        installed
  codegen             Tanzu code generation tool                                         Standalone             v0.16.0        installed
  diagnostics         Cluster diagnostics                                                Standalone             v0.11.0-dev.1  installed
  feature             Operate on features and featuregates                               Standalone             v0.16.0        installed
  login               Login to the platform                                              Standalone             v0.16.0        installed
  package             Tanzu package management                                           Standalone             v0.16.0        installed
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)  Standalone             v0.16.0        installed
  builder             Build Tanzu components                                             Standalone             v0.16.0        installed
  conformance         Run Sonobuoy conformance tests against clusters                    Standalone             v0.11.0-dev.1  installed
  kubernetes-release  Kubernetes release operations                                      Standalone             v0.16.0        installed
  management-cluster  Kubernetes management cluster operations                           Standalone             v0.16.0        installed
  secret              Tanzu secret management                                            Standalone             v0.16.0        installed
  unmanaged-cluster   Deploy and manage single-node, static, Tanzu clusters.             Standalone             v0.11.0-dev.1  installed
```

Started management cluster
```
$ CLUSTER_PLAN=dev tanzu management-cluster create mytest -i docker -v 10
```