### PR TITLE
Perform signing check with source code from the release and not main

### DIFF
--- a/.github/workflows/release-gate-macos-linux-builds.yaml
+++ b/.github/workflows/release-gate-macos-linux-builds.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v1
+        with:
+          ref: ${{ github.event.inputs.release_version }}
 
       - name: Release Gate - MacOS and Linux OS Release Builds
         env:

--- a/.github/workflows/release-gate-windows-build.yaml
+++ b/.github/workflows/release-gate-windows-build.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v1
+        with:
+          ref: ${{ github.event.inputs.release_version }}
 
       - name: Release Gate - Windows OS Release Build
         shell: powershell


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
When we cut a release, the signing check workflows is triggered off main and not off source code the release. So, for the signing check we want to checkout source code from the tag of the release and run those check scripts instead.

This is definitely an experiment, but one which we can revert the changes if this doesn't work. Depending on the input, there is another variation on this ref value and that would be `ref/tags/<version>`

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA