### PR TITLE
Docs: Update docsearch facetfilters version variable

### DIFF
--- a/docs/site/themes/template/layouts/_default/baseof.html
+++ b/docs/site/themes/template/layouts/_default/baseof.html
@@ -45,12 +45,14 @@
 	{{ partial "footer" . }}
     {{ if .Site.Params.docs_search }}
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@docsearch/js@3.0.0-alpha.42" integrity="sha384-s1m6svX516FE0be94T37dhqnS6QpunAkjRntpP4YQp+mUzWPOK3QM/I+ngbzlwI2" crossorigin="anonymous"></script>
-    <script type="text/javascript"> docsearch({
+    <script type="text/javascript">
+      {{ $version := index (split .File.Path "/") 1 }}
+      docsearch({
         appId: '{{ .Site.Params.Docs_search_app_id }}',
         apiKey: '{{ .Site.Params.Docs_search_api_key }}',
         indexName: '{{ .Site.Params.Docs_search_index_name }}',
         container: '.algolia-autocomplete',
-        searchParameters: {'facetFilters': ['version:{{ .CurrentSection.Params.version }}']},
+        searchParameters: {'facetFilters': ['version:{{ $version }}']},
         debug: false // Set debug to true if you want to inspect the dropdown
       });
     </script>


### PR DESCRIPTION
Signed-off-by: Garry Ing <ging@vmware.com>

## What this PR does / why we need it
Updates the version variable in the `docsearch` configuration to use the relative version the user is on. Algolia indexes have been updated to reflect docs versioning.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3653

## Describe testing done for PR
- `hugo server`
- Navigate to `/docs/v0.10/`

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
