### PR TITLE
Pin GCP upload action to v0.5.0 [main]

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -59,7 +59,7 @@ jobs:
           make build-cli-plugins-nopublish
       - name: Upload Artifacts to Staging Bucket
         id: upload-artifacts-staging
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0.5.0
         with:
           path: ./artifacts
           destination: tce-cli-plugins-staging

--- a/.github/workflows/release-bucket.yaml
+++ b/.github/workflows/release-bucket.yaml
@@ -71,21 +71,21 @@ jobs:
           make release-buckets
       - name: Upload TCE Artifacts to Staging Bucket
         id: upload-artifacts-staging
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0.5.0
         with:
           path: ./artifacts
           destination: tce-cli-plugins-staging
           credentials: ${{ secrets.GCP_BUCKET_SA }}
       - name: Upload TCE Artifacts to Update Bucket
         id: upload-tce-artifacts-update
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0.5.0
         with:
           path: ./artifacts
           destination: tce-cli-plugins
           credentials: ${{ secrets.GCP_BUCKET_SA }}
       - name: Upload TF Artifacts to Update Bucket
         id: upload-tf-artifacts-update
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0.5.0
         with:
           path: /tmp/tce-scratch-space/tanzu-framework/artifacts
           destination: tce-framework-cli-plugins/artifacts
@@ -93,7 +93,7 @@ jobs:
           parent: false
       - name: Upload TF Admin Artifacts to Update Bucket
         id: upload-tf-artifacts-admin-update
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0.5.0
         with:
           path: /tmp/tce-scratch-space/tanzu-framework/artifacts-admin
           destination: tce-framework-cli-plugins-admin/artifacts-admin
@@ -106,14 +106,14 @@ jobs:
         run: make prune-buckets
       - name: Upload TCE Artifacts to Release Bucket
         id: upload-tce-artifacts-release
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0.5.0
         with:
           path: ./artifacts
           destination: tce-tanzu-cli-plugins
           credentials: ${{ secrets.GCP_BUCKET_SA }}
       - name: Upload TF Artifacts to Release Bucket
         id: upload-tf-artifacts-release
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0.5.0
         with:
           path: /tmp/tce-scratch-space/tanzu-framework/artifacts
           destination: tce-tanzu-cli-framework/artifacts
@@ -121,7 +121,7 @@ jobs:
           parent: false
       - name: Upload TF Artifacts-Admin to Release Bucket
         id: upload-tf-artifacts-admin-release
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0.5.0
         with:
           path: /tmp/tce-scratch-space/tanzu-framework/artifacts-admin
           destination: tce-tanzu-cli-framework-admin/artifacts-admin


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
There were breaking changes that occurred in the past couple of days on the GCP bucket upload action. This pins to an older version.

A similar commit was made on the release-0.11 branch here:
https://github.com/vmware-tanzu/community-edition/pull/3709

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA
