### PR TITLE
Update docs url version detection for includes

### DIFF
--- a/docs/site/layouts/shortcodes/include.html
+++ b/docs/site/layouts/shortcodes/include.html
@@ -1,6 +1,5 @@
 {{ $include_file := .Get 0 }} 
-{{ $latest := (cond (.Site.Params.docs_versioning) .Site.Params.docs_latest "") }}
-{{ $include_file := replace $include_file "/docs" ( printf "/docs/%s" $latest ) }}
+{{ $include_file := replace $include_file "/docs/" .Page.File.Dir }}
 {{ with .Site.GetPage $include_file }}
   {{ .Content | markdownify }}
 {{ end }}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

The current implementation of the `include` shortcode was updated to
detect the right path to support versioned docs. There was an error with
this implementation though, with the version always being detected as
the most recent official release. This would cause other versions of the
docs to try to pull in a files from other versions.

This updates the version detection logic to match our sidebar logic to
extract the version from the current path.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3667 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make preview-build` from the `docs/site` directory and made sure rendered docs were able to include local files.
