### PR TITLE
Use `antrea` as default CNI for unmanaged-clusters

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -32,7 +32,7 @@ func init() {
 	ConfigureCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "Configuration file for unmanaged cluster creation")
 	ConfigureCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider to use for cluster creation. Default is 'kind'")
 	ConfigureCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The Tanzu Kubernetes Release location.")
-	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'calico'")
+	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'antrea'")
 	ConfigureCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR to use for Pod IP addresses. Default and format is '10.244.0.0/16'")
 	ConfigureCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR to use for Service IP addresses. Default and format is '10.96.0.0/16'")
 	ConfigureCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -79,7 +79,7 @@ func init() {
 	CreateCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider for cluster creation; default is kind")
 	CreateCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The URL to the image containing a Tanzu Kubernetes release")
 	CreateCmd.Flags().StringSliceVar(&co.additionalRepo, "additional-repo", []string{}, "Addresses for additional package repositories to install")
-	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy; default is calico")
+	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy; default is antrea")
 	CreateCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR for Pod IP allocation; default is 10.244.0.0/16")
 	CreateCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR for Service IP allocation; default is 10.96.0.0/16")
 	CreateCmd.Flags().StringSliceVarP(&co.portMapping, "port-map", "p", []string{}, "Ports to map between container node and the host (format: '80:80/tcp' or just '80')")

--- a/cli/cmd/plugin/unmanaged-cluster/config/config.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config.go
@@ -45,7 +45,7 @@ const (
 var defaultConfigValues = map[string]interface{}{
 	TKRLocation:           "projects.registry.vmware.com/tce/tkr:v0.17.0",
 	Provider:              "kind",
-	Cni:                   "calico",
+	Cni:                   "antrea",
 	PodCIDR:               "10.244.0.0/16",
 	ServiceCIDR:           "10.96.0.0/16",
 	Tty:                   "true",


### PR DESCRIPTION
## What this PR does / why we need it
Switches back to `antrea` for default CNI

## Which issue(s) this PR fixes
Fixes: #3564

_Note_: This should **not** be merged until the underlying `antrea` fixes have merged and are consumed by `unmanaged-cluster`

## Describe testing done for PR
Deployed a cluster:
```
❯ k get pods -A
NAMESPACE            NAME                                              READY   STATUS    RESTARTS   AGE
kube-system          antrea-agent-mdjk4                                2/2     Running   0          36s
kube-system          antrea-controller-775d9d788b-54tjk                1/1     Running   0          36s
kube-system          coredns-78fcd69978-cvfk6                          1/1     Running   0          87s
kube-system          coredns-78fcd69978-tqkhs                          1/1     Running   0          87s
kube-system          etcd-test-test-control-plane                      1/1     Running   0          102s
kube-system          kube-apiserver-test-test-control-plane            1/1     Running   0          101s
kube-system          kube-controller-manager-test-test-control-plane   1/1     Running   0          101s
kube-system          kube-proxy-59h7t                                  1/1     Running   0          88s
kube-system          kube-scheduler-test-test-control-plane            1/1     Running   0          103s
local-path-storage   local-path-provisioner-85494db59d-85cjc           1/1     Running   0          87s
tkg-system           kapp-controller-779d9777dc-jq6rp                  1/1     Running   0          86s
```
