### PR TITLE
Post daily build notifications to an existing pinned discussion

### DIFF
--- a/hack/dailybuild/dailybuild.go
+++ b/hack/dailybuild/dailybuild.go
@@ -234,7 +234,6 @@ func releaseNotes() (string, error) {
 }
 
 func postDiscussion(token string, builds *Builds, releaseNotes string) error {
-	titleTemplate := "Daily Development Build for %s"
 	bodyTemplate := "# Downloadable assets:\\n\\n" +
 		"Linux AMD64 - %s\\n" +
 		"Darwin AMD64 - %s\\n" +
@@ -244,15 +243,15 @@ func postDiscussion(token string, builds *Builds, releaseNotes string) error {
 	} else {
 		bodyTemplate += "%s" // this effectively becomes a noop because it will be empty
 	}
+
 	jsonTemplate := "{\n" +
-		"\"query\": \"mutation {   createDiscussion(input: {repositoryId: \\\"MDEwOlJlcG9zaXRvcnkzMDM4MDIzMzI\\\", categoryId: \\\"DIC_kwDOEhun3M4CA9pd\\\", body: \\\"%s\\\", title: \\\"%s\\\"}) {     discussion {       id     }   } }\"\n" +
+		"\"query\": \"mutation {   addDiscussionComment(input: {discussionId: \\\"D_kwDOEhun3M4AO9Ut\\\", body: \\\"%s\\\"}) { comment {       id     }   } }\"\n" +
 		"}\n"
 
 	url := "https://api.github.com/graphql"
-	titleStr := fmt.Sprintf(titleTemplate, builds.BuildDate)
 	bodyStr := fmt.Sprintf(bodyTemplate, builds.LinuxAmd64, builds.DarwinAmd64, builds.WindowsAmd64, releaseNotes)
 	authStr := fmt.Sprintf("token %s", token)
-	jsonStr := fmt.Sprintf(jsonTemplate, bodyStr, titleStr)
+	jsonStr := fmt.Sprintf(jsonTemplate, bodyStr)
 
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*1200)


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This changes the behavior for the notification of daily builds to post a reply to a pinned existing discussion (https://github.com/vmware-tanzu/community-edition/discussions/3379) instead of creating a new discussion in the "Daily Builds" category. This change was done because new discussions flood the "discussion" view when first opening the page.

Once this PR gets merged, will delete all older threads to clean up the mess and delete the "Daily Build" category since it will no longer be used.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Post daily build to an existing pinned discussion
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Ran functionality manually

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA