### PR TITLE
Update Grafana/Prometheus packages to work with latest cert-manager APIs

### DIFF
--- a/addons/packages/grafana/7.5.7/bundle/config/certificates.lib.yaml
+++ b/addons/packages/grafana/7.5.7/bundle/config/certificates.lib.yaml
@@ -3,7 +3,7 @@
 #@ load("@ytt:yaml", "yaml")
 
 #@ def get_issuer():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: "issuer"
@@ -47,7 +47,7 @@ spec:
 #@ end
 
 #@ def get_certificate():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "certificate"

--- a/addons/packages/grafana/7.5.7/package.yaml
+++ b/addons/packages/grafana/7.5.7/package.yaml
@@ -1,12 +1,12 @@
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: grafana.community.tanzu.vmware.com.7.5.7
+  name: grafana.community.tanzu.vmware.com.7.5.7-1
 spec:
   refName: grafana.community.tanzu.vmware.com
-  version: 7.5.7
+  version: 7.5.7-1
   releasedAt: 2021-05-19T18:00:00Z
-  releaseNotes: "grafana 7.5.7 https://github.com/grafana/grafana/releases/tag/v7.5.7"
+  releaseNotes: "grafana 7.5.7-1 https://github.com/grafana/grafana/releases/tag/v7.5.7"
   capacityRequirementsDescription: "Varies significantly based on cluster size. A starting point is 6GB RAM and 1 CPU, but this should be tuned based on observed usage."
   valuesSchema:
     openAPIv3:
@@ -178,7 +178,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/grafana@sha256:53d41d9ac1534fc381efa5bb181aa4cac1ec26fc77c7ffadb34550930112e193
+            image: projects.registry.vmware.com/tce/grafana@sha256:041d84a24c6faa3918ed3902643aec193cab2acec4d14c1035d7d29bfc9bc5c6
       template:
         - ytt:
             paths:

--- a/addons/packages/prometheus/2.27.0/bundle/config/certificates.lib.yaml
+++ b/addons/packages/prometheus/2.27.0/bundle/config/certificates.lib.yaml
@@ -3,7 +3,7 @@
 #@ load("@ytt:yaml", "yaml")
 
 #@ def get_issuer():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: "issuer"
@@ -47,7 +47,7 @@ spec:
 #@ end
 
 #@ def get_certificate():
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "certificate"

--- a/addons/packages/prometheus/2.27.0/package.yaml
+++ b/addons/packages/prometheus/2.27.0/package.yaml
@@ -1,12 +1,12 @@
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: prometheus.community.tanzu.vmware.com.2.27.0
+  name: prometheus.community.tanzu.vmware.com.2.27.0-1
 spec:
   refName: prometheus.community.tanzu.vmware.com
-  version: 2.27.0
+  version: 2.27.0-1
   releasedAt: 2021-05-12T18:00:00Z
-  releaseNotes: "prometheus 2.27.0 https://github.com/prometheus/prometheus/releases/tag/v2.27.0"
+  releaseNotes: "prometheus 2.27.0-1 https://github.com/prometheus/prometheus/releases/tag/v2.27.0"
   capacityRequirementsDescription: "Varies significantly based on cluster size. A starting point is 16GB RAM and 4 CPU, but this should be tuned based on observed usage."
   valuesSchema:
     openAPIv3:
@@ -486,7 +486,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/prometheus@sha256:78ccd19454aa309b4e43e529e787d9e15d7ec95e469bcfe9e2f42c05973ae4c5
+            image: projects.registry.vmware.com/tce/prometheus@sha256:6f99e170b544291e2eab415b89aa215cb8cfbf53e60d5102b0d717e5c14ee1c1
       template:
         - ytt:
             paths:


### PR DESCRIPTION
The current Grafana/Prometheus packages are using `cert-manager.io/v1alpha2` APIs
which have been deprecated and removed in the latest versions of cert-manager

Signed-off-by: Nicholas Seemiller <nseemiller@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3292

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
