### PR TITLE
Adding vendir for fluxcd-source-controller

### DIFF
--- a/addons/packages/fluxcd-source-controller/vendir.lock.yml
+++ b/addons/packages/fluxcd-source-controller/vendir.lock.yml
@@ -1,0 +1,8 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/package-for-source-controller/releases/61458219
+    path: .
+  path: 0.21.2
+kind: LockConfig

--- a/addons/packages/fluxcd-source-controller/vendir.yml
+++ b/addons/packages/fluxcd-source-controller/vendir.yml
@@ -1,0 +1,14 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.12.0
+directories:
+  - path: 0.21.2
+    contents:
+      - path: .
+        githubRelease:
+          slug: vmware-tanzu/package-for-source-controller
+          tag: v0.21.2
+          disableAutoChecksumValidation: true
+          assetNames:
+          - "package.yaml"
+          - "README.md"


### PR DESCRIPTION
## What this PR does / why we need it
Adding vendir to fluxcd-source-controller folder so we keep sync tce release with [package-for-source-controller](https://github.com/vmware-tanzu/package-for-source-controller)

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Adding vendir conf to fluxcd-source-controller
```

## Which issue(s) this PR fixes
Fixes: #3463 

## Describe testing done for PR
running 

```shell
vendir sync
```
Inside fluxcd-source-controller should create the folder `0.21.2` with the files `package.yaml` and `README.md`

## Special notes for your reviewer
[package-for-source-controller](https://github.com/vmware-tanzu/package-for-source-controller) is still a private repo, so remember to add your personal token to vendir in order to work correctly

```shell
export VENDIR_GITHUB_API_TOKEN=123abc
```
