### PR TITLE
Fix continuous reconciliation in load-balancer-and-ingress-service

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/crds/gatewayclasses.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/crds/gatewayclasses.yaml
@@ -136,9 +136,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/crds/gateways.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/crds/gateways.yaml
@@ -405,9 +405,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
## What this PR does / why we need it

Remove empty `status` fields on Gateway and GatewayClass so that `kapp-controller` doesn't continuously try to reconcile them. When these fields are set but empty, `kapp-controller` will attempt to clear them, and then apiserver will 


## Details for the Release Notes
```release-note
Fixes continuous reconciliation of the load-balancer-and-ingress-service package.
```

## Describe testing done for PR

Examined CRD definitions, `kapp-controller` output, and reviewed documentation from other systems.

## Special notes for your reviewer

I didn't load this onto a VSphere cluster for testing; I'm not sure how to add a test for this in this repo, but this can be recognized when "soaking" a cluster for e.g. 4 hours. If this is a problem, you will see approx 40 ConfigMaps (one every 5 minutes) in the `tkg-system` namespace with the format `load-balancer-and-ingress-service-ctrl-change-xyz12`
