### PR TITLE
Fix harbor e2e contour service type

### DIFF
--- a/addons/packages/harbor/2.3.3/test/e2e/fixtures/contour.yaml
+++ b/addons/packages/harbor/2.3.3/test/e2e/fixtures/contour.yaml
@@ -1,5 +1,7 @@
 namespace: projectcontour
 
 envoy:
+  service:
+    type: LoadBalancer
   hostPorts:
     enable: true


### PR DESCRIPTION
## What this PR does / why we need it
Fix harbor e2e contour service type
for the contour service type if provider is `vc` change contour service type to `NodePort`, otherwise use `LoadBalancer`

