### PR TITLE
Adds deploy sample workload doc

### DIFF
--- a/docs/site/content/docs/assets/next-steps.md
+++ b/docs/site/content/docs/assets/next-steps.md
@@ -1,5 +1,7 @@
 Now that you have deployed a management cluster and a workload cluster, you can take the next steps to deploy and manage application workloads. Here are some next steps you can take:
 
+* [Deploy a Test Workload to a Workload Cluster](../sample)
+
 * Learn more about how to work with packages or furthermore learn how to create your own packages. For more information see:  
 
     [Work with packages](../package-management)  

--- a/docs/site/content/docs/getting-started-unmanaged.md
+++ b/docs/site/content/docs/getting-started-unmanaged.md
@@ -87,4 +87,5 @@ Choose your operating system below for guidance on installation.
 
 ## Next Steps
 
-* [Unmanaged Clusters Reference Documentation](/docs/ref-unmanaged-cluster)
+* [Unmanaged Clusters Reference Documentation](ref-unmanaged-cluster)
+* [Deploy a Test Workload to an Unmanaged Cluster](sample)

--- a/docs/site/content/docs/sample.md
+++ b/docs/site/content/docs/sample.md
@@ -1,0 +1,86 @@
+# Deploy a Test Workload to a Workload or Unmanaged Cluster
+
+After you have provisioned a workload cluster, it is good practice to deploy and test a workload to validate cluster functionality.
+
+Use the [kuard](https://github.com/kubernetes-up-and-running/kuard#demo-application-for-kubernetes-up-and-running) demo app to verify that your workload cluster is up and running.
+
+## Prerequisites
+
+You must have a workload or unmanaged cluster deployed.
+
+## Procedure
+
+1. If you are deploying to a workload cluster, switch configuration context to the target workload cluster.
+
+    ```sh
+    kubectl config use-context <WORKLOAD-CLUSTER-NAME>
+    ```
+
+    For example:
+
+    ```sh
+    kubectl config use-context tce-cluster-1
+
+    Switched to context "tce-cluster-1".
+    ```
+
+1. Deploy the kuard demo app.
+
+    ```sh
+    kubectl run --restart=Never --image=gcr.io/kuar-demo/kuard-amd64:blue kuard
+    ```
+
+    Expected result:
+
+    ```sh
+    pod/kuard created
+    ```
+
+1. Verify that the pod is running.
+
+    ```sh
+    kubectl get pods
+    ```
+
+    Expected result:
+
+    ```sh
+    NAME                     READY   STATUS    RESTARTS   AGE
+    kuard                    1/1     Running   0          10d
+    ```
+
+1. Forward the pod container port 8080 to your local host port 8080.
+
+    ```sh
+    kubectl port-forward kuard 8080:8080
+    ```
+
+    Expected result:
+
+    ```sh
+    Forwarding from 127.0.0.1:8080 -> 8080
+    Forwarding from [::1]:8080 -> 8080
+    Handling connection for 8080
+    ```
+
+1. Using a browser go to ``http://localhost:8080``.
+The kuard demo app web page appears which you can interact with and verify aspects of your cluster. For example, perform liveness and readiness probes.
+1. Stop port forwarding by pressing Ctrl+C in the kubectl session.
+
+1. Delete the kuard pod.
+
+    ```sh
+    kubectl delete pod kuard
+    ```
+
+    Expected result:
+
+    ```sh
+    pod "kuard" deleted
+    ```
+
+1. Verify that the pod is deleted.
+
+    ```sh
+    kubectl get pods
+    ```

--- a/docs/site/data/docs/main-toc.yml
+++ b/docs/site/data/docs/main-toc.yml
@@ -199,6 +199,8 @@ toc:
           url: /vsphere-volume-expansion
     - title: Guides
       subfolderitems:
+        - page: Deploy a Test Workload to a Workload or Unmanaged Cluster
+          url: /sample
         - page: Secure automated ingress on AWS
           url: /solutions-secure-ingress
         - page: Opinionated installation package


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
Adds new topic for deploying a sample workload to a workload cluster or unmanaged cluster.
Adds links to Getting Started guides 


## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3002 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
This PR replaces a previous PR #3666 3467 which was based on the old folder structure using `/latest`


Example: Please verify how I handled foo aligns with overall plan.
