### PR TITLE
Updates default CNI value to `calico` in config package for `unmanaged-cluster`

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -32,7 +32,7 @@ func init() {
 	ConfigureCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "Configuration file for unmanaged cluster creation")
 	ConfigureCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider to use for cluster creation. Default is 'kind'")
 	ConfigureCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The Tanzu Kubernetes Release location.")
-	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "calico", "The CNI to deploy. Default is 'calico'")
+	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'calico'")
 	ConfigureCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR to use for Pod IP addresses. Default and format is '10.244.0.0/16'")
 	ConfigureCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR to use for Service IP addresses. Default and format is '10.96.0.0/16'")
 	ConfigureCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -60,7 +60,7 @@ func init() {
 	CreateCmd.Flags().StringVarP(&co.existingClusterKubeconfig, "existing-cluster-kubeconfig", "e", "", "Use an existing kubeconfig to tanzu-ify a cluster")
 	CreateCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider for cluster creation; default is kind")
 	CreateCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The URL to the image containing a Tanzu Kubernetes release")
-	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "calico", "The CNI to deploy; default is calico")
+	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy; default is calico")
 	CreateCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR for Pod IP allocation; default is 10.244.0.0/16")
 	CreateCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR for Service IP allocation; default is 10.96.0.0/16")
 	CreateCmd.Flags().StringSliceVarP(&co.portMapping, "port-map", "p", []string{}, "Ports to map between container node and the host (format: '80:80/tcp' or just '80')")

--- a/cli/cmd/plugin/unmanaged-cluster/config/config.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config.go
@@ -44,7 +44,7 @@ const (
 var defaultConfigValues = map[string]string{
 	TKRLocation:           "projects.registry.vmware.com/tce/tkr:v1.22.5",
 	Provider:              "kind",
-	Cni:                   "antrea",
+	Cni:                   "calico",
 	PodCIDR:               "10.244.0.0/16",
 	ServiceCIDR:           "10.96.0.0/16",
 	Tty:                   "true",
@@ -81,7 +81,7 @@ type UnmanagedClusterConfig struct {
 	// ProviderConfiguration offers optional provider-specific configuration.
 	// The exact keys and values accepted are determined by the provider.
 	ProviderConfiguration map[string]interface{} `yaml:"ProviderConfiguration"`
-	// CNI is the networking CNI to use in the cluster. Default is antrea.
+	// CNI is the networking CNI to use in the cluster. Default is calico.
 	Cni string `yaml:"Cni"`
 	// CNIConfiguration offers optional cni-plugin specific configuration.
 	// The exact keys and values accepted are determined by the CNI choice.


### PR DESCRIPTION
## What this PR does / why we need it
- default value for CNI in `config`
- removes setting the default value in the `cmd`

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
NONE
```

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
```
❯ tanzu unmanaged-cluster create woof

📁 Created cluster directory

🔧 Resolving Tanzu Kubernetes Release (TKR)
   projects.registry.vmware.com/tce/tkr:v1.22.5
   TKR exists at /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v1.22.5
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/woof/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/woof/bootstrap.log

🔧 Processing Tanzu Kubernetes Release

🎨 Selected base image
   projects.registry.vmware.com/tce/kind/node:v1.22.5

📦 Selected core package repository
   projects-stg.registry.vmware.com/tkg/packages/core/repo:v1.22.5_vmware.1-tkg.3-tf-v0.11.2

📦 Selected additional package repositories
   projects.registry.vmware.com/tce/main:0.10.1

📦 Selected kapp-controller image bundle
   projects-stg.registry.vmware.com/tkg/packages/core/kapp-controller:v0.30.0_vmware.1-tkg.1

🚀 Creating cluster woof
   Cluster creation using kind!
   ❤️ Checkout this awesome project at https://kind.sigs.k8s.io
   Base image downloaded
   Cluster created
   To troubleshoot, use:

   kubectl ${COMMAND} --kubeconfig /home/jmcb/.config/tanzu/tkg/unmanaged/woof/kube.conf

📧 Installing kapp-controller
   kapp-controller status: Running

📧 Installing package repositories
   Core package repo status: Reconcile succeeded

🌐 Installing CNI
   calico.tanzu.vmware.com:3.19.1+vmware.1-tkg.3

✅ Cluster created

🎮 kubectl context set to woof

View available packages:
   tanzu package available list
View running pods:
   kubectl get po -A
Delete this cluster:
   tanzu unmanaged delete woof

❯ k get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
kube-system          calico-kube-controllers-898c5fdc7-jxthp      1/1     Running   0          2m7s
kube-system          calico-node-xwtd4                            1/1     Running   0          2m7s
kube-system          coredns-78fcd69978-b2rm9                     1/1     Running   0          3m19s
kube-system          coredns-78fcd69978-zkkns                     1/1     Running   0          3m19s
kube-system          etcd-woof-control-plane                      1/1     Running   0          3m26s
kube-system          kube-apiserver-woof-control-plane            1/1     Running   0          3m26s
kube-system          kube-controller-manager-woof-control-plane   1/1     Running   0          3m26s
kube-system          kube-proxy-qgx4b                             1/1     Running   0          3m19s
kube-system          kube-scheduler-woof-control-plane            1/1     Running   0          3m26s
local-path-storage   local-path-provisioner-547f784dff-fd79s      1/1     Running   0          3m19s
tkg-system           kapp-controller-77d4dc7994-7zd6w             1/1     Running   0          3m19s

```