### PR TITLE
adjust harbor e2e test get package version

### DIFF
--- a/addons/packages/harbor/2.2.3/test/e2e/harbor_suite_test.go
+++ b/addons/packages/harbor/2.2.3/test/e2e/harbor_suite_test.go
@@ -102,7 +102,8 @@ var _ = BeforeSuite(func() {
 		By(fmt.Sprintf("installing %s addon package", dependency.Name))
 
 		packageName := utils.TanzuPackageName(dependency.DisplayName)
-		version := utils.TanzuPackageAvailableVersion(packageName)
+
+		version := findPackageAvailableVersion(packageName, "")
 		installPackage(dependency.Name, packageName, version, dependency.ValuesFile)
 	}
 
@@ -160,17 +161,16 @@ func findPackageAvailableVersion(packageName string, versionSubstr string) strin
 	Expect(err).NotTo(HaveOccurred())
 	Expect(len(versions)).To(BeNumerically(">", 0))
 
-	var version string
+	var matchedVersions []string
 	for _, v := range versions {
-		if strings.Contains(v["version"], versionSubstr) {
-			version = v["version"]
-			break
+		if versionSubstr == "" || strings.Contains(v["version"], versionSubstr) {
+			matchedVersions = append(matchedVersions, v["version"])
 		}
 	}
 
-	Expect(version).NotTo(BeEmpty(), fmt.Sprintf("version contains %s for package %s not found", versionSubstr, packageName))
+	Expect(len(matchedVersions)).To(BeNumerically(">", 0), fmt.Sprintf("version contains %s for package %s not found", versionSubstr, packageName))
 
-	return version
+	return matchedVersions[len(matchedVersions)-1]
 }
 
 func hasDefaultStorageClass() bool {

--- a/addons/packages/harbor/2.3.3/test/e2e/harbor_suite_test.go
+++ b/addons/packages/harbor/2.3.3/test/e2e/harbor_suite_test.go
@@ -102,7 +102,8 @@ var _ = BeforeSuite(func() {
 		By(fmt.Sprintf("installing %s addon package", dependency.Name))
 
 		packageName := utils.TanzuPackageName(dependency.DisplayName)
-		version := utils.TanzuPackageAvailableVersion(packageName)
+
+		version := findPackageAvailableVersion(packageName, "")
 		installPackage(dependency.Name, packageName, version, dependency.ValuesFile)
 	}
 
@@ -160,17 +161,16 @@ func findPackageAvailableVersion(packageName string, versionSubstr string) strin
 	Expect(err).NotTo(HaveOccurred())
 	Expect(len(versions)).To(BeNumerically(">", 0))
 
-	var version string
+	var matchedVersions []string
 	for _, v := range versions {
-		if strings.Contains(v["version"], versionSubstr) {
-			version = v["version"]
-			break
+		if versionSubstr == "" || strings.Contains(v["version"], versionSubstr) {
+			matchedVersions = append(matchedVersions, v["version"])
 		}
 	}
 
-	Expect(version).NotTo(BeEmpty(), fmt.Sprintf("version contains %s for package %s not found", versionSubstr, packageName))
+	Expect(len(matchedVersions)).To(BeNumerically(">", 0), fmt.Sprintf("version contains %s for package %s not found", versionSubstr, packageName))
 
-	return version
+	return matchedVersions[len(matchedVersions)-1]
 }
 
 func hasDefaultStorageClass() bool {


### PR DESCRIPTION
## What this PR does / why we need it
adjust harbor e2e test to get latest available package version
harbor package 2.2.3
harbor package 2.3.3

for the dependency package (cert-manager & contour) e2e test version
 ***get latest package version***

for the harbor package e2e test version
***get the available latest package version. 
for example  harbor package 2.3.3 has two available version in tkg1.5 repo`2.2.3+vmware.1-tkg.1` , `2.2.3+vmware.1-tkg.2`, we need to get the latest version `2.2.3+vmware.1-tkg.2`***