### PR TITLE
Fix in-yaml fancy quotes in the secure-ingress guide

### DIFF
--- a/docs/site/content/docs/latest/solutions-secure-ingress.md
+++ b/docs/site/content/docs/latest/solutions-secure-ingress.md
@@ -167,7 +167,7 @@ Complete the following steps:
           envoy:
             service:
               annotations:
-                external-dns.alpha.kubernetes.io/hostname: “*.example.com”
+                external-dns.alpha.kubernetes.io/hostname: "*.example.com"
           ```
 
       1. Ensure that the file is saved and then install the Contour package by running:
@@ -479,7 +479,7 @@ spec:
     name: wildcard-lets-encrypt
     kind: ClusterIssuer
   dnsNames:
-  - “*.example.com”
+  - "*.example.com"
 EOF
 ```
 


### PR DESCRIPTION
## What this PR does / why we need it
There are fancy-quotes in the yaml object. (common error when editing YAML on MacOS)
This causes the chars to be included in the domain string.

If users edit the domain without replacing the fancy quotes (like I did):
- The cert-manager controller logs will indicate a Certificate cannot be reconciled
  (the leading fancy-quote causes the wildcard domain to fail to encode to an [IA5string](https://en.wikipedia.org/wiki/IA5STRING))
- I think external-dns will either fail or create the wrong subdomain record

This patch replaces them with normal quotes.

## Describe testing done for PR
I experienced pain running into this problem.
When I fixed it, my world contained less pain than before.

Cheers friends! :)

### release-note
```release-note
Fix in-yaml fancy quotes in the secure-ingress guide to avoid cert-manger and external-dns errors and misconfigurations.
```