### PR TITLE
Removes unused const from `unmanaged-cluster`

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -38,7 +38,6 @@ const (
 	tkgCoreRepoName       = "tkg-core-repository"
 	tkgGlobalPkgNamespace = "tanzu-package-repo-global"
 	tceRepoName           = "community-repository"
-	tceRepoURL            = "projects.registry.vmware.com/tce/main:v0.11.0"
 	outputIndent          = 3
 	maxProgressLength     = 4
 )


### PR DESCRIPTION
## What this PR does / why we need it
The `tceRepoURL` is unused and should have been removed with https://github.com/vmware-tanzu/community-edition/pull/3299#discussion_r819833782 but was missed

The user managed package repo is now pulled in through the `additionaPackageRepos` in the `config` package; not the `tanzu` package.

## Which issue(s) this PR fixes
N/a

Related: 
- https://github.com/vmware-tanzu/community-edition/pull/3641#discussion_r833800401
- https://github.com/vmware-tanzu/community-edition/pull/3359#discussion_r820031981

## Describe testing done for PR
Able to bootstrap cluster with `tanzu unmanaged-cluster create test` and make a config file with `tanzu unmanaged-cluster config test`
