### PR TITLE
Add start and stop lifecycle hooks for unmanaged-clusters

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cluster/cluster.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cluster/cluster.go
@@ -14,6 +14,13 @@ const (
 	NoneClusterManagerProvider     = "none"
 	KindClusterManagerProvider     = "kind"
 	MinikubeClusterManagerProvider = "minikube"
+
+	// represents a provider believes the cluster is running.
+	StatusRunning = "Running"
+	// represents a provider believes the cluster is stopped.
+	StatusStopped = "Stopped"
+	// represents a provider does not know the state of a cluster.
+	StatusUnknown = "Unknown"
 )
 
 // KubernetesCluster represents a defines k8s cluster.
@@ -22,6 +29,12 @@ type KubernetesCluster struct {
 	Name string
 	// KubeConfig contains the Kubeconfig data for the cluster.
 	Kubeconfig []byte
+	// The state of the cluster as defined by the provider. Examples may be
+	// "Running", "Stopped", or "Unknown".
+	Status string
+	// Specifies the underlying host driver used by the cluster provider. For example,
+	// minikube supports drivers like docker and kvm.
+	Driver string
 }
 
 // Manager provides methods for creating and managing Kubernetes
@@ -50,6 +63,10 @@ type Manager interface {
 	// to log after bootstrapping has finished.
 	// Each string will be displayed on its own line.
 	PostProviderNotify() []string
+	/// Stop attempts to stop a running cluster.
+	Stop(c *config.UnmanagedClusterConfig) error
+	// Start attempts to start a stopped cluster.
+	Start(c *config.UnmanagedClusterConfig) error
 }
 
 // NewClusterManager provides a way to dynamically get a cluster manager based on the unmanaged cluster config provider

--- a/cli/cmd/plugin/unmanaged-cluster/cluster/kind.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cluster/kind.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/yaml.v3"
 	kindconfig "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	kindcluster "sigs.k8s.io/kind/pkg/cluster"
+	"sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/exec"
 
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/config"
@@ -104,8 +105,8 @@ func (kcm *KindClusterManager) Create(c *config.UnmanagedClusterConfig) (*Kubern
 	}
 
 	if strings.Contains(c.Cni, "antrea") {
-		nodes, _ := kindProvider.ListNodes(c.ClusterName)
-		for _, n := range nodes {
+		kindNodes, _ := kindProvider.ListNodes(c.ClusterName)
+		for _, n := range kindNodes {
 			if err := patchForAntrea(n.String()); err != nil { //nolint:staticcheck
 				// TODO(stmcginnis): We probably don't want to just error out
 				// since the cluster has already been created, but we should
@@ -144,11 +145,11 @@ func kindConfigFromClusterConfig(c *config.UnmanagedClusterConfig) ([]byte, erro
 	kindConfig.Kind = "Cluster"
 	kindConfig.APIVersion = "kind.x-k8s.io/v1alpha4"
 	kindConfig.Name = c.ClusterName
-	nodes, err := setNumberOfNodes(c)
+	kindNodes, err := setNumberOfNodes(c)
 	if err != nil {
 		return nil, err
 	}
-	kindConfig.Nodes = nodes
+	kindConfig.Nodes = kindNodes
 	kindconfig.SetDefaultsCluster(kindConfig)
 
 	// Now populate or override with the specified configuration
@@ -247,14 +248,14 @@ func setNumberOfNodes(c *config.UnmanagedClusterConfig) ([]kindconfig.Node, erro
 		return nil, fmt.Errorf("multiple control plane nodes require at least one worker node for workload placement")
 	}
 
-	nodes := []kindconfig.Node{}
+	kindNodes := []kindconfig.Node{}
 
 	for i := 1; i <= cpnc; i++ {
 		n := kindconfig.Node{
 			Role: kindconfig.ControlPlaneRole,
 		}
 
-		nodes = append(nodes, n)
+		kindNodes = append(kindNodes, n)
 	}
 
 	for i := 1; i <= wnc; i++ {
@@ -262,22 +263,151 @@ func setNumberOfNodes(c *config.UnmanagedClusterConfig) ([]kindconfig.Node, erro
 			Role: kindconfig.WorkerRole,
 		}
 
-		nodes = append(nodes, n)
+		kindNodes = append(kindNodes, n)
 	}
 
-	return nodes, nil
+	return kindNodes, nil
 }
 
-// Get retrieves cluster information or return an error indicating a problem.
-// TODO - (jpmcb) We currently do not utilize the Get API on cluster providers
+// Get retrieves cluster information. An error is returned if no cluster is
+// found or if there is a failure communicating with kind/docker.
 func (kcm *KindClusterManager) Get(clusterName string) (*KubernetesCluster, error) {
-	return nil, nil
+	var resolvedStatus string
+
+	// use kind APIs to get node name
+	provider := kindcluster.NewProvider()
+	kindNodes, err := provider.ListNodes(clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	// no cluster corresponding to name found
+	if len(kindNodes) < 1 {
+		return nil, fmt.Errorf("cluster %s could not be found by kind", clusterName)
+	}
+
+	// get the JSON-representation of the control-plane node and serialize it into a map
+	cmdFindStatus := exec.Command("docker",
+		"container",
+		"ls",
+		"-a",
+		"--filter",
+		// name filter prepends names with ^/ and appends with $ since name filtering is a fuzzy
+		// search by default.
+		fmt.Sprintf("name=^/%s$", kindNodes[0]),
+		"--format",
+		"{{json .}}")
+
+	cmdFindStatusOutput, err := exec.Output(cmdFindStatus)
+	if err != nil {
+		return nil, err
+	}
+
+	// serialize into a map. No need to maintain a struct to serialize over time.
+	// we are only interested in a single key. If it isn't found, we return status of
+	// Unknown.
+	var container map[string]interface{}
+	err = json.Unmarshal(cmdFindStatusOutput, &container)
+	if err != nil {
+		return nil, fmt.Errorf("data returned from kind/docker could not be parsed as valid JSON. Error: %s", err)
+	}
+
+	if _, ok := container["State"]; !ok {
+		return nil, fmt.Errorf("docker returned no status field for container")
+	}
+
+	// "running" and "existing" are known-good status from docker. Any other value should be
+	// considered unknown.
+	switch container["State"] {
+	case "running":
+		resolvedStatus = StatusRunning
+	case "exited":
+		resolvedStatus = StatusStopped
+	default:
+		resolvedStatus = StatusUnknown
+	}
+
+	kc := &KubernetesCluster{
+		Name: clusterName,
+		// TODO(joshrosso): We should consider this field in future
+		// work. Perhaps when we expose get at the CLI level, we could
+		// do a command like `tanzu uc get ${CLUSTER_NAME} --kubeconfig` and return this value.
+		Kubeconfig: []byte{},
+		Status:     resolvedStatus,
+	}
+
+	return kc, nil
 }
 
 // Delete removes a kind cluster.
 func (kcm *KindClusterManager) Delete(c *config.UnmanagedClusterConfig) error {
 	provider := kindcluster.NewProvider()
 	return provider.Delete(c.ClusterName, "")
+}
+
+// Stop takes a running kind cluster and stops the host.
+func (kcm *KindClusterManager) Stop(c *config.UnmanagedClusterConfig) error {
+	// verify cluster is in a "Running" state before attempting to stop.
+	kc, err := kcm.Get(c.ClusterName)
+	if err != nil {
+		return fmt.Errorf("cannot stop this cluster. Error occurred retrieving status: %s", err.Error())
+	}
+	if kc.Status != StatusRunning {
+		return fmt.Errorf("cannot stop this cluster. The status must be %s, it was %s", StatusRunning, kc.Status)
+	}
+
+	kindNode, err := resolveKindNodesForSingleNodeCluster(c.ClusterName)
+	if err != nil {
+		return err
+	}
+
+	id, err := retrieveContainerIDFromName(kindNode.String())
+	if err != nil {
+		return err
+	}
+
+	// note: originally tried "docker stop" but found clusters could not recover.
+	//       perhaps due to an improper signal being sent to them?
+	stopCmd := exec.Command("docker", "kill", id)
+	_, err = exec.Output(stopCmd)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Start attempts to start a kind cluster. It returns an error when:
+// 1. The cluster is already running.
+// 2. There are issues communicating with kind/docker.
+// 3. The cluster fails to start.
+func (kcm *KindClusterManager) Start(c *config.UnmanagedClusterConfig) error {
+	// verify cluster is in a "Stopped" state before attempting to start.
+	kc, err := kcm.Get(c.ClusterName)
+	if err != nil {
+		return fmt.Errorf("cannot start this cluster. Error occurred retrieving status: %s", err.Error())
+	}
+	if kc.Status != StatusStopped {
+		return fmt.Errorf("cannot start this cluster. The status must be %s, it was %s", StatusStopped, kc.Status)
+	}
+
+	kindNode, err := resolveKindNodesForSingleNodeCluster(c.ClusterName)
+	if err != nil {
+		return err
+	}
+
+	id, err := retrieveContainerIDFromName(kindNode.String())
+	if err != nil {
+		return err
+	}
+
+	startCmd := exec.Command("docker", "start", id)
+	_, err = exec.Output(startCmd)
+	if err != nil {
+		return fmt.Errorf("failed to start cluster via kind. Error was: %s", err)
+	}
+
+	return nil
 }
 
 // Prepare will fetch a container image to the cluster host.
@@ -361,6 +491,71 @@ func validateDockerInfo(output []byte) ([]string, []error) {
 	}
 
 	return warnings, issues
+}
+
+// resolveKindNodesForSingleNodeCluster resolves the node that makes up a single-node kind cluster.
+// This helper-function supports the start/stop functionality of this kind provider. It returns an
+// error when:
+// a. There is a failure to communicate with kind or docker
+// b. It finds no nodes associated with the cluster
+// c. It find more than 1 nodes associated with the cluster
+//
+// c is required as, at the time of writing, kind does not supporting starting/stopping a
+// multi-node cluster.
+func resolveKindNodesForSingleNodeCluster(clusterName string) (nodes.Node, error) {
+	// use kind APIs to get node name
+	provider := kindcluster.NewProvider()
+	kindNodes, err := provider.ListNodes(clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	// if kind does not find any nodes associated with the cluster name, fail and return an error.
+	if len(kindNodes) < 1 {
+		return nil, fmt.Errorf("kind failed to find nodes associated with the cluster %s", clusterName)
+	}
+
+	// kind does not support starting/stopping of multi-node clusters. If the cluster contains
+	// more than one node, do attempt to stop the cluster and return the error to the user.
+	if len(kindNodes) > 1 {
+		return nil, fmt.Errorf("cannot stop cluster. Kind does not support stopping and starting multi-node clusters")
+	}
+
+	return kindNodes[0], nil
+}
+
+// retrieveContainerIDFromName returns a container's ID based on the name provided. It uses docker
+// to retrieve the ID. If there are issues communicating with docker, an error is returned.
+func retrieveContainerIDFromName(name string) (string, error) {
+	// get the json-representation of the control-plane node and serialize it into a map
+	cmdFindID := exec.Command("docker",
+		"container",
+		"ls",
+		"-a",
+		"--filter",
+		// name filter prepends names with ^/ and appends with $ since name filtering is a fuzzy
+		// search by default.
+		fmt.Sprintf("name=^/%s$", name),
+		"--format",
+		"{{json .}}")
+
+	findIDOutput, err := exec.Output(cmdFindID)
+	if err != nil {
+		return "", err
+	}
+
+	var container map[string]interface{}
+	err = json.Unmarshal(findIDOutput, &container)
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve valid JSON from docker when looking up containerId for %s. Error: %s", name, err)
+	}
+
+	// If no ID field is present on the container, return an error.
+	if _, ok := container["ID"]; !ok {
+		return "", fmt.Errorf("found no ID associated with container")
+	}
+
+	return container["ID"].(string), nil
 }
 
 // patchForAntrea modifies the node network settings to allow local routing.

--- a/cli/cmd/plugin/unmanaged-cluster/cluster/minikube.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cluster/minikube.go
@@ -27,13 +27,52 @@ type MinikubeClusterManager struct {
 }
 
 type MinikubeProfile struct {
-	Name   string `json:"Name"`
-	Status string `json:"Status"`
+	Name   string         `json:"Name"`
+	Status string         `json:"Status"`
+	Config MinikubeConfig `json:"Config"`
 }
 
 type MinikubeProfiles struct {
 	Invalid []MinikubeProfile `json:"invalid"`
 	Valid   []MinikubeProfile `json:"valid"`
+}
+
+type MinikubeConfig struct {
+	Driver string `json:"Driver"`
+}
+
+// Get retrieves cluster information. An error is returned if no cluster is
+// found or if there is a failure communicating with minikube.
+func (mkcm *MinikubeClusterManager) Get(clusterName string) (*KubernetesCluster, error) {
+	var resolvedStatus string
+
+	mkp, err := mkcm.getProfile(clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find a cluster profile with name %s via minikube", clusterName)
+	}
+
+	// "Running" and "Stopped" are known-good status from minikube. Any other value should be
+	// considered unknown.
+	switch mkp.Status {
+	case "Running":
+		resolvedStatus = StatusRunning
+	case "Stopped":
+		resolvedStatus = StatusStopped
+	default:
+		resolvedStatus = StatusUnknown
+	}
+
+	kc := &KubernetesCluster{
+		Name: clusterName,
+		// TODO(joshrosso): We should consider this field in future
+		// work. Perhaps when we expose get at the CLI level, we could
+		// do a command like `tanzu uc get ${CLUSTER_NAME} --kubeconfig` and return this value.
+		Kubeconfig: []byte{},
+		Status:     resolvedStatus,
+		Driver:     mkp.Config.Driver,
+	}
+
+	return kc, nil
 }
 
 // Create creates a minikube cluster with a given profile name
@@ -153,12 +192,6 @@ func (mkcm *MinikubeClusterManager) Create(c *config.UnmanagedClusterConfig) (*K
 	return kc, nil
 }
 
-// Get returns cluster information or returns an error
-// TODO - (jpmcb) We currently do not utilize the Get API on cluster providers
-func (mkcm *MinikubeClusterManager) Get(clusterName string) (*KubernetesCluster, error) {
-	return nil, nil
-}
-
 // Delete will delete the minikube cluster given a named profile
 func (mkcm *MinikubeClusterManager) Delete(c *config.UnmanagedClusterConfig) error {
 	profile, err := mkcm.getProfile(c.ClusterName)
@@ -220,6 +253,69 @@ func (mkcm *MinikubeClusterManager) PreProviderNotify() []string {
 // PostProviderNotify returns the aggregate logs from the minikube bootstrapping
 func (mkcm *MinikubeClusterManager) PostProviderNotify() []string {
 	return mkcm.logs
+}
+
+// Start attempts to start a stopped minikube cluster. An error is returned when:
+// 1. The cluster is already running.
+// 2. There are issues communicating with minikube.
+// 3. The cluster fails to start.
+func (mkcm *MinikubeClusterManager) Start(c *config.UnmanagedClusterConfig) error {
+	// verify cluster is in a "Stopped" state before attempting to start.
+	kc, err := mkcm.Get(c.ClusterName)
+	if err != nil {
+		return fmt.Errorf("cannot start this cluster. Error occurred retrieving status: %s", err.Error())
+	}
+	if kc.Status != StatusStopped {
+		return fmt.Errorf("cannot start this cluster. The status must be %s, it was %s", StatusStopped, kc.Status)
+	}
+
+	args := []string{
+		"start",
+		"--profile",
+		kc.Name,
+		// specifying the driver is key as the user may have a global driver config with minikube
+		// (via minikube config) and if their global setting is different from the driver used
+		// to start this cluser, creation will fail. Since we lookup the cluster details and know
+		// the driver, we always specify it when running Start.
+		"--driver",
+		kc.Driver,
+	}
+	cmd := exec.Command(minikubeBinName, args...)
+
+	// TODO(joshrosso): starting a cluster can take 1+ minute(s). Could be worth finding a way
+	// to propagate details to the client.
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to start cluster via minikube. Error: %s", err)
+	}
+
+	return nil
+}
+
+// Stop takes a running minikube cluster and stops the host(s).
+func (mkcm *MinikubeClusterManager) Stop(c *config.UnmanagedClusterConfig) error {
+	// verify cluster is in a "Running" state before attempting to stop.
+	kc, err := mkcm.Get(c.ClusterName)
+	if err != nil {
+		return fmt.Errorf("cannot stop this cluster. Error occurred retrieving status: %s", err.Error())
+	}
+	if kc.Status != StatusRunning {
+		return fmt.Errorf("cannot stop this cluster. The status must be %s, it was %s", StatusRunning, kc.Status)
+	}
+
+	args := []string{
+		"stop",
+		"--profile",
+		kc.Name,
+	}
+	cmd := exec.Command(minikubeBinName, args...)
+
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to stop cluster via minikube. Error: %s", err)
+	}
+
+	return nil
 }
 
 // getProfile attempts to retrieve a minikube profile by name

--- a/cli/cmd/plugin/unmanaged-cluster/cluster/noop.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cluster/noop.go
@@ -4,6 +4,7 @@
 package cluster
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/config"
@@ -29,7 +30,12 @@ func (ncm NoopClusterManager) Create(c *config.UnmanagedClusterConfig) (*Kuberne
 
 // Get retrieves cluster information or return an error indicating a problem.
 func (ncm NoopClusterManager) Get(clusterName string) (*KubernetesCluster, error) {
-	return nil, nil
+	c := KubernetesCluster{
+		Name:       clusterName,
+		Kubeconfig: []byte{},
+		Status:     StatusUnknown,
+	}
+	return &c, nil
 }
 
 // Delete for noop does nothing since these clusters have no provider and are not lifecycled
@@ -56,4 +62,14 @@ func (ncm NoopClusterManager) PreProviderNotify() []string {
 // PostProviderNotify is a noop. Nothing to log about for the noop provider
 func (ncm NoopClusterManager) PostProviderNotify() []string {
 	return []string{}
+}
+
+// Stop returns an error letting the client know we cannot stop a Noop cluster.
+func (ncm NoopClusterManager) Stop(c *config.UnmanagedClusterConfig) error {
+	return fmt.Errorf("this cluster was not created by \"tanzu unmanaged-cluster create\". It cannot be stopped")
+}
+
+// Start returns an error letting the client know we cannot start a Noop cluster.
+func (ncm NoopClusterManager) Start(c *config.UnmanagedClusterConfig) error {
+	return fmt.Errorf("this cluster was not created by \"tanzu unmanaged-cluster create\". It cannot be started")
 }

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -67,7 +67,7 @@ Exit codes are provided to enhance the automation of bootstrapping and are defin
 // CreateCmd creates an unmanaged workload cluster.
 var CreateCmd = &cobra.Command{
 	Use:   "create <cluster name>",
-	Short: "Create an unmanaged Tanzu cluster",
+	Short: "Create an unmanaged cluster",
 	Long:  createDesc,
 	Run:   create,
 	Args:  cobra.MaximumNArgs(1),

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
@@ -19,7 +19,7 @@ and remove the configuration stored in $HOME/.config/tanzu/tkg/unmanaged/${CLUST
 // DeleteCmd deletes an unmanaged workload cluster.
 var DeleteCmd = &cobra.Command{
 	Use:   "delete <cluster name>",
-	Short: "Delete an unmanaged tanzu cluster",
+	Short: "Delete an unmanaged cluster",
 	Long:  deleteDesc,
 	PreRunE: func(cmd *cobra.Command, args []string) (err error) {
 		return nil
@@ -35,7 +35,7 @@ func init() {
 	DeleteCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
 }
 
-func destroy(cmd *cobra.Command, args []string) error {
+func destroy(cmd *cobra.Command, args []string) error { //nolint
 	var clusterName string
 
 	// validate a cluster name was passed

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/start.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/start.go
@@ -1,0 +1,58 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd // nolint:dupl
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/log"
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/tanzu"
+)
+
+const startDesc = `
+Start an existing Tanzu unmanaged cluster.`
+
+// StartCmd starts a stopped cluster.
+var StartCmd = &cobra.Command{
+	Use:   "start <cluster name>",
+	Short: "(experimental) Start an unmanaged cluster",
+	Long:  startDesc,
+	PreRunE: func(cmd *cobra.Command, args []string) (err error) {
+		return nil
+	},
+	RunE: start,
+	PostRunE: func(cmd *cobra.Command, args []string) (err error) {
+		return nil
+	},
+}
+
+func init() {
+	StartCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
+}
+
+func start(cmd *cobra.Command, args []string) error { // nolint:dupl
+	var clusterName string
+
+	// validate a cluster name was passed
+	if len(args) < 1 {
+		return fmt.Errorf("must specify cluster name to start")
+	} else if len(args) == 1 {
+		clusterName = args[0]
+	}
+	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+
+	log.Eventf(logger.TestTubeEmoji, "Attempting to start cluster: %s\n", clusterName)
+	tClient := tanzu.New(log)
+	err := tClient.Start(clusterName)
+	if err != nil {
+		log.Errorf("Failed to start cluster. Error: %s\n", err.Error())
+		return nil
+	}
+
+	log.Eventf(logger.TestTubeEmoji, "Started cluster: %s\n", clusterName)
+
+	return nil
+}

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/stop.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/stop.go
@@ -1,0 +1,59 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd // nolint:dupl
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/log"
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/tanzu"
+)
+
+const stopDesc = `
+Stop a Tanzu unmanaged cluster. If supported, you can start it at a later point
+in time.`
+
+// StopCmd stops a running cluster.
+var StopCmd = &cobra.Command{
+	Use:   "stop <cluster name>",
+	Short: "(experimental) Stop an unmanaged cluster",
+	Long:  stopDesc,
+	PreRunE: func(cmd *cobra.Command, args []string) (err error) {
+		return nil
+	},
+	RunE: stop,
+	PostRunE: func(cmd *cobra.Command, args []string) (err error) {
+		return nil
+	},
+}
+
+func init() {
+	StopCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
+}
+
+func stop(cmd *cobra.Command, args []string) error { // nolint:dupl
+	var clusterName string
+
+	// validate a cluster name was passed
+	if len(args) < 1 {
+		return fmt.Errorf("must specify cluster name to stop")
+	} else if len(args) == 1 {
+		clusterName = args[0]
+	}
+	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+
+	log.Eventf(logger.TestTubeEmoji, "Attempting to stop cluster: %s\n", clusterName)
+	tClient := tanzu.New(log)
+	err := tClient.Stop(clusterName)
+	if err != nil {
+		log.Errorf("Failed to stop cluster. Error: %s\n", err.Error())
+		return nil
+	}
+
+	log.Eventf(logger.TestTubeEmoji, "Stopped cluster: %s\n", clusterName)
+
+	return nil
+}

--- a/cli/cmd/plugin/unmanaged-cluster/main.go
+++ b/cli/cmd/plugin/unmanaged-cluster/main.go
@@ -43,6 +43,8 @@ func main() {
 		cmd.CreateCmd,
 		cmd.DeleteCmd,
 		cmd.ListCmd,
+		cmd.StopCmd,
+		cmd.StartCmd,
 	)
 
 	cmd.SetupRootCommand(p.Cmd)

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -58,6 +58,7 @@ const cniNoneName = "none"
 type Cluster struct {
 	Name     string
 	Provider string
+	Status   string
 }
 
 // UnmanagedCluster contains information about an unmanaged Tanzu cluster.
@@ -88,6 +89,13 @@ type Manager interface {
 	// Delete takes a cluster name and removes the cluster from the underlying cluster provider. If it is unable
 	// to communicate with the underlying cluster provider, it returns an error.
 	Delete(name string) error
+	// Stop takes a cluster name and attempts to stop a running cluster. If it is unable
+	// to communicate with the underlying cluster provider, it returns an error.
+	Stop(name string) error
+	// Start takes a cluster name and attempts to start a stopped cluster. If
+	// there are issues starting the cluster or communitcating with the
+	// underlying provider, an error is returned.
+	Start(name string) error
 }
 
 // New returns a TanzuMgr for interacting with unmanaged clusters. It is implemented by TanzuUnmanaged.
@@ -465,6 +473,48 @@ func (t *UnmanagedCluster) Delete(name string) error {
 	}
 
 	log.Style(outputIndent, color.Faint).Infof("Local config files directory deleted: %s\n", t.clusterDirectory)
+	return nil
+}
+
+// Stop tells an unmanaged cluster to no longer continue running.
+func (t *UnmanagedCluster) Stop(name string) error {
+	configPath, err := resolveClusterConfig(name)
+	if err != nil {
+		return err
+	}
+	t.config, err = config.RenderFileToConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	cm := cluster.NewClusterManager(t.config)
+
+	err = cm.Stop(t.config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Start tells an unmanaged cluster to start a cluster that is not currently running.
+func (t *UnmanagedCluster) Start(name string) error {
+	configPath, err := resolveClusterConfig(name)
+	if err != nil {
+		return err
+	}
+	t.config, err = config.RenderFileToConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	cm := cluster.NewClusterManager(t.config)
+
+	err = cm.Start(t.config)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## What this PR does / why we need it

This commit adds start and stop functionality to the cluster manager
interface. Providers can implement the ability to start or stop clusters
based on the call to this method.

## Which issue(s) this PR fixes

Fixes: https://github.com/vmware-tanzu/community-edition/issues/2987

## Describe testing done for PR

### Example usage

**:speaker:  audio included**

https://user-images.githubusercontent.com/6200057/162794149-afa9057c-2f25-452b-8ac9-ce2b5ad117d3.mp4

## Special notes for your reviewer

See the example usage above. Otherwise, please review, suggest, and test.

## Next steps:

* [x] Add cluster status column to `tanzu uc ls`
* [x] Implement start stop in minikube provider (awaiting https://github.com/vmware-tanzu/community-edition/pull/3674)
* [x] Make kind container resolution smarter (some refactoring in the provider)
* [x] Open an issue in upstream kind to see if they'd be interested in native Start/Stop support for single node clusters.
    * https://github.com/kubernetes-sigs/kind/issues/2715
* [x] Create issue for tracking viability of start/stop with `kind`. Reassess during next release.
    * https://github.com/vmware-tanzu/community-edition/issues/3977