### PR TITLE
Make install/uninstall output more friendly

### DIFF
--- a/hack/release/install.sh
+++ b/hack/release/install.sh
@@ -1,17 +1,38 @@
-#!/bin/bash
+#!/bin/env bash
 
-# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# Copyright 2021-2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # set -o errexit
 set -o nounset
 set -o pipefail
 set -o xtrace
+set +x
+
+debug="false"
+if [[ $# -eq 1 ]] && [[ "$1" == "-d" ]]; then
+    debug="true"
+fi
+
+echo_debug () {
+    if [[ "${debug}" == "true" ]]; then
+        echo "${1}"
+    fi
+}
+
+error_exit () {
+    echo "ERROR: ${1}"
+    exit 1
+}
+
+echo "===================================="
+echo " Installing Tanzu Community Edition"
+echo "===================================="
+echo
 
 ALLOW_INSTALL_AS_ROOT="${ALLOW_INSTALL_AS_ROOT:-""}"
 if [[ "$EUID" -eq 0 && "${ALLOW_INSTALL_AS_ROOT}" != "true" ]]; then
-  echo "Do not run this script as root"
-  exit 1
+  error_exit "Do not run this script as root"
 fi
 
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -32,13 +53,10 @@ case "${BUILD_OS}" in
     exit 1
     ;;
 esac
-echo "${XDG_DATA_HOME}"
-echo "${XDG_CONFIG_HOME}"
 
-handle_sudo_failure() {
-    echo "sudo access required to install to ${TANZU_BIN_PATH}"
-    exit 1
-}
+echo_debug "Data home:   ${XDG_DATA_HOME}"
+echo_debug "Config home: ${XDG_CONFIG_HOME}"
+echo_debug ""
 
 # check if the tanzu CLI already exists and remove it to avoid conflicts
 TANZU_BIN_PATH=$(command -v tanzu)
@@ -59,12 +77,13 @@ fi
 TANZU_BIN_PATH="/usr/local/bin"
 if [[ ":${PATH}:" == *":$HOME/bin:"* && -d "${HOME}/bin" ]]; then
   TANZU_BIN_PATH="${HOME}/bin"
-  echo Installing tanzu cli to "${TANZU_BIN_PATH}"
+  echo Installing tanzu cli to "${TANZU_BIN_PATH}/tanzu"
   install "${MY_DIR}/tanzu" "${TANZU_BIN_PATH}"
 else
-  echo Installing tanzu cli to "${TANZU_BIN_PATH}"
+  echo Installing tanzu cli to "${TANZU_BIN_PATH}/tanzu"
   sudo install "${MY_DIR}/tanzu" "${TANZU_BIN_PATH}" || handle_sudo_failure
 fi
+echo
 
 # copy the uninstall script to tanzu-cli directory
 mkdir -p "${XDG_DATA_HOME}/tce"
@@ -73,7 +92,7 @@ install "${MY_DIR}/uninstall.sh" "${XDG_DATA_HOME}/tce"
 # if plugin cache pre-exists, remove it so new plugins are detected
 TANZU_PLUGIN_CACHE="${HOME}/.cache/tanzu/catalog.yaml"
 if [[ -n "${TANZU_PLUGIN_CACHE}" ]]; then
-  echo "Removing old plugin cache from ${TANZU_PLUGIN_CACHE}"
+  echo_debug "Removing old plugin cache from ${TANZU_PLUGIN_CACHE}"
   rm -f "${TANZU_PLUGIN_CACHE}" > /dev/null
 fi
 
@@ -114,4 +133,5 @@ if [[ -z "${TCE_REPO}"  ]]; then
   tanzu plugin repo add --name core-admin --gcp-bucket-name tce-tanzu-cli-framework-admin --gcp-root-path artifacts-admin
 fi
 
+echo
 echo "Installation complete!"

--- a/hack/release/uninstall.sh
+++ b/hack/release/uninstall.sh
@@ -1,12 +1,34 @@
-#!/bin/bash
+#!/bin/env bash
 
-# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# Copyright 2021-2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # set -o errexit
 set -o nounset
 set -o pipefail
 set -o xtrace
+set +x
+
+debug="false"
+if [[ $# -eq 1 ]] && [[ "$1" == "-d" ]]; then
+    debug="true"
+fi
+
+echo_debug () {
+    if [[ "${debug}" == "true" ]]; then
+        echo "${1}"
+    fi
+}
+
+error_exit() {
+    echo "ERROR: ${1}"
+    exit 1
+}
+
+echo "======================================"
+echo " Uninstalling Tanzu Community Edition"
+echo "======================================"
+echo
 
 BUILD_OS=$(uname 2>/dev/null || echo Unknown)
 
@@ -18,24 +40,35 @@ case "${BUILD_OS}" in
     XDG_DATA_HOME="${HOME}/Library/Application Support"
     ;;
   *)
-    echo "${BUILD_OS} is unsupported"
-    exit 1
+    error_exit "${BUILD_OS} is unsupported"
     ;;
 esac
-echo "${XDG_DATA_HOME}"
+
+echo_debug "Data home: ${XDG_DATA_HOME}"
 
 # check if the tanzu CLI already exists and remove it to avoid conflicts
 TANZU_BIN_PATH=$(command -v tanzu)
 if [[ -n "${TANZU_BIN_PATH}" ]]; then
   # best effort, so just ignore errors
-  sudo rm -f "${TANZU_BIN_PATH}" > /dev/null
+  if [[ "${TANZU_BIN_PATH}" == *"/usr/local"* ]]; then
+    sudo rm -f "${TANZU_BIN_PATH}" > /dev/null
+  else
+    rm -f "${TANZU_BIN_PATH}" > /dev/null
+  fi
 fi
 
+echo_debug "Removing: ${HOME}/.tanzu"
 rm -rf "${HOME}/.tanzu"
+echo_debug "Removing: ${HOME}/.config/tanzu"
 rm -rf "${HOME}/.config/tanzu"
+echo_debug "Removing: ${HOME}/.config/tanzu-plugins"
 rm -rf "${HOME}/.config/tanzu-plugins"
+echo_debug "Removing: ${HOME}/.cache/tanzu"
 rm -rf "${HOME}/.cache/tanzu"
+echo_debug "Removing: ${XDG_DATA_HOME}/tanzu-cli"
 rm -rf "${XDG_DATA_HOME}/tanzu-cli"
+echo_debug "Removing: ${XDG_DATA_HOME}/tce"
 rm -rf "${XDG_DATA_HOME}/tce"
+echo_debug ""
 
 echo "Uninstall complete!"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

While watching a demo, I realized the output of an install shown was
just a wall of text that didn't add much value to the end user.

This makes the output from our `install.sh` and `uninstall.sh` scripts a
little more user friendly by making the output easier to read and by
removing output that may not be as useful or meaningful to most users.

### Installation

Current `install.sh` output:

```
$ ./install.sh 
+ ALLOW_INSTALL_AS_ROOT=
+ [[ 1000 -eq 0 ]]
+++ dirname ./install.sh
++ cd .
++ pwd
+ MY_DIR=/tmp/tce-linux-amd64-v0.10.0
++ uname
+ BUILD_OS=Linux
+ case "${BUILD_OS}" in
+ XDG_DATA_HOME=/home/smcginnis/.local/share
+ echo /home/smcginnis/.local/share
/home/smcginnis/.local/share
++ command -v tanzu
+ TANZU_BIN_PATH=
+ [[ -n '' ]]
+ TANZU_BIN_PATH=/usr/local/bin
+ [[ :/home/smcginnis/.nvm/versions/node/v14.17.5/bin:/home/smcginnis/.local/bin:/home/smcginnis/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/usr/local/go/bin:/home/smcginnis/go/bin: == *\:\/\h\o\m\e\/\s\m\c\g\i\n\n\i\s\/\b\i\n\:* ]]
+ [[ -d /home/smcginnis/bin ]]
+ TANZU_BIN_PATH=/home/smcginnis/bin
+ echo Installing tanzu cli to /home/smcginnis/bin
Installing tanzu cli to /home/smcginnis/bin
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu /home/smcginnis/bin
+ mkdir -p /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-builder /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-cluster /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-codegen /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-conformance /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-diagnostics /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-kubernetes-release /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-login /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-management-cluster /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-package /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-pinniped-auth /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-secret /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-standalone-cluster /home/smcginnis/.local/share/tanzu-cli
+ for plugin in "${MY_DIR}"/bin/tanzu-plugin*
+ install /tmp/tce-linux-amd64-v0.10.0/bin/tanzu-plugin-unmanaged-cluster /home/smcginnis/.local/share/tanzu-cli
+ mkdir -p /home/smcginnis/.local/share/tce
+ install /tmp/tce-linux-amd64-v0.10.0/uninstall.sh /home/smcginnis/.local/share/tce
+ TANZU_PLUGIN_CACHE=/home/smcginnis/.cache/tanzu/catalog.yaml
+ [[ -n /home/smcginnis/.cache/tanzu/catalog.yaml ]]
+ echo 'Removing old plugin cache from /home/smcginnis/.cache/tanzu/catalog.yaml'
Removing old plugin cache from /home/smcginnis/.cache/tanzu/catalog.yaml
+ rm -f /home/smcginnis/.cache/tanzu/catalog.yaml
+ tanzu init
| initializing ✔  successfully initialized CLI 
++ tanzu plugin repo list
++ grep tce
+ TCE_REPO=
+ [[ -z '' ]]
+ tanzu plugin repo add --name tce --gcp-bucket-name tce-tanzu-cli-plugins --gcp-root-path artifacts
++ tanzu plugin repo list
++ grep core-admin
+ TCE_REPO=
+ [[ -z '' ]]
+ tanzu plugin repo add --name core-admin --gcp-bucket-name tce-tanzu-cli-framework-admin --gcp-root-path artifacts-admin
+ echo 'Installation complete!'
Installation complete!
```

Updated `install.sh` output:

```
$ ./install.sh 
+ set +x
====================================
 Installing Tanzu Community Edition
====================================

Installing tanzu cli to /home/smcginnis/bin/tanzu

Installing plugin 'builder:v0.11.2'
✔  successfully installed 'builder' plugin
Installing plugin 'codegen:v0.11.2'
✔  successfully installed 'codegen' plugin
Installing plugin 'cluster:v0.11.2'
✔  successfully installed 'cluster' plugin
Installing plugin 'kubernetes-release:v0.11.2'
✔  successfully installed 'kubernetes-release' plugin
Installing plugin 'login:v0.11.2'
✔  successfully installed 'login' plugin
Installing plugin 'management-cluster:v0.11.2'
✔  successfully installed 'management-cluster' plugin
Installing plugin 'package:v0.11.2'
✔  successfully installed 'package' plugin
Installing plugin 'pinniped-auth:v0.11.2'
✔  successfully installed 'pinniped-auth' plugin
Installing plugin 'secret:v0.11.2'
✔  successfully installed 'secret' plugin
Installing plugin 'conformance:v0.11.0-dev.2'
✔  successfully installed 'conformance' plugin
Installing plugin 'diagnostics:v0.11.0-dev.2'
✔  successfully installed 'diagnostics' plugin
Installing plugin 'unmanaged-cluster:v0.11.0-dev.2'
✔  successfully installed 'unmanaged-cluster' plugin

Installation complete!
```

### Uninstall

Current `uninstall.sh` output:

```
$ ./uninstall.sh 
++ uname
+ BUILD_OS=Linux
+ case "${BUILD_OS}" in
+ XDG_DATA_HOME=/home/smcginnis/.local/share
+ echo /home/smcginnis/.local/share
/home/smcginnis/.local/share
++ command -v tanzu
+ TANZU_BIN_PATH=
+ [[ -n '' ]]
+ rm -rf /home/smcginnis/.tanzu
+ rm -rf /home/smcginnis/.config/tanzu
+ rm -rf /home/smcginnis/.cache/tanzu
+ rm -rf /home/smcginnis/.local/share/tanzu-cli
+ rm -rf /home/smcginnis/.local/share/tce
+ echo 'Uninstall complete!'
Uninstall complete!
```

New `uninstall.sh` output, with debug output enabled by using `-d`:

```
$ ./uninstall.sh -d
+ set +x
======================================
 Uninstalling Tanzu Community Edition
======================================

Data home: /home/smcginnis/.local/share
Removing: /home/smcginnis/.tanzu
Removing: /home/smcginnis/.config/tanzu
Removing: /home/smcginnis/.config/tanzu-plugins
Removing: /home/smcginnis/.cache/tanzu
Removing: /home/smcginnis/.local/share/tanzu-cli
Removing: /home/smcginnis/.local/share/tce

Uninstall complete!
```

And without debug output:

```
$ ./uninstall.sh
+ set +x
======================================
 Uninstalling Tanzu Community Edition
======================================

Uninstall complete!
```