### PR TITLE
Add preflight warnings

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cluster/cluster.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cluster/cluster.go
@@ -39,7 +39,8 @@ type Manager interface {
 	// PreflightCheck performs any pre-checks that can find issues up front that
 	// would cause problems for cluster creation. Returns nil if there are no
 	// errors found, otherwise a list of the errors that need to be resolved.
-	PreflightCheck() []error
+	// A list of warning messages can be returned that are not blocking errors.
+	PreflightCheck() ([]string, []error)
 	// ProviderNotify returns any provider specific notifications or messages.
 	// Each string will be displayed on its own line.
 	ProviderNotify() []string

--- a/cli/cmd/plugin/unmanaged-cluster/cluster/noop.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cluster/noop.go
@@ -44,8 +44,8 @@ func (ncm NoopClusterManager) Prepare(c *config.UnmanagedClusterConfig) error {
 
 // PreflightCheck performs any pre-checks that can find issues up front that
 // would cause problems for cluster creation.
-func (ncm NoopClusterManager) PreflightCheck() []error {
-	return nil
+func (ncm NoopClusterManager) PreflightCheck() ([]string, []error) {
+	return nil, nil
 }
 
 // ProviderNotify is a noop. Nothing to notify about for the noop provider

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -578,13 +578,18 @@ func runClusterCreate(scConfig *config.UnmanagedClusterConfig) (*cluster.Kuberne
 
 	clusterManager := cluster.NewClusterManager(scConfig)
 
-	for _, message := range clusterManager.ProviderNotify() {	
+	for _, message := range clusterManager.ProviderNotify() {
 		log.Style(outputIndent, color.Faint).Info(message)
 	}
-	
+
 	if !scConfig.SkipPreflightChecks {
-		if issues := clusterManager.PreflightCheck(); issues != nil {
+		warnings, issues := clusterManager.PreflightCheck()
+		if issues != nil {
 			return nil, fmt.Errorf("system checks detected issues, please resolve first: %v", issues)
+		}
+
+		for _, warning := range warnings {
+			log.Warnf("WARNING: %s", warning)
 		}
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We had previously only supported returning errors from preflight checks
when certain conditions were not met. We now have experimental support
for ARM64 platforms, so we would like to also have the ability to return
warnings from the results of our preflights.

This plumbs in the ability for our preflight calls to return warning
messages. It also adds a check for arm64 and uses the warning mechanism
to alert the user that this is an experimental platform that may not
entirely work.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Unmanaged clusters will now only warn if running on an arm64 platform. Support for this platform is only experimental at this point.
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3555 