### PR TITLE
Fix for the docs TOC view and URLs

### DIFF
--- a/docs/site/themes/template/layouts/_default/versions.html
+++ b/docs/site/themes/template/layouts/_default/versions.html
@@ -3,7 +3,8 @@
         {{ if .Site.Params.docs_versioning }}
             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown"
                     aria-haspopup="true" aria-expanded="false">
-                {{ .CurrentSection.Params.version }}
+                    {{ $version       := index (split .File.Path "/") 1 }}
+                    {{ $version }}
             </button>
             <div class="dropdown-menu" id="dropdown-menu" aria-labelledby="dropdownMenuButton">
                 {{ $original_version := printf "/%s/" .CurrentSection.Params.version }}

--- a/docs/site/themes/template/layouts/partials/docs-sidebar.html
+++ b/docs/site/themes/template/layouts/partials/docs-sidebar.html
@@ -3,7 +3,7 @@
 <div class="side-nav" id="docsNav">
     {{ if .Site.Params.use_advanced_docs }}
         <noscript>Please enable javascript to use dropdown navigation</noscript>
-        {{ $version := .CurrentSection.Params.version }}
+        {{ $version       := index (split .File.Path "/") 1 }}
         {{ .Render "versions" }}
         {{ .Render "search" }}
         {{ if $version }}


### PR DESCRIPTION
Signed-off-by: Jonas Rosland <jrosland@vmware.com>

## What this PR does / why we need it
The docs TOC isn't showing up properly with the new versioning changes, and the URLs seem to go to `/latest`. This PR fixes that so that is links to the correct version.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
