### PR TITLE
Daily Builds for a Given Month Under a Single Discussion Thread

### DIFF
--- a/hack/dailybuild/dailybuild.go
+++ b/hack/dailybuild/dailybuild.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -15,29 +16,51 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
 )
 
 const (
-	regexReadmeLinuxAmd64   string = "\\[Linux AMD64.*\\]\\(.*\\)"
-	regexReadmeDarwinAmd64  string = "\\[Darwin AMD64.*\\]\\(.*\\)"
-	regexReadmeWindowsAmd64 string = "\\[Windows AMD64.*\\]\\(.*\\)"
+	// GH discussion related consts
+	githubDiscussionURI string = "https://api.github.com/graphql"
 
+	// GCP related consts
 	projectID  string = "vmware-cna"
 	bucketName string = "tce-cli-plugins-staging"
 	gcpFile    string = "gcptokenfile.json"
 
-	fullPathReadme string = "../../README.md"
+	// README.md related consts
+	fullPathReadme          string = "../../README.md"
+	regexReadmeLinuxAmd64   string = "\\[Linux AMD64.*\\]\\(.*\\)"
+	regexReadmeDarwinAmd64  string = "\\[Darwin AMD64.*\\]\\(.*\\)"
+	regexReadmeWindowsAmd64 string = "\\[Windows AMD64.*\\]\\(.*\\)"
 )
 
+type Result struct {
+	Data struct {
+		Repository struct {
+			Discussions struct {
+				Nodes []struct {
+					ID    string `json:"id"`
+					Title string `json:"title"`
+				} `json:"nodes"`
+			} `json:"discussions"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
 type Builds struct {
+	BuildYear    int
+	BuildMonth   string
 	BuildDate    string
 	DarwinAmd64  string
 	DarwinArm64  string
 	WindowsAmd64 string
 	LinuxAmd64   string
+	PreviousHash string
+	CurrentHash  string
 }
 
 type ClientUploader struct {
@@ -47,7 +70,149 @@ type ClientUploader struct {
 	uploadPath string
 }
 
-// UploadFile uploads an object
+// the upload function
+func uploadAll(tag, gcpToken, previous, current string) (*Builds, error) {
+	err := os.WriteFile(gcpFile, []byte(gcpToken), 0644)
+	if err != nil {
+		fmt.Printf("WriteFile failed: %v\n", err)
+		return nil, err
+	}
+
+	myNow := time.Now()
+	year, month, _ := myNow.Date()
+	buildDate := myNow.Format("2006-01-02")
+
+	urlLinuxAmd64, err := uploadTarball(buildDate, "linux", "amd64", tag, "tar.gz")
+	if err != nil {
+		fmt.Printf("uploadLinux failed: %v\n", err)
+
+		errFile := os.Remove(gcpFile)
+		if err != nil {
+			fmt.Printf("Remove failed: %v\n", errFile)
+		}
+
+		return nil, err
+	}
+
+	urlWindowsAmd64, err := uploadTarball(buildDate, "windows", "amd64", tag, "zip")
+	if err != nil {
+		fmt.Printf("uploadWindows failed: %v\n", err)
+
+		errFile := os.Remove(gcpFile)
+		if err != nil {
+			fmt.Printf("Remove failed: %v\n", errFile)
+		}
+
+		return nil, err
+	}
+
+	urlDarwinAmd64, err := uploadTarball(buildDate, "darwin", "amd64", tag, "tar.gz")
+	if err != nil {
+		fmt.Printf("uploadDarwinAmd64 failed: %v\n", err)
+
+		errFile := os.Remove(gcpFile)
+		if err != nil {
+			fmt.Printf("Remove failed: %v\n", errFile)
+		}
+
+		return nil, err
+	}
+
+	_, err = uploadTarball(buildDate, "darwin", "arm64", tag, "tar.gz")
+	if err != nil {
+		fmt.Printf("uploadDarwinArm64 failed: %v\n", err)
+
+		errFile := os.Remove(gcpFile)
+		if err != nil {
+			fmt.Printf("Remove failed: %v\n", errFile)
+		}
+
+		return nil, err
+	}
+
+	errFile := os.Remove(gcpFile)
+	if err != nil {
+		fmt.Printf("Remove failed: %v\n", errFile)
+	}
+
+	builds := &Builds{
+		BuildYear:    year,
+		BuildMonth:   month.String(),
+		BuildDate:    buildDate,
+		LinuxAmd64:   urlLinuxAmd64,
+		WindowsAmd64: urlWindowsAmd64,
+		DarwinAmd64:  urlDarwinAmd64,
+		PreviousHash: previous,
+		CurrentHash:  current,
+	}
+
+	return builds, nil
+}
+
+// the readme update function
+func updateReadme(builds *Builds) error {
+	readme, err := os.ReadFile(fullPathReadme)
+	if err != nil {
+		fmt.Printf("Failed to parse README file at %s: %v\n", fullPathReadme, err)
+		return err
+	}
+
+	replaceLinuxAmd64 := fmt.Sprintf("[Linux AMD64 - %s](%s)", builds.BuildDate, builds.LinuxAmd64)
+	var expLinuxAmd64 = regexp.MustCompile(regexReadmeLinuxAmd64)
+	replace1 := expLinuxAmd64.ReplaceAllString(string(readme), replaceLinuxAmd64)
+
+	replaceDarwinAmd64 := fmt.Sprintf("[Darwin AMD64 - %s](%s)", builds.BuildDate, builds.DarwinAmd64)
+	var expDarwinAmd64 = regexp.MustCompile(regexReadmeDarwinAmd64)
+	replace2 := expDarwinAmd64.ReplaceAllString(replace1, replaceDarwinAmd64)
+
+	replaceWindowsAmd64 := fmt.Sprintf("[Windows AMD64 - %s](%s)", builds.BuildDate, builds.WindowsAmd64)
+	var expWindowsAmd64 = regexp.MustCompile(regexReadmeWindowsAmd64)
+	replaceFinal := expWindowsAmd64.ReplaceAllString(replace2, replaceWindowsAmd64)
+
+	err = os.Remove(fullPathReadme)
+	if err != nil {
+		fmt.Printf("Remove failed: %v\n", err)
+		return err
+	}
+	err = os.WriteFile(fullPathReadme, []byte(replaceFinal), 0644)
+	if err != nil {
+		fmt.Printf("WriteFile failed: %v\n", err)
+		return err
+	}
+
+	return nil
+}
+
+// the post discussion function
+func doDailyBuildNotification(token string, builds *Builds) error {
+	discussID, err := getDiscussionID(token, builds)
+	if err != nil {
+		fmt.Printf("Discussion for this month doesnt exist. Create it!")
+
+		err = createDiscussion(token, builds)
+		if err != nil {
+			fmt.Printf("createDiscussion failed: %v\n", err)
+			return err
+		}
+
+		discussID, err = getDiscussionID(token, builds)
+		if err != nil {
+			fmt.Printf("getDiscussionID failed: %v\n", err)
+			return err
+		}
+	}
+	fmt.Printf("ID: %s\n", discussID)
+
+	err = postComment(token, discussID, builds)
+	if err != nil {
+		fmt.Printf("postComment failed: %v\n", err)
+		return err
+	}
+
+	return nil
+}
+
+// helper bucket functions
 func (c *ClientUploader) UploadFile(filename string) error {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*1200)
@@ -104,137 +269,28 @@ func uploadTarball(buildDate, platform, arch, tag, extension string) (string, er
 	return urlUpload, nil
 }
 
-func uploadAll(tag, gcpToken string) (*Builds, error) {
-	err := os.WriteFile(gcpFile, []byte(gcpToken), 0644)
-	if err != nil {
-		fmt.Printf("WriteFile failed: %v\n", err)
-		return nil, err
-	}
-
-	buildDate := time.Now().Format("2006-01-02")
-
-	urlLinuxAmd64, err := uploadTarball(buildDate, "linux", "amd64", tag, "tar.gz")
-	if err != nil {
-		fmt.Printf("uploadLinux failed: %v\n", err)
-
-		errFile := os.Remove(gcpFile)
-		if err != nil {
-			fmt.Printf("Remove failed: %v\n", errFile)
-		}
-
-		return nil, err
-	}
-
-	urlWindowsAmd64, err := uploadTarball(buildDate, "windows", "amd64", tag, "zip")
-	if err != nil {
-		fmt.Printf("uploadWindows failed: %v\n", err)
-
-		errFile := os.Remove(gcpFile)
-		if err != nil {
-			fmt.Printf("Remove failed: %v\n", errFile)
-		}
-
-		return nil, err
-	}
-
-	urlDarwinAmd64, err := uploadTarball(buildDate, "darwin", "amd64", tag, "tar.gz")
-	if err != nil {
-		fmt.Printf("uploadDarwinAmd64 failed: %v\n", err)
-
-		errFile := os.Remove(gcpFile)
-		if err != nil {
-			fmt.Printf("Remove failed: %v\n", errFile)
-		}
-
-		return nil, err
-	}
-
-	_, err = uploadTarball(buildDate, "darwin", "arm64", tag, "tar.gz")
-	if err != nil {
-		fmt.Printf("uploadDarwinArm64 failed: %v\n", err)
-
-		errFile := os.Remove(gcpFile)
-		if err != nil {
-			fmt.Printf("Remove failed: %v\n", errFile)
-		}
-
-		return nil, err
-	}
-
-	errFile := os.Remove(gcpFile)
-	if err != nil {
-		fmt.Printf("Remove failed: %v\n", errFile)
-	}
-
-	builds := &Builds{
-		BuildDate:    buildDate,
-		LinuxAmd64:   urlLinuxAmd64,
-		WindowsAmd64: urlWindowsAmd64,
-		DarwinAmd64:  urlDarwinAmd64,
-	}
-
-	return builds, nil
-}
-
-func updateReadme(builds *Builds) error {
-	readme, err := os.ReadFile(fullPathReadme)
-	if err != nil {
-		fmt.Printf("Failed to parse README file at %s: %v\n", fullPathReadme, err)
-		return err
-	}
-
-	replaceLinuxAmd64 := fmt.Sprintf("[Linux AMD64 - %s](%s)", builds.BuildDate, builds.LinuxAmd64)
-	var expLinuxAmd64 = regexp.MustCompile(regexReadmeLinuxAmd64)
-	replace1 := expLinuxAmd64.ReplaceAllString(string(readme), replaceLinuxAmd64)
-
-	replaceDarwinAmd64 := fmt.Sprintf("[Darwin AMD64 - %s](%s)", builds.BuildDate, builds.DarwinAmd64)
-	var expDarwinAmd64 = regexp.MustCompile(regexReadmeDarwinAmd64)
-	replace2 := expDarwinAmd64.ReplaceAllString(replace1, replaceDarwinAmd64)
-
-	replaceWindowsAmd64 := fmt.Sprintf("[Windows AMD64 - %s](%s)", builds.BuildDate, builds.WindowsAmd64)
-	var expWindowsAmd64 = regexp.MustCompile(regexReadmeWindowsAmd64)
-	replaceFinal := expWindowsAmd64.ReplaceAllString(replace2, replaceWindowsAmd64)
-
-	err = os.Remove(fullPathReadme)
-	if err != nil {
-		fmt.Printf("Remove failed: %v\n", err)
-		return err
-	}
-	err = os.WriteFile(fullPathReadme, []byte(replaceFinal), 0644)
-	if err != nil {
-		fmt.Printf("WriteFile failed: %v\n", err)
-		return err
-	}
-
-	return nil
-}
-
-func postDiscussion(token string, builds *Builds, previous, current string) error {
+// helper discussion functions start
+func createDiscussion(token string, builds *Builds) error {
+	titleTemplate := "%s %d: Daily Development Builds"
 	bodyTemplate := "# Downloadable assets:\\n\\n" +
-		"Linux AMD64 - %s\\n" +
-		"Darwin AMD64 - %s\\n" +
-		"Windows AMD64 - %s\\n\\n"
-	if previous != current {
-		changelog := fmt.Sprintf("https://github.com/vmware-tanzu/community-edition/compare/%s...%s\\n", previous, current)
-
-		bodyTemplate += "# Full Changelog From Last Daily Build\\n\\n"
-		bodyTemplate += changelog
-	}
+		"You can find published daily development builds for %s %d here. These builds are intentionally unsigned " +
+		"as they aren't apart of any supported release. These builds are for development/test purposes only. " +
+		"To get the latest, sort the replies in this discussion from newest to oldest.\\n\\n"
 
 	jsonTemplate := "{\n" +
-		"\"query\": \"mutation {   addDiscussionComment(input: {discussionId: \\\"D_kwDOEhun3M4AO9Ut\\\", body: \\\"%s\\\"}) { comment {       id     }   } }\"\n" +
+		"\"query\": \"mutation {   createDiscussion(input: {repositoryId: \\\"MDEwOlJlcG9zaXRvcnkzMDM4MDIzMzI\\\", categoryId: \\\"DIC_kwDOEhun3M4COOTN\\\", body: \\\"%s\\\", title: \\\"%s\\\"}) {     discussion {       id     }   } }\"\n" +
 		"}\n"
 
-	url := "https://api.github.com/graphql"
-	bodyStr := fmt.Sprintf(bodyTemplate, builds.LinuxAmd64, builds.DarwinAmd64, builds.WindowsAmd64)
+	titleStr := fmt.Sprintf(titleTemplate, builds.BuildMonth, builds.BuildYear)
+	bodyStr := fmt.Sprintf(bodyTemplate, builds.BuildMonth, builds.BuildYear)
 	authStr := fmt.Sprintf("token %s", token)
-	jsonStr := fmt.Sprintf(jsonTemplate, bodyStr)
+	jsonStr := fmt.Sprintf(jsonTemplate, bodyStr, titleStr)
 
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*1200)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer([]byte(jsonStr)))
+	req, err := http.NewRequestWithContext(ctx, "POST", githubDiscussionURI, bytes.NewBuffer([]byte(jsonStr)))
 	if err != nil {
 		fmt.Printf("http.NewRequest failed. Err: %v\n", err)
 		return err
@@ -264,8 +320,127 @@ func postDiscussion(token string, builds *Builds, previous, current string) erro
 	return nil
 }
 
-func uploadAndUpdateDiscussion(ghToken, gcpToken, tag, previous, current string) error {
-	builds, err := uploadAll(tag, gcpToken)
+func postComment(token, discussID string, builds *Builds) error {
+	bodyTemplate := "# Downloadable assets:\\n\\n" +
+		"Linux AMD64 - %s\\n" +
+		"Darwin AMD64 - %s\\n" +
+		"Windows AMD64 - %s\\n\\n"
+	if builds.PreviousHash != builds.CurrentHash {
+		changelog := fmt.Sprintf("https://github.com/vmware-tanzu/community-edition/compare/%s...%s\\n", builds.PreviousHash, builds.CurrentHash)
+
+		bodyTemplate += "# Full Changelog From Last Daily Build\\n\\n"
+		bodyTemplate += changelog
+	}
+
+	jsonTemplate := "{\n" +
+		"\"query\": \"mutation {   addDiscussionComment(input: {discussionId: \\\"%s\\\", body: \\\"%s\\\"}) { comment {       id     }   } }\"\n" +
+		"}\n"
+
+	bodyStr := fmt.Sprintf(bodyTemplate, builds.LinuxAmd64, builds.DarwinAmd64, builds.WindowsAmd64)
+	authStr := fmt.Sprintf("token %s", token)
+	jsonStr := fmt.Sprintf(jsonTemplate, discussID, bodyStr)
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*1200)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", githubDiscussionURI, bytes.NewBuffer([]byte(jsonStr)))
+	if err != nil {
+		fmt.Printf("http.NewRequest failed. Err: %v\n", err)
+		return err
+	}
+	req.Header.Set("Authorization", authStr)
+	req.Header.Set("Content-Type", "application/json")
+
+	/* #nosec G402 */
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("client.Do failed. Err: %v\n", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	fmt.Printf("StatusCode: %d\n", resp.StatusCode)
+	fmt.Printf("Status: %s\n", resp.Status)
+	if resp.StatusCode != http.StatusOK {
+		fmt.Printf("resp.StatusCode failed: %d\n", resp.StatusCode)
+		return errors.New(resp.Status)
+	}
+
+	return nil
+}
+
+func getDiscussionID(token string, builds *Builds) (string, error) {
+	authStr := fmt.Sprintf("token %s", token)
+	jsonStr := "{\n" +
+		"\"query\": \"query {   repository(owner: \\\"vmware-tanzu\\\", name: \\\"community-edition\\\") {     discussions(first: 25) {       nodes {         id title       }     }   } }\"\n" +
+		"}\n"
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*1200)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", githubDiscussionURI, bytes.NewBuffer([]byte(jsonStr)))
+	if err != nil {
+		fmt.Printf("http.NewRequest failed. Err: %v\n", err)
+		return "", err
+	}
+	req.Header.Set("Authorization", authStr)
+	req.Header.Set("Content-Type", "application/json")
+
+	/* #nosec G402 */
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("client.Do failed. Err: %v\n", err)
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	fmt.Printf("StatusCode: %d\n", resp.StatusCode)
+	fmt.Printf("Status: %s\n", resp.Status)
+	if resp.StatusCode != http.StatusOK {
+		fmt.Printf("resp.StatusCode failed: %d\n", resp.StatusCode)
+		return "", errors.New(resp.Status)
+	}
+
+	byFile, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf("ReadAll failed. Err: %v\n", err)
+		return "", err
+	}
+
+	fmt.Printf("DATA:\n\n%s\n\n", string(byFile))
+
+	result := Result{}
+	err = json.Unmarshal(byFile, &result)
+	if err != nil {
+		fmt.Printf("json.Unmarshal failed. Err: %v\n", err)
+		return "", err
+	}
+
+	titleMatch := fmt.Sprintf("%s %d:", builds.BuildMonth, builds.BuildYear)
+	for _, article := range result.Data.Repository.Discussions.Nodes {
+		if strings.Index(article.Title, titleMatch) == 0 {
+			fmt.Printf("ID: %s\n", article.ID)
+			return article.ID, nil
+		}
+	}
+
+	fmt.Printf("ID NOT FOUND\n")
+	return "", errors.New("ID not found")
+}
+
+// do it all
+func doWork(ghToken, gcpToken, tag, previous, current string) error {
+	builds, err := uploadAll(tag, gcpToken, previous, current)
 	if err != nil {
 		fmt.Printf("uploadAll failed: %v\n", err)
 		return err
@@ -277,9 +452,9 @@ func uploadAndUpdateDiscussion(ghToken, gcpToken, tag, previous, current string)
 		return err
 	}
 
-	err = postDiscussion(ghToken, builds, previous, current)
+	err = doDailyBuildNotification(ghToken, builds)
 	if err != nil {
-		fmt.Printf("postDiscussion failed: %v\n", err)
+		fmt.Printf("doDailyBuildNotification failed: %v\n", err)
 		return err
 	}
 
@@ -328,9 +503,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	err := uploadAndUpdateDiscussion(ghToken, gcpToken, tag, previous, current)
+	err := doWork(ghToken, gcpToken, tag, previous, current)
 	if err != nil {
-		fmt.Printf("uploadAndUpdateDiscussion failed: %v\n", err)
+		fmt.Printf("doWork failed: %v\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
If a discussion thread starting with `YEAR MONTH:` doesn't exist (ie the first of the month), a new discussion with a "generic" comment for the thread is started in the `daily builds` category.  Please see https://github.com/vmware-tanzu/community-edition/discussions/3379. Then we always post a new comment (either on the newly created discussion or the existing months discussion) with today's build details.

Moved some things around for better organization.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Test that the `getDiscussionId()` function works locally which is net new functionality. Restored the old implementation for creating a new discussion post. Then reused the existing post comment functionality.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA