### PR TITLE
Update TOC file for package README updates

### DIFF
--- a/hack/workflows/packages/copy-package-readmes-to-docs.go
+++ b/hack/workflows/packages/copy-package-readmes-to-docs.go
@@ -119,7 +119,7 @@ func main() {
 	}
 
 	// load the table of contents yaml
-	var latestTocPath = filepath.Join("..", "..", "..", "docs", "site", "data", "docs", "latest-toc.yml")
+	var latestTocPath = filepath.Join("..", "..", "..", "docs", "site", "data", "docs", "main-toc.yml")
 	var toc Toc
 
 	source, err = os.ReadFile(latestTocPath)


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This updates the name of the yaml configuration file referenced for docs
updates from package READMEs. This file name was changed to support
versioned docs, so this changes the script to match the new name.