### PR TITLE
Adding fluxcd-source-controller 0.21.2 for TCE

### DIFF
--- a/addons/packages/fluxcd-source-controller/0.21.2/README.md
+++ b/addons/packages/fluxcd-source-controller/0.21.2/README.md
@@ -1,0 +1,172 @@
+# Fluxcd-source-controller
+
+The source-controller is a Kubernetes operator, specialised in artifacts acquisition
+from external sources such as Git, Helm repositories and S3 buckets.
+The source-controller implements the
+[source.toolkit.fluxcd.io](https://github.com/fluxcd/source-controller/tree/master/docs/spec/v1beta1) API
+and is a core component of the [GitOps toolkit](https://toolkit.fluxcd.io).
+
+## Configuration
+
+Source controller package has no configurable properties.
+
+## Installation
+
+To install FluxCD source-controller from the Tanzu Application Platform package repository:
+
+1. List version information for the package by running:
+
+    ```shell
+    tanzu package available list fluxcd-source-controller.community.tanzu.vmware.com
+    ```
+
+    For example:
+
+    ```shell
+    $ tanzu package available list fluxcd-source-controller.community.tanzu.vmware.com
+        \ Retrieving package versions for fluxcd-source-controller.tanzu.vmware.com...
+          NAME                                                VERSION  RELEASED-AT
+          fluxcd-source-controller.community.tanzu.vmware.com  0.21.2   2021-10-27 19:00:00 -0500 -05
+    ```
+
+2. Install the package by running:
+
+    ```shell
+    tanzu package install fluxcd-source-controller -p fluxcd-source-controller.community.tanzu.vmware.com -v VERSION-NUMBER
+    ```
+
+    Where:
+
+    - `VERSION-NUMBER` is the version of the package listed in step 1.
+
+    For example:
+
+    ```shell
+    tanzu package install fluxcd-source-controller -p fluxcd-source-controller.community.tanzu.vmware.com -v 0.21.2
+    \ Installing package 'fluxcd-source-controller.community.tanzu.vmware.com'
+    | Getting package metadata for 'fluxcd-source-controller.community.tanzu.vmware.com'
+    | Creating service account 'fluxcd-source-controller-default-sa'
+    | Creating cluster admin role 'fluxcd-source-controller-default-cluster-role'
+    | Creating cluster role binding 'fluxcd-source-controller-default-cluster-rolebinding'
+    | Creating package resource
+    / Waiting for 'PackageInstall' reconciliation for 'fluxcd-source-controller'
+    \ 'PackageInstall' resource install status: Reconciling
+
+
+     Added installed package 'fluxcd-source-controller'
+    ```
+
+3. Verify the package install by running:
+
+    ```shell
+    tanzu package installed get fluxcd-source-controller
+    ```
+
+    For example:
+
+    ```shell
+    \ Retrieving installation details for fluxcd-source-controller...
+    NAME:                    fluxcd-source-controller
+    PACKAGE-NAME:            fluxcd-source-controller.community.tanzu.vmware.com
+    PACKAGE-VERSION:         0.21.2
+    STATUS:                  Reconcile succeeded
+    CONDITIONS:              [{ReconcileSucceeded True  }]
+    USEFUL-ERROR-MESSAGE:
+    ```
+
+    Verify that `STATUS` is `Reconcile succeeded`
+
+    ```shell
+    kubectl get pods -n flux-system
+    ```
+
+    For example:
+
+    ```shell
+    $ kubectl get pods -n flux-system
+    NAME                                 READY   STATUS    RESTARTS   AGE
+    source-controller-69859f545d-ll8fj   1/1     Running   0          3m38s
+    ```
+
+    Verify that `STATUS` is `Running`
+
+## Try fluxcd-source-controller
+
+1. Verify all the objects are installed:
+
+    This package would create a new namespace where all the elements of fluxcd will be hosted called `flux-system`
+
+    you can verify the main components of `fluxcd-source-controller` were installed by running:
+
+    ```shell
+    kubectl get all -n flux-system
+    NAME                                     READY   STATUS    RESTARTS   AGE
+    pod/source-controller-7684c85659-2zfxb   1/1     Running   0          40m
+
+    NAME                        TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
+    service/source-controller   ClusterIP   10.108.138.74   <none>        80/TCP    40m
+
+    NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
+    deployment.apps/source-controller   1/1     1            1           40m
+
+    NAME                                           DESIRED   CURRENT   READY   AGE
+    replicaset.apps/source-controller-7684c85659   1         1         1       40m
+    ```
+
+    you should get something really similar!
+
+2. Verify all the CRD were installed correctly:
+
+    The way you would communicate with `fluxcd-source-controller` would be through its CRDs, this will be your main action point.
+
+    In order to check all the CRDs were installed you can run:
+
+    ```shell
+    kubectl get crds -n flux-system | grep ".fluxcd.io"
+    buckets.source.toolkit.fluxcd.io                         2022-03-07T19:20:14Z
+    gitrepositories.source.toolkit.fluxcd.io                 2022-03-07T19:20:14Z
+    helmcharts.source.toolkit.fluxcd.io                      2022-03-07T19:20:14Z
+    helmrepositories.source.toolkit.fluxcd.io                2022-03-07T19:20:14Z
+    ```
+
+3. Try one simple example:
+
+    Try one quick example yourself, so you can check everything is working as expected
+
+    - Let's consume a `GitRepository` object,
+
+      - Create the following `gitrepository-sample.yaml` file:
+
+          ```yaml
+          apiVersion: source.toolkit.fluxcd.io/v1beta1
+          kind: GitRepository
+          metadata:
+            name: gitrepository-sample
+          spec:
+            interval: 1m
+            url: https://github.com/stefanprodan/podinfo
+            ref:
+              branch: master
+          ```
+
+      - Apply the created conf
+
+          ```shell
+          kubectl apply -f gitrepository-sample.yaml
+          gitrepository.source.toolkit.fluxcd.io/gitrepository-sample created
+          ```
+
+      - Check the git-repository was fetched correctly
+
+          ```shell
+          kubectl get GitRepository
+          NAME                   URL                                       READY   STATUS                                                              AGE
+          gitrepository-sample   https://github.com/stefanprodan/podinfo   True    Fetched revision: master/132f4e719209eb10b9485302f8593fc0e680f4fc   4s
+          ```
+
+    You can find more examples checking out the samples folder on [fluxcd/source-controller/samples](https://github.com/fluxcd/source-controller/tree/main/config/samples)
+
+## Documentation
+
+For documentation specific to fluxcd-source-controller, check out the main repository
+[fluxcd/source-controller](https://github.com/fluxcd/source-controller).

--- a/addons/packages/fluxcd-source-controller/0.21.2/package.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.2/package.yaml
@@ -1,0 +1,27 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: fluxcd-source-controller.community.tanzu.vmware.com.0.21.2
+spec:
+  refName: fluxcd-source-controller.community.tanzu.vmware.com
+  version: 0.21.2
+  releasedAt: "2022-02-07T11:14:08Z"
+  valuesSchema:
+    openAPIv3:
+      properties: {}
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/fluxcd-source-controller-bundle@sha256:020f9efbc07d439bc9bc1857abdca053a9470eb98ba5d5af8de1fa43db141c93
+      template:
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
+          - config/kapp.yml
+      deploy:
+      - kapp: {}

--- a/addons/packages/fluxcd-source-controller/metadata.yaml
+++ b/addons/packages/fluxcd-source-controller/metadata.yaml
@@ -1,0 +1,14 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  name: fluxcd-source-controller.community.tanzu.vmware.com
+spec:
+  displayName: "Flux Source Controller"
+  longDescription: "The source-controller is a Kubernetes operator, specialised in artifacts acquisition from external sources such as Git, Helm repositories and S3 buckets. The source-controller implements the source.toolkit.fluxcd.io API and is a core component of the GitOps toolkit."
+  shortDescription: "The source-controller is a Kubernetes operator, specialised in artifacts acquisition from external sources such as Git, Helm repositories and S3 buckets."
+  supportDescription: "https://tanzu.vmware.com/support"
+  providerName: "VMware"
+  categories:
+  - gitops
+  maintainers:
+  - name: "Esteban Foronda"

--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -18,6 +18,9 @@ packages:
   - name: fluent-bit
     versions:
       - 1.7.5
+  - name: fluxcd-source-controller
+    versions:
+      - 0.21.2
   - name: gatekeeper
     versions:
       - 3.2.3


### PR DESCRIPTION
## What this PR does / why we need it
This PR adds the [fluxcd-source-controller](https://github.com/fluxcd/source-controller) package as an addon having the Package bits coming out of [vmware-tanzu/package-for-source-controller](https://github.com/vmware-tanzu/package-for-source-controller).

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Add fluxcd-source-controller v0.21.2 package
```
## Which issue(s) this PR fixes
Fixes: #3087

## Describe testing done for PR

1. Create a cluster provisioned with kapp-controller and cert-manager
2. Submit the metadata.yaml and 0.2.2/package.yaml files
3. Install the package using the tanzu cli

```text
tanzu package install fluxcd-source-controller -p fluxcd.source.controller.community.tanzu.vmware.com -v 0.21.2
\ Installing package 'fluxcd.source.controller.community.tanzu.vmware.com'
| Getting package metadata for 'fluxcd.source.controller.community.tanzu.vmware.com'
| Creating service account 'fluxcd-source-controller-default-sa'
| Creating cluster admin role 'fluxcd-source-controller-default-cluster-role'
| Creating cluster role binding 'fluxcd-source-controller-default-cluster-rolebinding'
| Creating package resource
/ Waiting for 'PackageInstall' reconciliation for 'fluxcd-source-controller'
\ 'PackageInstall' resource install status: Reconciling


 Added installed package 'fluxcd-source-controller'
```
run the smoke test from package-for-source-controller (see https://github.com/vmware-tanzu/package-for-source-controller/blob/main/test/e2e.sh)

you can also see more deeper tests executed on our pipeline:

- [test-installation](https://runway-ci.eng.vmware.com/teams/tce-fluxcd-source-controller/pipelines/tce-flux-source-controller/jobs/test/builds/19#L621c6b83:31:43)
- [test -smoke](https://runway-ci.eng.vmware.com/teams/tce-fluxcd-source-controller/pipelines/tce-flux-source-controller/jobs/test/builds/19#L621c6b84:35:143)

