### PR TITLE
Update path for /usr/bin/env reference

### DIFF
--- a/hack/release/install.sh
+++ b/hack/release/install.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # Copyright 2021-2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/hack/release/uninstall.sh
+++ b/hack/release/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # Copyright 2021-2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Install scripts were updated to use the preferred shebang of referencing
`bash` through the use of `env`. The location of `env` is somewhat
standardized as `/usr/bin/env`, but the update referred to `/bin/env`.

This is fine on most systems, but at least our GitHub Action runners
aren't able to resolve and run the install script properly with the
current path. This updates those shebangs to point to the canonical
locaiton of `env`.