### PR TITLE
Update SHA for secretgen-controller 0.8.0

### DIFF
--- a/addons/packages/secretgen-controller/0.8.0/package.yaml
+++ b/addons/packages/secretgen-controller/0.8.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/secretgen-controller@sha256:0e2791ab37768fa1dd843454a1fac9403539930362f128e3a897419fa431d96c
+          image: projects.registry.vmware.com/tce/secretgen-controller@sha256:95ee2b63de1f53f5938254e567845eb8641546cf0e0fd8f0e3d5aa9ef290c017
       template:
       - ytt:
           paths:


### PR DESCRIPTION
## What this PR does / why we need it
The image SHA was not correct for secretgen-controller 0.8.0. I push the package to a registry and obtained a SHA which I then verified matched an image already in the TCE Harbor project.

I updated the package.yaml to obtain the correct SHA.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3671 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
