### PR TITLE
Docs: Fix TOC visibility when navigating to packages

### DIFF
--- a/docs/site/themes/template/assets/js/main.js
+++ b/docs/site/themes/template/assets/js/main.js
@@ -121,7 +121,11 @@ document.addEventListener('DOMContentLoaded', function(){
         var active = document.querySelectorAll('.collapse .active');
         
         if(active.length) {
-            toggleAccordion(active[0].closest('.collapse').previousElementSibling);
+            var activeToggle = active[0].closest('.collapse').previousElementSibling
+            toggleAccordion(activeToggle);
+            if (activeToggle.closest('.collapse')) {
+              toggleAccordion(activeToggle.closest('.collapse').previousElementSibling);
+            }
         } else {
             toggleAccordion(document.querySelector('.collapse-trigger'));
             document.querySelector('.collapse a').classList.add('active');


### PR DESCRIPTION
Signed-off-by: Garry Ing <ging@vmware.com>

## What this PR does / why we need it
Fixes an issue where the TOC closes when visiting the readme for a package. `Packages` will remain expanded as a package readme is opened.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #1776

## Describe testing done for PR
- `hugo server --disableFastRender`
- Navigate to a package: e.g. `/docs/latest/package-readme-cert-manager-1.3.3/`
- Note the `Packages` remains expanded

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
