### PR TITLE
Enable linting for addon test packages

### DIFF
--- a/addons/packages/multus-cni/3.7.1/test/Makefile
+++ b/addons/packages/multus-cni/3.7.1/test/Makefile
@@ -23,11 +23,13 @@ e2e-test: ## e2e tests
 	cd "${MULTUS_E2E_TEST_ROOT}" && ginkgo --flakeAttempts=2 -v . -- --version=${VERSION} --use-conf=${USE_CONF_FILE}
 
 lint: ## lint check for tests files
-	@printf "\nlint check for tests files\n\n"; \
-	echo "TODO: Currently no lint"
+ifeq ($(origin GOLANGCI_LINT),undefined)
+	@echo "Error! GOLANGCI_LINT env var not set"
+else
+	$(GOLANGCI_LINT) run -v --timeout=5m
+endif
 
 get-deps: ## get go sources dependencies.
-	@printf "\nget go sources dependencies\n\n"; \
 	go mod tidy
 
 build: ## build

--- a/addons/packages/multus-cni/3.7.1/test/e2e/multuscni_suite_test.go
+++ b/addons/packages/multus-cni/3.7.1/test/e2e/multuscni_suite_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/utils"
 )
 

--- a/addons/packages/multus-cni/3.7.1/test/e2e/multuscni_test.go
+++ b/addons/packages/multus-cni/3.7.1/test/e2e/multuscni_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/utils"
 )
 

--- a/addons/packages/sriov-network-device-plugin/3.3.2/test/Makefile
+++ b/addons/packages/sriov-network-device-plugin/3.3.2/test/Makefile
@@ -25,11 +25,13 @@ e2e-test: ## e2e tests
 all-test: unittest e2e-test ## run all tests
 
 lint: ## lint check for tests files
-	@printf "\nlint check for tests files\n\n"; \
-	echo "TODO: Currently no lint"
+ifeq ($(origin GOLANGCI_LINT),undefined)
+	@echo "Error! GOLANGCI_LINT env var not set"
+else
+	$(GOLANGCI_LINT) run -v --timeout=5m
+endif
 
 get-deps: ## get go sources dependencies.
-	@printf "\nget go sources dependencies\n\n"; \
 	go mod download
 
 build: ## build

--- a/addons/packages/sriov-network-device-plugin/3.3.2/test/unit/sriov_dp_suite_test.go
+++ b/addons/packages/sriov-network-device-plugin/3.3.2/test/unit/sriov_dp_suite_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/instrumenta/kubeval/kubeval"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/ytt"
 )
 

--- a/addons/packages/sriov-network-device-plugin/3.3.2/test/unit/sriov_dp_test.go
+++ b/addons/packages/sriov-network-device-plugin/3.3.2/test/unit/sriov_dp_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/instrumenta/kubeval/kubeval"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/repo"
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/utils"
 )
@@ -37,7 +38,7 @@ var _ = Describe("SR-IOV NETWORK DEVICE PLUGIN Template Test", func() {
 	It("Should be the same with expected base file", func() {
 		for k, v := range testFiles {
 			By("Check generated templates content", func() {
-				fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Compare %s with %s\n", k, v))
+				fmt.Fprintf(GinkgoWriter, "Compare %s with %s\n", k, v)
 			})
 			// Render templates with values
 			if strings.Compare(k, "base") == 0 {
@@ -74,7 +75,7 @@ var _ = Describe("SR-IOV NETWORK DEVICE PLUGIN Template Test", func() {
 			for _, result := range results {
 				Expect(len(result.Errors)).Should(BeNumerically("==", 0))
 				fmt.Fprintf(GinkgoWriter,
-					fmt.Sprintf("resource %s/%s %s in %s is ok to create as defined in file %s\n", result.APIVersion, result.Kind, result.ResourceName, result.ResourceNamespace, v))
+					"resource %s/%s %s in %s is ok to create as defined in file %s\n", result.APIVersion, result.Kind, result.ResourceName, result.ResourceNamespace, v)
 			}
 		}
 

--- a/addons/packages/whereabouts/0.5.0/test/Makefile
+++ b/addons/packages/whereabouts/0.5.0/test/Makefile
@@ -23,11 +23,13 @@ e2e-test: ## e2e tests
 	cd "${WHEREABOUTS_E2E_TEST_ROOT}" && ginkgo --flakeAttempts=2 -v . -- --version=${VERSION} --whereabouts-use-conf=${USE_CONF_FILE}
 
 lint: ## lint check for tests files
-	@printf "\nlint check for tests files\n\n"; \
-	echo "TODO: Currently no lint"
+ifeq ($(origin GOLANGCI_LINT),undefined)
+	@echo "Error! GOLANGCI_LINT env var not set"
+else
+	$(GOLANGCI_LINT) run -v --timeout=5m
+endif
 
 get-deps: ## get go sources dependencies.
-	@printf "\nget go sources dependencies\n\n"; \
 	go mod download
 
 build: ## build

--- a/addons/packages/whereabouts/0.5.0/test/e2e/whereabouts_suite_test.go
+++ b/addons/packages/whereabouts/0.5.0/test/e2e/whereabouts_suite_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/utils"
 )
 

--- a/addons/packages/whereabouts/0.5.0/test/e2e/whereabouts_test.go
+++ b/addons/packages/whereabouts/0.5.0/test/e2e/whereabouts_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/utils"
 )
 

--- a/hack/tagger/main.go
+++ b/hack/tagger/main.go
@@ -1,3 +1,6 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

There were a few addon test modules that no-op'd the lint target in
their Makefiles. These modules contain go source files, so they should
be included in the go linting. This updates those make targets so they
run the expected golangci-lint checks and fixes the minor issues that
uncovered.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```