### PR TITLE
Update tasks to require a tag when pushing to the oci registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,10 +439,10 @@ lock-package-images: check-carvel # Updates the image lock file for a package. U
 	@printf "\n===> Updating image lockfile for package $${PACKAGE}/$${VERSION}\n";\
 	cd addons/packages/$${PACKAGE}/$${VERSION} && kbld --file bundle --imgpkg-lock-output bundle/.imgpkg/images.yml >> /dev/null;\
 
-push-package: check-carvel # Verify openAPIv3 schema in package before build and push a package template. Tag will default to `latest`. Usage: make push-package PACKAGE=foobar VERSION=1.0.0
+push-package: check-carvel # Verify openAPIv3 schema in package before build and push a package template. A tag is required, and may be different from the version (e.g. versions including build-metadata). Usage: make push-package PACKAGE=foobar VERSION=1.0.0 TAG=1.0.0-beta.1
 	@printf "\n===> pushing $${PACKAGE}/$${VERSION}\n";\
 	./hack/packages/verify-openapischema-for-package.sh $(PACKAGE) $(VERSION) \
-	&& cd addons/packages/$${PACKAGE}/$${VERSION} && imgpkg push --bundle $(OCI_REGISTRY)/$${PACKAGE}:$${VERSION} --file bundle/;\
+	&& cd addons/packages/$${PACKAGE}/$${VERSION} && imgpkg push --bundle $(OCI_REGISTRY)/$${PACKAGE}:$${TAG} --file bundle/;\
 
 generate-openapischema-package: #Generate package with OpenAPI v3 schema
 	@printf "\n===> generating OpenAPIv3 schema for $${PACKAGE}/$${VERSION}\n";\
@@ -455,8 +455,7 @@ generate-openapischema-package: #Generate package with OpenAPI v3 schema
 	&& mv generated-package.yaml ../package.yaml
 	@printf "===> package.yaml has been updated with openAPIv3 schema in its valuesSchema field for $${PACKAGE}/$${VERSION}\n";
 
-export CHANNEL
-generate-package-repo: check-carvel # Generate and push the package repository. Usage: make generate-package-repo CHANNEL=main
+generate-package-repo: check-carvel # Generate and push the package repository. Usage: make generate-package-repo CHANNEL=main TAG=0.11.0
 	cd ./hack/packages/ && $(MAKE) run
 
 get-package-config: # Extracts the package values.yaml file. Usage: make get-package-config PACKAGE=foo VERSION=1.0.0

--- a/docs/site/content/docs/latest/designs/package-process.md
+++ b/docs/site/content/docs/latest/designs/package-process.md
@@ -375,7 +375,7 @@ imgpkg push \
 There is also a make task for this.
 
 ```sh
-make push-package PACKAGE=gatekeeper VERSION=3.2.3
+make push-package PACKAGE=gatekeeper VERSION=3.2.3 TAG=3.2.3-beta.1
 ```
 
 The results of this look as follows. Notice at the end of a successful push, imgpkg reports the URL and digest of
@@ -589,7 +589,7 @@ packages:
 
 There is a makefile task, `generate-package-repo`, that generates the package repository from this file. `kapp-controller`
 currently expects the package repositories to be in the format of an imgpkgBundle. This task will generate that bundle.
-When the task is executed, `make generate-package-repo CHANNEL=main`, the following steps are performed:
+When the task is executed, `make generate-package-repo CHANNEL=main TAG=0.11.0`, the following steps are performed:
 
 * Create `addons/repos/generated/main` directory
 * Create `addons/repos/generated/main/.imgpkg` for imgpkg
@@ -598,7 +598,7 @@ When the task is executed, `make generate-package-repo CHANNEL=main`, the follow
 * Create an imgpkg `images.yml` lock file
 * Push the bundle to the OCI Registry.
 
-> The package repository will be tagged `:latest`
+> The package repository has immutable tags enabled, so a unique tag must be provided
 
 Upon successful completion, instructions for installing the package repository to your cluster are shown.
 

--- a/hack/packages/Makefile
+++ b/hack/packages/Makefile
@@ -28,7 +28,9 @@ build: ## Build the executable
 run: ## Run the generate-package-repository program for the specified channel
 ifeq ($(origin CHANNEL),undefined)
 	@echo "Error! CHANNEL env var not set"
+else ifeq ($(origin TAG),undefined)
+	@echo "Error! TAG env var not set"
 else
-	go run generate-package-repository.go $(CHANNEL)
+	go run generate-package-repository.go $(CHANNEL) $(TAG)
 endif
 

--- a/hack/packages/generate-package-repository.go
+++ b/hack/packages/generate-package-repository.go
@@ -43,6 +43,7 @@ func main() {
 	var repository Repository
 
 	channel := os.Args[1]
+	tag := os.Args[2]
 	channelDir := filepath.Join(GeneratedRepoDirectoryPath, channel)
 	imgpkgDir := filepath.Join(channelDir, ".imgpkg")
 	packagesDir := filepath.Join(channelDir, "packages")
@@ -86,7 +87,7 @@ func main() {
 	execCommand("kbld", []string{"--file", packagesDir, "--imgpkg-lock-output", imagesLockFile})
 
 	bundleLockFilename := "output.yaml"
-	registryPathAndTag := OciRegistry + "/" + channel + ":latest"
+	registryPathAndTag := OciRegistry + "/" + channel + ":" + tag
 	execCommand("imgpkg", []string{"push", "--tty", "--bundle", registryPathAndTag, "--file", channelDir, "--lock-output", bundleLockFilename})
 
 	bundleLockYamlFile, err := os.ReadFile(bundleLockFilename)
@@ -134,4 +135,10 @@ func check(e error) {
 	if e != nil {
 		panic(e)
 	}
+}
+
+func usage(arg string) {
+	fmt.Println("Missing " + arg)
+	fmt.Println("usage: make generate-package-repo CHANNEL=main TAG=1.2.3")
+	os.Exit(1)
 }


### PR DESCRIPTION
## What this PR does / why we need it

Now that our Harbor registry has immutable tags enabled, when an image/bundle is pushed, a tag will be required.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Tags are now required for the push-package and generate-package-repo make tasks.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3448 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
