### PR TITLE
Fixing doc versions for release-0.10

### DIFF
--- a/docs/site/content/docs/assets/cli-install-linux.md
+++ b/docs/site/content/docs/assets/cli-install-linux.md
@@ -25,7 +25,7 @@
 
 ### Option 2: Curl GitHub release
 
-1. Download the release for [Linux](https://github.com/vmware-tanzu/community-edition/releases/download/{{< release_latest >}}/tce-linux-amd64-{{< release_latest >}}.tar.gz) via web browser.
+1. Download the release for [Linux](https://github.com/vmware-tanzu/community-edition/releases/download/v0.10.0/tce-linux-amd64-v0.10.0.tar.gz) via web browser.
 
 1. _[Alternative]_ Download the release using the CLI. You may download a release using the provided remote script piped into bash.
 
@@ -37,21 +37,21 @@
 
     > - Where ``<RELEASE-VERSION>`` is the Tanzu Community Edition release version. This is a required argument.
     > - Where ``<RELEASE-OS-DISTRIBUTION>`` is the Tanzu Community Edition release version and distribution. This is a required argument.
-    > - For example, to download {{< release_latest >}} for Linux, provide:  <br>`bash -s {{< release_latest >}} linux`
+    > - For example, to download v0.10.0 for Linux, provide:  <br>`bash -s v0.10.0 linux`
     > - This script requires `curl`, `grep`, `sed`, `tr`, and `jq` in order to work
-    > - The release will be downloaded to the local directory as `tce-linux-amd64-{{< release_latest >}}.tar.gz`
+    > - The release will be downloaded to the local directory as `tce-linux-amd64-v0.10.0.tar.gz`
     > - *_Note:_* A GitHub personal access token may be provided to the script as the `GITHUB_TOKEN` environment variable. This bypasses GitHub API rate limiting but is _not_ required. Follow [the GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to acquire and use a personal access token.
 
 1. Unpack the release.
 
     ```sh
-    tar xzvf ~/<DOWNLOAD-DIR>/tce-linux-amd64-{{< release_latest >}}.tar.gz
+    tar xzvf ~/<DOWNLOAD-DIR>/tce-linux-amd64-v0.10.0.tar.gz
     ```
 
 1. Run the install script (make sure to use the appropriate directory for your platform).
 
     ```sh
-    cd tce-linux-amd64-{{< release_latest >}}
+    cd tce-linux-amd64-v0.10.0
     ./install.sh
     ```
 

--- a/docs/site/content/docs/assets/cli-install-mac.md
+++ b/docs/site/content/docs/assets/cli-install-mac.md
@@ -15,24 +15,24 @@ You can install the Tanzu CLI using Homebrew **or** you can download the binary 
 1. Run the post install configuration script. Note the output of the `brew install` step for the correct location of the configure script:
 
     ```sh
-    <HOMEBREW-INSTALL-LOCATION>/{{< release_latest >}}/libexec/configure-tce.sh
+    <HOMEBREW-INSTALL-LOCATION>/v0.10.0/libexec/configure-tce.sh
     ```
 
 ## Option 2: Use the binary download/install  method
 
-1. Download the release for [macOS](https://github.com/vmware-tanzu/community-edition/releases/download/{{< release_latest >}}/tce-darwin-amd64-{{< release_latest >}}.tar.gz).
+1. Download the release for [macOS](https://github.com/vmware-tanzu/community-edition/releases/download/v0.10.0/tce-darwin-amd64-v0.10.0.tar.gz).
 
 1. Change to the download directory and unpack the release. Run the following in your terminal:
 
     ```sh
     cd <DOWNLOAD-DIR>
-    tar xzvf ~/<DOWNLOAD-DIR>/tce-darwin-amd64-{{< release_latest >}}.tar.gz
+    tar xzvf ~/<DOWNLOAD-DIR>/tce-darwin-amd64-v0.10.0.tar.gz
 
     ```
 
 1. Change to the extracted directory and run the install script.
 
     ```sh
-    cd tce-darwin-amd64-{{< release_latest >}}
+    cd tce-darwin-amd64-v0.10.0
     ./install.sh
     ```

--- a/docs/site/content/docs/assets/cli-install-windows.md
+++ b/docs/site/content/docs/assets/cli-install-windows.md
@@ -15,19 +15,19 @@ You can install the Tanzu CLI using Chocolatey **or** you can download the binar
 
 ### Option 2: Use the Binary download/installation method
 
-1. Download the release for [Windows](https://github.com/vmware-tanzu/community-edition/releases/download/{{< release_latest >}}/tce-windows-amd64-{{< release_latest >}}.zip).
+1. Download the release for [Windows](https://github.com/vmware-tanzu/community-edition/releases/download/v0.10.0/tce-windows-amd64-v0.10.0.zip).
 
 1. Open Windows PowerShell **as an administrator**, change to the download directory and unpack the release, for example,
 
     ```sh
     cd <DOWNLOAD-DIR>
-    Expand-Archive -Path 'tce-windows-amd64-{{< release_latest >}}.zip'
+    Expand-Archive -Path 'tce-windows-amd64-v0.10.0.zip'
     ```
 
 1. Change to the extracted directory and run `.\install.bat`.
 
     ```sh
-    cd tce-windows-amd64-{{< release_latest >}}\tce-windows-amd64-{{< release_latest >}}
+    cd tce-windows-amd64-v0.10.0\tce-windows-amd64-v0.10.0
     .\install.bat
     ```
 

--- a/docs/site/content/docs/assets/package-installation.md
+++ b/docs/site/content/docs/assets/package-installation.md
@@ -27,7 +27,7 @@ For more information, see [Planning Your Installation](https://tanzucommunityedi
 1. Install the Tanzu Community Edition package repository into the `tanzu-package-repo-global` namespace.
 
     ```sh
-    tanzu package repository add tce-repo --url projects.registry.vmware.com/tce/main:{{< pkg_repo_latest >}} --namespace tanzu-package-repo-global
+    tanzu package repository add tce-repo --url projects.registry.vmware.com/tce/main:0.10.0 --namespace tanzu-package-repo-global
     ```
 
     > * Package repositories are installed into the `default` namespace by default.  
@@ -47,7 +47,7 @@ For more information, see [Planning Your Installation](https://tanzucommunityedi
     / Retrieving repositories...
       NAME      REPOSITORY                                    STATUS
     DETAILS
-      tce-repo  projects.registry.vmware.com/tce/main:{{< pkg_repo_latest >}}  Reconcile succeeded
+      tce-repo  projects.registry.vmware.com/tce/main:0.10.0  Reconcile succeeded
     ```
     > It may take some time to see `Reconcile succeeded`. Until then, packages
     > won't show up in the available list described in the next step.

--- a/docs/site/content/docs/azure-mgmt.md
+++ b/docs/site/content/docs/azure-mgmt.md
@@ -82,7 +82,7 @@ To run management cluster VMs on Microsoft Azure, accept the license for their b
 
 1. Run the `az vm image terms accept` command, specifying the `--plan` and your Subscription ID.
 
-   In Tanzu Community Edition {{< release_latest_no_v >}}, the default cluster image `--plan` value is `k8s-1dot21dot5-ubuntu-2004`, based on Kubernetes version 1.21 and the machine OS, Ubuntu 20.04. Run the following command:
+   In Tanzu Community Edition 0.10.0, the default cluster image `--plan` value is `k8s-1dot21dot5-ubuntu-2004`, based on Kubernetes version 1.21 and the machine OS, Ubuntu 20.04. Run the following command:
 
    ```sh
    az vm image terms accept --publisher vmware-inc --offer tkg-capi --plan k8s-1dot21dot5-ubuntu-2004 --subscription AZURE_SUBSCRIPTION_ID

--- a/docs/site/content/docs/docker-monitoring-stack.md
+++ b/docs/site/content/docs/docker-monitoring-stack.md
@@ -52,7 +52,7 @@ By default, only the `tanzu core` packages are available on the Tanzu cluster. T
 To access the community packages, you will first need to add the `tce` repository.
 
 ```sh
-% tanzu package repository add tce-repo --url projects.registry.vmware.com/tce/main:{{< pkg_repo_latest >}}
+% tanzu package repository add tce-repo --url projects.registry.vmware.com/tce/main:0.10.0
 / Adding package repository 'tce-repo'...
 Added package repository 'tce-repo'
  ```
@@ -63,13 +63,13 @@ Monitor the repo until the STATUS changes to `Reconcile succeeded`. The communit
 % tanzu package repository list -A
 / Retrieving repositories...
   NAME        REPOSITORY                                                                                 STATUS               DETAILS  NAMESPACE
-  tce-repo    projects.registry.vmware.com/tce/main:{{< pkg_repo_latest >}}                                               Reconciling                   default
+  tce-repo    projects.registry.vmware.com/tce/main:0.10.0                                               Reconciling                   default
   tanzu-core  projects-stg.registry.vmware.com/tkg/packages/core/repo:v1.21.2_vmware.1-tkg.1-zshippable  Reconcile succeeded           tkg-system
 
 % tanzu package repository list -A
 / Retrieving repositories...
   NAME        REPOSITORY                                                                                 STATUS               DETAILS  NAMESPACE
-  tce-repo    projects.registry.vmware.com/tce/main:{{< pkg_repo_latest >}}                                               Reconcile succeeded           default
+  tce-repo    projects.registry.vmware.com/tce/main:0.10.0                                               Reconcile succeeded           default
   tanzu-core  projects-stg.registry.vmware.com/tkg/packages/core/repo:v1.21.2_vmware.1-tkg.1-zshippable  Reconcile succeeded           tkg-system
   ```
 

--- a/docs/site/content/docs/package-management.md
+++ b/docs/site/content/docs/package-management.md
@@ -51,7 +51,7 @@ tanzu package repository \
 
     ```sh
     tanzu package repository add tce-repo \
-      --url projects.registry.vmware.com/tce/main:{{< release_latest_no_v >}} \
+      --url projects.registry.vmware.com/tce/main:0.10.0 \
       --namespace tanzu-package-repo-global
     ```
 
@@ -60,7 +60,7 @@ tanzu package repository \
 
     ```sh
     tanzu package repository add tce-repo \
-      --url projects.registry.vmware.com/tce/main:{{< release_latest_no_v >}}
+      --url projects.registry.vmware.com/tce/main:0.10.0
     ```
 
 ### Discovering Package Repositories

--- a/docs/site/content/docs/solutions-secure-ingress.md
+++ b/docs/site/content/docs/solutions-secure-ingress.md
@@ -115,7 +115,7 @@ Complete the following steps:
 1. Install the Tanzu Community Edition package repository into the `tanzu-package-repo-global` namespace.
 
     ```sh
-    tanzu package repository add tce-repo --url projects.registry.vmware.com/tce/main:{{< pkg_repo_latest >}} --namespace tanzu-package-repo-global
+    tanzu package repository add tce-repo --url projects.registry.vmware.com/tce/main:0.10.0 --namespace tanzu-package-repo-global
     ```
 
 1. To list details for the Contour ingress controller package run:

--- a/docs/site/content/docs/vsphere-monitoring-stack.md
+++ b/docs/site/content/docs/vsphere-monitoring-stack.md
@@ -52,7 +52,7 @@ To access the community packages, you will first need to add the `tce` repositor
 
 ```sh
 % tanzu package repository add tce-repo \
-  --url projects.registry.vmware.com/tce/main:{{< pkg_repo_latest >}}
+  --url projects.registry.vmware.com/tce/main:0.10.0
 / Adding package repository 'tce-repo'...
  Added package repository 'tce-repo'
  ```
@@ -63,7 +63,7 @@ Monitor the repo until the STATUS changes to `Reconcile succeeded`. The communit
 % tanzu package repository list -A
 | Retrieving repositories...
   NAME        REPOSITORY                                                                                 STATUS               DETAILS  NAMESPACE
-  tce-repo    projects.registry.vmware.com/tce/main:{{< pkg_repo_latest >}}                                               Reconcile succeeded           default
+  tce-repo    projects.registry.vmware.com/tce/main:0.10.0                                               Reconcile succeeded           default
   tanzu-core  projects-stg.registry.vmware.com/tkg/packages/core/repo:v1.21.2_vmware.1-tkg.1-zshippable  Reconcile succeeded           tkg-system
   ```
 


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
**On release-0.10 branch:** Replaced the following shortcode variables with hard coded values because with new doc versioning, by default- anything outside of docs/content will always read from the main branch - which results in wrong version.

{{< release_latest >}}
{{< release_latest_no_v >}}
{{< pkg_repo_latest >}}

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3750

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
