### PR TITLE
Fix lint error with extra whitespace in unmanaged code

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -188,7 +188,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int,
 			scConfig.AdditionalPackageRepos = []string{
 				userRepo,
 			}
-		}	
+		}
 	}
 
 	// 3. Resolve all required images
@@ -208,7 +208,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int,
 			log.Style(outputIndent, color.Faint).Infof("%s\n", additionalRepo)
 		}
 	}
-	
+
 	// kapp-controller
 	err = resolveKappBundle(t)
 	if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it

Some whitespace got merged in #3641 - this PR removes that

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
```
❯ golangci-lint run -c ../../../../.golangci.yaml
```
