### PR TITLE
Use `calico` as the default CNI for `unmanaged` clusters

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -31,7 +31,7 @@ func init() {
 	ConfigureCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "Configuration file for unmanaged cluster creation")
 	ConfigureCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider to use for cluster creation. Default is 'kind'")
 	ConfigureCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The Tanzu Kubernetes Release location.")
-	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'antrea'")
+	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "calico", "The CNI to deploy. Default is 'calico'")
 	ConfigureCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR to use for Pod IP addresses. Default and format is '10.244.0.0/16'")
 	ConfigureCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR to use for Service IP addresses. Default and format is '10.96.0.0/16'")
 	ConfigureCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -58,7 +58,7 @@ func init() {
 	CreateCmd.Flags().StringVarP(&co.existingClusterKubeconfig, "existing-cluster-kubeconfig", "e", "", "Use an existing kubeconfig to tanzu-ify a cluster")
 	CreateCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider for cluster creation; default is kind")
 	CreateCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The URL to the image containing a Tanzu Kubernetes release")
-	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy; default is antrea")
+	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "calico", "The CNI to deploy; default is calico")
 	CreateCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR for Pod IP allocation; default is 10.244.0.0/16")
 	CreateCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR for Service IP allocation; default is 10.96.0.0/16")
 	CreateCmd.Flags().StringSliceVarP(&co.portMapping, "port-map", "p", []string{}, "Ports to map between container node and the host (format: '80:80/tcp' or just '80')")


### PR DESCRIPTION
## What this PR does / why we need it
Currently, on restart, managed/unmanaged clusters on docker
with antrea CNI do not reconnect. This means a user would have
to rebuild their cluster if they `docker stop <cluster>`
or suffer a system reboot. This patch sets calico as the
default CNI for unmanaged clusters

Related: https://github.com/vmware-tanzu/community-edition/issues/3058

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Calico is the default CNI for unmanaged clusters
```

## Which issue(s) this PR fixes
Fixes: https://github.com/vmware-tanzu/community-edition/issues/3239

## Describe testing done for PR
Build binaries and configure works as expected
```
$ ./build configure test
Wrote configuration file to: test.yaml
$ cat test.yaml
ClusterName: test
KubeconfigPath: ""
ExistingClusterKubeconfig: ""
NodeImage: ""
Provider: kind
ProviderConfiguration: {}
Cni: calico
CniConfiguration: {}
PodCidr: 10.244.0.0/16
ServiceCidr: 10.96.0.0/16
TkrLocation: projects.registry.vmware.com/tce/tkr:v1.21.5
PortsToForward: []
SkipPreflight: false
ControlPlaneNodeCount: "1"
WorkerNodeCount: "0"
```

Started a new default cluster (that gets calico CNI):
```
$ k get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
kube-system          calico-kube-controllers-c46d6db79-wjqqc      1/1     Running   0          20s
kube-system          calico-node-ttb46                            1/1     Running   0          20s
kube-system          coredns-558bd4d5db-q6p57                     1/1     Running   0          76s
kube-system          coredns-558bd4d5db-zbmkf                     1/1     Running   0          76s
kube-system          etcd-meow-control-plane                      1/1     Running   0          79s
kube-system          kube-apiserver-meow-control-plane            1/1     Running   0          79s
kube-system          kube-controller-manager-meow-control-plane   1/1     Running   0          79s
kube-system          kube-proxy-7g9xg                             1/1     Running   0          77s
kube-system          kube-scheduler-meow-control-plane            1/1     Running   0          79s
local-path-storage   local-path-provisioner-547f784dff-x594n      1/1     Running   0          76s
tkg-system           kapp-controller-555f8b88d5-9zbjg             1/1     Running   0          76s
```
and on `systemctl restart docker`, the pods come back up and am able to run `k get pods -A` successfully again