### PR TITLE
Enforce deployment and daemonset update strategy in packages

### DIFF
--- a/addons/packages/antrea/1.2.3/bundle/config/overlay/infra_specific_overlay.yaml
+++ b/addons/packages/antrea/1.2.3/bundle/config/overlay/infra_specific_overlay.yaml
@@ -1,0 +1,27 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@ if data.values.infraProvider == "vsphere":
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"Deployment"})
+---
+kind: Deployment
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
+---
+kind: DaemonSet
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    type: onDelete
+
+
+#@ end

--- a/addons/packages/antrea/1.2.3/bundle/config/overlay/infra_specific_overlay.yaml
+++ b/addons/packages/antrea/1.2.3/bundle/config/overlay/infra_specific_overlay.yaml
@@ -14,6 +14,17 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+  #@ if data.values.nodeSelector:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@ for key in data.values.nodeSelector:
+        #@overlay/match missing_ok=True
+        #@yaml/text-templated-strings
+        (@= key @): #@ data.values.nodeSelector[key]
+        #@ end
+  #@ end
 
 #@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
 ---

--- a/addons/packages/antrea/1.2.3/bundle/config/schema.yaml
+++ b/addons/packages/antrea/1.2.3/bundle/config/schema.yaml
@@ -5,6 +5,9 @@
 ---
 #@schema/desc "The cloud provider in use. One of the following options => aws, azure, vsphere, docker"
 infraProvider: vsphere
+#@schema/desc "NodeSelector configuration applied to all the deployments"
+#@schema/type any=True
+nodeSelector:
 antrea:
   #@schema/desc "Configuration for antrea"
   config:

--- a/addons/packages/antrea/1.2.3/bundle/config/values.yaml
+++ b/addons/packages/antrea/1.2.3/bundle/config/values.yaml
@@ -3,6 +3,7 @@
 
 ---
 infraProvider: vsphere
+nodeSelector: null
 antrea:
   config:
     serviceCIDR: 10.96.0.0/12

--- a/addons/packages/antrea/1.2.3/package.yaml
+++ b/addons/packages/antrea/1.2.3/package.yaml
@@ -13,7 +13,7 @@ spec:
       syncPeriod: 5m
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/antrea@sha256:b5772748c5df17dbf3bc14a435b1609f7ef81623dbef1443904d8b8a4767972e
+          image: projects.registry.vmware.com/tce/antrea@sha256:d3d7f93a1e7f603f1a8ee4a4db7098208b25784ec3c33752cfd0b16d225bdaa0
       template:
       - ytt:
           paths:

--- a/addons/packages/antrea/1.2.3/package.yaml
+++ b/addons/packages/antrea/1.2.3/package.yaml
@@ -13,7 +13,7 @@ spec:
       syncPeriod: 5m
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/antrea@sha256:d3d7f93a1e7f603f1a8ee4a4db7098208b25784ec3c33752cfd0b16d225bdaa0
+          image: projects.registry.vmware.com/tce/antrea@sha256:c0089cd5c15de9202b2708c65feda0dce89d237eebe5bdc991b1ce95355f083f
       template:
       - ytt:
           paths:
@@ -36,6 +36,10 @@ spec:
           type: string
           default: vsphere
           description: The cloud provider in use. One of the following options => aws, azure, vsphere, docker
+        nodeSelector:
+          nullable: true
+          default: null
+          description: NodeSelector configuration applied to all the deployments
         antrea:
           type: object
           additionalProperties: false

--- a/addons/packages/calico/3.19.1/bundle/config/overlay/infra_specific_overlay.yaml
+++ b/addons/packages/calico/3.19.1/bundle/config/overlay/infra_specific_overlay.yaml
@@ -1,0 +1,27 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@ if data.values.infraProvider == "vsphere":
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"Deployment"})
+---
+kind: Deployment
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
+---
+kind: DaemonSet
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    type: onDelete
+
+
+#@ end

--- a/addons/packages/calico/3.19.1/bundle/config/overlay/infra_specific_overlay.yaml
+++ b/addons/packages/calico/3.19.1/bundle/config/overlay/infra_specific_overlay.yaml
@@ -14,6 +14,17 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+  #@ if data.values.nodeSelector:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@ for key in data.values.nodeSelector:
+        #@overlay/match missing_ok=True
+        #@yaml/text-templated-strings
+        (@= key @): #@ data.values.nodeSelector[key]
+        #@ end
+  #@ end
 
 #@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
 ---

--- a/addons/packages/calico/3.19.1/bundle/config/schema.yaml
+++ b/addons/packages/calico/3.19.1/bundle/config/schema.yaml
@@ -7,6 +7,9 @@
 namespace: kube-system
 #@schema/desc "Infrastructure provider in use"
 infraProvider: vsphere
+#@schema/desc "NodeSelector configuration applied to all the deployments"
+#@schema/type any=True
+nodeSelector:
 #@schema/desc "The IP family calico should be configured with"
 #@schema/nullable
 ipFamily: "ipv4,ipv6"

--- a/addons/packages/calico/3.19.1/bundle/config/values.yaml
+++ b/addons/packages/calico/3.19.1/bundle/config/values.yaml
@@ -3,6 +3,7 @@
 
 namespace: kube-system
 infraProvider: vsphere
+nodeSelector: null
 ipFamily: null
 calico:
   config:

--- a/addons/packages/calico/3.19.1/package.yaml
+++ b/addons/packages/calico/3.19.1/package.yaml
@@ -18,6 +18,10 @@ spec:
           type: string
           default: vsphere
           description: Infrastructure provider in use
+        nodeSelector:
+          nullable: true
+          default: null
+          description: NodeSelector configuration applied to all the deployments
         ipFamily:
           type: string
           default: null
@@ -51,7 +55,7 @@ spec:
       syncPeriod: 5m
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/calico@sha256:19904e9e83612c11bc935a8ff1ed99a9834d555f9328da802f483e759e3a267f
+          image: projects.registry.vmware.com/tce/calico@sha256:081ed0e85b59d0d4f3886bb3b655848cac18840b62add300d485d34ed42dbe86
       template:
       - ytt:
           paths:

--- a/addons/packages/calico/3.19.1/package.yaml
+++ b/addons/packages/calico/3.19.1/package.yaml
@@ -51,7 +51,7 @@ spec:
       syncPeriod: 5m
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/calico@sha256:99873e9319bcb4bb47dc3e9e80f6b26b2ff89f336744dc3281d138d6b0a077b5
+          image: projects.registry.vmware.com/tce/calico@sha256:19904e9e83612c11bc935a8ff1ed99a9834d555f9328da802f483e759e3a267f
       template:
       - ytt:
           paths:

--- a/addons/packages/kapp-controller/0.33.1/bundle/config/overlays/infra_specific_overlay.yaml
+++ b/addons/packages/kapp-controller/0.33.1/bundle/config/overlays/infra_specific_overlay.yaml
@@ -1,0 +1,27 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@ if data.values.infraProvider == "vsphere":
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"Deployment"})
+---
+kind: Deployment
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
+---
+kind: DaemonSet
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    type: onDelete
+
+
+#@ end

--- a/addons/packages/kapp-controller/0.33.1/bundle/config/overlays/infra_specific_overlay.yaml
+++ b/addons/packages/kapp-controller/0.33.1/bundle/config/overlays/infra_specific_overlay.yaml
@@ -14,6 +14,17 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+  #@ if data.values.nodeSelector:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@ for key in data.values.nodeSelector:
+        #@overlay/match missing_ok=True
+        #@yaml/text-templated-strings
+        (@= key @): #@ data.values.nodeSelector[key]
+        #@ end
+  #@ end
 
 #@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
 ---

--- a/addons/packages/kapp-controller/0.33.1/bundle/config/values.yaml
+++ b/addons/packages/kapp-controller/0.33.1/bundle/config/values.yaml
@@ -3,6 +3,7 @@
 ---
 namespace: kapp-controller
 infraProvider: vsphere
+nodeSelector: null
 kappController:
   namespace: null
   createNamespace: true

--- a/addons/packages/kapp-controller/0.33.1/bundle/config/values.yaml
+++ b/addons/packages/kapp-controller/0.33.1/bundle/config/values.yaml
@@ -2,6 +2,7 @@
 #@overlay/match-child-defaults missing_ok=True
 ---
 namespace: kapp-controller
+infraProvider: vsphere
 kappController:
   namespace: null
   createNamespace: true

--- a/addons/packages/kapp-controller/0.33.1/package.yaml
+++ b/addons/packages/kapp-controller/0.33.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:58849bfe4ec31d510135f3ea057c34201c7eb9c769a915e6fc57f27ae9e3e818
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:10fc86e53cd8481b4b1602a17fea73ae9e8eef0d139d37fe5bb6ae5dbd40f585
       template:
         - ytt:
             paths:

--- a/addons/packages/kapp-controller/0.33.1/package.yaml
+++ b/addons/packages/kapp-controller/0.33.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:e2198f0668e34f69625206fa77363525931d1c1a2742a5f31cb1677b390f68e5
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:58849bfe4ec31d510135f3ea057c34201c7eb9c769a915e6fc57f27ae9e3e818
       template:
         - ytt:
             paths:

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/overlays/vsphere_specific_overlay.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/overlays/vsphere_specific_overlay.yaml
@@ -1,0 +1,22 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"Deployment"})
+---
+kind: Deployment
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
+---
+kind: DaemonSet
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    type: onDelete

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/overlays/vsphere_specific_overlay.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/overlays/vsphere_specific_overlay.yaml
@@ -12,6 +12,17 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+  #@ if data.values.nodeSelector:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@ for key in data.values.nodeSelector:
+        #@overlay/match missing_ok=True
+        #@yaml/text-templated-strings
+        (@= key @): #@ data.values.nodeSelector[key]
+        #@ end
+  #@ end
 
 #@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
 ---

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/schema.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/schema.yaml
@@ -3,6 +3,9 @@
 #@data/values-schema
 #@schema/desc "OpenAPIv3 Schema for vsphere-cpi"
 ---
+#@schema/desc "NodeSelector configuration applied to all the deployments"
+#@schema/type any=True
+nodeSelector:
 #@schema/desc "Configurations for vsphere-cpi"
 vsphereCPI:
   #@schema/desc "The vSphere mode. Either vsphereCPI or vsphereParavirtualCPI. Default value is vsphereCPI"

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/values.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/values.yaml
@@ -2,6 +2,7 @@
 #@overlay/match-child-defaults missing_ok=True
 
 ---
+nodeSelector: null
 vsphereCPI:
   mode: vsphereCPI
   tlsThumbprint: ""

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/package.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:fc62b30db062856c6fb4439b2b3d7355758038fa7c9d3fe0aaa478245e29c235
+          image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:a2fc3720c8b282d9ad848345481b2fc97bed38b9a684bcbe2a4f1fbbb5f8dd55
       template:
       - ytt:
           paths:
@@ -29,6 +29,10 @@ spec:
       additionalProperties: false
       description: OpenAPIv3 Schema for vsphere-cpi
       properties:
+        nodeSelector:
+          nullable: true
+          default: null
+          description: NodeSelector configuration applied to all the deployments
         vsphereCPI:
           type: object
           additionalProperties: false

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/package.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:7894ffd9b9fca6a53f2277159304b5966fa9bd1dcc1f416f74dfb7ebfe95d96c
+          image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:fc62b30db062856c6fb4439b2b3d7355758038fa7c9d3fe0aaa478245e29c235
       template:
       - ytt:
           paths:

--- a/addons/packages/vsphere-csi/2.4.1/bundle/config/overlays/vsphere_specific_overlay.yaml
+++ b/addons/packages/vsphere-csi/2.4.1/bundle/config/overlays/vsphere_specific_overlay.yaml
@@ -1,0 +1,22 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"Deployment"})
+---
+kind: Deployment
+spec:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: RollingUpdate
+    #@overlay/match missing_ok=True
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
+---
+kind: DaemonSet
+spec:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    type: onDelete

--- a/addons/packages/vsphere-csi/2.4.1/bundle/config/overlays/vsphere_specific_overlay.yaml
+++ b/addons/packages/vsphere-csi/2.4.1/bundle/config/overlays/vsphere_specific_overlay.yaml
@@ -12,6 +12,17 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+  #@ if data.values.nodeSelector:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@ for key in data.values.nodeSelector:
+        #@overlay/match missing_ok=True
+        #@yaml/text-templated-strings
+        (@= key @): #@ data.values.nodeSelector[key]
+        #@ end
+  #@ end
 
 #@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
 ---

--- a/addons/packages/vsphere-csi/2.4.1/bundle/config/values.yaml
+++ b/addons/packages/vsphere-csi/2.4.1/bundle/config/values.yaml
@@ -2,6 +2,7 @@
 #@overlay/match-child-defaults missing_ok=True
 
 ---
+nodeSelector: null
 vsphereCSI:
   tlsThumbprint: ""
   namespace: kube-system

--- a/addons/packages/vsphere-csi/2.4.1/package.yaml
+++ b/addons/packages/vsphere-csi/2.4.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:c615f4a95de0161f244f644cfb512449ef8b2c233e63541d16fa44bcd7bd28b6
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:cc7de2983580c1872b7bcef9fbc7f03092f29c922acbf37d1fae2387d3026048
       template:
         - ytt:
             paths:

--- a/addons/packages/vsphere-csi/2.4.1/package.yaml
+++ b/addons/packages/vsphere-csi/2.4.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:cc7de2983580c1872b7bcef9fbc7f03092f29c922acbf37d1fae2387d3026048
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:6fe0dda064892d98da2766c0cec2a545a8e2e6b0837e9ca6db5f33a44edf8673
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
We need to enforce the update strategy of all the deployment and daemonset running on vSphere infra. Also, add nodeSelector configuration to deployments.

The behavior is just patching all the deployments and daemonset regardless of which addon it is.

Need review from stakeholders to see if this cause issues @vijaykatam 
* Antrea: @vmware-tanzu/pkg-antrea-owners 
* Calico: @vmware-tanzu/pkg-calico-owners 
* CPI: @vmware-tanzu/pkg-vsphere-cpi-owners 
* Kapp-Controller: @vmware-tanzu/pkg-kapp-controller-owners 
* CSI: @vmware-tanzu/pkg-vsphere-csi-owners 

##### `DaemonSets`

For `DaemonSets`, we configure the
[`.spec.updateStrategy.type`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#daemonsetupdatestrategy-v1-apps)
to `OnDelete`. This ensures that the existing `Pods` will not be spun down on
older nodes (thereby keeping the application available), but that new nodes
entering the cluster will receive the new configuration and spin up the
appropriate `Pods`. As the old nodes exit the cluster, so too will the `Pods`
containing the stale configuration.

##### `Deployments`

For `Deployments` we configure four things:

* [`.spec.strategy.type`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#deploymentstrategy-v1-apps)
  is configured to `RollingUpdate`
* [`.spec.strategy.rollingUpdate.maxUnavailable`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#rollingupdatedeployment-v1-apps)
  is set to `0`.
* [`.spec.strategy.rollingUpdate.maxSurge`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#rollingupdatedeployment-v1-apps)
  is set to `1`.
* [`.spec.template.spec.nodeSelector`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podspec-v1-core)
  is set to target only `Nodes` where the label
  `run.tanzu.vmware.com/kubernetesDistributionVersion` contains the appropriate
  distribution version (i.e.
  `run.tanzu.vmware.com/kubernetesDistributionVersion=v1.16.7+vmware.1-guest.1`).
  This label is set at creation time for every node in the cluster and will not
  be mutated (short of an end-user `cluster-admin` overwriting the label).

The `nodeSelector` ensures that the new `Pods` only target the nodes which will
have the container image available, while the `maxUnavailable` and `maxSurge`
settings ensure that the old `Pods` will not be spun down until there is a
viable replacement.


## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Add overlays for update strategy and nodeSelectors into core packages
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
