### PR TITLE
Docs: Fix syntax highlighting for vSphere workload template

### DIFF
--- a/docs/site/content/docs/vsphere-wl-template.md
+++ b/docs/site/content/docs/vsphere-wl-template.md
@@ -6,7 +6,7 @@ The template below includes all of the options that are relevant to deploying Ta
 
 Mandatory options are uncommented. Optional settings are commented out. Default values are included where applicable.
 
-```sh
+```yaml
 #! ---------------------------------------------------------------------
 #! Basic cluster creation configuration
 #! ---------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Garry Ing <ging@vmware.com>

## What this PR does / why we need it
This changes the syntax highlighting for the vSphere workload template to use `yaml` instead of `sh`.

| Before     | After |
| ----------- | ----------- |
|   ![Screen Shot 2022-03-21 at 4 25 17 PM](https://user-images.githubusercontent.com/227587/159358019-9d91cbec-346f-42f8-8869-78ea3d11b8b5.png)   | ![Screen Shot 2022-03-21 at 4 25 55 PM](https://user-images.githubusercontent.com/227587/159358036-5a3b2f22-201d-49a9-a514-6e6590259af2.png)       |




## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: n/a

## Describe testing done for PR
- `hugo server`
- Navigate to `/docs/latest/vsphere-wl-template/`

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
