### PR TITLE
Update `actions/checkout` to v3

### DIFF
--- a/.github/workflows/build-daily.yaml
+++ b/.github/workflows/build-daily.yaml
@@ -43,7 +43,7 @@ jobs:
           git config --global pull.rebase true
           git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -40,7 +40,7 @@ jobs:
           go-version: "1.17"
         id: go
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/check-actionlint.yaml
+++ b/.github/workflows/check-actionlint.yaml
@@ -22,7 +22,7 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Run actionlint
         run: |

--- a/.github/workflows/check-chocolatey-package.yaml
+++ b/.github/workflows/check-chocolatey-package.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Run E2E Tests
         shell: powershell

--- a/.github/workflows/check-imagelint.yaml
+++ b/.github/workflows/check-imagelint.yaml
@@ -23,7 +23,7 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Run imagelint
         run: |

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2

--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -31,7 +31,7 @@ jobs:
           go-version: "1.17"
         id: go
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/check-mdlint.yaml
+++ b/.github/workflows/check-mdlint.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Run mdlint
         run: |

--- a/.github/workflows/check-misspell.yaml
+++ b/.github/workflows/check-misspell.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Run misspell
         run: |

--- a/.github/workflows/check-pr-diagnostics-plugin.yaml
+++ b/.github/workflows/check-pr-diagnostics-plugin.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           git config --global init.defaultBranch main
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/check-pr-docker-management.yaml
+++ b/.github/workflows/check-pr-docker-management.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           git config --global init.defaultBranch main
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/check-shell.yaml
+++ b/.github/workflows/check-shell.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Run shellcheck
         run: |

--- a/.github/workflows/check-urllint.yaml
+++ b/.github/workflows/check-urllint.yaml
@@ -24,7 +24,7 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Run urllint
         run: |

--- a/.github/workflows/check-yaml.yaml
+++ b/.github/workflows/check-yaml.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Run yamllint
         run: |

--- a/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
@@ -51,7 +51,7 @@ jobs:
           df -h
 
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Run AWS Management and Workload Cluster E2E Tests
         env:

--- a/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
@@ -50,7 +50,7 @@ jobs:
           df -h
 
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Run Azure Management and Workload Cluster E2E Tests
         env:

--- a/.github/workflows/e2e-diagnostics-plugin.yaml
+++ b/.github/workflows/e2e-diagnostics-plugin.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2

--- a/.github/workflows/e2e-vsphere-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-vsphere-management-and-workload-cluster.yaml
@@ -19,7 +19,7 @@ jobs:
         id: go
 
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Run vSphere Management and Workload Cluster E2E Test
         env:

--- a/.github/workflows/package-copy-readmes-to-docs.yaml
+++ b/.github/workflows/package-copy-readmes-to-docs.yaml
@@ -29,7 +29,7 @@ jobs:
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Copy Package Readme Files
         run: |
           cd hack/workflows/packages && go run copy-package-readmes-to-docs.go

--- a/.github/workflows/release-choco-package.yaml
+++ b/.github/workflows/release-choco-package.yaml
@@ -21,7 +21,7 @@ jobs:
 
 
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Update Choco Package
         env:

--- a/.github/workflows/release-fake-bucket.yaml
+++ b/.github/workflows/release-fake-bucket.yaml
@@ -43,7 +43,7 @@ jobs:
           git config --global pull.rebase true
           git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release-fake.yaml
+++ b/.github/workflows/release-fake.yaml
@@ -43,7 +43,7 @@ jobs:
           git config --global pull.rebase true
           git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release-ga-bucket.yaml
+++ b/.github/workflows/release-ga-bucket.yaml
@@ -44,7 +44,7 @@ jobs:
           git config --global pull.rebase true
           git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release-ga.yaml
+++ b/.github/workflows/release-ga.yaml
@@ -44,7 +44,7 @@ jobs:
           git config --global pull.rebase true
           git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release-gate-macos-linux-builds.yaml
+++ b/.github/workflows/release-gate-macos-linux-builds.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Release Gate - MacOS and Linux OS Release Builds
         env:

--- a/.github/workflows/release-gate-windows-build.yaml
+++ b/.github/workflows/release-gate-windows-build.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Release Gate - Windows OS Release Build
         shell: powershell

--- a/.github/workflows/release-homebrew-package.yaml
+++ b/.github/workflows/release-homebrew-package.yaml
@@ -22,7 +22,7 @@ jobs:
           git config --global user.email github-actions@github.com
 
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Update Homebrew Package
         env:

--- a/.github/workflows/release-nonga-bucket.yaml
+++ b/.github/workflows/release-nonga-bucket.yaml
@@ -45,7 +45,7 @@ jobs:
           git config --global pull.rebase true
           git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release-nonga.yaml
+++ b/.github/workflows/release-nonga.yaml
@@ -45,7 +45,7 @@ jobs:
           git config --global pull.rebase true
           git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Restore Go Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/test-pr-external-dns.yaml
+++ b/.github/workflows/test-pr-external-dns.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This updates our usage of the GitHub Actions `actions/checkout` module
to the latest v3 release.