### PR TITLE
Bump GH CLI version 2.6.0 on ensure-deps

### DIFF
--- a/hack/ensure-deps/ensure-gh-cli.sh
+++ b/hack/ensure-deps/ensure-gh-cli.sh
@@ -13,7 +13,7 @@ set -o xtrace
 TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
 BUILD_OS=$(uname 2>/dev/null || echo Unknown)
 BUILD_ARCH=$(uname -m 2>/dev/null || echo Unknown)
-GH_CLI_VERSION="2.2.0"
+GH_CLI_VERSION="2.6.0"
 
 SUDO_CMD="sudo"
 if [[ "${TCE_CI_BUILD}" == "true" ]]; then


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Bumps the GH CLI to version `2.6.0` which is the latest. There is a new feature that was introduced that could address some auth issues in more complex workflows.

Verified using 2.5.2 with this PR, so the risk of breaking existing workflows is minimal.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Bump GH CLI version 2.6.0 on ensure-deps
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA