### PR TITLE
Parallel `make check` for improved linting times

### DIFF
--- a/.github/workflows/check-all.yaml
+++ b/.github/workflows/check-all.yaml
@@ -1,4 +1,4 @@
-name: Check - Main (All tests)
+name: Check - All linters, etc
 on:
   push:
     branches:
@@ -43,6 +43,7 @@ jobs:
       - name: Run all checks
         shell: bash
         run: |
+          make ensure-deps
           make check
       - name: Get dependencies
         shell: bash

--- a/hack/check/.misspellignore
+++ b/hack/check/.misspellignore
@@ -1,3 +1,4 @@
 go.mod
 go.sum
 addons.*upstream.*
+.git

--- a/hack/check/check-misspell.sh
+++ b/hack/check/check-misspell.sh
@@ -21,15 +21,15 @@ misspellignore_files="${CHECK_DIR}/.misspellignore"
 ignore_files=$(cat "${misspellignore_files}")
 
 # check spelling
-RET_VAL=$(git ls-files | grep -v "${ignore_files}" | xargs "${MISSPELL_DIR}/misspell" | grep "misspelling")
+FILES_TO_CHECK=$(git ls-files | grep -v "${ignore_files}")
+echo " "
+echo " "
+echo "Files to check spelling:"
+echo "${FILES_TO_CHECK}"
+echo " "
+echo " "
+echo "Errors:"
+git ls-files | grep -v "${ignore_files}" | xargs "${MISSPELL_DIR}/misspell"
 
 # delete the directory to return environment to original condition
 rm -rf "${MISSPELL_DIR}"
-
-# check return value
-if [[ "${RET_VAL}" != "" ]]; then
-  echo "Please fix the listed misspell errors and verify using 'make misspell'"
-  exit 1
-else
-  echo "misspell check passed!"
-fi


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This does 2 things:
- fix `make misspell` wasn't outputting files with misspelled words
- outlined below... do linting in paralell

In order to reduce the amount of time needed to run a `make check`, we need to parallelize all of the linting targets. To do this, we inspect on mac and linux the number of physical CPUs on the system and run with that many jobs in parallel. We are using physical number of CPUs because that's what is the github runners provide (probably running under some form of virtualization).

Added `--output-sync=target` which basically holds all the output for a given sub-target until the entire target is complete. This is needed because without this option all the output for all the concurrent jobs would be interleaved and show up all at once as lines for each job was emitted.

A side effect is had to break out the `ensure-deps` into a separate explicit step.

Here is the time difference on my Linux VM running with 4 CPUs (note: your actual times are going to vary by number of CPUs and the current load running on them):
```
> make check-parallel
real	4m48.355s
user	1m6.138s
sys	0m33.509s

> make check
real	17m19.689s
user	1m3.225s
sys	0m33.851s
```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/vmware-tanzu/community-edition/issues/3756

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA
