### PR TITLE
Implements `unmanged-cluster docs` command

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -42,7 +42,25 @@ When create is called, it respects the following precedence for all configuratio
 1. flags (most respected)
 2. environment variables
 3. config file
-4. defaults (least respected)`
+4. defaults (least respected)
+
+Exit codes are provided to enhance the automation of bootstrapping and are defined as follows:
+
+0  - Success.
+1  - Configuration is invalid.
+2  - Could not create local cluster directories.
+3  - Unable to get TKR BOM.
+4  - Could not render config.
+5  - TKR BOM not parseable.
+6  - Could not resolve kapp controller bundle.
+7  - Unable to create cluster.
+8  - Unable to use existing cluster (if provided).
+9  - Could not install kapp controller to cluster.
+10 - Could not install core package repo to cluster.
+11 - Could not install additional package repo
+12 - Could not install CNI package.
+13 - Failed to merge kubeconfig and set context
+`
 
 // CreateCmd creates an unmanaged workload cluster.
 var CreateCmd = &cobra.Command{

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/docs.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/docs.go
@@ -1,0 +1,170 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+const docsDesc = `
+Provides documentation and usage for unmanaged-cluster in multiple formats.
+Gives all commands, their flags, and related commands.
+This can then be used as a local documentation resource when working with unmanaged-clusters.
+
+Users may generate man pages that can then be zipped and placed on the system.
+The 'man' program expects the zipped bundle to be in a location defined by 'manpath'
+and the user must run 'mandb' to inject the manpages onto their system.
+`
+
+var (
+	docsFormat    = ""
+	docsOutputDir = ""
+	noStdout      = false
+)
+
+// ListCmd returns a list of existing clusters.
+var DocsCmd = &cobra.Command{
+	Use:   "docs",
+	Short: "Generated documentation & usage of unmanaged-cluster",
+	Long:  docsDesc,
+	PreRunE: func(cmd *cobra.Command, args []string) (err error) {
+		return nil
+	},
+	RunE: startDocsGen,
+	PostRunE: func(cmd *cobra.Command, args []string) (err error) {
+		return nil
+	},
+}
+
+func init() {
+	DocsCmd.Flags().StringVar(&docsFormat, "format", "markdown", "Output format (markdown|manpage|rest|yaml); default is markdown")
+	DocsCmd.Flags().BoolVar(&noStdout, "no-stdout", false, "Ignores printing to stdout and inspects 'output-dir' for location to dump files")
+	DocsCmd.Flags().StringVar(&docsOutputDir, "output-dir", "", "Location to output the doc page files; providing this prevents printing to stdout. Defaults to the current working dir")
+}
+
+// list outputs a list of all unmanaged clusters on the system.
+func startDocsGen(cmd *cobra.Command, args []string) error {
+	var err error
+
+	if len(args) != 0 {
+		return fmt.Errorf("docs generation does not support any arguments")
+	}
+
+	// Valid formats
+	if (docsFormat != "markdown" && docsFormat != "manpage") && (docsFormat != "rest" && docsFormat != "yaml") {
+		return fmt.Errorf("unsupported format: %s - Valid formats: (markdown|manpage|rest|yaml)", docsFormat)
+	}
+
+	if noStdout || cmd.Flags().Changed("output-dir") {
+		err = docsToFiles(cmd)
+	} else {
+		err = docsToStdout(cmd)
+	}
+
+	return err
+}
+
+func docsToFiles(cmd *cobra.Command) error {
+	if docsOutputDir == "" {
+		p, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		docsOutputDir = p
+	}
+
+	switch docsFormat {
+	case "markdown":
+		err := doc.GenMarkdownTree(cmd.Parent().Root(), docsOutputDir)
+		if err != nil {
+			return err
+		}
+	case "manpage":
+		manHeader := &doc.GenManHeader{
+			Title:   "Tanzu Community Edition",
+			Section: "1",
+		}
+		err := doc.GenManTree(cmd.Parent().Root(), manHeader, docsOutputDir)
+		if err != nil {
+			return err
+		}
+	case "rest":
+		err := doc.GenReSTTree(cmd.Parent().Root(), docsOutputDir)
+		if err != nil {
+			return err
+		}
+	case "yaml":
+		err := doc.GenYamlTree(cmd.Parent().Root(), docsOutputDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+func docsToStdout(cmd *cobra.Command) error {
+	buf := new(bytes.Buffer)
+
+	switch docsFormat {
+	case "markdown":
+		if err := doc.GenMarkdown(cmd.Root(), buf); err != nil {
+			return err
+		}
+
+		for _, c := range cmd.Root().Commands() {
+			if err := doc.GenMarkdown(c, buf); err != nil {
+				return err
+			}
+		}
+	case "manpage":
+		manHeader := &doc.GenManHeader{
+			Title:   "Tanzu Community Edition",
+			Section: "1",
+		}
+
+		if err := doc.GenMan(cmd.Root(), manHeader, buf); err != nil {
+			return err
+		}
+
+		for _, c := range cmd.Root().Commands() {
+			if err := doc.GenMan(c, manHeader, buf); err != nil {
+				return err
+			}
+		}
+	case "rest":
+		if err := doc.GenReST(cmd.Root(), buf); err != nil {
+			return err
+		}
+
+		if err := doc.GenReST(cmd.Root(), buf); err != nil {
+			return err
+		}
+
+		for _, c := range cmd.Root().Commands() {
+			if err := doc.GenReST(c, buf); err != nil {
+				return err
+			}
+		}
+	case "yaml":
+		if err := doc.GenYaml(cmd.Root(), buf); err != nil {
+			return err
+		}
+		for _, c := range cmd.Root().Commands() {
+			if err := doc.GenYaml(c, buf); err != nil {
+				return err
+			}
+		}
+	}
+
+	fmt.Print(buf)
+
+	return nil
+}

--- a/cli/cmd/plugin/unmanaged-cluster/go.mod
+++ b/cli/cmd/plugin/unmanaged-cluster/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.10.0 // indirect
 	github.com/cppforlife/cobrautil v0.0.0-20200514214827-bb86e6965d72 // indirect
 	github.com/cppforlife/color v1.9.1-0.20200716202919-6706ac40b835 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v20.10.10+incompatible // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
@@ -75,6 +76,7 @@ require (
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/vito/go-interact v0.0.0-20171111012221-fa338ed9e9ec // indirect

--- a/cli/cmd/plugin/unmanaged-cluster/go.sum
+++ b/cli/cmd/plugin/unmanaged-cluster/go.sum
@@ -368,9 +368,11 @@ github.com/cppforlife/go-cli-ui v0.0.0-20200505234325-512793797f05/go.mod h1:I0q
 github.com/cppforlife/go-cli-ui v0.0.0-20200506005011-4268990983cc/go.mod h1:I0qrzCmuPWYI6kAOvkllYjaW2aovclWbJ96+v+YyHb0=
 github.com/cppforlife/go-cli-ui v0.0.0-20200716203538-1e47f820817f h1:yVW0v4zDXzJo1i8G9G3vtvNpyzhvtLalO34BsN/K88E=
 github.com/cppforlife/go-cli-ui v0.0.0-20200716203538-1e47f820817f/go.mod h1:L18TqO77ci8i+hFtlMC4zSFz/D3O8lf84TyVU+zFF8E=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -1099,8 +1101,10 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
 github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryancurrah/gomodguard v1.0.4/go.mod h1:9T/Cfuxs5StfsocWr4WzDL36HqnX0fVb9d5fSEaLhoE=
 github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUccKSJBU0UMXJFVM=

--- a/cli/cmd/plugin/unmanaged-cluster/main.go
+++ b/cli/cmd/plugin/unmanaged-cluster/main.go
@@ -38,11 +38,15 @@ func main() {
 	p.Cmd.PersistentFlags().Int32VarP(&logLevel, "verbose", "v", 0, "Number for the log level verbosity(0-9)")
 	p.Cmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Log file path")
 
+	// Disable docs generation footer
+	p.Cmd.DisableAutoGenTag = true
+	
 	p.AddCommands(
 		cmd.ConfigureCmd,
 		cmd.CreateCmd,
 		cmd.DeleteCmd,
 		cmd.ListCmd,
+		cmd.DocsCmd,
 	)
 	if err := p.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
## What this PR does / why we need it
- Provides docs generation in multiple formats of the `unmanaged-cluster` commands in support of having a
  local resource for users to reference
- Adds docs for exit codes

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Added unmanaged-cluster docs command for local documentation generation
```

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR

Print docs to stdout. The default is markdown

```
$ tanzu unmanaged-cluster docs
## unmanaged-cluster completion

Generate the autocompletion script for the specified shell
...
```

Print docs to stdout in a different format
```
$ tanzu unmanaged-cluster docs --format rest
.. _unmanaged-cluster_completion:

unmanaged-cluster completion
----------------------------

Generate the autocompletion script for the specified shell
...
```

Don't print to `stdout`, dump to current working dir

```
$ tanzu unmanaged-cluster docs --format rest --no-stdout
$ tree
├── unmanaged-cluster_completion_bash.rst
├── unmanaged-cluster_completion_fish.rst
├── unmanaged-cluster_completion_powershell.rst
├── unmanaged-cluster_completion.rst
├── unmanaged-cluster_completion_zsh.rst
├── unmanaged-cluster_configure.rst
├── unmanaged-cluster_create.rst
├── unmanaged-cluster_delete.rst
├── unmanaged-cluster_docs.rst
├── unmanaged-cluster_list.rst
└── unmanaged-cluster.rst
```

Or the equivalent command is:
```
$ tanzu unmanaged-cluster docs --format rest --output-dir ./
$ tree
├── unmanaged-cluster_completion_bash.rst
├── unmanaged-cluster_completion_fish.rst
├── unmanaged-cluster_completion_powershell.rst
├── unmanaged-cluster_completion.rst
├── unmanaged-cluster_completion_zsh.rst
├── unmanaged-cluster_configure.rst
├── unmanaged-cluster_create.rst
├── unmanaged-cluster_delete.rst
├── unmanaged-cluster_docs.rst
├── unmanaged-cluster_list.rst
└── unmanaged-cluster.rst
```

Set the output directory to dump the files
```
$ tanzu unmanaged-cluster docs --format rest --output-dir /tmp
$ tree /tmp
├── unmanaged-cluster_completion_bash.rst
├── unmanaged-cluster_completion_fish.rst
├── unmanaged-cluster_completion_powershell.rst
├── unmanaged-cluster_completion.rst
├── unmanaged-cluster_completion_zsh.rst
├── unmanaged-cluster_configure.rst
├── unmanaged-cluster_create.rst
├── unmanaged-cluster_delete.rst
├── unmanaged-cluster_docs.rst
├── unmanaged-cluster_list.rst
└── unmanaged-cluster.rst
```
