### PR TITLE
Fix file access issue in kapp-controller package

### DIFF
--- a/addons/packages/kapp-controller/0.30.0/bundle/config/values.star
+++ b/addons/packages/kapp-controller/0.30.0/bundle/config/values.star
@@ -14,5 +14,5 @@ def generateBashCmdForDNS(coreDNSIP):
     # In this way, Kapp Controller will have cluster IP access,
     # and still able to resolve enternal urls when core DNS is unavailable
 
-    return "cp /etc/resolv.conf /etc/resolv.conf.bak; sed '1 i nameserver " + coreDNSIP + "' /etc/resolv.conf.bak > /etc/resolv.conf; rm /etc/resolv.conf.bak; cp -R /etc/* /kapp-etc"
+    return "cp /etc/resolv.conf /etc/resolv.conf.bak; sed '1 i nameserver " + coreDNSIP + "' /etc/resolv.conf.bak > /etc/resolv.conf; rm /etc/resolv.conf.bak; cp -R /etc/* /kapp-etc; chmod g+w /kapp-etc/pki/tls/certs/ca-bundle.crt && chgrp 2000 /kapp-etc/pki/tls/certs/ca-bundle.crt"
 end

--- a/addons/packages/kapp-controller/0.30.0/package.yaml
+++ b/addons/packages/kapp-controller/0.30.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/kapp-controller@sha256:c496bc7d583eb5f4273d4b31f37c89d35b4d41b78d703727c6d344edb07276a0
+          image: projects.registry.vmware.com/tce/kapp-controller@sha256:4bd886a42a802890834ec8d34fa89e56b6fd150c059a877d402d6c8ae3afa492
       template:
       - ytt:
           paths:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Add write access to `/etc/pki/tls/certs/ca-bundle.crt` so kapp-controller will have no issue in writing custom certificates into it.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix a bug that prevents kapp-controller using custom certificates.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested package in a local environment.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
