### PR TITLE
Deploy aviinfra setting only in workload cluster to fix ako upgrade issue

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/crds/aviinfrasettings.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/crds/aviinfrasettings.yaml
@@ -100,6 +100,6 @@ spec:
       status: {}
 #@ end
 
-#@ if data.values.loadBalancerAndIngressService.config.tkg_cluster_role != "management":
+#@ if data.values.loadBalancerAndIngressService.config.tkg_cluster_role == "workload":
 --- #@ avi_infra_setting_crd()
 #@ end


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Because we leverage AVIInfraSetting CRD in ako operator to do the VIP network separation, we need to avoid that crd deployed in ako package when in TKG management cluster.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
