### PR TITLE
move to prod harbor for v0.11.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ TANZU_FRAMEWORK_REPO_BRANCH ?= v0.11.2
 TANZU_FRAMEWORK_REPO_HASH ?=
 # TKG_DEFAULT_IMAGE_REPOSITORY override for using a different image repo
 ifndef TKG_DEFAULT_IMAGE_REPOSITORY
-TKG_DEFAULT_IMAGE_REPOSITORY ?= projects-stg.registry.vmware.com/tkg
+TKG_DEFAULT_IMAGE_REPOSITORY ?= projects.registry.vmware.com/tkg
 endif
 # TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH override for using a different image path
 ifndef TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH


### PR DESCRIPTION
This commit moves us to production harbor for compatibility and bill of
material (bom) files.


## Which issue(s) this PR fixes

Fixes: https://github.com/vmware-tanzu/community-edition/issues/3478

## Describe testing done for PR

```
$ tanzu mc create --ui
Downloading TKG compatibility file from 'projects.registry.vmware.com/tkg/framework-zshippable/tkg-compatibility'
Downloading the TKG Bill of Materials (BOM) file from 'projects.registry.vmware.com/tkg/tkg-bom:v1.5.1-tf-v0.11.2'
Downloading the TKr Bill of Materials (BOM) file from 'projects.registry.vmware.com/tkg/tkr-bom:v1.22.5_vmware.1-tkg.3-tf-v0.11.2'
```
