### PR TITLE
Update package readme script for new doc structure (#3626)

### DIFF
--- a/hack/workflows/packages/copy-package-readmes-to-docs.go
+++ b/hack/workflows/packages/copy-package-readmes-to-docs.go
@@ -53,7 +53,7 @@ type Toc struct {
 
 //nolint:funlen
 func main() {
-	docsDir := filepath.Join("..", "..", "..", "docs", "site", "content", "docs", "latest")
+	docsDir := filepath.Join("..", "..", "..", "docs", "site", "content", "docs")
 	imgsDir := filepath.Join("..", "..", "..", "docs", "site", "content", "docs", "img")
 	addonsPackagesDir := filepath.Join("..", "..", "..", "addons", "packages")
 


### PR DESCRIPTION
The "latest" folder has been removed from our docs structure to support
our current method for versioning docs. The script to update package
READMEs into the published docs was missed during this update, so it was
still trying to use the deeper folder structure and failing. This
updates the script to remove the "latest" folder.

(cherry picked from commit 6f2f76e8a2fb80e1b84e1a511f3b3d819a4a82ff)