### PR TITLE
Delay pruning binaries until after the update buckets have been uploaded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ prune-buckets:
 
 # The main target for GCP buckets. Please see above
 .PHONY: release-buckets
-release-buckets: version prep-gcp-tanzu-bucket prep-gcp-tce-bucket build-cli-plugins-nopublish prune-buckets
+release-buckets: version prep-gcp-tanzu-bucket prep-gcp-tce-bucket build-cli-plugins-nopublish
 
 .PHONY: upload-signed-assets
 upload-signed-assets:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This is true for the other upload GCP workflows as well... we are deleting the binaries too soon. We need to build them in the right directory structure first:
https://github.com/vmware-tanzu/community-edition/blob/main/.github/workflows/release-ga-bucket.yaml#L67

But we had an oops where `prune-buckets` was added to the `release-buckets` target. We need to upload to the update GCP buckets, then call prune which we are doing here already:
https://github.com/vmware-tanzu/community-edition/blob/main/.github/workflows/release-ga-bucket.yaml#L102

Then upload the release GCP buckets.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Delay pruning binaries until after the update buckets have been uploaded
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA