### PR TITLE
update adc crd to enable webhook

### DIFF
--- a/addons/packages/ako-operator/1.6.0/bundle/config/overlays/overlay-deployment.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/overlays/overlay-deployment.yaml
@@ -42,6 +42,10 @@ spec:
             - /manager
           image: projects-stg.registry.vmware.com/tkg/ako-operator:v1.6.0_vmware.1
           name: manager
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
           env:
             - name: bootstrap_cluster
               value: "False"
@@ -60,3 +64,7 @@ spec:
             requests:
               cpu: 100m
               memory: 100Mi
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true

--- a/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/deployment.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/deployment.yaml
@@ -28,6 +28,10 @@ spec:
             - /manager
           image: projects-stg.registry.vmware.com/tkg/ako-operator:v1.6.0_vmware.1
           name: manager
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
           env:
             - name: bootstrap_cluster
               value: "False"
@@ -44,4 +48,13 @@ spec:
             requests:
               cpu: 100m
               memory: 100Mi
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
       terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: webhook-server-cert

--- a/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/static.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/static.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
+  labels:
+    app: tanzu-ako-operator
   name: akodeploymentconfigs.networking.tkg.tanzu.vmware.com
 spec:
   group: networking.tkg.tanzu.vmware.com
@@ -572,3 +574,108 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: tkg-system-networking
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tanzu-ako-operator
+  name: ako-operator-webhook-service
+  namespace: tkg-system-networking
+spec:
+  ports:
+    - port: 443
+      targetPort: 9443
+  selector:
+    app: tanzu-ako-operator
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: tanzu-ako-operator
+  name: ako-operator-serving-cert
+  namespace: tkg-system-networking
+spec:
+  dnsNames:
+    - ako-operator-webhook-service.tkg-system-networking.svc
+    - ako-operator-webhook-service.tkg-system-networking.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: ako-operator-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: tanzu-ako-operator
+  name: ako-operator-selfsigned-issuer
+  namespace: tkg-system-networking
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: tkg-system-networking/ako-operator-serving-cert
+  labels:
+    app: tanzu-ako-operator
+  name: ako-operator-mutating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1alpha1
+    clientConfig:
+      service:
+        name: ako-operator-webhook-service
+        namespace: tkg-system-networking
+        path: /validate-networking-tkg-tanzu-vmware-com-v1alpha1-akodeploymentconfig
+    failurePolicy: Fail
+    name: vakodeploymentconfig.kb.io
+    rules:
+      - apiGroups:
+          - networking.tkg.tanzu.vmware.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - akodeploymentconfigs
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: tkg-system-networking/ako-operator-serving-cert
+  labels:
+    app: tanzu-ako-operator
+  name: ako-operator-validating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1alpha1
+    clientConfig:
+      service:
+        name: ako-operator-webhook-service
+        namespace: tkg-system-networking
+        path: /validate-networking-tkg-tanzu-vmware-com-v1alpha1-akodeploymentconfig
+    failurePolicy: Fail
+    name: vakodeploymentconfig.kb.io
+    rules:
+      - apiGroups:
+          - networking.tkg.tanzu.vmware.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - akodeploymentconfigs
+    sideEffects: None


### PR DESCRIPTION
## What this PR does / why we need it
<!--
In this PR, we added a webhook to enable runtime validation for AviDeploymentConfig to ensure user can't update control plane network config after the cluster has been deployed.
-->

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Currently, this PR is under testing
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
