### PR TITLE
Implements saving `kind` config during cluster creation for `unmanaged-cluster` creation

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/config/config.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config.go
@@ -31,6 +31,8 @@ const (
 	ServiceCIDR               = "ServiceCidr"
 	configDir                 = ".config"
 	tanzuConfigDir            = "tanzu"
+	tkgConfigDir              = "tkg"
+	unmanagedConfigDir        = "unmanaged"
 	yamlIndent                = 2
 	ProtocolTCP               = "tcp"
 	ProtocolUDP               = "udp"
@@ -105,8 +107,49 @@ type UnmanagedClusterConfig struct {
 }
 
 // KubeConfigPath gets the full path to the KubeConfig for this unmanaged cluster.
-func (scc *UnmanagedClusterConfig) KubeConfigPath() string {
-	return filepath.Join(os.Getenv("HOME"), configDir, tanzuConfigDir, scc.ClusterName+".yaml")
+func (scc *UnmanagedClusterConfig) KubeConfigPath() (string, error) {
+	path, err := GetTanzuConfigPath()
+	if err != nil {
+		return "", fmt.Errorf("")
+	}
+
+	return filepath.Join(path, scc.ClusterName+".yaml"), nil
+}
+
+// GetTanzuConfigPath returns the filepath to the config directory.
+// For example, on linux, "~/.config/tanzu/"
+// Returns an error if the user home directory path cannot be resolved
+func GetTanzuConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve tanzu config path. Error: %s", err.Error())
+	}
+
+	return filepath.Join(home, configDir, tanzuConfigDir), nil
+}
+
+// GetTanzuTkgConfigPath returns the filepath to the tanzu tkg config directory.
+// For example, on linux, "~/.config/tanzu/tkg"
+// Returns an error if the path cannot be resolved
+func GetTanzuTkgConfigPath() (string, error) {
+	path, err := GetTanzuConfigPath()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve tanzu TKG config path. Error: %s", err.Error())
+	}
+
+	return filepath.Join(path, tkgConfigDir), nil
+}
+
+// GetUnmanagedConfigPath returns the filepath to the unmanaged config directory.
+// For example, on linux, "~/.config/tanzu/tkg/unmanaged"
+// Returns an error if the path cannot be resolved
+func GetUnmanagedConfigPath() (string, error) {
+	path, err := GetTanzuTkgConfigPath()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve unmanaged-cluster config path. Error: %s", err.Error())
+	}
+
+	return filepath.Join(path, unmanagedConfigDir), nil
 }
 
 // InitializeConfiguration determines the configuration to use for cluster creation.

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -30,12 +30,8 @@ import (
 
 //nolint
 const (
-	configDir             = ".config"
 	configFileName        = "config.yaml"
 	bootstrapLogName      = "bootstrap.log"
-	tanzuConfigDir        = "tanzu"
-	tkgConfigDir          = "tkg"
-	unmanagedConfigDir    = "unmanaged"
 	bomDir                = "bom"
 	tkgSysNamespace       = "tkg-system"
 	tkgSvcAcctName        = "core-pkgs"
@@ -272,7 +268,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (erro
 func (t *UnmanagedCluster) List() ([]Cluster, error) {
 	var clusters []Cluster
 
-	configDir, err := getTkgUnmanagedConfigDir()
+	configDir, err := config.GetUnmanagedConfigPath()
 	if err != nil {
 		return nil, err
 	}
@@ -348,27 +344,8 @@ func (t *UnmanagedCluster) Delete(name string) error {
 	return nil
 }
 
-// getTkgConfigDir returns the configuration directory used by tce.
-func getTkgConfigDir() (path string, err error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return path, fmt.Errorf("failed to resolve home dir. Error: %s", err.Error())
-	}
-	path = filepath.Join(home, configDir, tanzuConfigDir, tkgConfigDir)
-	return path, nil
-}
-
-func getTkgUnmanagedConfigDir() (path string, err error) {
-	tkgConfigDir, err := getTkgConfigDir()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(tkgConfigDir, unmanagedConfigDir), nil
-}
-
 func getUnmanagedBomPath() (path string, err error) {
-	tkgUnmanagedConfigDir, err := getTkgUnmanagedConfigDir()
+	tkgUnmanagedConfigDir, err := config.GetUnmanagedConfigPath()
 	if err != nil {
 		return "", err
 	}
@@ -404,7 +381,7 @@ func buildFilesystemSafeBomName(bomFileName string) (path string) {
 }
 
 func resolveClusterDir(clusterName string) (string, error) {
-	scd, err := getTkgUnmanagedConfigDir()
+	scd, err := config.GetUnmanagedConfigPath()
 	if err != nil {
 		return "", err
 	}
@@ -420,7 +397,7 @@ func resolveClusterDir(clusterName string) (string, error) {
 }
 
 func resolveClusterConfig(clusterName string) (string, error) {
-	scd, err := getTkgUnmanagedConfigDir()
+	scd, err := config.GetUnmanagedConfigPath()
 	if err != nil {
 		return "", err
 	}
@@ -449,7 +426,7 @@ func resolveClusterConfig(clusterName string) (string, error) {
 }
 
 func createClusterDirectory(clusterName string) (string, error) {
-	scd, err := getTkgUnmanagedConfigDir()
+	scd, err := config.GetUnmanagedConfigPath()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## What this PR does / why we need it
Now saves the kind config used during bootstrapping for unmanaged-clusters

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
unmanaged-cluster saves kind configuration used during bootstrapping
```

## Which issue(s) this PR fixes
Fixes: https://github.com/vmware-tanzu/community-edition/issues/3061

## Describe testing done for PR
Created a new cluster:

```
$ tanzu unmanaged-cluster create my-cluster --worker-node-count 2
```

And see cluster is created and the config file is found:
```
$ pwd
/home/jmcb/.config/tanzu/tkg/unmanaged/my-cluster

$ cat kindconfig.yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
name: my-cluster
nodes:
    - role: control-plane
      image: projects.registry.vmware.com/tce/kind/node:v1.21.5
    - role: worker
      image: projects.registry.vmware.com/tce/kind/node:v1.21.5
    - role: worker
      image: projects.registry.vmware.com/tce/kind/node:v1.21.5
networking:
    ipFamily: ipv4
    apiServerAddress: 127.0.0.1
    podSubnet: 10.244.0.0/16
    serviceSubnet: 10.96.0.0/16
    disableDefaultCNI: true
    kubeProxyMode: iptables
```
