### PR TITLE
cartographer: add smoke test

### DIFF
--- a/test/smoke/Makefile
+++ b/test/smoke/Makefile
@@ -4,7 +4,7 @@
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-smoke-test: install-ginkgo cert-manager fluent-bit local-path-storage prometheus knative-serving contour grafana gatekeeper external-dns multus-cni 
+smoke-test: install-ginkgo cert-manager fluent-bit local-path-storage prometheus knative-serving contour grafana cartographer gatekeeper external-dns multus-cni
 
 install-ginkgo:
 	go get github.com/onsi/ginkgo/ginkgo
@@ -30,6 +30,9 @@ knative-serving:
 
 grafana:
 	./packages/grafana/7.5.7/grafana-test.sh
+
+cartographer:
+	./packages/cartographer/0.2.2/cartographer-test.sh
 
 external-dns:
 	cd "${ROOT_DIR}"/test/e2e && ginkgo -v -- --packages="external-dns" --version="0.8.0" --guest-cluster-name="tce.public"

--- a/test/smoke/packages/cartographer/0.2.2/cartographer-test.sh
+++ b/test/smoke/packages/cartographer/0.2.2/cartographer-test.sh
@@ -35,7 +35,7 @@ for sleep_duration in {1..10}; do
     echo "sleeping ${sleep_duration}s to wait for configmap"
     sleep "$sleep_duration"
 
-    kubectl get configmap workload-test-basic && {
+    kubectl get configmap -n ${NAMESPACE} workload-test-basic && {
         packageCleanup cartographer cert-manager
         namespaceCleanup ${NAMESPACE}
         successMessage cartographer

--- a/test/smoke/packages/cartographer/0.2.2/cartographer-test.sh
+++ b/test/smoke/packages/cartographer/0.2.2/cartographer-test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TCE_REPO_PATH="$(git rev-parse --show-toplevel)"
+# shellcheck source=test/smoke/packages/utils/smoke-tests-utils.sh
+source "${TCE_REPO_PATH}/test/smoke/packages/utils/smoke-tests-utils.sh"
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Checking package is installed or not
+tanzu package installed list | grep "cert-manager.community.tanzu.vmware.com" || {
+    version=$(tanzu package available list cert-manager.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+    tanzu package install cert-manager --package-name cert-manager.community.tanzu.vmware.com --version "${version}"
+}
+
+tanzu package installed list | grep "cartographer.community.tanzu.vmware.com" || {
+    version=$(tanzu package available list cartographer.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+    tanzu package install cartographer --package-name cartographer.community.tanzu.vmware.com --version "${version}"
+}
+
+
+NAMESPACE_SUFFIX=${RANDOM}
+NAMESPACE="cartographer-${NAMESPACE_SUFFIX}"
+kubectl create ns ${NAMESPACE}
+
+kubectl apply -n ${NAMESPACE} --filename "${MY_DIR}"/testdata.yaml
+
+for sleep_duration in {1..10}; do
+    echo "sleeping ${sleep_duration}s to wait for configmap"
+    sleep "$sleep_duration"
+
+    kubectl get configmap workload-test-basic && {
+        packageCleanup cartographer cert-manager
+        namespaceCleanup ${NAMESPACE}
+        successMessage cartographer
+        exit 0
+    }
+done
+
+packageCleanup cartographer cert-manager
+namespaceCleanup ${NAMESPACE}
+failureMessage cartographer

--- a/test/smoke/packages/cartographer/0.2.2/testdata.yaml
+++ b/test/smoke/packages/cartographer/0.2.2/testdata.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-basic
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-basic
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["*"]
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-basic
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-basic
+subjects:
+  - kind: ServiceAccount
+    name: test-basic
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: test-basic
+spec:
+  template:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: workload-$(workload.metadata.name)$
+    data: {}
+
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSupplyChain
+metadata:
+  name: test-basic
+spec:
+  selector:
+    test-basic: test-basic
+
+  resources:
+    - name: test-basic
+      templateRef:
+        kind: ClusterTemplate
+        name: test-basic
+
+
+---
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: test-basic
+  labels:
+    test-basic: test-basic
+spec:
+  serviceAccountName: test-basic


### PR DESCRIPTION
## What this PR does / why we need it

similar to other components that already have smoke tests, include one
for the cartographer package.

the test is limited to making sure that Cartographer has been properly
installed by submitting a couple of objects to kubernetes and then
waiting for the result of the supplychain to be materialized:

- supplychain w/ template for stamping out a configmap is submitted
- rbac-related objects are submitted so that the workload in the test
  namespace can have the controller creating what it needs to create
  (the configmap)
- workload is submitted; the controller then matches it against the
  supplychain, resulting in a configmap named `workload-<workload-name>`,
  which we wait for as a way of checking if things went well.


## Details for the Release Notes (PLEASE PROVIDE)


```release-note
Add smoke tests for Cartographer
```


## Describe testing done for PR

1. created a cluster where the package provided by this repository (including 
  cert-manager, a dependency or Cartographer) are installed
2. ran the smoke test added in here
3. observed success

```console
$ make cartographer
./packages/cartographer/0.2.2/cartographer-test.sh
  cert-manager              cert-manager.community.tanzu.vmware.com       1.6.1            Reconcile succeeded
  cartographer              cartographer.community.tanzu.vmware.com       0.2.2            Reconcile succeeded
namespace/cartographer-14866 created
serviceaccount/test-basic created
role.rbac.authorization.k8s.io/test-basic created
rolebinding.rbac.authorization.k8s.io/test-basic created
clustertemplate.carto.run/test-basic unchanged
clustersupplychain.carto.run/test-basic unchanged
workload.carto.run/test-basic created

sleeping 1s to wait for configmap
Error from server (NotFound): configmaps "workload-test-basic" not found
sleeping 2s to wait for configmap
NAME                  DATA   AGE
workload-test-basic   0      0s

 Uninstalling package 'cartographer' from namespace 'default'
 Getting package install for 'cartographer'
 Deleting package install 'cartographer' from namespace 'default'
 'PackageInstall' resource deletion status: Deleting
 Deleting admin role 'cartographer-default-cluster-role'
 Deleting role binding 'cartographer-default-cluster-rolebinding'
 Deleting service account 'cartographer-default-sa'
Uninstalled package 'cartographer' from namespace 'default'

 Uninstalling package 'cert-manager' from namespace 'default'
 Getting package install for 'cert-manager'
 Deleting package install 'cert-manager' from namespace 'default'
 'PackageInstall' resource deletion status: Deleting
 Deleting admin role 'cert-manager-default-cluster-role'
 Deleting role binding 'cert-manager-default-cluster-rolebinding'
 Deleting service account 'cert-manager-default-sa'
Uninstalled package 'cert-manager' from namespace 'default'

namespace "cartographer-14866" deleted

cartographer passed
```