### PR TITLE
Implements setting additional package repositories to install for `unmanaged-cluster`

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -36,6 +36,7 @@ func init() {
 	ConfigureCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR to use for Pod IP addresses. Default and format is '10.244.0.0/16'")
 	ConfigureCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR to use for Service IP addresses. Default and format is '10.96.0.0/16'")
 	ConfigureCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
+	ConfigureCmd.Flags().StringSliceVar(&co.additionalRepo, "additional-repo", []string{}, "Addresses for additional package repositories to install")
 }
 
 func configure(cmd *cobra.Command, args []string) error {
@@ -51,14 +52,15 @@ func configure(cmd *cobra.Command, args []string) error {
 	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
 
 	// Determine our configuration to use
-	configArgs := map[string]string{
-		config.ClusterConfigFile: co.clusterConfigFile,
-		config.ClusterName:       clusterName,
-		config.Provider:          co.infrastructureProvider,
-		config.TKRLocation:       co.tkrLocation,
-		config.Cni:               co.cni,
-		config.PodCIDR:           co.podcidr,
-		config.ServiceCIDR:       co.servicecidr,
+	configArgs := map[string]interface{}{
+		config.ClusterConfigFile:      co.clusterConfigFile,
+		config.ClusterName:            clusterName,
+		config.Provider:               co.infrastructureProvider,
+		config.TKRLocation:            co.tkrLocation,
+		config.Cni:                    co.cni,
+		config.PodCIDR:                co.podcidr,
+		config.ServiceCIDR:            co.servicecidr,
+		config.AdditionalPackageRepos: co.additionalRepo,
 	}
 
 	scConfig, err := config.InitializeConfiguration(configArgs)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -20,6 +20,7 @@ type createUnmanagedOpts struct {
 	existingClusterKubeconfig string
 	infrastructureProvider    string
 	tkrLocation               string
+	additionalRepo            []string
 	cni                       string
 	podcidr                   string
 	servicecidr               string
@@ -60,6 +61,7 @@ func init() {
 	CreateCmd.Flags().StringVarP(&co.existingClusterKubeconfig, "existing-cluster-kubeconfig", "e", "", "Use an existing kubeconfig to tanzu-ify a cluster")
 	CreateCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider for cluster creation; default is kind")
 	CreateCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The URL to the image containing a Tanzu Kubernetes release")
+	CreateCmd.Flags().StringSliceVar(&co.additionalRepo, "additional-repo", []string{}, "Addresses for additional package repositories to install")
 	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy; default is calico")
 	CreateCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR for Pod IP allocation; default is 10.244.0.0/16")
 	CreateCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR for Service IP allocation; default is 10.96.0.0/16")
@@ -94,7 +96,7 @@ func create(cmd *cobra.Command, args []string) {
 	}
 
 	// Determine our configuration to use
-	configArgs := map[string]string{
+	configArgs := map[string]interface{}{
 		config.ClusterConfigFile:         co.clusterConfigFile,
 		config.ExistingClusterKubeconfig: co.existingClusterKubeconfig,
 		config.ClusterName:               clusterName,
@@ -105,6 +107,7 @@ func create(cmd *cobra.Command, args []string) {
 		config.ServiceCIDR:               co.servicecidr,
 		config.ControlPlaneNodeCount:     co.numContPlanes,
 		config.WorkerNodeCount:           co.numWorkers,
+		config.AdditionalPackageRepos:    co.additionalRepo,
 	}
 	clusterConfig, err := config.InitializeConfiguration(configArgs)
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -166,7 +166,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int,
 	log.Style(outputIndent, color.Faint).Infof("%s\n", t.bom.GetTKRCoreRepoBundlePath())
 	// core user package repositories
 	log.Event(logger.PackageEmoji, "Selected additional package repositories")
-	for _, additionalRepo := range t.bom.GetAdditionalRepoBundlesPaths() {
+	for _, additionalRepo := range scConfig.AdditionalPackageRepos {
 		log.Style(outputIndent, color.Faint).Infof("%s\n", additionalRepo)
 	}
 	// kapp-controller
@@ -218,8 +218,12 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int,
 	if err != nil {
 		return ErrCorePackageRepoInstall, fmt.Errorf("failed to install core package repo. Error: %s", err.Error())
 	}
-	for _, additionalRepo := range t.bom.GetAdditionalRepoBundlesPaths() {
-		_, err = createPackageRepo(pkgClient, tkgGlobalPkgNamespace, tceRepoName, additionalRepo)
+
+	// Install the additional package repos
+	for _, additionalRepo := range scConfig.AdditionalPackageRepos {
+		kappFriendlyRepoName := strings.ReplaceAll(additionalRepo, "/", "-")
+		kappFriendlyRepoName = strings.ReplaceAll(kappFriendlyRepoName, ":", "-")
+		_, err = createPackageRepo(pkgClient, tkgGlobalPkgNamespace, kappFriendlyRepoName, additionalRepo)
 		if err != nil {
 			return ErrOtherPackageRepoInstall, fmt.Errorf("failed to install adiditonal package repo. Error: %s", err.Error())
 		}

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/tkr.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/tkr.go
@@ -11,10 +11,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	tceRepoURL = "projects.registry.vmware.com/tce/main:0.10.1"
-)
-
 // ImagePackage represents information for an image.
 type ImagePackage struct {
 	ImagePath  string `yaml:"imagePath"`
@@ -489,12 +485,6 @@ func (tkr *Bom) GetTKRCoreRepoBundlePath() string {
 	tag := tkr.Components.TkgCorePackages[0].Images.TanzuCorePackageRepositoryImage.Tag
 
 	return fmt.Sprintf("%s/%s:%s", registry, path, tag)
-}
-
-// TODO(joshrosso): We're waiting on this information to be available in the TKR API
-// for now, we are hard-coding the response
-func (tkr *Bom) GetAdditionalRepoBundlesPaths() []string {
-	return []string{tceRepoURL}
 }
 
 func (tkr *Bom) GetTKRKappImage() (ImageReader, error) {


### PR DESCRIPTION
## What this PR does / why we need it
- Users can now set the additional repos to install during bootstrapping of `unmanaged-cluster`.
  - Either via config file or flags
- Additional package repos are named in a DNS / kapp control friendly way and directly reflect their repo URL
  - Ex: `projects.registry.vmware.com/tce/main:0.10.2` -> `projects.registry.vmware.com-tce-main-0.10.2` 
- If the user provides this configuration, the default package repository is _ignored._ Otherwise, the default package repo is used (which is hardcoded into the released binary)
- Refactors config setting to accept a `map[string]interface{}` in order for `AdditionalPackageRepos` to be set and work with all options (flags, env vars, defaults, etc.)

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Can now set the unmanaged-cluster additional packages that are installed during bootstrapping
```

## Which issue(s) this PR fixes
Fixes: #3458

## Describe testing done for PR
Default install still works:
```
❯ tanzu unmanaged-cluster create test
...

❯ tanzu package repository list -A
| Retrieving repositories...
  NAME                                          REPOSITORY                                           TAG                     STATUS               DETAILS  NAMESPACE
  projects.registry.vmware.com-tce-main-0.10.1  projects.registry.vmware.com/tce/main                0.10.1                  Reconciling                   tanzu-package-repo-global
  tkg-core-repository                           projects.registry.vmware.com/tkg/packages/core/repo  v1.21.2_vmware.1-tkg.1  Reconcile succeeded           tkg-system
```

Setting flag works
```
❯ tanzu unmanaged-cluster create --additional-repo projects.registry.vmware.com/tce/main:0.10.2 test

...

📦 Selected additional package repositories
   projects.registry.vmware.com/tce/main:0.10.2

...

❯ tanzu package repository list -A
| Retrieving repositories...
  NAME                                          REPOSITORY                                           TAG                     STATUS               DETAILS  NAMESPACE
  projects.registry.vmware.com-tce-main-0.10.2  projects.registry.vmware.com/tce/main                0.10.2                  Reconcile succeeded           tanzu-package-repo-global
  tkg-core-repository                           projects.registry.vmware.com/tkg/packages/core/repo  v1.21.2_vmware.1-tkg.1  Reconcile succeeded           tkg-system
```

Setting multiple package repos works (note, this fails because I'm installing the _same_ package repo twice, just different versions. Kapp controller complains due to "ownership" over packages of the same name. But it gets the idea across):
```
❯ tanzu unmanaged-cluster create --additional-repo projects.registry.vmware.com/tce/main:0.10.2 --additional-repo projects.registry.vmware.com/tce/main:dev test-2

...

📦 Selected additional package repositories
   projects.registry.vmware.com/tce/main:0.10.2
   projects.registry.vmware.com/tce/main:dev

...

❯ tanzu package repository list -A
| Retrieving repositories...
  NAME                                          REPOSITORY                                           TAG                     STATUS                   DETAILS                  NAMESPACE
  projects.registry.vmware.com-tce-main-0.10.2  projects.registry.vmware.com/tce/main                0.10.2                  Reconcile succeeded                               tanzu-package-repo-global
  projects.registry.vmware.com-tce-main-dev     projects.registry.vmware.com/tce/main                dev                     Reconcile failed: Fe...  Error: Syncing direc...  tanzu-package-repo-global
  tkg-core-repository                           projects.registry.vmware.com/tkg/packages/core/repo  v1.21.2_vmware.1-tkg.1  Reconcile succeeded                               tkg-system


```

Works with env vars (note, this splits on the comma `,`):
```
$ TANZU_ADDITIONAL_PACKAGE_REPOS=example.repo.com,another.example.com ./unmanaged-cluster create test-envs
...
📦 Selected additional package repositories
   example.repo.com
   another.example.com
```

Creating a config file sets the default:
```
$ tanzu unmanaged-cluster create test
Wrote configuration file to: test.yaml

$ cat test.yaml
ClusterName: test
KubeconfigPath: ""
ExistingClusterKubeconfig: ""
NodeImage: ""
Provider: kind
ProviderConfiguration: {}
Cni: calico
CniConfiguration: {}
PodCidr: 10.244.0.0/16
ServiceCidr: 10.96.0.0/16
TkrLocation: projects.registry.vmware.com/tce/tkr:v1.21.5
AdditionalPackageRepos:
  - projects.registry.vmware.com/tce/main:0.10.1
PortsToForward: []
SkipPreflight: false
ControlPlaneNodeCount: "1"
WorkerNodeCount: "0"
```

and setting flags during config creation:
```
$ tanzu config another-test --additional-repo woof.repo.com --additional-repo meow.repo.com
Wrote configuration file to: another-test.yaml

$ cat another-test.yaml
ClusterName: another-test
KubeconfigPath: ""
ExistingClusterKubeconfig: ""
NodeImage: ""
Provider: kind
ProviderConfiguration: {}
Cni: calico
CniConfiguration: {}
PodCidr: 10.244.0.0/16
ServiceCidr: 10.96.0.0/16
TkrLocation: projects.registry.vmware.com/tce/tkr:v1.21.5
AdditionalPackageRepos:
  - woof.repo.com
  - meow.repo.com
PortsToForward: []
SkipPreflight: false
ControlPlaneNodeCount: "1"
WorkerNodeCount: "0"
```

Works when creating with a config file (again, this fails since there are multiple repos):
```
❯ cat test.yaml
ClusterName: my-test
KubeconfigPath: ""
ExistingClusterKubeconfig: ""
NodeImage: ""
Provider: kind
ProviderConfiguration: {}
Cni: calico
CniConfiguration: {}
PodCidr: 10.244.0.0/16
ServiceCidr: 10.96.0.0/16
TkrLocation: projects.registry.vmware.com/tce/tkr:v1.21.5
AdditionalPackageRepos:
  - projects.registry.vmware.com/tce/main:dev
  - projects.registry.vmware.com/tce/main:0.10.2
PortsToForward: []
SkipPreflight: false
ControlPlaneNodeCount: "1"
WorkerNodeCount: "0"

❯ tanzu unmanaged-cluster create my-test -f test.yaml

...

📦 Selected additional package repositories
   projects.registry.vmware.com/tce/main:dev
   projects.registry.vmware.com/tce/main:0.10.2

...

❯ tanzu package repository list -A
| Retrieving repositories...
  NAME                                          REPOSITORY                                           TAG                     STATUS                   DETAILS                  NAMESPACE
  projects.registry.vmware.com-tce-main-0.10.2  projects.registry.vmware.com/tce/main                0.10.2                  Reconcile succeeded                               tanzu-package-repo-global
  projects.registry.vmware.com-tce-main-dev     projects.registry.vmware.com/tce/main                dev                     Reconcile failed: Fe...  Error: Syncing direc...  tanzu-package-repo-global
  tkg-core-repository                           projects.registry.vmware.com/tkg/packages/core/repo  v1.21.2_vmware.1-tkg.1  Reconcile succeeded                               tkg-system
```

## Special notes for your reviewer
Let me know if the naming of anything doesn't make sense! Happy to rearrange how some of the vars and such are named
