### PR TITLE
Fix mdlint error in support-matrix doc

### DIFF
--- a/docs/site/content/docs/support-matrix.md
+++ b/docs/site/content/docs/support-matrix.md
@@ -51,4 +51,3 @@ Mac and Windows: In Docker Desktop, select Preferences > Resources > Advanced
 ## Supported Kubernetes Versions
 
 Tanzu Community Edition supports the following Kubernetes versions: `1.21.2, 1.20.8, 1.19.12`
-


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

The support matrix documentation was recently updates to remove
references to cgroupv1 limitations. For some reason the mdlint check did
not run on that change, and there was a minor issue with its formatting.

This removes an extra blank line from the end of the file to make the
linter happy.