### PR TITLE
change the default value of ako operator package

### DIFF
--- a/addons/packages/ako-operator/1.5.0/bundle/config/values.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/values.yaml
@@ -19,7 +19,7 @@ akoOperator:
     avi_password: ""
     avi_cloud_name: "Default-Cloud"
     avi_service_engine_group: "Default-Group"
-    avi_management_cluster_service_engine_group: "MC-SEG"
+    avi_management_cluster_service_engine_group: null
     avi_data_network: ""
     avi_data_network_cidr: ""
     avi_control_plane_network: ""
@@ -34,14 +34,14 @@ akoOperator:
     avi_management_cluster_control_plane_vip_network_name: ""
     avi_management_cluster_control_plane_vip_network_cidr: ""
     avi_control_plane_endpoint_port: 6443
-    avi_enable_evh: false
-    avi_l7_only: false
-    avi_services_api: false
+    avi_enable_evh: null
+    avi_l7_only: null
+    avi_services_api: null
     avi_namespace_selector_label_key: ""
     avi_namespace_selector_label_value: ""
-    avi_enable_rhi: false
+    avi_enable_rhi: null
     avi_bgp_peer_labels: ""
-    avi_no_pg_for_sni: false
-    avi_advanced_l4: false
-    avi_auto_fqdn: disabled
-    avi_nsxt_t1_lr: test-t1-router
+    avi_no_pg_for_sni: null
+    avi_advanced_l4: null
+    avi_auto_fqdn: null
+    avi_nsxt_t1_lr: null

--- a/addons/packages/ako-operator/1.6.0/bundle/config/values.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/values.yaml
@@ -19,7 +19,7 @@ akoOperator:
     avi_password: ""
     avi_cloud_name: "Default-Cloud"
     avi_service_engine_group: "Default-Group"
-    avi_management_cluster_service_engine_group: "MC-SEG"
+    avi_management_cluster_service_engine_group: null
     avi_data_network: ""
     avi_data_network_cidr: ""
     avi_control_plane_network: ""
@@ -34,14 +34,14 @@ akoOperator:
     avi_management_cluster_control_plane_vip_network_name: ""
     avi_management_cluster_control_plane_vip_network_cidr: ""
     avi_control_plane_endpoint_port: 6443
-    avi_enable_evh: false
-    avi_l7_only: false
-    avi_services_api: false
+    avi_enable_evh: null
+    avi_l7_only: null
+    avi_services_api: null
     avi_namespace_selector_label_key: ""
     avi_namespace_selector_label_value: ""
-    avi_enable_rhi: false
+    avi_enable_rhi: null
     avi_bgp_peer_labels: ""
-    avi_no_pg_for_sni: false
-    avi_advanced_l4: false
-    avi_auto_fqdn: disabled
-    avi_nsxt_t1_lr: test-t1-router
+    avi_no_pg_for_sni: null
+    avi_advanced_l4: null
+    avi_auto_fqdn: null
+    avi_nsxt_t1_lr: null


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Omit optional ako operator package configuration field instead of filling default values.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
omit optional ako operator package configurations
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
