### PR TITLE
Fix continuous reconcilation in ako-operator

### DIFF
--- a/addons/packages/ako-operator/1.4.0/bundle/config/upstream/akooperator/static.yaml
+++ b/addons/packages/ako-operator/1.4.0/bundle/config/upstream/akooperator/static.yaml
@@ -297,12 +297,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/addons/packages/ako-operator/1.5.0/bundle/config/upstream/akooperator/static.yaml
+++ b/addons/packages/ako-operator/1.5.0/bundle/config/upstream/akooperator/static.yaml
@@ -388,12 +388,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/static.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/static.yaml
@@ -388,12 +388,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
## What this PR does / why we need it
Remove empty `status` fields on AKODeploymentConfig CRD so that kapp-controller doesn't continuously try to reconcile them. 

<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Details for the Release Notes (PLEASE PROVIDE)

<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fixes continuous reconciliation of ako-operator
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
