### PR TITLE
remove kube-rbac-proxy in ako operator package and aligin nsx alb default resource request value

### DIFF
--- a/addons/packages/ako-operator/1.6.0/bundle/.imgpkg/images.yml
+++ b/addons/packages/ako-operator/1.6.0/bundle/.imgpkg/images.yml
@@ -4,7 +4,4 @@ images:
 - annotations:
     kbld.carvel.dev/id: projects-stg.registry.vmware.com/tkg/ako-operator:v1.5.0_vmware.1
   image: projects-stg.registry.vmware.com/tkg/ako-operator@sha256:53926b85c969126fb9893c45e6d8fee29bb1d1b082b27946a72c2dd8b2d26442
-- annotations:
-    kbld.carvel.dev/id: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2
-  image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy@sha256:6b83d791388546ce66372f621435d55bea57d892675c3180d85a4d9dc7bb818f
 kind: ImagesLock

--- a/addons/packages/ako-operator/1.6.0/bundle/config/overlays/overlay-deployment.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/overlays/overlay-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         #@overlay/match by="name"
         #@overlay/replace
         - args:
-            - --metrics-addr=127.0.0.1:8080
+            - --metrics-addr=:8080
           command:
             - /manager
           image: projects-stg.registry.vmware.com/tkg/ako-operator:v1.6.0_vmware.1

--- a/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/deployment.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/deployment.yaml
@@ -23,17 +23,7 @@ spec:
     spec:
       containers:
         - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --logtostderr=true
-            - --v=10
-          image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-        - args:
-            - --metrics-addr=127.0.0.1:8080
+            - --metrics-addr=:8080
           command:
             - /manager
           image: projects-stg.registry.vmware.com/tkg/ako-operator:v1.6.0_vmware.1

--- a/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/static.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/static.yaml
@@ -535,26 +535,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: tanzu-ako-operator
-  name: ako-operator-proxy-role
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app: tanzu-ako-operator
   name: ako-operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -592,33 +572,3 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: tkg-system-networking
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app: tanzu-ako-operator
-  name: ako-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: ako-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: tkg-system-networking
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: tanzu-ako-operator
-  name: ako-operator-controller-manager-metrics-service
-  namespace: tkg-system-networking
-spec:
-  ports:
-  - name: https
-    port: 8443
-    targetPort: https
-  selector:
-    app: tanzu-ako-operator

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
@@ -98,8 +98,8 @@ spec:
               cpu: 350m
               memory: 400Mi
             requests:
-              cpu: 100m
-              memory: 200Mi
+              cpu: 200m
+              memory: 300Mi
           livenessProbe:
             httpGet:
               path: /api/status

--- a/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/values.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.6.1/bundle/config/values.yaml
@@ -60,8 +60,8 @@ loadBalancerAndIngressService:
         cpu: 350m
         memory: 400Mi
       request:
-        cpu: 100m
-        memory: 200Mi
+        cpu: 200m
+        memory: 300Mi
     rbac:
       psp_enabled: false
       psp_policy_api_version:


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
1. remove `kube-rbac-proxy` in ako-operator package due to CVEs
2. aligin nsx alb default resource request value

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
remove unneeded kube-rbac-proxy image in ako operator package
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
