### PR TITLE
Fix automation for creating patch release to use correct branch (main)

### DIFF
--- a/hack/release/cut-release.sh
+++ b/hack/release/cut-release.sh
@@ -120,12 +120,12 @@ echo "NEW_FAKE_BUILD_VERSION: ${NEW_FAKE_BUILD_VERSION}"
 
 git stash
 
-DOES_NEW_BRANCH_EXIST=$(git branch -a | grep remotes | grep "${NEW_FAKE_BUILD_VERSION}")
+DOES_NEW_BRANCH_EXIST=$(git branch -a | grep remotes | grep "automation-${NEW_FAKE_BUILD_VERSION}")
 echo "does branch exist: ${DOES_NEW_BRANCH_EXIST}"
 if [[ "${DOES_NEW_BRANCH_EXIST}" == "" ]]; then
-    git checkout -b "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}" "${WHICH_BRANCH}"
+    git checkout -b "automation-${NEW_FAKE_BUILD_VERSION}" "${WHICH_BRANCH}"
 else
-    git checkout "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}"
+    git checkout "automation-${NEW_FAKE_BUILD_VERSION}"
     git rebase -Xtheirs "origin/${WHICH_BRANCH}"
 fi
 
@@ -133,9 +133,9 @@ git stash pop
 
 git add hack/FAKE_BUILD_VERSION.yaml
 git commit -s -m "auto-generated - update fake version"
-git push origin "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}"
-gh pr create --title "auto-generated - update fake version" --body "auto-generated - update fake version"
-gh pr merge "${WHICH_BRANCH}-update-${NEW_FAKE_BUILD_VERSION}" --delete-branch --squash --admin
+git push origin "automation-${NEW_FAKE_BUILD_VERSION}"
+gh pr create --title "auto-generated - update fake version" --body "auto-generated - update fake version" --base "${WHICH_BRANCH}"
+gh pr merge "automation-${NEW_FAKE_BUILD_VERSION}" --delete-branch --squash --admin
 
 # skip the tagging the dev release... commit the file is a good enough simulation
 
@@ -147,12 +147,12 @@ echo "NEW_DEV_BUILD_VERSION: ${NEW_DEV_BUILD_VERSION}"
 
 git stash
 
-DOES_NEW_BRANCH_EXIST=$(git branch -a | grep remotes | grep "${NEW_DEV_BUILD_VERSION}")
+DOES_NEW_BRANCH_EXIST=$(git branch -a | grep remotes | grep "automation-${NEW_DEV_BUILD_VERSION}")
 echo "does branch exist: ${DOES_NEW_BRANCH_EXIST}"
 if [[ "${DOES_NEW_BRANCH_EXIST}" == "" ]]; then
-    git checkout -b "${WHICH_BRANCH}-update-${NEW_DEV_BUILD_VERSION}" "${WHICH_BRANCH}"
+    git checkout -b "automation-${NEW_DEV_BUILD_VERSION}" "${WHICH_BRANCH}"
 else
-    git checkout "${WHICH_BRANCH}-update-${NEW_DEV_BUILD_VERSION}"
+    git checkout "automation-${NEW_DEV_BUILD_VERSION}"
     git rebase -Xtheirs "origin/${WHICH_BRANCH}"
 fi
 
@@ -164,9 +164,9 @@ if [[ "${BUILD_VERSION}" != *"-"* ]]; then
     git add hack/PREVIOUS_RELEASE_HASH
 fi
 git commit -s -m "auto-generated - update dev version"
-git push origin "${WHICH_BRANCH}-update-${NEW_DEV_BUILD_VERSION}"
-gh pr create --title "auto-generated - update dev version" --body "auto-generated - update dev version"
-gh pr merge "${WHICH_BRANCH}-update-${NEW_DEV_BUILD_VERSION}" --delete-branch --squash --admin
+git push origin "automation-${NEW_DEV_BUILD_VERSION}"
+gh pr create --title "auto-generated - update dev version" --body "auto-generated - update dev version" --base "${WHICH_BRANCH}"
+gh pr merge "automation-${NEW_DEV_BUILD_VERSION}" --delete-branch --squash --admin
 
 # tag the new dev release
 git tag -m "${NEW_DEV_BUILD_VERSION}" "${NEW_DEV_BUILD_VERSION}"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This handles branch reuse and also when we create a PR to merge, we need to select the correct branch by providing `--base <branch>`. It was assumed that creating the branch from the `release-X.YY` branch would handle this like on the command line, but I was wrong.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Fix automation for creating patch release to use correct branch
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA