### PR TITLE
Fix install.sh sudo failure handling

### DIFF
--- a/hack/release/install.sh
+++ b/hack/release/install.sh
@@ -32,6 +32,11 @@ case "${BUILD_OS}" in
 esac
 echo "${XDG_DATA_HOME}"
 
+handle_sudo_failure() {
+    echo "sudo access required to install to ${TANZU_BIN_PATH}"
+    exit 1
+}
+
 # check if the tanzu CLI already exists and remove it to avoid conflicts
 TANZU_BIN_PATH=$(command -v tanzu)
 if [[ -n "${TANZU_BIN_PATH}" ]]; then
@@ -55,9 +60,7 @@ if [[ ":${PATH}:" == *":$HOME/bin:"* && -d "${HOME}/bin" ]]; then
   install "${MY_DIR}/tanzu" "${TANZU_BIN_PATH}"
 else
   echo Installing tanzu cli to "${TANZU_BIN_PATH}"
-  sudo install "${MY_DIR}/tanzu" "${TANZU_BIN_PATH}" || \
-      echo "sudo access required to install to ${TANZU_BIN_PATH}"; \
-      exit 1
+  sudo install "${MY_DIR}/tanzu" "${TANZU_BIN_PATH}" || handle_sudo_failure
 fi
 
 # copy the uninstall script to tanzu-cli directory


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Error handling was added to exit if we are unable to sudo when trying to
install the tanzu binary into a system path. This had an error though
where the "exit 1" would be executed outside of the "or", so whether
sudo worked or not it would still exit with a failure.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```


## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make release`. Then `cd release/tce-linux-amd64-v0.11.0-dev.1/` to get the full release bundle.
From there, ran `install.sh` and the first time through entered the wrong sudo password three times
to get it to fail. On sudo failure, it correctly echoed the error message and exited with a 1 return code.
Then ran `install.sh` again, this time giving the correct password. Install proceeded and no errors.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
