### PR TITLE
`unmanaged-cluster` uses `v0.10.1` TCE package repo named `tce-core`

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -42,7 +42,7 @@ const (
 	tkgCoreRepoName       = "tkg-core-repository"
 	tkgGlobalPkgNamespace = "tanzu-package-repo-global"
 	tceRepoName           = "community-repository"
-	tceRepoURL            = "projects.registry.vmware.com/tce/main:0.9.1"
+	tceRepoURL            = "projects.registry.vmware.com/tce/main:0.10.1"
 	outputIndent          = 3
 	maxProgressLength     = 4
 )
@@ -218,7 +218,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) error
 		return fmt.Errorf("failed to install core package repo. Error: %s", err.Error())
 	}
 	for _, additionalRepo := range t.bom.GetAdditionalRepoBundlesPaths() {
-		_, err = createPackageRepo(pkgClient, tkgGlobalPkgNamespace, tkgCoreRepoName, additionalRepo)
+		_, err = createPackageRepo(pkgClient, tkgGlobalPkgNamespace, tceRepoName, additionalRepo)
 		if err != nil {
 			return fmt.Errorf("failed to install adiditonal package repo. Error: %s", err.Error())
 		}

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/tkr.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/tkr.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	tceRepoURL = "projects.registry.vmware.com/tce/main:0.9.1"
+	tceRepoURL = "projects.registry.vmware.com/tce/main:0.10.1"
 )
 
 // ImagePackage represents information for an image.


### PR DESCRIPTION
## What this PR does / why we need it
- Bumps the package repo used by TCE to `v0.10.1`
- Names "core" package repo `tce-core` instead of `tkg-core-repository`

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
unmanaged-cluster uses v0.10.1 TCE package repo named tce-core
```

## Which issue(s) this PR fixes
Fixes: #3180

## Describe testing done for PR
Built and deployed a `unmanaged-cluster`

Package repo:

```
❯ tanzu package repository list -A

  NAME                  REPOSITORY                                           TAG                     STATUS               DETAILS  NAMESPACE
  community-repository  projects.registry.vmware.com/tce/main                0.10.1                  Reconciling                   tanzu-package-repo-global
  tkg-core-repository   projects.registry.vmware.com/tkg/packages/core/repo  v1.21.2_vmware.1-tkg.1  Reconcile succeeded           tkg-system

```

Available packages (including kpack)

```
❯ tanzu package available list

  NAME                                           DISPLAY-NAME        SHORT-DESCRIPTION                                                                                                             LATEST-VERSION
  cert-manager.community.tanzu.vmware.com        cert-manager        Certificate management                                                                                                        1.6.1
  contour.community.tanzu.vmware.com             contour             An ingress controller                                                                                                         1.19.1
  external-dns.community.tanzu.vmware.com        external-dns        This package provides DNS synchronization functionality.                                                                      0.10.0
  fluent-bit.community.tanzu.vmware.com          fluent-bit          Fluent Bit is a fast Log Processor and Forwarder                                                                              1.7.5
  gatekeeper.community.tanzu.vmware.com          gatekeeper          policy management                                                                                                             3.7.0
  grafana.community.tanzu.vmware.com             grafana             Visualization and analytics software                                                                                          7.5.7
  harbor.community.tanzu.vmware.com              harbor              OCI Registry                                                                                                                  2.3.3
  knative-serving.community.tanzu.vmware.com     knative-serving     Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers  1.0.0
  kpack.community.tanzu.vmware.com               kpack               kpack builds application source code into OCI compliant images using Cloud Native Buildpacks                                  0.5.0
  local-path-storage.community.tanzu.vmware.com  local-path-storage  This package provides local path node storage and primarily supports RWO AccessMode.                                          0.0.20
  multus-cni.community.tanzu.vmware.com          multus-cni          This package provides the ability for enabling attaching multiple network interfaces to pods in Kubernetes                    3.7.1
  prometheus.community.tanzu.vmware.com          prometheus          A time series database for your metrics                                                                                       2.27.0
  velero.community.tanzu.vmware.com              velero              Disaster recovery capabilities                                                                                                1.7.1

```
