### PR TITLE
Replace deprecated strings.Title()

### DIFF
--- a/hack/workflows/packages/copy-package-readmes-to-docs.go
+++ b/hack/workflows/packages/copy-package-readmes-to-docs.go
@@ -12,6 +12,8 @@ import (
 	"sort"
 	"strings"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"gopkg.in/yaml.v3"
 )
 
@@ -140,7 +142,7 @@ func main() {
 	for key, value := range currentPackageVersions {
 		newPackageVersions = append(newPackageVersions, SubFolderItem{
 			Package: MyPackage{
-				DisplayName: strings.Title(strings.Replace(key, "-", " ", -1)),
+				DisplayName: cases.Title(language.Und).String(strings.Replace(key, "-", " ", -1)),
 				Name:        key,
 				Versions:    value,
 			},

--- a/hack/workflows/packages/go.mod
+++ b/hack/workflows/packages/go.mod
@@ -2,4 +2,7 @@ module github.com/vmware-tanzu/community-edition/hack/packages
 
 go 1.17
 
-require gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+require (
+	golang.org/x/text v0.3.7
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)

--- a/hack/workflows/packages/go.sum
+++ b/hack/workflows/packages/go.sum
@@ -1,3 +1,6 @@
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

The strings.Title() method is deprecated. This replaces its usage with
the recommended `golang.org/x/text/cases` equivalent.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```