### PR TITLE
Add aviinfrasetting crd to ako operator package

### DIFF
--- a/addons/packages/ako-operator/1.5.0/bundle/config/upstream/akooperator/aviinfrasettings.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/upstream/akooperator/aviinfrasettings.yaml
@@ -1,0 +1,97 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: aviinfrasettings.ako.vmware.com
+spec:
+  conversion:
+    strategy: None
+  group: ako.vmware.com
+  names:
+    kind: AviInfraSetting
+    listKind: AviInfraSettingList
+    plural: aviinfrasettings
+    singular: aviinfrasetting
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AviInfraSetting is used to select specific Avi controller infra attributes.
+        properties:
+          spec:
+            properties:
+              network:
+                properties:
+                  vipNetworks:
+                    items:
+                      properties:
+                        networkName:
+                          type: string
+                        cidr:
+                          type: string
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  nodeNetworks:
+                    items:
+                      properties:
+                        networkName:
+                          type: string
+                        cidrs:
+                          type: array
+                          items:
+                            type: string
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  enableRhi:
+                    type: boolean
+                  enablePublicIP:
+                    type: boolean
+                  bgpPeerLabels:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              seGroup:
+                properties:
+                  name:
+                    type: string
+                type: object
+                required:
+                - name
+              l7Settings:
+                properties:
+                  shardSize:
+                    enum:
+                    - SMALL
+                    - MEDIUM
+                    - LARGE
+                    - DEDICATED
+                    type: string
+                type: object
+                required:
+                - shardSize
+            type: object
+          status:
+            properties:
+              error:
+                type: string
+              status:
+                type: string
+            type: object
+        type: object
+    additionalPrinterColumns:
+    - description: status of the nas object
+      jsonPath: .status.status
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/aviinfrasettings.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/aviinfrasettings.yaml
@@ -1,0 +1,97 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: aviinfrasettings.ako.vmware.com
+spec:
+  conversion:
+    strategy: None
+  group: ako.vmware.com
+  names:
+    kind: AviInfraSetting
+    listKind: AviInfraSettingList
+    plural: aviinfrasettings
+    singular: aviinfrasetting
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AviInfraSetting is used to select specific Avi controller infra attributes.
+        properties:
+          spec:
+            properties:
+              network:
+                properties:
+                  vipNetworks:
+                    items:
+                      properties:
+                        networkName:
+                          type: string
+                        cidr:
+                          type: string
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  nodeNetworks:
+                    items:
+                      properties:
+                        networkName:
+                          type: string
+                        cidrs:
+                          type: array
+                          items:
+                            type: string
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  enableRhi:
+                    type: boolean
+                  enablePublicIP:
+                    type: boolean
+                  bgpPeerLabels:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              seGroup:
+                properties:
+                  name:
+                    type: string
+                type: object
+                required:
+                - name
+              l7Settings:
+                properties:
+                  shardSize:
+                    enum:
+                    - SMALL
+                    - MEDIUM
+                    - LARGE
+                    - DEDICATED
+                    type: string
+                type: object
+                required:
+                - shardSize
+            type: object
+          status:
+            properties:
+              error:
+                type: string
+              status:
+                type: string
+            type: object
+        type: object
+    additionalPrinterColumns:
+    - description: status of the nas object
+      jsonPath: .status.status
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Because we start to support leveraging `aviinfrasetting` to separate VIP network from 1.5,  ako-operator will need to view the `aviinfrasetting` resources in k8s cluster, to make `ako-operator` can work independently, add this crd to it's package. 


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
add aviinfrasetting crd to ako operator package
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
