### PR TITLE
Windows: hide error deleting non-existent path

### DIFF
--- a/hack/release/install.bat
+++ b/hack/release/install.bat
@@ -20,7 +20,7 @@ SET TANZU_CACHE_DIR="%LocalAppData%\.cache\tanzu"
 mkdir %PLUGIN_DIR%
 mkdir %TCE_DIR%
 :: delete the plugin cache if it exists, before installing new plugins
-rmdir /Q /S %TANZU_CACHE_DIR%
+rmdir /Q /S %TANZU_CACHE_DIR% 2>nul
 
 :: core
 copy /B /Y bin\tanzu-plugin-builder.exe %PLUGIN_DIR%


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Our install.bat script tries to clean up a cache directory during
install to make sure there aren't any stale cached entries. This works,
but in cases where that directory does not exist, the command still
would emit the error message:

```
The system cannot find the path specified.
```

This may cause confusion to end users thinking something has gone wrong,
and it does not matter because ultimately we do not want the path
specified to exist anyway. So this change swallows any stderr output so
this result is silently ignored.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #2381 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

In Windows cmd.exe, ran `rmdir /S /Q c:\foo` to reproduce the error. Then ran `rmdir /S /Q c:\foo 2>nul` to verify command would complete quietly.