### PR TITLE
Modify velero AWS plugin name in deployment

### DIFF
--- a/addons/packages/velero/1.7.1/bundle/config/upstream/velero/velero.yaml
+++ b/addons/packages/velero/1.7.1/bundle/config/upstream/velero/velero.yaml
@@ -3699,7 +3699,7 @@ spec:
       initContainers:
       - image: velero/velero-plugin-for-aws:v1.3.0
         imagePullPolicy: IfNotPresent
-        name: velero-velero-plugin-for-aws
+        name: velero-plugin-for-aws
         resources: {}
         volumeMounts:
         - mountPath: /target

--- a/addons/packages/velero/1.7.1/package.yaml
+++ b/addons/packages/velero/1.7.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/velero@sha256:fe89fb0897df4f9df2665c305909c6cc5cda42bacf2fbfc2e111764e0431baf8
+            image: projects.registry.vmware.com/tce/velero@sha256:e6958a538a2e8f81894fdf388ee973d281f4aeaba6c1a9da4668603edd168345
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Signed-off-by: Xun Jiang <jxun@vmware.com>

## What this PR does / why we need it
Change AWS plugin name from "velero-velero-plugin-for-aws" to "velero-plugin-for-aws".

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
