### PR TITLE
Implements meaningful exit codes for create `unmanaged` cluster

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -5,6 +5,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/config"
@@ -47,7 +49,7 @@ var CreateCmd = &cobra.Command{
 	Use:   "create <cluster name>",
 	Short: "Create an unmanaged Tanzu cluster",
 	Long:  createDesc,
-	RunE:  create,
+	Run:  create,
 	Args:  cobra.MaximumNArgs(1),
 }
 
@@ -68,7 +70,7 @@ func init() {
 	CreateCmd.Flags().StringVar(&co.numWorkers, "worker-node-count", "", "The number of worker nodes to deploy; default is 0")
 }
 
-func create(cmd *cobra.Command, args []string) error {
+func create(cmd *cobra.Command, args []string) {
 	var clusterName string
 
 	// Set the cluster name if it was provided, otherwise read from config file
@@ -95,7 +97,7 @@ func create(cmd *cobra.Command, args []string) error {
 	clusterConfig, err := config.InitializeConfiguration(configArgs)
 	if err != nil {
 		log.Errorf("Failed to initialize configuration. Error %v\n", err)
-		return nil
+		os.Exit(tanzu.InvalidConfig)
 	}
 	clusterConfig.SkipPreflightChecks = co.skipPreflightChecks
 
@@ -112,11 +114,9 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 
 	tm := tanzu.New(log)
-	err = tm.Deploy(clusterConfig)
+	err, exitCode := tm.Deploy(clusterConfig)
 	if err != nil {
 		log.Error(err.Error())
-		return nil
+		os.Exit(exitCode)
 	}
-
-	return nil
 }

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/codes.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/codes.go
@@ -1,0 +1,51 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package tanzu is responsible for orchestrating the various packages that satisfy unmanaged
+// operations such as create, configure, list, and delete. This package is meant to be the API
+// entrypoint for those calling unmanaged programmatically.
+package tanzu
+
+const (
+	// 0  - Success!
+	Success int = iota
+
+	// 1  - Provided configurations could not be validated
+	InvalidConfig
+
+	// 2  - Could not create local cluster directories
+	ErrCreatingClusterDirs
+
+	// 3  - Unable to get TKR BOM
+	ErrTkrBom
+
+	// 4  - Could not render config
+	ErrRenderingConfig
+
+	// 5  - TKR BOM not parseable
+	ErrTkrBomParsing
+
+	// 6  - Could not resolve kapp controller bundle
+	ErrKappBundleResolving
+
+	// 7  - Unable to create new cluster
+	ErrCreateCluster
+
+	// 8  - Unable to use existing cluster (if provided)
+	ErrExistingCluster
+
+	// 9  - Could not install kapp controller to cluster
+	ErrKappInstall
+
+	// 10 - Could not install core package repo to cluster
+	ErrCorePackageRepoInstall
+
+	// 11 - Could not install additional package repo
+	ErrOtherPackageRepoInstall
+
+	// 12 - Could not install CNI package
+	ErrCniInstall
+
+	// 13 - Failed to merge kubeconfig and set context
+	ErrKubeconfigContextSet
+)

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -77,9 +77,9 @@ type CNIPackage struct {
 type Manager interface {
 	// Deploy orchestrates all the required steps in order to create an unmanaged Tanzu cluster. This can involve
 	// cluster creation, kapp-controller installation, CNI installation, and more. The steps that are taken
-	// depend on the configuration passed into Deploy. If something goes wrong during deploy, an error is
-	// returned.
-	Deploy(scConfig *config.UnmanagedClusterConfig) error
+	// depend on the configuration passed into Deploy.
+	// If something goes wrong during deploy, an error and it's corresponding exit code is returned.
+	Deploy(scConfig *config.UnmanagedClusterConfig) (error, int)
 	// List retrieves all known tanzu clusters are returns a list of them. If it's unable to interact with the
 	// underlying cluster provider, it returns an error.
 	List() ([]Cluster, error)
@@ -115,18 +115,18 @@ func validateConfiguration(scConfig *config.UnmanagedClusterConfig) error {
 
 // Deploy deploys a new cluster.
 //nolint:funlen,gocyclo
-func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error {
+func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (error, int) {
 	var err error
 
 	// 1. Validate the configuration
 	if err := validateConfiguration(scConfig); err != nil {
-		return err
+		return err, InvalidConfig
 	}
 	t.config = scConfig
 
 	t.clusterDirectory, err = createClusterDirectory(t.config.ClusterName)
 	if err != nil {
-		return err
+		return err, ErrCreatingClusterDirs
 	}
 
 	// Configure the logger to capture all bootstrap activity
@@ -138,12 +138,12 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 	log.Event(logger.WrenchEmoji, "Resolving Tanzu Kubernetes Release (TKR)")
 	bomFileName, err := getTkrBom(scConfig.TkrLocation)
 	if err != nil {
-		return fmt.Errorf("failed getting TKR BOM. Error: %s", err.Error())
+		return fmt.Errorf("failed getting TKR BOM. Error: %s", err.Error()), ErrTkrBom
 	}
 	configFp := filepath.Join(t.clusterDirectory, configFileName)
 	err = config.RenderConfigToFile(configFp, t.config)
 	if err != nil {
-		return err
+		return err, ErrRenderingConfig
 	}
 	log.Style(outputIndent, color.Faint).Infof("Rendered Config: %s\n", configFp)
 	log.Style(outputIndent, color.Faint).Infof("Bootstrap Logs: %s\n", bootstrapLogsFp)
@@ -151,7 +151,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 	log.Event(logger.WrenchEmoji, "Processing Tanzu Kubernetes Release")
 	t.bom, err = parseTKRBom(bomFileName)
 	if err != nil {
-		return fmt.Errorf("failed parsing TKR BOM. Error: %s", err.Error())
+		return fmt.Errorf("failed parsing TKR BOM. Error: %s", err.Error()), ErrTkrBomParsing
 	}
 
 	// 3. Resolve all required images
@@ -171,7 +171,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 	// kapp-controller
 	err = resolveKappBundle(t)
 	if err != nil {
-		return fmt.Errorf("failed resolving kapp-controller bundle. Error: %s", err.Error())
+		return fmt.Errorf("failed resolving kapp-controller bundle. Error: %s", err.Error()), ErrKappBundleResolving
 	}
 	log.Event(logger.PackageEmoji, "Selected kapp-controller image bundle")
 	log.Style(outputIndent, color.Faint).Infof("%s\n", t.kappControllerBundle.GetRegistryURL())
@@ -183,13 +183,13 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 		log.Eventf(logger.RocketEmoji, "Using existing cluster\n")
 		clusterToUse, err = useExistingCluster(scConfig)
 		if err != nil {
-			return fmt.Errorf("failed to use existing cluster, Error: %s", err.Error())
+			return fmt.Errorf("failed to use existing cluster, Error: %s", err.Error()), ErrExistingCluster
 		}
 	} else {
 		log.Eventf(logger.RocketEmoji, "Creating cluster %s\n", scConfig.ClusterName)
 		clusterToUse, err = runClusterCreate(scConfig)
 		if err != nil {
-			return fmt.Errorf("failed to create cluster, Error: %s", err.Error())
+			return fmt.Errorf("failed to create cluster, Error: %s", err.Error()), ErrCreateCluster
 		}
 	}
 
@@ -200,13 +200,13 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 	// 5. Install kapp-controller
 	kc, err := kapp.New(kcBytes)
 	if err != nil {
-		return fmt.Errorf("failed to create kapp-controller manager, Error: %s", err.Error())
+		return fmt.Errorf("failed to create kapp-controller manager, Error: %s", err.Error()), ErrKappInstall
 	}
 
 	log.Event(logger.EnvelopeEmoji, "Installing kapp-controller")
 	kappDeployment, err := installKappController(t, kc)
 	if err != nil {
-		return fmt.Errorf("failed to install kapp-controller, Error: %s", err.Error())
+		return fmt.Errorf("failed to install kapp-controller, Error: %s", err.Error()), ErrKappInstall
 	}
 	blockForKappStatus(kappDeployment, kc)
 
@@ -215,12 +215,12 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 	log.Event(logger.EnvelopeEmoji, "Installing package repositories")
 	createdCoreRepo, err := createPackageRepo(pkgClient, tkgSysNamespace, tkgCoreRepoName, t.bom.GetTKRCoreRepoBundlePath())
 	if err != nil {
-		return fmt.Errorf("failed to install core package repo. Error: %s", err.Error())
+		return fmt.Errorf("failed to install core package repo. Error: %s", err.Error()), ErrCorePackageRepoInstall
 	}
 	for _, additionalRepo := range t.bom.GetAdditionalRepoBundlesPaths() {
 		_, err = createPackageRepo(pkgClient, tkgGlobalPkgNamespace, tkgCoreRepoName, additionalRepo)
 		if err != nil {
-			return fmt.Errorf("failed to install adiditonal package repo. Error: %s", err.Error())
+			return fmt.Errorf("failed to install adiditonal package repo. Error: %s", err.Error()), ErrOtherPackageRepoInstall
 		}
 	}
 	blockForRepoStatus(createdCoreRepo, pkgClient)
@@ -239,7 +239,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 		log.Style(outputIndent, color.Faint).Infof("%s:%s\n", t.selectedCNIPkg.fqPkgName, t.selectedCNIPkg.pkgVersion)
 		err = installCNI(pkgClient, t)
 		if err != nil {
-			return fmt.Errorf("failed to install the CNI package. Error: %s", err.Error())
+			return fmt.Errorf("failed to install the CNI package. Error: %s", err.Error()), ErrCniInstall
 		}
 	}
 
@@ -260,7 +260,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 	log.Style(outputIndent, color.FgGreen).Infof("kubectl get po -A\n")
 	log.Infof("Delete this cluster:\n")
 	log.Style(outputIndent, color.FgGreen).Infof("tanzu unmanaged delete %s\n", scConfig.ClusterName)
-	return nil
+	return nil, Success
 }
 
 // List lists the unmanaged clusters.


### PR DESCRIPTION
## What this PR does / why we need it
As outlined in https://github.com/vmware-tanzu/community-edition/pull/3072

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Adds meaningful exit codes to unmanaged cluster create
```

## Describe testing done for PR
Build binaries and runs as expected
