### PR TITLE
Updates docs for `unmanaged-cluster` in upcoming v0.11.0 release

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
@@ -41,7 +41,7 @@ var ListCmd = &cobra.Command{
 
 func init() {
 	ListCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
-	ListCmd.Flags().StringVarP(&lo.outputFormat, "output", "o", "table", "Output format (yaml|json|table); default is table")
+	ListCmd.Flags().StringVarP(&lo.outputFormat, "output", "o", "table", "Output format (yaml|json|table)")
 	ListCmd.Flags().BoolVarP(&lo.quiet, "quiet", "q", false, "Only display cluster names")
 }
 


### PR DESCRIPTION
## What this PR does / why we need it
Updates docs for `unmanaged-cluster` and it's reference to reflect changes and features in the upcoming v0.11.0

## Details for the Release Notes (PLEASE PROVIDE)
```release-note
Updated unmanaged-clsuter docs
```

## Which issue(s) this PR fixes
Fixes: #3472
Fixes: #3339

## Describe testing done for PR
`hugo serve` and `make mdlint`
