### PR TITLE
Deletes release note section in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,17 +3,6 @@
 Add a detailed explanation of what this PR does and why it is needed.
 -->
 
-## Details for the Release Notes (PLEASE PROVIDE)
-<!--
-Unless this is a trivial change, we want to know more about your contribution!
-This can even be a TLDR version of the "What this PR does".
-If a trivial change, just write "NONE" in the release-note block below.
-Otherwise, a release note is required:
--->
-```release-note
-
-```
-
 ## Which issue(s) this PR fixes
 <!--
 Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Since we deleted the release notes utility and PR listing in the release page in favor of just using a GitHub compare (done here: https://github.com/vmware-tanzu/community-edition/pull/3601), we no longer need this section of the PR Template to put in a human-readable release note entry.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA