### PR TITLE
Implements `unmanaged-cluster` diagnostics collection

### DIFF
--- a/cli/cmd/plugin/diagnostics/e2e-test/e2e-test.sh
+++ b/cli/cmd/plugin/diagnostics/e2e-test/e2e-test.sh
@@ -32,6 +32,9 @@ if [[ ! -f "${TANZU_DIAGNOSTICS_BIN}" ]]; then
         --workload-cluster-kubeconfig "${HOME}/.kube/config" \
         --workload-cluster-context ${CLUSTER_KUBE_CONTEXT} \
         --workload-cluster-name ${CLUSTER_NAME} \
+        --unmanaged-cluster-kubeconfig "${HOME}/.kube/config" \
+        --unmanaged-cluster-context ${CLUSTER_KUBE_CONTEXT} \
+        --unmanaged-cluster-name ${CLUSTER_NAME} \
         --output-dir "${OUTPUT_DIR}" || {
             echo "Error running tanzu diagnostics collect command!"
             exit 1
@@ -45,6 +48,9 @@ else
         --workload-cluster-kubeconfig "${HOME}/.kube/config" \
         --workload-cluster-context ${CLUSTER_KUBE_CONTEXT} \
         --workload-cluster-name ${CLUSTER_NAME} \
+        --unmanaged-cluster-kubeconfig "${HOME}/.kube/config" \
+        --unmanaged-cluster-context ${CLUSTER_KUBE_CONTEXT} \
+        --unmanaged-cluster-name ${CLUSTER_NAME} \
         --output-dir "${OUTPUT_DIR}" || {
             echo "Error running tanzu diagnostics collect command!"
             exit 1
@@ -56,6 +62,7 @@ echo "Checking if the diagnostics tar balls for the different clusters have been
 EXPECTED_BOOTSTRAP_CLUSTER_DIAGNOSTICS="${OUTPUT_DIR}/bootstrap.${CLUSTER_NAME}.diagnostics.tar.gz"
 EXPECTED_MANAGEMENT_CLUSTER_DIAGNOSTICS="${OUTPUT_DIR}/management-cluster.${CLUSTER_NAME}.diagnostics.tar.gz"
 EXPECTED_WORKLOAD_CLUSTER_DIAGNOSTICS="${OUTPUT_DIR}/workload-cluster.${CLUSTER_NAME}.diagnostics.tar.gz"
+EXPECTED_UNMANAGED_CLUSTER_DIAGNOSTICS="${OUTPUT_DIR}/unmanaged-cluster.${CLUSTER_NAME}.diagnostics.tar.gz"
 
 errors=0
 
@@ -71,6 +78,11 @@ fi
 
 if [ ! -f "$EXPECTED_WORKLOAD_CLUSTER_DIAGNOSTICS" ]; then
     echo "$EXPECTED_WORKLOAD_CLUSTER_DIAGNOSTICS does not exist. Expected workload cluster diagnostics tar ball to be present"
+    ((errors=errors+1))
+fi
+
+if [ ! -f "$EXPECTED_UNMANAGED_CLUSTER_DIAGNOSTICS" ]; then
+    echo "$EXPECTED_UNMANAGED_CLUSTER_DIAGNOSTICS does not exist. Expected unmanaged cluster diagnostics tar ball to be present"
     ((errors=errors+1))
 fi
 

--- a/cli/cmd/plugin/diagnostics/e2e-test/setup-e2e-test.sh
+++ b/cli/cmd/plugin/diagnostics/e2e-test/setup-e2e-test.sh
@@ -8,7 +8,7 @@ set -e
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 TCE_REPO_PATH="$(git rev-parse --show-toplevel)"
 
-TCE_VERSION="v0.9.1"
+TCE_VERSION="v0.10.0"
 
 echo "Installing TCE ${TCE_VERSION}"
 
@@ -25,7 +25,7 @@ tar xzvf "${TCE_RELEASE_TAR_BALL}" --directory="${INSTALLATION_DIR}"
 "${INSTALLATION_DIR}"/"${TCE_RELEASE_DIR}"/install.sh || { error "Unexpected failure during TCE installation"; exit 1; }
 
 echo "TCE version: "
-tanzu standalone-cluster version || { error "Unexpected failure during TCE installation"; exit 1; }
+tanzu unmanaged-cluster version || { error "Unexpected failure during TCE installation"; exit 1; }
 
 TANZU_DIAGNOSTICS_PLUGIN_DIR=${MY_DIR}/..
 TANZU_DIAGNOSTICS_BIN=${MY_DIR}/tanzu-diagnostics-e2e-bin

--- a/cli/cmd/plugin/diagnostics/pkg/collect_unmanaged.go
+++ b/cli/cmd/plugin/diagnostics/pkg/collect_unmanaged.go
@@ -1,0 +1,51 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package pkg
+
+import (
+	"bytes"
+	"fmt"
+
+	crashdexec "github.com/vmware-tanzu/crash-diagnostics/exec"
+)
+
+// collectUnmanagedDiags runs command/scripts to collect unmanaged cluster diagnostics data
+func collectUnmanagedDiags() error {
+	if unmanagedArgs.clusterName == "" {
+		return fmt.Errorf("unmanaged cluster: cluster name not set")
+	}
+	if unmanagedArgs.kubeconfig == "" {
+		unmanagedArgs.kubeconfig = getDefaultKubeconfig()
+	}
+	if unmanagedArgs.contextName == "" {
+		unmanagedArgs.contextName = getDefaultClusterContext(unmanagedArgs.clusterName)
+	}
+
+	scriptName := umScriptPath
+	argsMap := crashdexec.ArgMap{
+		"workdir":                 commonArgs.workDir,
+		"outputdir":               commonArgs.outputDir,
+		"unmanaged_cluster_name": unmanagedArgs.clusterName,
+		"unmanaged_kubeconfig":   unmanagedArgs.kubeconfig,
+		"unmanaged_context":      unmanagedArgs.contextName,
+	}
+
+	libScript := libScriptPath
+	libData, err := scriptFS.ReadFile(libScript)
+	if err != nil {
+		return err
+	}
+
+	scriptData, err := scriptFS.ReadFile(scriptName)
+	if err != nil {
+		return err
+	}
+
+	return crashdexec.ExecuteWithModules(
+		scriptName,
+		bytes.NewReader(scriptData),
+		argsMap,
+		crashdexec.StarlarkModule{Name: libScript, Source: bytes.NewReader(libData)},
+	)
+}

--- a/cli/cmd/plugin/diagnostics/pkg/types.go
+++ b/cli/cmd/plugin/diagnostics/pkg/types.go
@@ -8,6 +8,12 @@ type collectCommonArgs struct {
 	outputDir string
 }
 
+type collectUnmanagedArgs struct {
+	kubeconfig string
+	clusterName string
+	contextName string
+}
+
 type collectBootsrapArgs struct {
 	skip        bool
 	clusterName string

--- a/cli/cmd/plugin/diagnostics/scripts/unmanaged_cluster.star
+++ b/cli/cmd/plugin/diagnostics/scripts/unmanaged_cluster.star
@@ -1,0 +1,35 @@
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# diagnose_unmanaged_cluster retrieves cluster information
+# from a non-management unmanaged cluster.
+def diagnose_unmanaged_cluster(workdir, kubeconfig, cluster_name, context_name, outputdir):
+    conf = crashd_config(workdir=workdir)
+    k8sconfig = kube_config(path=kubeconfig, cluster_context=context_name)
+    log(prefix="Info", msg="Retrieving unmanaged cluster: cluster={}; context={}; kubeconfig={};".format(cluster_name, context_name, kubeconfig))
+
+    nspaces=[
+        "tkg-system",
+        "kube-system",
+		"local-path-storage",
+		"tanzu-package-repo-global"
+    ]
+
+    capture_k8s_objects(k8sconfig, cluster_name, nspaces)
+    capture_pod_describe(workdir=workdir,k8sconf=kubeconfig,context=context_name,namespaces=nspaces)
+    capture_node_describe(workdir=workdir,k8sconf=kubeconfig,context=context_name)
+    capture_summary(workdir=workdir,k8sconf=kubeconfig,context=context_name)
+
+    arc_file = "{}/unmanaged-cluster.{}.diagnostics.tar.gz".format(outputdir, cluster_name)
+    log(prefix="Info", msg="Archiving: {}".format(arc_file))
+    archive(output_file=arc_file, source_paths=[conf.workdir])
+
+
+# starting point
+diagnose_unmanaged_cluster(
+    workdir=args.workdir,
+    kubeconfig=args.unmanaged_kubeconfig,
+    context_name=args.unmanaged_context,
+    cluster_name=args.unmanaged_cluster_name,
+    outputdir=args.outputdir,
+) 


### PR DESCRIPTION
## What this PR does / why we need it
Adds `unmanaged-cluster` diagnostics collection through the `diagnostics` plugin.

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Introduce unmanaged-cluster diagnostics collection
```

## Which issue(s) this PR fixes
Fixes: #2936

## Describe testing done for PR
Build the plugins and made a new unmanaged-cluster. Then collected diagnostics on it with:
```
$ tanzu diagnostics collect --unmanaged-cluster-kubeconfig ~/.kube/config --unmanaged-cluster-context kind-my-cluster --unmanaged-cluster-name my-cluster
```

I see the objects have been collected and dumped into the tar ball:
```
unmanaged-cluster.my-cluster.diagnostics.tar.gz
```

Untaring it and inspecting it's tree:
```
└── diagnostics
    ├── cluster-summary.txt
    ├── describe
    │   ├── kube-system_pods.txt
    │   ├── local-path-storage_pods.txt
    │   ├── nodes.txt
    │   ├── tanzu-package-repo-global_pods.txt
    │   └── tkg-system_pods.txt
    └── kubecapture
        ├── apps_v1
        │   ├── kube-system
        │   │   ├── deployments-202202281438.3089.json
        │   │   └── replicasets-202202281438.3109.json
        │   ├── local-path-storage
        │   │   ├── deployments-202202281438.3103.json
        │   │   └── replicasets-202202281438.3117.json
        │   └── tkg-system
        │       ├── deployments-202202281438.3085.json
        │       └── replicasets-202202281438.3106.json
        ├── core_v1
        │   ├── kube-system
        │   │   ├── antrea-agent-rbqft
        │   │   │   ├── antrea-agent
        │   │   │   │   └── antrea-agent.log
        │   │   │   ├── antrea-ovs
        │   │   │   │   └── antrea-ovs.log
        │   │   │   └── install-cni
        │   │   │       └── install-cni.log
        │   │   ├── antrea-controller-56d5dddd79-p5t5n
        │   │   │   └── antrea-controller
        │   │   │       └── antrea-controller.log
        │   │   ├── coredns-558bd4d5db-b8j7z
        │   │   │   └── coredns
        │   │   │       └── coredns.log
        │   │   ├── coredns-558bd4d5db-vdnkn
        │   │   │   └── coredns
        │   │   │       └── coredns.log
        │   │   ├── etcd-woof-control-plane
        │   │   │   └── etcd
        │   │   │       └── etcd.log
        │   │   ├── kube-apiserver-woof-control-plane
        │   │   │   └── kube-apiserver
        │   │   │       └── kube-apiserver.log
        │   │   ├── kube-controller-manager-woof-control-plane
        │   │   │   └── kube-controller-manager
        │   │   │       └── kube-controller-manager.log
        │   │   ├── kube-proxy-g2prk
        │   │   │   └── kube-proxy
        │   │   │       └── kube-proxy.log
        │   │   ├── kube-scheduler-woof-control-plane
        │   │   │   └── kube-scheduler
        │   │   │       └── kube-scheduler.log
        │   │   ├── pods-202202281438.0773.json
        │   │   ├── pods-202202281438.3910.json
        │   │   └── services-202202281438.0838.json
        │   ├── local-path-storage
        │   │   ├── local-path-provisioner-547f784dff-dzf2z
        │   │   │   └── local-path-provisioner
        │   │   │       └── local-path-provisioner.log
        │   │   ├── pods-202202281438.0832.json
        │   │   └── pods-202202281438.7580.json
        │   └── tkg-system
        │       ├── kapp-controller-555f8b88d5-ln7cg
        │       │   └── kapp-controller
        │       │       └── kapp-controller.log
        │       ├── pods-202202281438.0768.json
        │       ├── pods-202202281438.3442.json
        │       └── services-202202281438.0836.json
        └── kappctrl.k14s.io_v1alpha1
            └── tkg-system
                └── apps-202202281438.4991.json

```
