### PR TITLE
Removes `standalone` from diagnostics README

### DIFF
--- a/cli/cmd/plugin/diagnostics/README.md
+++ b/cli/cmd/plugin/diagnostics/README.md
@@ -9,7 +9,7 @@ By default, the diagnostics plugin will attempt to collect information from:
 * Any bootstrap cluster (with name `tkg-kind-*`) in kind
 * The current Tanzu management cluster
 * Any specified workload cluster
-* Any specified standalone cluster
+* Any specified unmanaged cluster
 
 For instance, the following command will collect logs, API objects, and other API server info:
 
@@ -71,10 +71,10 @@ Flags:
       --management-cluster-name string         The name of the management cluster (required)
       --management-cluster-skip                If true, skips management cluster diagnostics
       --output-dir string                      Output directory for collected bundle (default "./")
-      --standalone-cluster-context string      The context name of the standalone cluster
-      --standalone-cluster-kubeconfig string   The standalone cluster config file (required) (default "${HOME}/.kube/config")
-      --standalone-cluster-name string         The name for the standalone cluster (required)
-      --work-dir string                        Working directory for collected data (default "${HOME}/.config/tanzu/diagnostics")
+      --unmanaged-cluster-context string       The context name of the unmanaged cluster
+      --unmanaged-cluster-kubeconfig string    The unmanaged cluster config file (required) (default "${HOME}/.kube/config")
+      --unmanaged-cluster-name string          The name for the unmanaged cluster (required)
+      --work-dir string                        Working directory for collected data (default "${HOME}.config/tanzu/diagnostics")
       --workload-cluster-context string        The context name of the workload cluster
       --workload-cluster-infra string          Overrides the infrastructure type for the managed cluster (i.e. aws, azure, vsphere, etc) (default "docker")
       --workload-cluster-kubeconfig string     The workload cluster config file

--- a/cli/cmd/plugin/diagnostics/scripts/management_cluster.star
+++ b/cli/cmd/plugin/diagnostics/scripts/management_cluster.star
@@ -1,8 +1,8 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# diagnose_standalone_cluster retrieves cluster information
-# from a non-management standalone cluster.
+# diagnose_management_cluster retrieves cluster information
+# from a management cluster.
 def diagnose_management_cluster(workdir, kubeconfig, cluster_name, context_name, outputdir):
     conf = crashd_config(workdir=workdir)
     k8sconfig = kube_config(path=kubeconfig, cluster_context=context_name)


### PR DESCRIPTION
## What this PR does / why we need it
Removes stale references to `standalone` in the Diagnostics plugin 

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Removed stale references to standalone-cluster in the diagnostics plugin
```

## Which issue(s) this PR fixes
Related to: #3382