### PR TITLE
Fix linting error in harbor tests

### DIFF
--- a/addons/packages/harbor/2.3.3/test/e2e/harbor_suite_test.go
+++ b/addons/packages/harbor/2.3.3/test/e2e/harbor_suite_test.go
@@ -215,7 +215,6 @@ func hasCSIDriver(provisioner string) bool {
 	csidriver, err := utils.Kubectl(nil, "get", "csidriver", "-o", "json")
 	Expect(err).NotTo(HaveOccurred())
 	return strings.Contains(csidriver, provisioner)
-
 }
 
 func getKubernetesVersion() string {


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

PR https://github.com/vmware-tanzu/community-edition/pull/3729 was
merged with failing lint checks caused by an extra line in the code.
This removes the line to get things passing again.

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make lint` and verified it now passes.