### PR TITLE
Fix staging build after reverting back to 0.11.1

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         run: |
           make prep-gcp-tce-bucket
-          make build-tce-cli-plugins
+          make build-cli-plugins-nopublish
       - name: Upload Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@main

--- a/Makefile
+++ b/Makefile
@@ -211,11 +211,11 @@ $(TOOLING_BINARIES):
 ##### Tooling Binaries
 
 ##### BUILD TARGETS #####
-build-tce-cli-plugins: version clean-plugin build-cli-plugins ## builds the CLI plugins that live in the TCE repo into the artifacts directory
+build-tce-cli-plugins: version build-cli-plugins ## builds the CLI plugins that live in the TCE repo into the artifacts directory
 	@printf "\n[COMPLETE] built TCE-specific plugins at $(ARTIFACTS_DIR)\n"
 	@printf "To install these plugins, run \`make install-tce-cli-plugins\`\n"
 
-install-tce-cli-plugins: version clean-plugin build-cli-plugins install-plugins ## builds and installs CLI plugins found in artifacts directory
+install-tce-cli-plugins: version build-cli-plugins install-plugins ## builds and installs CLI plugins found in artifacts directory
 	@printf "\n[COMPLETE] built and installed TCE-specific plugins at $${XDG_DATA_HOME}/tanzu-cli/. "
 	@printf "These plugins will be automatically detected by your tanzu CLI.\n"	
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
A little oops on the staging build workflow. Since we upload staging build bits in this workflow, we don't want to do the publish step because the new standalone discovery directory structure differs from what the GCP bucket structure should look like. Thus causing the error found here:
https://github.com/vmware-tanzu/community-edition/actions/runs/1919589042

Removed "clean-plugin" because the build-cli-plugins target already depends/calls clean-plugin.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix staging build after reverting back to 0.11.1
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Verified calling  `make prep-gcp-tce-bucket` before `make build-cli-plugins-nopublish` produces the desired result

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA