### PR TITLE
Update pinniped package 0.12.1 to pick up dex 2.31.0 support for distroless base image

### DIFF
--- a/addons/packages/pinniped/0.12.1/bundle/.imgpkg/images.yml
+++ b/addons/packages/pinniped/0.12.1/bundle/.imgpkg/images.yml
@@ -9,12 +9,12 @@ images:
           url: docker.io/getpinniped/pinniped-server:v0.12.1
   image: index.docker.io/getpinniped/pinniped-server@sha256:8b4ee3b279d8d1d1f1c65d95f8611a99e00c6d2fbb5dbf974ad76ac4ca563d73
 - annotations:
-    kbld.carvel.dev/id: projects.registry.vmware.com/tce/dex:v2.31.0_vmware.1
+    kbld.carvel.dev/id: projects.registry.vmware.com/tce/dex:v2.31.0_vmware.2
     kbld.carvel.dev/origins: |
       - resolved:
-          tag: v2.31.0_vmware.1
-          url: projects.registry.vmware.com/tce/dex:v2.31.0_vmware.1
-  image: projects.registry.vmware.com/tce/dex@sha256:0e00ed8835ca00a1a7fd95be7d4cba0808f7f6c71e8624e8270e69c51c48a431
+          tag: v2.31.0_vmware.2
+          url: projects.registry.vmware.com/tce/dex:v2.31.0_vmware.2
+  image: projects.registry.vmware.com/tce/dex@sha256:c67d22fe25475fce7f63dacd5e6e3a9b4a0c69669a30ce5140fedd2a7fd7b6b6
 - annotations:
     kbld.carvel.dev/id: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
     kbld.carvel.dev/origins: |

--- a/addons/packages/pinniped/0.12.1/bundle/.imgpkg/images.yml
+++ b/addons/packages/pinniped/0.12.1/bundle/.imgpkg/images.yml
@@ -9,12 +9,12 @@ images:
           url: docker.io/getpinniped/pinniped-server:v0.12.1
   image: index.docker.io/getpinniped/pinniped-server@sha256:8b4ee3b279d8d1d1f1c65d95f8611a99e00c6d2fbb5dbf974ad76ac4ca563d73
 - annotations:
-    kbld.carvel.dev/id: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+    kbld.carvel.dev/id: projects.registry.vmware.com/tce/dex:v2.31.0_vmware.1
     kbld.carvel.dev/origins: |
       - resolved:
-          tag: v2.30.2_vmware.1
-          url: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
-  image: projects.registry.vmware.com/tce/dex@sha256:b9e2f32b864f83a5f3e7b555b876c40665576bc09b20de745b3675238fd7657d
+          tag: v2.31.0_vmware.1
+          url: projects.registry.vmware.com/tce/dex:v2.31.0_vmware.1
+  image: projects.registry.vmware.com/tce/dex@sha256:0e00ed8835ca00a1a7fd95be7d4cba0808f7f6c71e8624e8270e69c51c48a431
 - annotations:
     kbld.carvel.dev/id: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
     kbld.carvel.dev/origins: |

--- a/addons/packages/pinniped/0.12.1/bundle/config/overlay/dex-deployment.yaml
+++ b/addons/packages/pinniped/0.12.1/bundle/config/overlay/dex-deployment.yaml
@@ -29,7 +29,9 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+      #! we are currently manually building an image based on OSS upstream dex and
+      #! pushing to registry projects.registry.vmware.com/tce/dex
+      - image: projects.registry.vmware.com/tce/dex:v2.31.0_vmware.1
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/bundle/config/overlay/dex-deployment.yaml
+++ b/addons/packages/pinniped/0.12.1/bundle/config/overlay/dex-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
       #! we are currently manually building an image based on OSS upstream dex and
       #! pushing to registry projects.registry.vmware.com/tce/dex
-      - image: projects.registry.vmware.com/tce/dex:v2.31.0_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.31.0_vmware.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex


### PR DESCRIPTION

Signed-off-by: Benjamin A. Petersen <ben@benjaminapetersen.me>

## What this PR does / why we need it

Update pinniped package 0.12.1 to pick up dex 2.31.0 support for distroless base image.

```bash
# build dex using distroless
docker build -t projects.registry.vmware.com/tce/dex:v2.31.0_vmware.1 --build-arg=BASEIMAGE=gcr.io/distroless/base:latest .
docker push projects.registry.vmware.com/tce/dex:v2.31.0_vmware.1
```

## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Update pinniped package 0.12.1 to pick up dex 2.31.0 support for distroless base image.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
