### PR TITLE
fix harbor 2.2.3 e2e test package Displayname

### DIFF
--- a/addons/packages/harbor/2.2.3/test/e2e/harbor_suite_test.go
+++ b/addons/packages/harbor/2.2.3/test/e2e/harbor_suite_test.go
@@ -89,7 +89,7 @@ var _ = BeforeSuite(func() {
 
 	packageDependencies = []*packageDependency{
 		{"cert-manager", "cert-manager", ""},
-		{"contour", "Contour", filepath.Join("fixtures", "contour.yaml")},
+		{"contour", "contour", filepath.Join("fixtures", "contour.yaml")},
 	}
 
 	if !hasDefaultStorageClass() {
@@ -112,7 +112,7 @@ var _ = BeforeSuite(func() {
 
 	harborAdminPassword = generateHarborPassword()
 
-	packageName := utils.TanzuPackageName("Harbor")
+	packageName := utils.TanzuPackageName("harbor")
 
 	version := findPackageAvailableVersion(packageName, "2.2.3")
 
@@ -288,6 +288,7 @@ func installPackage(name, packageName, version, valuesFilename string) {
 	}
 
 	_, err := utils.Tanzu(nil, args...)
+	utils.Tanzu(nil, "package", "installed", "list")
 	Expect(err).NotTo(HaveOccurred())
 }
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
fix harbor 2.2.3 e2e test package Displayname



## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->


`cd test/e2e && ginkgo -v -- --packages=harbor --version=2.2.3 --guest-cluster-name="tce"`



## Environment Details

* Build version (`tanzu version`): `v0.10.1`
* Deployment (Managed/Standalone cluster): Unmanaged cluster
* Infrastructure Provider (Docker/AWS/Azure/vSphere): Docker
* Operating System (client): Ubuntu 20.04.3 LTS
