### PR TITLE
Correct link for new folder structure

### DIFF
--- a/docs/designs/2967-package-image-vulnerability-scanning.md
+++ b/docs/designs/2967-package-image-vulnerability-scanning.md
@@ -162,7 +162,7 @@ turtle@turtle-a01 tce-main % cat /tmp/tce-main/.imgpkg/images.yml | grep "image:
 ```
 
 These are the two packages of `harbor` which are
-supported [tanzu packages](https://tanzucommunityedition.io/docs/latest/package-management/)
+supported [tanzu packages](https://tanzucommunityedition.io/docs/package-management/)
 
 Let's get a list of images from one of these packages
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

There was one link that still included the "/latest" folder path that
was removed as part of our docs versioning restructuring. This updates
the URL to the new path so it gets redirected to the appropriate
versioned location.