### PR TITLE
Docs: Apply proper bolding for strong elements

### DIFF
--- a/docs/site/themes/template/assets/scss/_base.scss
+++ b/docs/site/themes/template/assets/scss/_base.scss
@@ -134,7 +134,8 @@ button {
     background-color: unset;
     border: none;
 }
-.strong {
+
+strong, .strong {
     font-family: $metropolis-medium;
 }
 


### PR DESCRIPTION
Signed-off-by: Garry Ing <ging@vmware.com>

## What this PR does / why we need it
This adds `strong` elements to the `.strong` utility class so that proper bolding is applied to docs/site content without needing to add the strong class.

| Before (browser bolding)      | After |
| ----------- | ----------- |
| ![Screen Shot 2022-03-03 at 11 15 31 AM](https://user-images.githubusercontent.com/227587/156605555-2d812281-97cc-483d-9521-7186a3796a92.png) | ![Screen Shot 2022-03-03 at 11 15 39 AM](https://user-images.githubusercontent.com/227587/156605584-79ea5a74-8fa0-40b1-80d6-bad08cbb0fce.png) |

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: n/a

## Describe testing done for PR
- `hugo server`
- visit `/docs/latest/#who-should-use-tanzu-community-edition`

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
