### PR TITLE
Uses the new `v1.22.5` TKR for `unmanaged-cluster`

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/config/config.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config.go
@@ -42,7 +42,7 @@ const (
 )
 
 var defaultConfigValues = map[string]string{
-	TKRLocation:           "projects.registry.vmware.com/tce/tkr:v1.21.5",
+	TKRLocation:           "projects.registry.vmware.com/tce/tkr:v1.22.5",
 	Provider:              "kind",
 	Cni:                   "antrea",
 	PodCIDR:               "10.244.0.0/16",


### PR DESCRIPTION
## What this PR does / why we need it

Uses the new `v1.22.5` TKR for `unmanaged-cluster`

See details under https://github.com/vmware-tanzu/community-edition/issues/3354 for creation and verification of TKR

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Unmanaged-cluster uses v1.22.5 TKR
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3354

## Describe testing done for PR

Created a new cluster with `tanzu unmanaged-cluster create my-cluster` and verified pulled TKR:
```
🎨 Selected base image
   projects.registry.vmware.com/tce/kind/node:v1.22.5
```
All pods and everything look 👍🏼 

And my cluster is correctly using `v1.22.5`:
```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-10T12:53:33Z", GoVersion:"go1.16.3", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.5", GitCommit:"5c99e2ac2ff9a3c549d9ca665e7bc05a3e18f07e", GitTreeState:"clean", BuildDate:"2022-03-10T17:06:50Z", GoVersion:"go1.16.12", Compiler:"gc", Platform:"linux/amd64"}
```
