### PR TITLE
Update package repo for v0.11.0 #3350 (#3453)

### DIFF
--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -3,6 +3,13 @@ packages:
   - name: app-toolkit
     versions:
       - 0.1.0
+  - name: cartographer
+    versions:
+      - 0.2.2
+  - name: cert-injection-webhook
+    versions:
+      - 0.1.0
+      - 0.1.1
   - name: cert-manager
     versions:
       - 1.3.3
@@ -21,6 +28,9 @@ packages:
   - name: fluent-bit
     versions:
       - 1.7.5
+  - name: fluxcd-source-controller
+    versions:
+      - 0.21.2
   - name: gatekeeper
     versions:
       - 3.2.3
@@ -28,6 +38,7 @@ packages:
   - name: grafana
     versions:
       - 7.5.7
+      - 7.5.11
   - name: harbor
     versions:
       - 2.2.3
@@ -41,6 +52,7 @@ packages:
     versions:
       - 0.5.0
       - 0.5.1
+      - 0.5.2
   - name: local-path-storage
     versions:
       - 0.0.19


### PR DESCRIPTION
* Update package repo for v0.11.0 #3350

- App-Toolkit 0.1.0
- Cartographer 0.2.2
- cert-injection-webhook 0.1.0
- Flux CD Source Controller 0.21.2

Signed-off-by: Nicholas Seemiller <nseemiller@vmware.com>

* add Grafana 7.5.11

* Add cert-injection-webhook 0.1.1 and kpack 0.5.2

(cherry picked from commit 1b455081b54e4a84f5250028a955abb10eab8760)

