### PR TITLE
Adds `unmanaged-cluster configure` aliases

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -21,10 +21,11 @@ a config file injected with default values. When flags are specified
 
 // ConfigureCmd creates an unmanaged workload cluster.
 var ConfigureCmd = &cobra.Command{
-	Use:   "configure <cluster name>",
-	Short: "Generate a config file to be used in cluster creation",
-	Long:  configureDesc,
-	RunE:  configure,
+	Use:     "configure <cluster name>",
+	Aliases: []string{"config", "conf"},
+	Short:   "Generate a config file to be used in cluster creation",
+	Long:    configureDesc,
+	RunE:    configure,
 }
 
 func init() {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -49,7 +49,7 @@ var CreateCmd = &cobra.Command{
 	Use:   "create <cluster name>",
 	Short: "Create an unmanaged Tanzu cluster",
 	Long:  createDesc,
-	Run:  create,
+	Run:   create,
 	Args:  cobra.MaximumNArgs(1),
 }
 


### PR DESCRIPTION
## What this PR does / why we need it

- `configure` command aliases to both `config` and `conf` (mostly because I'm lazy and don't like typing)
- Also corrects a small `go fmt` error in `cmd/create.go`

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
unmanaged-cluster configure aliases to "config" and "conf"
```

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR

Built the binary and able to use aliases:

```
❯ ./unmanaged-cluster conf -h

Generate a configuration file that can be used when running:
...

❯ ./unmanaged-cluster config -h

Generate a configuration file that can be used when running:
...
```
