### PR TITLE
Reenable submodule linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ lint: tools verify-modules
 			$(GOLANGCI_LINT) run -v --timeout=5m; \
 		else \
 			cd $${i}; \
-			echo $(MAKE) lint || exit 1; \
+			$(MAKE) lint || exit 1; \
 			cd $$working_dir; \
 		fi; \
 	done

--- a/addons/packages/ako-operator/1.6.0/test/ako_operator_test.go
+++ b/addons/packages/ako-operator/1.6.0/test/ako_operator_test.go
@@ -4,7 +4,6 @@
 package akooperator_test
 
 import (
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/providers/tests/unit/matchers"
 	"path/filepath"
 	"strings"
 
@@ -13,6 +12,7 @@ import (
 
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/repo"
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/ytt"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/providers/tests/unit/matchers"
 )
 
 func assertFoundOne(docs []string, err error) {

--- a/addons/packages/contour/1.20.1/test/unittest/contour_test.go
+++ b/addons/packages/contour/1.20.1/test/unittest/contour_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Contour Ytt Templates", func() {
 
 	Context("Envoy host ports enabled, no http port", func() {
 		BeforeEach(func() {
-			values = noHostPortHttp
+			values = noHostPortHTTP
 		})
 
 		It("renders with an error", func() {
@@ -119,7 +119,7 @@ var _ = Describe("Contour Ytt Templates", func() {
 
 	Context("Envoy host ports enabled, no https port", func() {
 		BeforeEach(func() {
-			values = noHostPortHttps
+			values = noHostPortHTTPS
 		})
 
 		It("renders with an error", func() {

--- a/addons/packages/contour/1.20.1/test/unittest/fixtures_test.go
+++ b/addons/packages/contour/1.20.1/test/unittest/fixtures_test.go
@@ -45,9 +45,9 @@ certificates:
   renewBefore: 0
 `
 
-// noHostPortHttp has envoy.hostPorts.enable set to true and
+// noHostPortHTTP has envoy.hostPorts.enable set to true and
 // an empty envoy.hostPorts.http value.
-const noHostPortHttp string = `
+const noHostPortHTTP string = `
 #@data/values
 ---
 envoy:
@@ -56,9 +56,9 @@ envoy:
     http: 0
 `
 
-// noHostPortHttps has envoy.hostPorts.enable set to true and
+// noHostPortHTTPS has envoy.hostPorts.enable set to true and
 // an empty envoy.hostPorts.https value.
-const noHostPortHttps string = `
+const noHostPortHTTPS string = `
 #@data/values
 ---
 envoy:

--- a/addons/packages/harbor/2.2.3/test/e2e/harbor_suite_test.go
+++ b/addons/packages/harbor/2.2.3/test/e2e/harbor_suite_test.go
@@ -288,7 +288,7 @@ func installPackage(name, packageName, version, valuesFilename string) {
 	}
 
 	_, err := utils.Tanzu(nil, args...)
-	utils.Tanzu(nil, "package", "installed", "list")
+	_, _ = utils.Tanzu(nil, "package", "installed", "list")
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/test/load_balancer_and_ingress_service_test.go
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/test/load_balancer_and_ingress_service_test.go
@@ -7,14 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/providers/tests/unit/matchers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/repo"
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/ytt"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/providers/tests/unit/matchers"
 )
 
 var _ = Describe("LoadBalancer And Ingress Service Ytt Templates", func() {
@@ -240,9 +240,9 @@ func AviInfraSettingCRDExists(output string) bool {
 }
 
 func getConfigKeyFromData(cfg corev1.ConfigMap, key string) string {
-	cfg_value, exists := cfg.Data[key]
+	cfgValue, exists := cfg.Data[key]
 	Expect(exists).To(Equal(true))
-	return cfg_value
+	return cfgValue
 }
 
 func unmarshalConfigMap(output string) corev1.ConfigMap {

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/test/go.mod
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/test/go.mod
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -22,6 +23,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
 	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 // indirect
 	golang.org/x/text v0.3.7 // indirect
@@ -30,6 +32,7 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apimachinery v0.23.1 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b // indirect

--- a/cli/cmd/plugin/diagnostics/pkg/collect_unmanaged.go
+++ b/cli/cmd/plugin/diagnostics/pkg/collect_unmanaged.go
@@ -24,8 +24,8 @@ func collectUnmanagedDiags() error {
 
 	scriptName := umScriptPath
 	argsMap := crashdexec.ArgMap{
-		"workdir":                 commonArgs.workDir,
-		"outputdir":               commonArgs.outputDir,
+		"workdir":                commonArgs.workDir,
+		"outputdir":              commonArgs.outputDir,
 		"unmanaged_cluster_name": unmanagedArgs.clusterName,
 		"unmanaged_kubeconfig":   unmanagedArgs.kubeconfig,
 		"unmanaged_context":      unmanagedArgs.contextName,

--- a/cli/cmd/plugin/diagnostics/pkg/types.go
+++ b/cli/cmd/plugin/diagnostics/pkg/types.go
@@ -9,7 +9,7 @@ type collectCommonArgs struct {
 }
 
 type collectUnmanagedArgs struct {
-	kubeconfig string
+	kubeconfig  string
 	clusterName string
 	contextName string
 }

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -114,7 +114,7 @@ func create(cmd *cobra.Command, args []string) {
 	}
 
 	tm := tanzu.New(log)
-	err, exitCode := tm.Deploy(clusterConfig)
+	exitCode, err := tm.Deploy(clusterConfig)
 	if err != nil {
 		log.Error(err.Error())
 		os.Exit(exitCode)

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -74,8 +74,8 @@ type Manager interface {
 	// Deploy orchestrates all the required steps in order to create an unmanaged Tanzu cluster. This can involve
 	// cluster creation, kapp-controller installation, CNI installation, and more. The steps that are taken
 	// depend on the configuration passed into Deploy.
-	// If something goes wrong during deploy, an error and it's corresponding exit code is returned.
-	Deploy(scConfig *config.UnmanagedClusterConfig) (error, int)
+	// If something goes wrong during deploy, an error and its corresponding exit code is returned.
+	Deploy(scConfig *config.UnmanagedClusterConfig) (int, error)
 	// List retrieves all known tanzu clusters are returns a list of them. If it's unable to interact with the
 	// underlying cluster provider, it returns an error.
 	List() ([]Cluster, error)
@@ -111,18 +111,18 @@ func validateConfiguration(scConfig *config.UnmanagedClusterConfig) error {
 
 // Deploy deploys a new cluster.
 //nolint:funlen,gocyclo
-func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (error, int) {
+func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int, error) {
 	var err error
 
 	// 1. Validate the configuration
 	if err := validateConfiguration(scConfig); err != nil {
-		return err, InvalidConfig
+		return InvalidConfig, err
 	}
 	t.config = scConfig
 
 	t.clusterDirectory, err = createClusterDirectory(t.config.ClusterName)
 	if err != nil {
-		return err, ErrCreatingClusterDirs
+		return ErrCreatingClusterDirs, err
 	}
 
 	// Configure the logger to capture all bootstrap activity
@@ -139,12 +139,12 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (erro
 	log.Event(logger.WrenchEmoji, "Resolving Tanzu Kubernetes Release (TKR)")
 	bomFileName, err := getTkrBom(scConfig.TkrLocation)
 	if err != nil {
-		return fmt.Errorf("failed getting TKR BOM. Error: %s", err.Error()), ErrTkrBom
+		return ErrTkrBom, fmt.Errorf("failed getting TKR BOM. Error: %s", err.Error())
 	}
 	configFp := filepath.Join(t.clusterDirectory, configFileName)
 	err = config.RenderConfigToFile(configFp, t.config)
 	if err != nil {
-		return err, ErrRenderingConfig
+		return ErrRenderingConfig, err
 	}
 	log.Style(outputIndent, color.Faint).Infof("Rendered Config: %s\n", configFp)
 	log.Style(outputIndent, color.Faint).Infof("Bootstrap Logs: %s\n", bootstrapLogsFp)
@@ -152,7 +152,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (erro
 	log.Event(logger.WrenchEmoji, "Processing Tanzu Kubernetes Release")
 	t.bom, err = parseTKRBom(bomFileName)
 	if err != nil {
-		return fmt.Errorf("failed parsing TKR BOM. Error: %s", err.Error()), ErrTkrBomParsing
+		return ErrTkrBomParsing, fmt.Errorf("failed parsing TKR BOM. Error: %s", err.Error())
 	}
 
 	// 3. Resolve all required images
@@ -172,7 +172,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (erro
 	// kapp-controller
 	err = resolveKappBundle(t)
 	if err != nil {
-		return fmt.Errorf("failed resolving kapp-controller bundle. Error: %s", err.Error()), ErrKappBundleResolving
+		return ErrKappBundleResolving, fmt.Errorf("failed resolving kapp-controller bundle. Error: %s", err.Error())
 	}
 	log.Event(logger.PackageEmoji, "Selected kapp-controller image bundle")
 	log.Style(outputIndent, color.Faint).Infof("%s\n", t.kappControllerBundle.GetRegistryURL())
@@ -184,13 +184,13 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (erro
 		log.Eventf(logger.RocketEmoji, "Using existing cluster\n")
 		clusterToUse, err = useExistingCluster(scConfig)
 		if err != nil {
-			return fmt.Errorf("failed to use existing cluster, Error: %s", err.Error()), ErrExistingCluster
+			return ErrExistingCluster, fmt.Errorf("failed to use existing cluster, Error: %s", err.Error())
 		}
 	} else {
 		log.Eventf(logger.RocketEmoji, "Creating cluster %s\n", scConfig.ClusterName)
 		clusterToUse, err = runClusterCreate(scConfig)
 		if err != nil {
-			return fmt.Errorf("failed to create cluster, Error: %s", err.Error()), ErrCreateCluster
+			return ErrCreateCluster, fmt.Errorf("failed to create cluster, Error: %s", err.Error())
 		}
 	}
 
@@ -201,13 +201,13 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (erro
 	// 5. Install kapp-controller
 	kc, err := kapp.New(kcBytes)
 	if err != nil {
-		return fmt.Errorf("failed to create kapp-controller manager, Error: %s", err.Error()), ErrKappInstall
+		return ErrKappInstall, fmt.Errorf("failed to create kapp-controller manager, Error: %s", err.Error())
 	}
 
 	log.Event(logger.EnvelopeEmoji, "Installing kapp-controller")
 	kappDeployment, err := installKappController(t, kc)
 	if err != nil {
-		return fmt.Errorf("failed to install kapp-controller, Error: %s", err.Error()), ErrKappInstall
+		return ErrKappInstall, fmt.Errorf("failed to install kapp-controller, Error: %s", err.Error())
 	}
 	blockForKappStatus(kappDeployment, kc)
 
@@ -216,12 +216,12 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (erro
 	log.Event(logger.EnvelopeEmoji, "Installing package repositories")
 	createdCoreRepo, err := createPackageRepo(pkgClient, tkgSysNamespace, tkgCoreRepoName, t.bom.GetTKRCoreRepoBundlePath())
 	if err != nil {
-		return fmt.Errorf("failed to install core package repo. Error: %s", err.Error()), ErrCorePackageRepoInstall
+		return ErrCorePackageRepoInstall, fmt.Errorf("failed to install core package repo. Error: %s", err.Error())
 	}
 	for _, additionalRepo := range t.bom.GetAdditionalRepoBundlesPaths() {
 		_, err = createPackageRepo(pkgClient, tkgGlobalPkgNamespace, tceRepoName, additionalRepo)
 		if err != nil {
-			return fmt.Errorf("failed to install adiditonal package repo. Error: %s", err.Error()), ErrOtherPackageRepoInstall
+			return ErrOtherPackageRepoInstall, fmt.Errorf("failed to install adiditonal package repo. Error: %s", err.Error())
 		}
 	}
 	blockForRepoStatus(createdCoreRepo, pkgClient)
@@ -240,7 +240,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (erro
 		log.Style(outputIndent, color.Faint).Infof("%s:%s\n", t.selectedCNIPkg.fqPkgName, t.selectedCNIPkg.pkgVersion)
 		err = installCNI(pkgClient, t)
 		if err != nil {
-			return fmt.Errorf("failed to install the CNI package. Error: %s", err.Error()), ErrCniInstall
+			return ErrCniInstall, fmt.Errorf("failed to install the CNI package. Error: %s", err.Error())
 		}
 	}
 
@@ -261,7 +261,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (erro
 	log.Style(outputIndent, color.FgGreen).Infof("kubectl get po -A\n")
 	log.Infof("Delete this cluster:\n")
 	log.Style(outputIndent, color.FgGreen).Infof("tanzu unmanaged delete %s\n", scConfig.ClusterName)
-	return nil, Success
+	return Success, nil
 }
 
 // List lists the unmanaged clusters.

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/image.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/image.go
@@ -14,6 +14,7 @@ import (
 	"github.com/k14s/ytt/pkg/cmd/template"
 	"github.com/k14s/ytt/pkg/cmd/ui"
 	"github.com/k14s/ytt/pkg/files"
+
 	kbld "github.com/vmware-tanzu/carvel-kbld/pkg/kbld/cmd"
 	kbldLogger "github.com/vmware-tanzu/carvel-kbld/pkg/kbld/logger"
 )

--- a/hack/packages/generate-package-repository.go
+++ b/hack/packages/generate-package-repository.go
@@ -136,9 +136,3 @@ func check(e error) {
 		panic(e)
 	}
 }
-
-func usage(arg string) {
-	fmt.Println("Missing " + arg)
-	fmt.Println("usage: make generate-package-repo CHANNEL=main TAG=1.2.3")
-	os.Exit(1)
-}


### PR DESCRIPTION
During restructuring to add a root go.mod, some debugging was left in
the Makefile definition for the "lint" target, leaving anything but the
root linting off by having it just echo the command.

This reenables linting for those submodules and addresses some of the
things that have crept in since then.