### PR TITLE
Fix workflows to handle 0.11.1 and 0.17.0 Discovery/Standalone Structure

### DIFF
--- a/.github/workflows/release-fake-bucket.yaml
+++ b/.github/workflows/release-fake-bucket.yaml
@@ -1,13 +1,11 @@
-name: Release - Upload RC, Beta, Alpha Bits to Buckets
+name: Release - Upload Test/Fake Bits to Buckets
 
 on:
   push:
     branches:
       - "!not_activated_on_branches!*"
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-fake.[0-9]+"
 
 jobs:
   setup-runner:
@@ -26,7 +24,7 @@ jobs:
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   build-release:
-    name: Alpha, Beta, or RC Release
+    name: Test/Fake Release
     # Only run this job if we're in the main repo, not a fork.
     if: github.repository == 'vmware-tanzu/community-edition'
     needs: setup-runner # required to start the main job when the runner is ready
@@ -96,7 +94,7 @@ jobs:
           destination: tce-framework-cli-plugins-admin/artifacts-admin
           credentials: ${{ secrets.GCP_BUCKET_SA }}
           parent: false
-      - name: Prune RC, Beta, Alpha Buckets
+      - name: Prune Test/Fake Buckets
         env:
           TCE_CI_BUILD: true
         shell: bash

--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -85,7 +85,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_path: ./release/tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
       - name: Upload Darwin AMD64 Asset
@@ -95,7 +95,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_path: ./release/tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
       - name: Upload Darwin ARM64 Asset
@@ -105,7 +105,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_path: ./release/tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
       - name: Upload Windows AMD64 Asset
@@ -115,7 +115,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_path: ./release/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.zip
           asset_content_type: application/zip
       - name: Commit Next Dev Version

--- a/.github/workflows/release-ga-bucket.yaml
+++ b/.github/workflows/release-ga-bucket.yaml
@@ -1,4 +1,4 @@
-name: Release - Create GA
+name: Release - Upload GA Bits to Buckets
 
 on:
   push:

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -86,7 +86,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_path: ./release/tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
       - name: Upload Darwin AMD64 Asset
@@ -96,7 +96,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_path: ./release/tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
       - name: Upload Darwin ARM64 Asset
@@ -106,7 +106,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_path: ./release/tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
       - name: Upload Windows AMD64 Asset
@@ -116,7 +116,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_path: ./release/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.zip
           asset_content_type: application/zip
       - name: Commit Next Dev Version

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -87,7 +87,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_path: ./release/tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-linux-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
       - name: Upload Darwin AMD64 Asset
@@ -97,7 +97,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_path: ./release/tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-darwin-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
       - name: Upload Darwin ARM64 Asset
@@ -107,7 +107,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_path: ./release/tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}.tar.gz
           asset_name: tce-darwin-arm64-${{ steps.get_version.outputs.VERSION }}-unsigned.tar.gz
           asset_content_type: application/gzip
       - name: Upload Windows AMD64 Asset
@@ -117,7 +117,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_path: ./release/tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: tce-windows-amd64-${{ steps.get_version.outputs.VERSION }}-unsigned.zip
           asset_content_type: application/zip
       - name: Commit Next Dev Version

--- a/hack/asset/asset.go
+++ b/hack/asset/asset.go
@@ -117,7 +117,7 @@ func main() {
 	}
 
 	darwinAMD64AssetFilename := fmt.Sprintf("tce-darwin-amd64-%s.tar.gz", tag)
-	darwinAMD64Asset := filepath.Join("..", "..", "build", darwinAMD64AssetFilename)
+	darwinAMD64Asset := filepath.Join("..", "..", "release", darwinAMD64AssetFilename)
 	err = uploadToDraftRelease(draftRelease, darwinAMD64Asset)
 	if err != nil {
 		fmt.Printf("uploadToDraftRelease(darwin-amd64) failed: %v\n", err)
@@ -126,7 +126,7 @@ func main() {
 
 	// TODO: Uncomment this when cluster creation is supported on Darwin/ARM64
 	// darwinARM64AssetFilename := fmt.Sprintf("tce-darwin-arm64-%s.tar.gz", tag)
-	// darwinARM64Asset := filepath.Join("..", "..", "build", darwinARM64AssetFilename)
+	// darwinARM64Asset := filepath.Join("..", "..", "release", darwinARM64AssetFilename)
 	// err = uploadToDraftRelease(draftRelease, darwinARM64Asset)
 	// if err != nil {
 	//     fmt.Printf("uploadToDraftRelease(darwin-arm64) failed: %v\n", err)
@@ -134,7 +134,7 @@ func main() {
 	//}
 
 	linuxAssetFilename := fmt.Sprintf("tce-linux-amd64-%s.tar.gz", tag)
-	linuxAsset := filepath.Join("..", "..", "build", linuxAssetFilename)
+	linuxAsset := filepath.Join("..", "..", "release", linuxAssetFilename)
 	err = uploadToDraftRelease(draftRelease, linuxAsset)
 	if err != nil {
 		fmt.Printf("uploadToDraftRelease(linux) failed: %v\n", err)
@@ -142,14 +142,14 @@ func main() {
 	}
 
 	windowsAssetFilename := fmt.Sprintf("tce-windows-amd64-%s.zip", tag)
-	windowsAsset := filepath.Join("..", "..", "build", windowsAssetFilename)
+	windowsAsset := filepath.Join("..", "..", "release", windowsAssetFilename)
 	err = uploadToDraftRelease(draftRelease, windowsAsset)
 	if err != nil {
 		fmt.Printf("uploadToDraftRelease(windows) failed: %v\n", err)
 		return
 	}
 
-	checksumAsset := filepath.Join("..", "..", "build", DefaultCheckSumFilename)
+	checksumAsset := filepath.Join("..", "..", "release", DefaultCheckSumFilename)
 	err = uploadToDraftRelease(draftRelease, checksumAsset)
 	if err != nil {
 		fmt.Printf("uploadToDraftRelease(checksum) failed: %v\n", err)

--- a/hack/dailybuild/dailybuild.go
+++ b/hack/dailybuild/dailybuild.go
@@ -56,7 +56,7 @@ func (c *ClientUploader) UploadFile(filename string) error {
 	defer cancel()
 
 	// open the src file
-	uploadFile := filepath.Join("..", "..", "build", filename)
+	uploadFile := filepath.Join("..", "..", "release", filename)
 	file, err := os.OpenFile(uploadFile, os.O_RDWR, 0755)
 	if err != nil {
 		fmt.Printf("OpenFile failed: %v\n", err)

--- a/hack/release/fix-for-ci-build.sh
+++ b/hack/release/fix-for-ci-build.sh
@@ -10,4 +10,4 @@ set -o xtrace
 
 # make user CI directory
 apt update
-apt install make zip unzip curl
+apt -y install make zip unzip curl


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Changes to support the new Discovery/Standalone Structure include:
- add a workflow `release-fake-bucket.yaml` which mimics the Non-GA Upload to GCP Buckets
- change the upload to the draft release from `build` to the `release` folder
- change the workflow names for the upload to the GCP buckets to not collide with the release worflows
- change the apt install to be silent

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix workflows to handle 0.11.1 and 0.17.0 Discovery/Standalone Structure
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
checked `make docker-release` and manually walkthrough of the release process.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA