### PR TITLE
add cartographer package

### DIFF
--- a/addons/packages/cartographer/0.2.2/README.md
+++ b/addons/packages/cartographer/0.2.2/README.md
@@ -1,0 +1,63 @@
+# Cartographer
+
+Cartographer allows you to create secure and reusable supply chains that define
+all of your application CI and CD in one place, in cluster.
+
+## Components
+
+* cartographer
+
+## Supported Providers
+
+The following table shows the providers this package can work with.
+
+| AWS  | Azure | vSphere | Docker |
+|------|-------|---------|--------|
+| ✅   | ✅    | ✅      | ✅     |
+
+## Configuration
+
+The Cartographer package has no configurable properties.
+
+## Installation
+
+The Cartographer package requires use of cert-manager for certificate
+generation.
+
+1. Install cert-manager Package
+
+   ```shell
+   tanzu package install cert-manager \
+      --package-name cert-manager.community.tanzu.vmware.com \
+      --version ${CERT_MANAGER_PACKAGE_VERSION}
+   ```
+
+   > You can get the `${CERT_MANAGER_PACKAGE_VERSION}` from running `tanzu
+   > package available list cert-manager.community.tanzu.vmware.com`.
+   > Specifying a namespace may be required depending on where your package
+   > repository was installed.
+
+2. Install the Cartographer package
+
+   ```shell
+   tanzu package install cartographer \
+      --package-name cartographer.community.tanzu.vmware.com \
+      --version ${CARTOGRAPHER_PACKAGE_VERSION}
+   ```
+
+   > You can get the `${CARTOGRAPHER_PACKAGE_VERSION}` from running `tanzu
+   > package available list cartographer.community.tanzu.vmware.com`.
+   > Specifying a namespace may be required depending on where your package
+   > repository was installed.
+
+## Documentation
+
+For documentation specific to Cartographer, check out
+[cartographer.sh](https://cartographer.sh) and the main repository
+[vmware-tanzu/cartographer](https://github.com/vmware-tanzu/cartographer).
+
+[carvel]: https://carvel.dev/
+[Cartographer]: https://cartographer.sh
+[kapp-controller]: https://github.com/vmware-tanzu/carvel-kapp-controller
+[Tanzu CLI]: https://github.com/vmware-tanzu/tanzu-framework
+[cert-manager]: https://github.com/cert-manager/cert-manager

--- a/addons/packages/cartographer/0.2.2/package.yaml
+++ b/addons/packages/cartographer/0.2.2/package.yaml
@@ -1,0 +1,24 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: cartographer.community.tanzu.vmware.com.0.2.2
+spec:
+  refName: cartographer.community.tanzu.vmware.com
+  version: 0.2.2
+  releaseNotes: https://github.com/vmware-tanzu/cartographer/releases/tag/0.2.2
+  releasedAt: "2022-03-01T19:19:34Z"
+  valuesSchema:
+    openAPIv3:
+      title: cartographer.community.tanzu.vmware.com.0.2.2 values schema
+      properties: {}
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/cartographer@sha256:5a58e3d9760b7972f0168161625cfd7be01fb55aff0b0983739e2d39f6794c1e
+      template:
+      - ytt:
+          ignoreUnknownComments: true
+      - kbld: {}
+      deploy:
+      - kapp: {}

--- a/addons/packages/cartographer/metadata.yaml
+++ b/addons/packages/cartographer/metadata.yaml
@@ -13,7 +13,7 @@ spec:
     Cartographer is a Kubernetes native Choreographer. It allows users to
     configure K8s resources into re-usable Supply Chains that can be used to
     define all of the stages that an Application Workload must go through to
-    get to an environment.
+    get to an environment. Requires cert-manager to be installed.
   maintainers:
   - name: VMware
   iconSVGBase64: PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNIDEwIDEwIEggOTAgViA5MCBIIDEwIEwgMTAgMTAiLz48L3N2Zz4K

--- a/addons/packages/cartographer/metadata.yaml
+++ b/addons/packages/cartographer/metadata.yaml
@@ -1,0 +1,19 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  name: cartographer.community.tanzu.vmware.com
+  annotations:
+    kapp.k14s.io/change-group: carto.run/meta
+spec:
+  displayName: Cartographer
+  providerName: VMware
+  shortDescription: Kubernetes native Supply Chain Choreographer.
+  supportDescription: https://github.com/vmware-tanzu/cartographer
+  longDescription: |-
+    Cartographer is a Kubernetes native Choreographer. It allows users to
+    configure K8s resources into re-usable Supply Chains that can be used to
+    define all of the stages that an Application Workload must go through to
+    get to an environment.
+  maintainers:
+  - name: VMware
+  iconSVGBase64: PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNIDEwIDEwIEggOTAgViA5MCBIIDEwIEwgMTAgMTAiLz48L3N2Zz4K

--- a/addons/packages/cartographer/vendir.lock.yml
+++ b/addons/packages/cartographer/vendir.lock.yml
@@ -1,0 +1,8 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/package-for-cartographer/releases/60735667
+    path: .
+  path: 0.2.2
+kind: LockConfig

--- a/addons/packages/cartographer/vendir.yml
+++ b/addons/packages/cartographer/vendir.yml
@@ -1,0 +1,14 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.12.0
+directories:
+  - path: 0.2.2
+    contents:
+      - path: .
+        githubRelease:
+          slug: vmware-tanzu/package-for-cartographer
+          tag: v0.2.2
+          disableAutoChecksumValidation: true
+          assetNames:
+          - "package.yaml"
+          - "README.md"

--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -1,5 +1,8 @@
 ---
 packages:
+  - name: cartographer
+    versions:
+      - 0.2.2
   - name: cert-manager
     versions:
       - 1.3.3


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds the [cartographer](https://github.com/vmware-tanzu/cartographer) package as an addon having the Package bits coming out of [`vmware-tanzu/package-for-cartographer`](https://github.com/vmware-tanzu/package-for-cartographer). 

~I'm currently marking this PR as a draft as there are at least two details to finish up:~

~1. [x] `package-for-cartographer` being made public~
~2. [x] image being hosted under `projects.registry.vmware.com`~


## Details for the Release Notes (PLEASE PROVIDE)

```release-note
Add Cartographer v0.2.2 package
```

## Which issue(s) this PR fixes

closes #3024 

## Describe testing done for PR

0. create a cluster provisioned with kapp-controller and cert-manager
1. submit the `metadata.yaml` and `0.2.2/package.yaml` files
2. install the package using the tanzu cli

```bash
CARTOGRAPHER_VERSION=0.2.2
tanzu package install cartographer \
     --package-name cartographer.community.tanzu.vmware.com \
     --version $CARTOGRAPHER_VERSION
```
```console
| Installing package 'cartographer.community.tanzu.vmware.com'
| Getting package metadata for 'cartographer.community.tanzu.vmware.com'
| Creating service account 'cartographer-default-sa'
| Creating cluster admin role 'cartographer-default-cluster-role'
| Creating cluster role binding 'cartographer-default-cluster-rolebinding'
| Creating package resource
/ Waiting for 'PackageInstall' reconciliation for 'cartographer'
/ 'PackageInstall' resource install status: Reconciling
 Added installed package 'cartographer'
```

3. run the smoke test from `package-for-cartographer` (see https://github.com/vmware-tanzu/package-for-cartographer/blob/c8db5d70b0ad231cddbeb0633f002b88439e7aac/tests/01-test-basic.sh)


## Special notes for your reviewer

~As I mentioned before, the repository is currently private, so, `ghcr.io` will require credentials for pulling the image. Fortunately `secretgen-controller` helps here:~

```
tanzu secret registry add ghcr --username <gh_user> --password <gh_password> --server ghcr.io --export-to-all-namespaces
```

~before `tanzu package install` will do the job (or .. just wait for the repository to be made public _soon^{tm}_)~
