### PR TITLE
Fail install if sudo access fails

### DIFF
--- a/hack/release/install.sh
+++ b/hack/release/install.sh
@@ -55,7 +55,9 @@ if [[ ":${PATH}:" == *":$HOME/bin:"* && -d "${HOME}/bin" ]]; then
   install "${MY_DIR}/tanzu" "${TANZU_BIN_PATH}"
 else
   echo Installing tanzu cli to "${TANZU_BIN_PATH}"
-  sudo install "${MY_DIR}/tanzu" "${TANZU_BIN_PATH}"
+  sudo install "${MY_DIR}/tanzu" "${TANZU_BIN_PATH}" || \
+      echo "sudo access required to install to ${TANZU_BIN_PATH}"; \
+      exit 1
 fi
 
 # copy the uninstall script to tanzu-cli directory


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

If someone installing TCE either does not have sudo access, or enters
the wrong password, it is currently ignored and the script continues on
but does not actually complete the install.

This adds a check on the sudo attempt to make sure it is successful. If
not, it gives an error and exits will a failure return code.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Install on Linux and MacOS will now return error if attempt to sudo fails.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1647 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Local test scripts to attempt to sudo and verify exit code if unable to do so.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
