### PR TITLE
Implements `unmanaged-cluster` using context name on passed in kubeconfig for existing-clusters

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -71,7 +71,10 @@ func init() {
 }
 
 func create(cmd *cobra.Command, args []string) {
-	var clusterName string
+	var (
+		clusterName string
+		err         error
+	)
 
 	// Set the cluster name if it was provided, otherwise read from config file
 	if len(args) == 1 {
@@ -80,6 +83,15 @@ func create(cmd *cobra.Command, args []string) {
 
 	// initial logger, needed for logging if something goes wrong
 	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+
+	// Attempt to read cluster name from provided kubeconfig
+	if co.existingClusterKubeconfig != "" {
+		clusterName, err = tanzu.ReadClusterContextFromKubeconfig(co.existingClusterKubeconfig)
+		if err != nil {
+			log.Error(err.Error())
+			os.Exit(tanzu.ErrExistingCluster)
+		}
+	}
 
 	// Determine our configuration to use
 	configArgs := map[string]string{

--- a/cli/cmd/plugin/unmanaged-cluster/kubeconfig/kubeconfig.go
+++ b/cli/cmd/plugin/unmanaged-cluster/kubeconfig/kubeconfig.go
@@ -18,6 +18,23 @@ import (
 	clientcmdapilatest "k8s.io/client-go/tools/clientcmd/api/latest"
 )
 
+// GetKubeconfigContext returns the current context for a passed in kubeconfig file
+// Returns an empty string if no context is set
+func GetKubeconfigContext(filepath string) (string, error) {
+	// Build a new client config and get the ConfigAccess
+	config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: filepath},
+		&clientcmd.ConfigOverrides{},
+	).ConfigAccess()
+
+	startingConfig, err := config.GetStartingConfig()
+	if err != nil {
+		return "", nil
+	}
+
+	return startingConfig.CurrentContext, nil
+}
+
 // KubeConfig contains information about the kubeconfig location.
 type KubeConfig struct {
 	defaultConfigLocation string

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -791,6 +791,22 @@ infraProvider: docker
 	return nil
 }
 
+// GetKubeconfigContext returns the current context for a passed in kubeconfig file
+// This is a utility function that enables users of the `tanzu` packages
+// to utilize an existing cluster with an existing kubeconfig and get it's current context
+func ReadClusterContextFromKubeconfig(kcPath string) (string, error) {
+	ctx, err := kubeconfig.GetKubeconfigContext(kcPath)
+	if err != nil {
+		return "", fmt.Errorf("could not get context from kubeconfig found at %s - Error: %s", kcPath, err.Error())
+	}
+
+	if ctx == "" {
+		return "", fmt.Errorf("no current context set")
+	}
+
+	return ctx, nil
+}
+
 func mergeKubeconfigAndSetContext(mgr kubeconfig.Manager, kcPath, clusterName string) error {
 	err := mgr.MergeToDefaultConfig(kcPath)
 	if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it
- Introspects _current_ context of passed in kubeconfig.
  - From what I saw online, the cluster name may not be a reliable reference. The current context (and it's name) should correctly point to the cluster that's being passed in
- Does not error out when no name is passed in

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
using an existing cluster for unmanaged-cluster does not require a name. Uses current context of passed in kubeconfig
```

## Which issue(s) this PR fixes
Fixes: #3524

## Describe testing done for PR
```sh
# Create new minikube cluster
❯ minikube start
😄  minikube v1.25.2 on Debian 11.0
✨  Automatically selected the docker driver. Other choices: virtualbox, ssh
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
💾  Downloading Kubernetes v1.23.3 preload ...
    > preloaded-images-k8s-v17-v1...: 505.68 MiB / 505.68 MiB  100.00% 58.82 Mi
    > gcr.io/k8s-minikube/kicbase: 379.06 MiB / 379.06 MiB  100.00% 29.58 MiB p
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.23.3 on Docker 20.10.12 ...
    ▪ kubelet.housekeeping-interval=5m
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass

❗  /home/linuxbrew/.linuxbrew/bin/kubectl is version 1.21.0, which may have incompatibilites with Kubernetes 1.23.3.
    ▪ Want kubectl v1.23.3? Try 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by defaul

# use the kubeconfig (pointing to minikube) as the passed in cluster
❯ tanzu unmanaged-cluster create -e ~/.kube/config --cni=none

📁 Created cluster directory

🔧 Resolving Tanzu Kubernetes Release (TKR)
   projects.registry.vmware.com/tce/tkr:v1.22.5
   TKR exists at /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v1.22.5
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/minikube/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/minikube/bootstrap.log

🔧 Processing Tanzu Kubernetes Release

🎨 Selected base image
   projects.registry.vmware.com/tce/kind/node:v1.22.5

📦 Selected core package repository
   projects-stg.registry.vmware.com/tkg/packages/core/repo:v1.22.5_vmware.1-tkg.3-tf-v0.11.2

📦 Selected additional package repositories
   projects.registry.vmware.com/tce/main:0.10.1

📦 Selected kapp-controller image bundle
   projects-stg.registry.vmware.com/tkg/packages/core/kapp-controller:v0.30.0_vmware.1-tkg.1

🚀 Using existing cluster
   Warning: Components installed using this method will need to be manually removed.

   To troubleshoot, use:

   kubectl ${COMMAND} --kubeconfig /home/jmcb/.kube/config

📧 Installing kapp-controller
   kapp-controller status: Running

📧 Installing package repositories
   Core package repo status: Reconcile succeeded

🌐 Installing CNI
   No CNI installed: CNI was set to none.

✅ Cluster created

🎮 kubectl context set to minikube

View available packages:
   tanzu package available list
View running pods:
   kubectl get po -A
Delete this cluster:
   tanzu unmanaged delete minikube
```

The directory structures are created:
```
❯ tanzu unmanaged-cluster ls
  NAME        PROVIDER
  minikube    kind
```

(FYI, the above provider being `kind` is newly captured in https://github.com/vmware-tanzu/community-edition/issues/3541)

```
❯ tree ~/.config/tanzu/tkg/unmanaged/minikube
/home/jmcb/.config/tanzu/tkg/unmanaged/minikube
├── bootstrap.log
└── config.yaml
```
