### PR TITLE
Switch to OVS kernel datapath for antrea cni

### DIFF
--- a/addons/packages/antrea/0.11.3/bundle/config/overlay/antrea_overlay.yaml
+++ b/addons/packages/antrea/0.11.3/bundle/config/overlay/antrea_overlay.yaml
@@ -35,9 +35,7 @@ featureGates:
 #! - netdev
 #! 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
 #! OVS in userspace mode. Userspace mode requires the tun device driver to be available.
-#@ if values.infraProvider == "docker":
-ovsDatapathType: netdev
-#@ end
+#!ovsDatapathType: system
 
 #! Name of the interface antrea-agent will create and use for host <--> pod communication.
 #! Make sure it doesn't conflict with your existing interfaces.
@@ -179,34 +177,10 @@ metadata:
 spec:
   template:
     spec:
-      containers:
-        #@ if values.infraProvider == "docker":
-        #@overlay/match by=overlay.subset({"name":"antrea-ovs"})
-        - command:
-          #@overlay/match by=overlay.subset("start_ovs")
-          #@overlay/replace
-            - start_ovs_netdev
-
-        #@overlay/match by=overlay.subset({"name":"antrea-ovs"})
-        - volumeMounts:
-          #@overlay/append
-            - mountPath: /dev/net/tun
-              name: dev-tun
-        #@ end
-
       initContainers:
-        #@ if values.infraProvider == "docker":
-        #@overlay/match by=overlay.subset({"name":"install-cni"})
-        - command:
-          #@overlay/match by=overlay.subset("install_cni")
-          #@overlay/replace
-            - install_cni_kind
-        #@ end
-      volumes:
-      #@ if values.infraProvider == "docker":
-      #@overlay/append
-        - hostPath:
-            path: /dev/net/tun
-            type: CharDevice
-          name: dev-tun
-      #@ end
+      #@overlay/match by=overlay.subset({"name": "install-cni"})
+      - name: install-cni
+        volumeMounts:
+        #@overlay/match by=overlay.subset({"name": "host-depmod"})
+        #@overlay/remove
+        - name host-depmod

--- a/addons/packages/antrea/0.13.3/bundle/config/overlay/antrea_overlay.yaml
+++ b/addons/packages/antrea/0.13.3/bundle/config/overlay/antrea_overlay.yaml
@@ -43,9 +43,7 @@ featureGates:
 #! - netdev
 #! 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
 #! OVS in userspace mode. Userspace mode requires the tun device driver to be available.
-#@ if values.infraProvider == "docker":
-ovsDatapathType: netdev
-#@ end
+#!ovsDatapathType: system
 
 #! Name of the interface antrea-agent will create and use for host <--> pod communication.
 #! Make sure it doesn't conflict with your existing interfaces.
@@ -223,37 +221,3 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
-spec:
-  template:
-    spec:
-      containers:
-        #@ if values.infraProvider == "docker":
-        #@overlay/match by=overlay.subset({"name":"antrea-ovs"})
-        - command:
-          #@overlay/match by=overlay.subset("start_ovs")
-          #@overlay/replace
-            - start_ovs_netdev
-
-        #@overlay/match by=overlay.subset({"name":"antrea-ovs"})
-        - volumeMounts:
-          #@overlay/append
-            - mountPath: /dev/net/tun
-              name: dev-tun
-        #@ end
-
-      initContainers:
-        #@ if values.infraProvider == "docker":
-        #@overlay/match by=overlay.subset({"name":"install-cni"})
-        - command:
-          #@overlay/match by=overlay.subset("install_cni")
-          #@overlay/replace
-            - install_cni_kind
-        #@ end
-      volumes:
-      #@ if values.infraProvider == "docker":
-      #@overlay/append
-        - hostPath:
-            path: /dev/net/tun
-            type: CharDevice
-          name: dev-tun
-      #@ end

--- a/addons/packages/antrea/1.2.3/bundle/config/overlay/antrea-overlay.yaml
+++ b/addons/packages/antrea/1.2.3/bundle/config/overlay/antrea-overlay.yaml
@@ -46,9 +46,7 @@ featureGates:
 #! - netdev
 #! 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
 #! OVS in userspace mode. Userspace mode requires the tun device driver to be available.
-#@ if values.infraProvider == "docker":
-ovsDatapathType: netdev
-#@ end
+#!ovsDatapathType: system
 
 #! Name of the interface antrea-agent will create and use for host <--> pod communication.
 #! Make sure it doesn't conflict with your existing interfaces.
@@ -262,37 +260,3 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
-spec:
-  template:
-    spec:
-      containers:
-        #@ if values.infraProvider == "docker":
-        #@overlay/match by=overlay.subset({"name":"antrea-ovs"})
-        - command:
-          #@overlay/match by=overlay.subset("start_ovs")
-          #@overlay/replace
-            - start_ovs_netdev
-
-        #@overlay/match by=overlay.subset({"name":"antrea-ovs"})
-        - volumeMounts:
-          #@overlay/append
-            - mountPath: /dev/net/tun
-              name: dev-tun
-        #@ end
-
-      initContainers:
-        #@ if values.infraProvider == "docker":
-        #@overlay/match by=overlay.subset({"name":"install-cni"})
-        - command:
-          #@overlay/match by=overlay.subset("install_cni")
-          #@overlay/replace
-            - install_cni_kind
-        #@ end
-      volumes:
-      #@ if values.infraProvider == "docker":
-      #@overlay/append
-        - hostPath:
-            path: /dev/net/tun
-            type: CharDevice
-          name: dev-tun
-      #@ end

--- a/addons/packages/antrea/1.5.2/bundle/config/overlay/antrea-overlay.yaml
+++ b/addons/packages/antrea/1.5.2/bundle/config/overlay/antrea-overlay.yaml
@@ -58,9 +58,7 @@ featureGates:
 #! - netdev
 #! 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
 #! OVS in userspace mode. Userspace mode requires the tun device driver to be available.
-#@ if values.infraProvider == "docker":
-ovsDatapathType: netdev
-#@ end
+#!ovsDatapathType: system
 
 #! Name of the interface antrea-agent will create and use for host <--> pod communication.
 #! Make sure it doesn't conflict with your existing interfaces.
@@ -382,37 +380,3 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
-spec:
-  template:
-    spec:
-      containers:
-        #@ if values.infraProvider == "docker":
-        #@overlay/match by=overlay.subset({"name":"antrea-ovs"})
-        - command:
-            #@overlay/match by=overlay.subset("start_ovs")
-            #@overlay/replace
-            - start_ovs_netdev
-
-        #@overlay/match by=overlay.subset({"name":"antrea-ovs"})
-        - volumeMounts:
-            #@overlay/append
-            - mountPath: /dev/net/tun
-              name: dev-tun
-        #@ end
-
-      initContainers:
-        #@ if values.infraProvider == "docker":
-        #@overlay/match by=overlay.subset({"name":"install-cni"})
-        - command:
-            #@overlay/match by=overlay.subset("install_cni")
-            #@overlay/replace
-            - install_cni_kind
-        #@ end
-      volumes:
-        #@ if values.infraProvider == "docker":
-        #@overlay/append
-        - hostPath:
-            path: /dev/net/tun
-            type: CharDevice
-          name: dev-tun
-      #@ end


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
When using OVS userspace (netdev) datapath, there was a known checksum
issue causing packets being dropped. The issue was prevented by
patching the network after deploying antrea. However, restarting docker
or machine recreates the docker network, then users wouldn't be able to
connect to the cluster until the network is patched again.

The Linux VM used for Docker Desktop on macOS now includes the
openvswitch kernel module. This patch switches OVS datapath to kernel
(system) to get rid of the checksum issue and the requirement of
patching the network, clusters will continue working after restarting
docker or machine.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Switch to OVS kernel datapath for antrea cni to fix the issue that clusters became unreachable after docker restart
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3058

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Create an unmanaged-cluster with antrea as the cni
Restart docker service
Make sure the cluster is still reachable and conformance test pass

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

I noticed unmanaged-clusters doesn't consume "addons/packages/antrea" but an antrea package in TKr, and "addons/packages/antrea"  is using upstream antrea image "antrea/antrea-ubuntu:v1.2.3" but its yaml has an init container "antrea-agent-tweaker" which uses a command only present in tkg specific image "tkg/antrea-standard-debian:v1.2.3_vmware.4". So the package itself cannot work directly. It should either remove the init container "antrea-agent-tweaker" from the yaml if using upstream antrea image is desired, or keep the init container but switches to the tkg specific image "tkg/antrea-standard-debian:v1.2.3_vmware.4".

The PR shouldn't be merged before TKr release is updated as removing "patchForAntrea" requires antrea's yaml is using kernel datapath.