### PR TITLE
Adds `unmanaged-cluster` TKR compatibility check

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/config/config.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config.go
@@ -43,7 +43,6 @@ const (
 )
 
 var defaultConfigValues = map[string]interface{}{
-	TKRLocation:           "projects.registry.vmware.com/tce/tkr:v0.17.0",
 	Provider:              "kind",
 	Cni:                   "calico",
 	PodCIDR:               "10.244.0.0/16",
@@ -51,9 +50,6 @@ var defaultConfigValues = map[string]interface{}{
 	Tty:                   "true",
 	ControlPlaneNodeCount: "1",
 	WorkerNodeCount:       "0",
-	AdditionalPackageRepos: []string{
-		"projects.registry.vmware.com/tce/main:v0.11.0",
-	},
 }
 
 // PortMap is the mapping between a host port and a container port.

--- a/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
@@ -48,16 +48,8 @@ func TestInitializeConfigurationDefaults(t *testing.T) {
 		t.Errorf("expected default Cni value, was: %q", config.Cni)
 	}
 
-	if config.TkrLocation != defaultConfigValues[TKRLocation] {
-		t.Errorf("expected default TkrLocation, was: %q", config.TkrLocation)
-	}
-
-	if len(config.AdditionalPackageRepos) != 1 {
-		t.Errorf("expected only 1 AdditionalPackageRepos, was: %q", config.AdditionalPackageRepos)
-	}
-
-	if config.AdditionalPackageRepos[0] != defaultConfigValues[AdditionalPackageRepos].([]string)[0] {
-		t.Errorf("expected default AdditionalPackageRepos, was: %q", config.AdditionalPackageRepos)
+	if len(config.AdditionalPackageRepos) != 0 {
+		t.Errorf("expected no AdditionalPackageRepos, was: %q", config.AdditionalPackageRepos)
 	}
 
 	if config.Provider != defaultConfigValues[Provider] {
@@ -101,16 +93,8 @@ func TestInitializeConfigurationEnvVariables(t *testing.T) {
 		t.Errorf("expected default Cni value, was: %q", config.Cni)
 	}
 
-	if config.TkrLocation != defaultConfigValues[TKRLocation] {
-		t.Errorf("expected default TkrLocation, was: %q", config.TkrLocation)
-	}
-
-	if len(config.AdditionalPackageRepos) != 1 {
-		t.Errorf("expected only 1 AdditionalPackageRepos, was: %q", config.AdditionalPackageRepos)
-	}
-
-	if config.AdditionalPackageRepos[0] != defaultConfigValues[AdditionalPackageRepos].([]string)[0] {
-		t.Errorf("expected default AdditionalPackageRepos, was: %q", config.AdditionalPackageRepos)
+	if len(config.AdditionalPackageRepos) != 0 {
+		t.Errorf("expected no AdditionalPackageRepos, was: %q", config.AdditionalPackageRepos)
 	}
 
 	if config.PodCidr != defaultConfigValues[PodCIDR] {
@@ -151,16 +135,8 @@ func TestInitializeConfigurationArgsTakePrecedent(t *testing.T) {
 		t.Errorf("expected default Cni value, was: %q", config.Cni)
 	}
 
-	if config.TkrLocation != defaultConfigValues[TKRLocation] {
-		t.Errorf("expected default TkrLocation, was: %q", config.TkrLocation)
-	}
-
-	if len(config.AdditionalPackageRepos) != 1 {
-		t.Errorf("expected only 1 AdditionalPackageRepos, was: %q", len(config.AdditionalPackageRepos))
-	}
-
-	if config.AdditionalPackageRepos[0] != defaultConfigValues[AdditionalPackageRepos].([]string)[0] {
-		t.Errorf("expected default AdditionalPackageRepos, was: %q", config.AdditionalPackageRepos)
+	if len(config.AdditionalPackageRepos) != 0 {
+		t.Errorf("expected no AdditionalPackageRepos, was: %q", len(config.AdditionalPackageRepos))
 	}
 
 	if config.PodCidr != defaultConfigValues[PodCIDR] {

--- a/cli/cmd/plugin/unmanaged-cluster/go.mod
+++ b/cli/cmd/plugin/unmanaged-cluster/go.mod
@@ -19,6 +19,7 @@ require (
 require (
 	github.com/cppforlife/go-cli-ui v0.0.0-20200716203538-1e47f820817f
 	github.com/fatih/color v1.13.0
+	github.com/google/go-containerregistry v0.7.0
 	github.com/k14s/imgpkg v0.6.0
 	github.com/k14s/ytt v0.37.0
 	github.com/olekukonko/tablewriter v0.0.5
@@ -54,7 +55,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
-	github.com/google/go-containerregistry v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect

--- a/cli/cmd/plugin/unmanaged-cluster/hack/push-new-compatibility-file.sh
+++ b/cli/cmd/plugin/unmanaged-cluster/hack/push-new-compatibility-file.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This is a helper script that makes it easier to push
+# a compatibility file to the VMware TCE registry, primarily for dev purposes
+
+# Expects imgpkg to be installed locally
+
+# Must provide 2 arguments
+if [ $# -ne 2 ]; then
+	echo "No arguments provided. Please give path to compatibility file and tag"
+	exit 1
+fi
+
+localFile=$1
+vmwareRegistry="projects.registry.vmware.com"
+compatPath="/tce/compatibility"
+tag=$2
+fullImage="${vmwareRegistry}${compatPath}:${tag}"
+
+docker login $vmwareRegistry
+
+echo
+echo "-----"
+echo "Pushing file $localFile to $fullImage"
+echo "-----"
+echo
+
+imgpkg push -i "$fullImage" -f "$localFile"
+

--- a/cli/cmd/plugin/unmanaged-cluster/hack/tce-compatibility.yaml
+++ b/cli/cmd/plugin/unmanaged-cluster/hack/tce-compatibility.yaml
@@ -1,0 +1,14 @@
+version: v1
+unmanagedClusterPluginVersions:
+- version: dev
+  supportedTkrVersions:
+  - image: projects.registry.vmware.com/tce/tkr:v0.17.0-dev-1
+  - image: projects.registry.vmware.com/tce/tkr:v0.17.0
+  - image: projects.registry.vmware.com/tce/tkr:v1.22.5
+- version: v0.11.0
+  supportedTkrVersions:
+  - image: projects.registry.vmware.com/tce/tkr:v0.17.0
+  - image: projects.registry.vmware.com/tce/tkr:v1.22.5
+- version: v0.10.0
+  supportedTkrVersions:
+  - image: projects.registry.vmware.com/tce/tkr:v0.21.5

--- a/cli/cmd/plugin/unmanaged-cluster/log/log.go
+++ b/cli/cmd/plugin/unmanaged-cluster/log/log.go
@@ -32,6 +32,7 @@ const (
 	GreenCheckEmoji = "\U00002705"
 	ControllerEmoji = "\U0001F3AE"
 	TestTubeEmoji   = "\U0001F9EA"
+	MagnetEmoji     = "\U0001F9F2"
 )
 
 // CMDLogger is the logger implementation used for high-level command line logging.

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -26,20 +26,24 @@ import (
 	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/log"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/packages"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/tkr"
+
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin"
 )
 
 //nolint
 const (
-	configFileName        = "config.yaml"
-	bootstrapLogName      = "bootstrap.log"
-	bomDir                = "bom"
-	tkgSysNamespace       = "tkg-system"
-	tkgSvcAcctName        = "core-pkgs"
-	tkgCoreRepoName       = "tkg-core-repository"
-	tkgGlobalPkgNamespace = "tanzu-package-repo-global"
-	tceRepoName           = "community-repository"
-	outputIndent          = 3
-	maxProgressLength     = 4
+	configFileName           = "config.yaml"
+	bootstrapLogName         = "bootstrap.log"
+	bomDir                   = "bom"
+	compatibilityDir         = "compatibility"
+	tkgSysNamespace          = "tkg-system"
+	tkgSvcAcctName           = "core-pkgs"
+	tkgCoreRepoName          = "tkg-core-repository"
+	tkgGlobalPkgNamespace    = "tanzu-package-repo-global"
+	tceCompatibilityRegistry = "projects.registry.vmware.com/tce/compatibility"
+	tceRepoName              = "community-repository"
+	outputIndent             = 3
+	maxProgressLength        = 4
 )
 
 // TODO(joshrosso): global logger for the package. This is kind gross, but really convenient.
@@ -92,9 +96,6 @@ func New(parentLogger logger.Logger) Manager {
 // validateConfiguration makes sure the configuration is valid, returning an
 // error if there is an issue.
 func validateConfiguration(scConfig *config.UnmanagedClusterConfig) error {
-	if scConfig.TkrLocation == "" {
-		return fmt.Errorf("Tanzu Kubernetes Release (TKR) not specified.") //nolint:revive,stylecheck
-	}
 	if scConfig.ClusterName == "" {
 		return fmt.Errorf("cluster name is required")
 	}
@@ -134,11 +135,36 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int,
 		log.Style(outputIndent, color.FgYellow).ReplaceLinef("Reading ProviderConfiguration from config file. All other provider specific configs may be ignored.")
 	}
 
-	// 2. Download and Read the TKR
-	log.Event(logger.WrenchEmoji, "Resolving Tanzu Kubernetes Release (TKR)")
+	// 2. Download and Read the compatible TKr
+
+	// Download compatibility file
+	log.Event(logger.MagnetEmoji, "Resolving and checking Tanzu Kubernetes release (TKr) compatibility file")
+	tkrCompatibility, err := getTkrCompatibility()
+	if err != nil {
+		return ErrTkrBom, fmt.Errorf("failed downloading and extracting TKr compatibility file. Error: %s", err.Error())
+	}
+
+	if scConfig.TkrLocation == "" {
+		// read TKr version compatible with version of unmanaged-cluster CLI
+		// when the user did _not_ set the TKr via a flag or configuration option
+		scConfig.TkrLocation, err = getLatestCompatibleTkr(tkrCompatibility)
+		if err != nil {
+			return ErrTkrBom, fmt.Errorf("failed parsing the TKr compatibility file. Error: %s", err.Error())
+		}
+	} else {
+		// check if the TKr specified by the user is in the list of compatible TKrs
+		// If not, log a warning
+		if !isTkrCompatible(tkrCompatibility, scConfig.TkrLocation) {
+			log.Style(outputIndent, color.FgYellow).Warnf("Custom TKr %s NOT found in compatibility file. Proceed with caution, the provided TKr may not work with this version of unmanaged-cluster\n", scConfig.TkrLocation)
+		} else {
+			log.Style(outputIndent, color.Faint).Infof("Custom Tkr %s found in compatibility file\n", scConfig.TkrLocation)
+		}
+	}
+
+	log.Event(logger.WrenchEmoji, "Resolving TKr")
 	bomFileName, err := getTkrBom(scConfig.TkrLocation)
 	if err != nil {
-		return ErrTkrBom, fmt.Errorf("failed getting TKR BOM. Error: %s", err.Error())
+		return ErrTkrBom, fmt.Errorf("failed getting TKr BOM. Error: %s", err.Error())
 	}
 	configFp := filepath.Join(t.clusterDirectory, configFileName)
 	err = config.RenderConfigToFile(configFp, t.config)
@@ -151,7 +177,18 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int,
 	log.Event(logger.WrenchEmoji, "Processing Tanzu Kubernetes Release")
 	t.bom, err = parseTKRBom(bomFileName)
 	if err != nil {
-		return ErrTkrBomParsing, fmt.Errorf("failed parsing TKR BOM. Error: %s", err.Error())
+		return ErrTkrBomParsing, fmt.Errorf("failed parsing TKr BOM. Error: %s", err.Error())
+	}
+
+	// Uses default user package repository found in the TKr if user did not provide one via config/flags
+	if len(scConfig.AdditionalPackageRepos) == 0 {
+		userRepo := t.bom.GetTKRUserRepoBundlePath()
+
+		if userRepo != "" {
+			scConfig.AdditionalPackageRepos = []string{
+				userRepo,
+			}
+		}	
 	}
 
 	// 3. Resolve all required images
@@ -163,11 +200,15 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int,
 	// core package repository
 	log.Event(logger.PackageEmoji, "Selected core package repository")
 	log.Style(outputIndent, color.Faint).Infof("%s\n", t.bom.GetTKRCoreRepoBundlePath())
-	// core user package repositories
-	log.Event(logger.PackageEmoji, "Selected additional package repositories")
-	for _, additionalRepo := range scConfig.AdditionalPackageRepos {
-		log.Style(outputIndent, color.Faint).Infof("%s\n", additionalRepo)
+
+	// core user package repositories if they exist
+	if len(scConfig.AdditionalPackageRepos) != 0 {
+		log.Event(logger.PackageEmoji, "Selected additional package repositories")
+		for _, additionalRepo := range scConfig.AdditionalPackageRepos {
+			log.Style(outputIndent, color.Faint).Infof("%s\n", additionalRepo)
+		}
 	}
+	
 	// kapp-controller
 	err = resolveKappBundle(t)
 	if err != nil {
@@ -356,6 +397,15 @@ func getUnmanagedBomPath() (path string, err error) {
 	return filepath.Join(tkgUnmanagedConfigDir, bomDir), nil
 }
 
+func getUnmanagedCompatibilityPath() (path string, err error) {
+	tkgUnmanagedConfigDir, err := config.GetUnmanagedConfigPath()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(tkgUnmanagedConfigDir, compatibilityDir), nil
+}
+
 func buildFilesystemSafeBomName(bomFileName string) (path string) {
 	var sb strings.Builder
 	for _, char := range bomFileName {
@@ -450,6 +500,141 @@ func createClusterDirectory(clusterName string) (string, error) {
 	return fp, nil
 }
 
+func getTkrCompatibility() (*tkr.Compatibility, error) {
+	compatibilityFileName, err := getCompatibilityFile()
+	if err != nil {
+		return nil, err
+	}
+
+	compatibilityDirPath, err := getUnmanagedCompatibilityPath()
+	if err != nil {
+		return nil, err
+	}
+
+	// Read compatibility file, returns a compatibility struct
+	c, err := tkr.ReadCompatibilityFile(filepath.Join(compatibilityDirPath, compatibilityFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func isTkrCompatible(c *tkr.Compatibility, tkrName string) bool {
+	// Inspect CLI version and get most recent compatible version of TKr
+	for _, cliVersion := range c.UnmanagedClusterPluginVersions {
+		if cliVersion.Version == plugin.Version {
+			for _, possibleTkr := range cliVersion.SupportedTkrVersions {
+				if possibleTkr.Path == tkrName {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// Returns the latest TKr compatible image path:tag string
+// If none is found for version of CLI, returns an error
+func getLatestCompatibleTkr(c *tkr.Compatibility) (string, error) {
+	// Inspect CLI version and get most recent compatible version of TKr
+	for _, cliVersion := range c.UnmanagedClusterPluginVersions {
+		if cliVersion.Version == plugin.Version {
+			// We've found a compatible version
+			// Check it's filled to prevent a panic. We should never ship a compatibility file with an empty compatibility for a CLI version
+			if len(cliVersion.SupportedTkrVersions) == 0 || cliVersion.SupportedTkrVersions[0].Path == "" {
+				return "", fmt.Errorf("most recent compatibility image path is invalid. Validate compatibility file")
+			}
+
+			return cliVersion.SupportedTkrVersions[0].Path, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find compatible CLI version in compatibility file")
+}
+
+// Returns the file path of the latest compatibility file
+// If the file is _not_ on the system, downloads it
+func getCompatibilityFile() (string, error) {
+	log.Style(outputIndent, color.Faint).Infof("%s\n", tceCompatibilityRegistry)
+
+	// Get latest versioned tag from the registry for the compatibility file
+	tag, err := tkr.GetLatestCompatibilityTag(tceCompatibilityRegistry)
+	if err != nil {
+		return "", err
+	}
+
+	expectedCompatibilityFileName := buildFilesystemSafeBomName(tceCompatibilityRegistry + ":" + tag)
+	compatibilityPath, err := getUnmanagedCompatibilityPath()
+	if err != nil {
+		return "", fmt.Errorf("failed to get tanzu unmanaged compatibility path: %s", err)
+	}
+
+	_, err = os.Stat(compatibilityPath)
+	if os.IsNotExist(err) {
+		err := os.MkdirAll(compatibilityPath, 0755)
+		if err != nil {
+			return "", fmt.Errorf("failed to make new tanzu unmanaged compatibility config directories %s", err)
+		}
+	}
+
+	items, err := os.ReadDir(compatibilityPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read tanzu unmanaged compatibility directories: %s", err)
+	}
+
+	// if the expected compatibility file is already in the config directory, don't download it again. return early
+	for _, file := range items {
+		if file.Name() == expectedCompatibilityFileName {
+			log.Style(outputIndent, color.Faint).Infof("Compatibility file exists at %s\n", filepath.Join(compatibilityPath, file.Name()))
+			return file.Name(), nil
+		}
+	}
+
+	registry := tceCompatibilityRegistry + ":" + tag
+
+	compatibilityImage, err := tkr.NewTkrImageReader(registry)
+	if err != nil {
+		return "", fmt.Errorf("failed to create new TkrImageReader: %s", err)
+	}
+
+	err = blockForImageDownload(compatibilityImage, compatibilityPath, expectedCompatibilityFileName)
+	if err != nil {
+		return "", fmt.Errorf("failed to download compatibility image: %s", err)
+	}
+
+	downloadedCompatibilityFiles, err := os.ReadDir(compatibilityImage.GetDownloadPath())
+	if err != nil {
+		return "", fmt.Errorf("failed to read downloaded compatibility files: %s", err)
+	}
+
+	// if there is more than 1 file in the downloaded image, fail
+	// this is a bit redundant since imgpkg librariers should fail if the image is a bundle with multiple files
+	if len(downloadedCompatibilityFiles) != 1 {
+		return "", fmt.Errorf("more than one file found in compatibility image. Expected 1 file: %s", compatibilityImage.GetDownloadPath())
+	}
+
+	downloadedCompatibilityFile, err := os.Open(filepath.Join(compatibilityImage.GetDownloadPath(), downloadedCompatibilityFiles[0].Name()))
+	if err != nil {
+		return "", fmt.Errorf("could not open downloaded compatibility file: %s", err)
+	}
+	defer downloadedCompatibilityFile.Close()
+
+	newCompatibilityFile, err := os.Create(filepath.Join(compatibilityPath, expectedCompatibilityFileName))
+	if err != nil {
+		return "", fmt.Errorf("could not create tanzu unmanaged compatibility file: %s", err)
+	}
+	defer newCompatibilityFile.Close()
+
+	_, err = io.Copy(newCompatibilityFile, downloadedCompatibilityFile)
+	if err != nil {
+		return "", fmt.Errorf("could not copy compatibility file contents: %s", err)
+	}
+
+	return expectedCompatibilityFileName, nil
+}
+
 func getTkrBom(registry string) (string, error) {
 	log.Style(outputIndent, color.Faint).Infof("%s\n", registry)
 	expectedBomName := buildFilesystemSafeBomName(registry)
@@ -475,7 +660,7 @@ func getTkrBom(registry string) (string, error) {
 	// if the expected bom is already in the config directory, don't download it again. return early
 	for _, file := range items {
 		if file.Name() == expectedBomName {
-			log.Style(outputIndent, color.Faint).Infof("TKR exists at %s\n", filepath.Join(bomPath, file.Name()))
+			log.Style(outputIndent, color.Faint).Infof("TKr exists at %s\n", filepath.Join(bomPath, file.Name()))
 			return file.Name(), nil
 		}
 	}
@@ -485,7 +670,7 @@ func getTkrBom(registry string) (string, error) {
 		return "", fmt.Errorf("failed to create new TkrImageReader: %s", err)
 	}
 
-	err = blockForBomImage(bomImage, bomPath, expectedBomName)
+	err = blockForImageDownload(bomImage, bomPath, expectedBomName)
 	if err != nil {
 		return "", fmt.Errorf("failed to download tkr image: %s", err)
 	}
@@ -498,7 +683,7 @@ func getTkrBom(registry string) (string, error) {
 	// if there is more than 1 file in the downloaded image, fail
 	// this is a bit redundant since imgpkg librariers should fail if the image is a bundle with multiple files
 	if len(downloadedBomFiles) != 1 {
-		return "", fmt.Errorf("more than one file found in TKR bom image. Expected 1 file: %s", bomImage.GetDownloadPath())
+		return "", fmt.Errorf("more than one file found in TKr bom image. Expected 1 file: %s", bomImage.GetDownloadPath())
 	}
 
 	downloadedBomFile, err := os.Open(filepath.Join(bomImage.GetDownloadPath(), downloadedBomFiles[0].Name()))
@@ -521,8 +706,8 @@ func getTkrBom(registry string) (string, error) {
 	return expectedBomName, nil
 }
 
-func blockForBomImage(b tkr.ImageReader, bomPath, expectedBomName string) error {
-	f := filepath.Join(bomPath, expectedBomName)
+func blockForImageDownload(b tkr.ImageReader, path, expectedName string) error {
+	f := filepath.Join(path, expectedName)
 
 	// start a go routine to animate the downloading logs while the imgpkg libraries get the bom image
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/compatibility.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/compatibility.go
@@ -1,0 +1,86 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkr
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TkrImage is the image:path combo of a compatible TKr
+type TkrImage struct { //nolint:revive
+	Path string `yaml:"image"`
+}
+
+// UnmanagedClusterPluginVersion is the version of the unmanaged cluster CLI plugin
+// and versions of TKrs it's compatible with
+type UnmanagedClusterPluginVersion struct {
+	Version              string     `yaml:"version"`
+	SupportedTkrVersions []TkrImage `yaml:"supportedTkrVersions"`
+}
+
+// TkrCompatibility is the top level compatibility structure
+type Compatibility struct {
+	Version                        string                          `yaml:"version"`
+	UnmanagedClusterPluginVersions []UnmanagedClusterPluginVersion `yaml:"unmanagedClusterPluginVersions"`
+}
+
+// GetLatestCompatibilityTag expects a non-tagged registry URL that references a compatibility file image
+// For example: projects.registry.vmware.com/tce/compatibility
+// And returns the latest major tagged version
+// For example, if a given registry is tagged [v1, v2, v3, v4],
+// this function will return "v4"
+// Otherwise, it returns an error
+func GetLatestCompatibilityTag(registryURL string) (string, error) {
+	img := Image{
+		RegistryURL: registryURL,
+	}
+
+	tags, err := img.GetTags()
+	if err != nil {
+		return "", err
+	}
+
+	// Sorts tags based on major version
+	// Reference similar TKG compatibility code:
+	// https://github.com/vmware-tanzu/tanzu-framework/blob/4e383ca5760a67b41ad27dd52c23ae78378d302c/pkg/v1/tkg/tkgconfigbom/bom.go#L461
+	// Expects tags to be formatted as `vN` where N is a number.
+	// Example: [v1, v2, v3, v4]
+	tagNum := []int{}
+	for _, tag := range tags {
+		ver, err := strconv.Atoi(tag[1:])
+		if err == nil {
+			tagNum = append(tagNum, ver)
+		}
+	}
+
+	sort.Ints(tagNum)
+	if len(tagNum) == 0 {
+		return "", fmt.Errorf("failed to get valid image tags for compatibility image. Expected tags to be formatted as `vN` where N is a number. Actual tags: %s", tags)
+	}
+
+	// Re-format last tag in list (since it is the "latest")
+	return fmt.Sprintf("v%d", tagNum[len(tagNum)-1]), nil
+}
+
+// ReadCompatibilityFile will process a given file on the filesystem
+// and return a TkrCompatibility struct
+func ReadCompatibilityFile(filePath string) (*Compatibility, error) {
+	c := &Compatibility{}
+	rawC, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read compatibility file. Error: %s", err.Error())
+	}
+
+	err = yaml.Unmarshal(rawC, c)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal local compatibility file yaml. Error: %s", err.Error())
+	}
+
+	return c, nil
+}

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/compatibility_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/compatibility_test.go
@@ -1,0 +1,98 @@
+// Copyright 2020-2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:goconst
+package tkr
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+var sampleTkrYamls = `version: v1
+unmanagedClusterPluginVersions:
+- version: dev
+  supportedTkrVersions:
+  - image: projects.registry.vmware.com/tce/tkr:v0.17.0
+  - image: projects.registry.vmware.com/tce/tkr:v0.16.0
+- version: v0.11.0
+  supportedTkrVersions:
+  - image: projects.registry.vmware.com/tce/tkr:v0.16.0
+  - image: projects.registry.vmware.com/tce/tkr:v0.15.0
+- version: v0.10.0
+  supportedTkrVersions:
+  - image: projects.registry.vmware.com/tce/tkr:v0.0.1
+`
+
+//nolint:gocyclo
+func TestOrderOfCompatibleTkrs(t *testing.T) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "compatibility-test-")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.Write([]byte(sampleTkrYamls))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	c, err := ReadCompatibilityFile(tmpFile.Name())
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if c.Version != "v1" {
+		t.Errorf("expected version of TKr compatibility to be v1, was: %s\n", c.Version)
+	}
+
+	if len(c.UnmanagedClusterPluginVersions) != 3 {
+		t.Errorf("expected to find 3 CLI plugin versions, was: %v\n", c.UnmanagedClusterPluginVersions)
+	}
+
+	if c.UnmanagedClusterPluginVersions[0].Version != "dev" {
+		t.Errorf("expected first CLI plugin version to be dev, was: %s\n", c.UnmanagedClusterPluginVersions[0])
+	}
+
+	if len(c.UnmanagedClusterPluginVersions[0].SupportedTkrVersions) != 2 {
+		t.Errorf("expected first CLI plugin to have 2 compatibility TKrs, was: %v\n", c.UnmanagedClusterPluginVersions[0].SupportedTkrVersions)
+	}
+
+	if c.UnmanagedClusterPluginVersions[0].SupportedTkrVersions[0].Path != "projects.registry.vmware.com/tce/tkr:v0.17.0" {
+		t.Errorf("expected first compatible TKR for first CLI plugin to be projects.registry.vmware.com/tce/tkr:v0.17.0, was: %s\n", c.UnmanagedClusterPluginVersions[0].SupportedTkrVersions[0].Path)
+	}
+
+	if c.UnmanagedClusterPluginVersions[0].SupportedTkrVersions[1].Path != "projects.registry.vmware.com/tce/tkr:v0.16.0" {
+		t.Errorf("expected second compatible TKR for first CLI plugin to be projects.registry.vmware.com/tce/tkr:v0.16.0, was: %s\n", c.UnmanagedClusterPluginVersions[0].SupportedTkrVersions[1].Path)
+	}
+
+	if c.UnmanagedClusterPluginVersions[1].Version != "v0.11.0" {
+		t.Errorf("expected second CLI plugin version to be v0.11.0, was: %s\n", c.UnmanagedClusterPluginVersions[1])
+	}
+
+	if len(c.UnmanagedClusterPluginVersions[1].SupportedTkrVersions) != 2 {
+		t.Errorf("expected second CLI plugin to have 2 compatibility TKrs, was: %v\n", c.UnmanagedClusterPluginVersions[1].SupportedTkrVersions)
+	}
+
+	if c.UnmanagedClusterPluginVersions[1].SupportedTkrVersions[0].Path != "projects.registry.vmware.com/tce/tkr:v0.16.0" {
+		t.Errorf("expected first compatible TKR for second CLI plugin to be projects.registry.vmware.com/tce/tkr:v0.16.0, was: %s\n", c.UnmanagedClusterPluginVersions[1].SupportedTkrVersions[0].Path)
+	}
+
+	if c.UnmanagedClusterPluginVersions[1].SupportedTkrVersions[1].Path != "projects.registry.vmware.com/tce/tkr:v0.15.0" {
+		t.Errorf("expected second compatible TKR for first CLI plugin to be projects.registry.vmware.com/tce/tkr:v0.15.0, was: %s\n", c.UnmanagedClusterPluginVersions[1].SupportedTkrVersions[1].Path)
+	}
+
+	if c.UnmanagedClusterPluginVersions[2].Version != "v0.10.0" {
+		t.Errorf("expected first CLI plugin version to be v0.10.0, was: %s\n", c.UnmanagedClusterPluginVersions[2])
+	}
+
+	if len(c.UnmanagedClusterPluginVersions[2].SupportedTkrVersions) != 1 {
+		t.Errorf("expected second CLI plugin to have 1 compatibility TKrs, was: %v\n", c.UnmanagedClusterPluginVersions[2].SupportedTkrVersions)
+	}
+
+	if c.UnmanagedClusterPluginVersions[2].SupportedTkrVersions[0].Path != "projects.registry.vmware.com/tce/tkr:v0.0.1" {
+		t.Errorf("expected first compatible TKR for third CLI plugin to be projects.registry.vmware.com/tce/tkr:v0.0.1, was: %s\n", c.UnmanagedClusterPluginVersions[2].SupportedTkrVersions[0].Path)
+	}
+}

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/tkr.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/tkr.go
@@ -269,6 +269,9 @@ type Bom struct {
 				TanzuCorePackageRepositoryImage struct {
 					ImagePackage `yaml:",inline"`
 				} `yaml:"tanzuCorePackageRepositoryImage"`
+				TanzuUserPackageRepositoryImage struct {
+					ImagePackage `yaml:",inline"`
+				} `yaml:"tanzuUserPackageRepositoryImage"`
 				VsphereCpiTanzuVmwareCom struct {
 					ImagePackage `yaml:",inline"`
 				} `yaml:"vsphere-cpi.tanzu.vmware.com"`
@@ -486,6 +489,21 @@ func (tkr *Bom) GetTKRCoreRepoBundlePath() string {
 	}
 	path := tkr.Components.TkgCorePackages[0].Images.TanzuCorePackageRepositoryImage.ImagePath
 	tag := tkr.Components.TkgCorePackages[0].Images.TanzuCorePackageRepositoryImage.Tag
+
+	return fmt.Sprintf("%s/%s:%s", registry, path, tag)
+}
+
+func (tkr *Bom) GetTKRUserRepoBundlePath() string {
+	registry := tkr.Components.TkgCorePackages[0].Images.TanzuUserPackageRepositoryImage.Repository
+	if registry == "" {
+		registry = tkr.getTKRRegistry()
+	}
+	path := tkr.Components.TkgCorePackages[0].Images.TanzuUserPackageRepositoryImage.ImagePath
+	tag := tkr.Components.TkgCorePackages[0].Images.TanzuUserPackageRepositoryImage.Tag
+
+	if path == "" || tag == "" {
+		return ""
+	}
 
 	return fmt.Sprintf("%s/%s:%s", registry, path, tag)
 }


### PR DESCRIPTION
## What this PR does / why we need it
- Queries registry for list of tags for compatibility file. Uses the most recently major versioned tag. I.e., if there are `[v1, v2, v3]` tags, it will select `v3` since it's the "latest" tag
- Checks if the tkr compatibility file is already downloaded. If it doesn't exist, downloads and unpacks it from the registry.
- Reads and unmarshals compatibility file
  - Assumes unmarshaled yaml is ordered. Selects first compatible TKr. PR includes test for this
- Checks version of unmanaged-cluster CLI plugin vs compatible TKR. Uses (and downloads if needed) tkr that corresponds to a compatible version.
- If user provides a tkr via `--tkr` flag, checks to see if it's in the compatibility file. If not, logs a warning.
- Helper script for pushing a compatibility file. Sample compatibility file also in PR
- Moves getting user package repo out of the `config` package and into the TKr.
  - If a user provides their own `additional-repo` via flags or configuration, uses that instead

## Which issue(s) this PR fixes
Fixes: #3538

## Describe testing done for PR
Compatibility file in registry:
```
$ crane ls projects.registry.vmware.com/tce/compatibility
v1
v2
v3
```

File contents:
```yaml
version: v1
unmanagedClusterPluginVersions:
- version: dev
  supportedTkrVersions:
  - image: projects.registry.vmware.com/tce/tkr:v0.17.0-dev-1
  - image: projects.registry.vmware.com/tce/tkr:v0.17.0
  - image: projects.registry.vmware.com/tce/tkr:v1.22.5
- version: v0.11.0
  supportedTkrVersions:
  - image: projects.registry.vmware.com/tce/tkr:v0.17.0
  - image: projects.registry.vmware.com/tce/tkr:v1.22.5
- version: v0.10.0
  supportedTkrVersions:
  - image: projects.registry.vmware.com/tce/tkr:v0.21.5
```

The TKr now should have the following section:
```yaml
  tkg-core-packages:
  - version: v1.21.2+vmware.1-tkg.1
    images:
      tanzuCorePackageRepositoryImage:
        imagePath: repo-10
        tag: 0.10.0
        repository: projects.registry.vmware.com/tce
      tanzuUserPackageRepositoryImage:
        imagePath: main
        tag: 0.11.0
        repository: projects.registry.vmware.com/tce
```

and is present in `projects.registry.vmware.com/tce/tkr:v0.17.0-dev-1` which is at the top of the compatibility file for the `dev` version

---

Creating a cluster, selects the correct TKR
```
$ tanzu unmanaged-cluster create test

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Downloaded to: /home/jmcb/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v3

🔧 Resolving TKr
   projects.registry.vmware.com/tce/tkr:v0.17.0-dev-1
   Downloaded to: /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v0.17.0-dev-1
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/test/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/test/bootstrap.log

🔧 Processing Tanzu Kubernetes Release

🎨 Selected base image
   projects.registry.vmware.com/tce/kind:v1.22.4

📦 Selected core package repository
   projects.registry.vmware.com/tce/repo-10:0.10.0

📦 Selected additional package repositories
   projects.registry.vmware.com/tce/main:v0.11.0

📦 Selected kapp-controller image bundle
   projects.registry.vmware.com/tce/kapp-controller-multi-pkg:v0.30.1

🚀 Creating cluster test
   Cluster creation using kind!
   ❤️  Checkout this awesome project at https://kind.sigs.k8s.io
   Base image downloaded
   Cluster created
   To troubleshoot, use:

   kubectl ${COMMAND} --kubeconfig /home/jmcb/.config/tanzu/tkg/unmanaged/test/kube.conf

📧 Installing kapp-controller
   kapp-controller status: Running

📧 Installing package repositories
   Core package repo status: Reconcile succeeded

🌐 Installing CNI
   calico.community.tanzu.vmware.com:3.22.1

✅ Cluster created

🎮 kubectl context set to test

View available packages:
   tanzu package available list
View running pods:
   kubectl get po -A
Delete this cluster:
   tanzu unmanaged delete test
```

Running create again skips downloading compatibility file since it already exists

```
$ tanzu unmanaged-cluster create test-2

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Compatibility file exists at /home/jmcb/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v3

🔧 Resolving TKr
   projects.registry.vmware.com/tce/tkr:v0.17.0-dev-1
   TKr exists at /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v0.17.0-dev-1
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/test/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/test/bootstrap.log

🔧 Processing Tanzu Kubernetes Release

🎨 Selected base image
   projects.registry.vmware.com/tce/kind:v1.22.4

📦 Selected core package repository
   projects.registry.vmware.com/tce/repo-10:0.10.0

📦 Selected additional package repositories
   projects.registry.vmware.com/tce/main:0.11.0

📦 Selected kapp-controller image bundle
   projects.registry.vmware.com/tce/kapp-controller-multi-pkg:v0.30.1
...
```

Using the `--tkr` flag works and checks to ensure it's in the compatibility file 👍🏼 
```
$ tanzu unmanaged-cluster create test --tkr projects.registry.vmware.com/tce/tkr:v1.22.5

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Compatibility file exists at /home/jmcb/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v3
   Custom Tkr projects.registry.vmware.com/tce/tkr:v1.22.5 found in compatibility file

🔧 Resolving TKr
   projects.registry.vmware.com/tce/tkr:v1.22.5
   TKr exists at /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v1.22.5
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/test-3/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/test-3/bootstrap.log

🔧 Processing Tanzu Kubernetes Release

🎨 Selected base image
   projects.registry.vmware.com/tce/kind/node:v1.22.5

📦 Selected core package repository
   projects-stg.registry.vmware.com/tkg/packages/core/repo:v1.22.5_vmware.1-tkg.3-tf-v0.11.2

📦 Selected kapp-controller image bundle
   projects-stg.registry.vmware.com/tkg/packages/core/kapp-controller:v0.30.0_vmware.1-tkg.1
...
```

If the tkr is _not_ in the compatibility file, it raises a warning, but proceeds (fyi, this fails to download tkr since it doesn't exist, but demonstrates tkr warning if not in compatibility file):
```
$ tanzu unmanaged-cluster create test --tkr projects.registry.vmware.com/tce/tkr:v1.99.99

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Compatibility file exists at /home/jmcb/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v3
   Custom TKr projects.registry.vmware.com/tce/tkr:v1.99.99 NOT found in compatibility file. Proceed with caution, the provided TKr may not work with this version of unmanaged-cluster

🔧 Resolving TKr
   projects.registry.vmware.com/tce/tkr:v1.99.99
   Downloading to: /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v1.99.99
...
```


Looking at the file system in `~/.config/tanzu/tkg/unmanaged/`:
```
❯ tree
.
├── bom
│   ├── projects.registry.vmware.com_tce_tkr_v0.17.0-dev-1
│   ├── projects.registry.vmware.com_tce_tkr_v0.17.0
│   └── projects.registry.vmware.com_tce_tkr_v1.22.5
├── compatibility
│   └── projects.registry.vmware.com_tce_compatibility_v3
├── test
│   ├── bootstrap.log
│   ├── config.yaml
│   └── kindconfig.yaml
```

Providing your _own_ user managed repo works as expected and will _not_ select the one in the downloaded tkr:
```
$ tanzu unmanaged-cluster create woof-test --additional-repo projects.registry.vmware.com/main:v0.10.0

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Compatibility file exists at /home/jmcb/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v3

🔧 Resolving TKr
   projects.registry.vmware.com/tce/tkr:v0.17.0-dev-1
   TKr exists at /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v0.17.0-dev-1
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/woof-test/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/woof-test/bootstrap.log

🔧 Processing Tanzu Kubernetes Release

🎨 Selected base image
   projects.registry.vmware.com/tce/kind:v1.22.4

📦 Selected core package repository
   projects.registry.vmware.com/tce/repo-10:0.10.0

📦 Selected additional package repositories
   projects.registry.vmware.com/main:v0.10.0

📦 Selected kapp-controller image bundle
   projects.registry.vmware.com/tce/kapp-controller-multi-pkg:v0.30.1
```

Note that if a user provides a tkr that does _not_ have a user managed repo in it, we won't attempt to select resolve any kind of default and it won't be logged as being selected.