### PR TITLE
Expose akoo nsx-t t1 router

### DIFF
--- a/addons/packages/ako-operator/1.5.0/bundle/config/overlays/overlay-akodeploymentconfig.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/overlays/overlay-akodeploymentconfig.yaml
@@ -76,7 +76,11 @@ spec:
             enableRHI: #@ values.akoOperator.config.avi_enable_rhi
 #@ if values.akoOperator.config.avi_bgp_peer_labels:
             #@overlay/match missing_ok=True
-            bgp_peer_labels: #@ values.akoOperator.config.avi_bgp_peer_labels.split(",")
+            bgpPeerLabels: #@ values.akoOperator.config.avi_bgp_peer_labels.split(",")
+#@ end
+#@ if values.akoOperator.config.avi_nsxt_t1_lr:
+            #@overlay/match missing_ok=True
+            nsxtT1LR: #@ values.akoOperator.config.avi_nsxt_t1_lr
 #@ end
 
 #@overlay/match by=overlay.subset({"kind": "AKODeploymentConfig", "metadata": {"name": "install-ako-for-management-cluster"}})
@@ -153,5 +157,9 @@ spec:
             enableRHI: #@ values.akoOperator.config.avi_enable_rhi
 #@ if values.akoOperator.config.avi_bgp_peer_labels:
             #@overlay/match missing_ok=True
-            bgp_peer_labels: #@ values.akoOperator.config.avi_bgp_peer_labels
+            bgpPeerLabels: #@ values.akoOperator.config.avi_bgp_peer_labels
+#@ end
+#@ if values.akoOperator.config.avi_nsxt_t1_lr:
+            #@overlay/match missing_ok=True
+            nsxtT1LR: #@ values.akoOperator.config.avi_nsxt_t1_lr
 #@ end

--- a/addons/packages/ako-operator/1.5.0/bundle/config/values.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/values.yaml
@@ -44,3 +44,4 @@ akoOperator:
     avi_no_pg_for_sni: false
     avi_advanced_l4: false
     avi_auto_fqdn: disabled
+    avi_nsxt_t1_lr: test-t1-router

--- a/addons/packages/ako-operator/1.6.0/bundle/config/overlays/overlay-akodeploymentconfig.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/overlays/overlay-akodeploymentconfig.yaml
@@ -76,7 +76,11 @@ spec:
             enableRHI: #@ values.akoOperator.config.avi_enable_rhi
 #@ if values.akoOperator.config.avi_bgp_peer_labels:
             #@overlay/match missing_ok=True
-            bgp_peer_labels: #@ values.akoOperator.config.avi_bgp_peer_labels.split(",")
+            bgpPeerLabels: #@ values.akoOperator.config.avi_bgp_peer_labels
+#@ end
+#@ if values.akoOperator.config.avi_nsxt_t1_lr:
+            #@overlay/match missing_ok=True
+            nsxtT1LR: #@ values.akoOperator.config.avi_nsxt_t1_lr
 #@ end
 
 #@overlay/match by=overlay.subset({"kind": "AKODeploymentConfig", "metadata": {"name": "install-ako-for-management-cluster"}})
@@ -153,5 +157,9 @@ spec:
             enableRHI: #@ values.akoOperator.config.avi_enable_rhi
 #@ if values.akoOperator.config.avi_bgp_peer_labels:
             #@overlay/match missing_ok=True
-            bgp_peer_labels: #@ values.akoOperator.config.avi_bgp_peer_labels
+            bgpPeerLabels: #@ values.akoOperator.config.avi_bgp_peer_labels
+#@ end
+#@ if values.akoOperator.config.avi_nsxt_t1_lr:
+            #@overlay/match missing_ok=True
+            nsxtT1LR: #@ values.akoOperator.config.avi_nsxt_t1_lr
 #@ end

--- a/addons/packages/ako-operator/1.6.0/bundle/config/values.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/values.yaml
@@ -44,3 +44,4 @@ akoOperator:
     avi_no_pg_for_sni: false
     avi_advanced_l4: false
     avi_auto_fqdn: disabled
+    avi_nsxt_t1_lr: test-t1-router

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/crds/aviinfrasettings.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/crds/aviinfrasettings.yaml
@@ -1,3 +1,6 @@
+#@ load("@ytt:data", "data")
+
+#@ def avi_infra_setting_crd():
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -95,3 +98,8 @@ spec:
     storage: true
     subresources:
       status: {}
+#@ end
+
+#@ if data.values.loadBalancerAndIngressService.config.tkg_cluster_role != "management":
+--- #@ avi_infra_setting_crd()
+#@ end

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/values.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/values.yaml
@@ -7,6 +7,7 @@ loadBalancerAndIngressService:
   config:
     is_cluster_service: false
     replica_count: 1
+    tkg_cluster_role: null
     ako_settings:
       log_level: INFO
       full_sync_frequency: 1800


### PR DESCRIPTION

Signed-off-by: Xudong Liu <xudongl@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

- Expose NSX-T T1 router configuration for AKO, enable AKO to be configured for a NSX-T cloud.
- Don't deploy `aviinfrasetting` crd in AKO package when ako needs to be deployed in tkg management cluster.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
expose NSX-T T1 Router configuration in ako operator package
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
