### PR TITLE
GitHub Actions: Use Unique Runners Per `RunAttempt`

### DIFF
--- a/.github/workflows/build-daily.yaml
+++ b/.github/workflows/build-daily.yaml
@@ -19,7 +19,10 @@ jobs:
         id: start-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   build-release:
@@ -88,5 +91,8 @@ jobs:
         id: stop-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -24,7 +24,10 @@ jobs:
         id: start-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   build-release:
@@ -77,5 +80,8 @@ jobs:
         id: stop-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/.github/workflows/check-all.yaml
+++ b/.github/workflows/check-all.yaml
@@ -18,7 +18,10 @@ jobs:
         id: start-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   build-release:
@@ -69,5 +72,8 @@ jobs:
         id: stop-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/.github/workflows/check-pr-diagnostics-plugin.yaml
+++ b/.github/workflows/check-pr-diagnostics-plugin.yaml
@@ -26,7 +26,10 @@ jobs:
         id: start-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   build-release:
@@ -88,5 +91,8 @@ jobs:
         id: stop-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/.github/workflows/check-pr-docker-management.yaml
+++ b/.github/workflows/check-pr-docker-management.yaml
@@ -23,7 +23,10 @@ jobs:
         id: start-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   build-release:
@@ -102,5 +105,8 @@ jobs:
         id: stop-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
@@ -2,6 +2,8 @@ name: E2E Test - AWS Management and Workload Cluster
 
 on:
   workflow_dispatch:
+  repository_dispatch:
+    types: [daily-build]
   push:
     branches:
       - main
@@ -27,7 +29,10 @@ jobs:
         id: start-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   e2e-aws-managed-test:
@@ -90,5 +95,8 @@ jobs:
         id: stop-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
@@ -2,6 +2,8 @@ name: E2E Test - Azure Management and Workload Cluster
 
 on:
   workflow_dispatch:
+  repository_dispatch:
+    types: [daily-build]
   push:
     branches:
       - main
@@ -27,7 +29,10 @@ jobs:
         id: start-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   e2e-azure-management-and-workload-test:
@@ -89,5 +94,8 @@ jobs:
         id: stop-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/.github/workflows/release-bucket.yaml
+++ b/.github/workflows/release-bucket.yaml
@@ -25,7 +25,10 @@ jobs:
         id: start-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   build-release:
@@ -140,5 +143,8 @@ jobs:
         id: stop-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,10 @@ jobs:
         id: start-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
   build-release:
@@ -153,5 +156,8 @@ jobs:
         id: stop-ec2-runner
         shell: bash
         run: |
-          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/hack/runner/webhook/server.go
+++ b/hack/runner/webhook/server.go
@@ -304,14 +304,18 @@ func doWorkflowJob(workflowJob *webhook.WorkflowJobPayload, create bool) error {
 		return err
 	}
 
+	workflowName := workflowRun.WorkflowRun.Name
 	workflowID := workflowRun.WorkflowRun.ID
 	workflowRunNumber := workflowRun.WorkflowRun.RunNumber
-	workflowName := workflowRun.WorkflowRun.Name
+	workflowRunAttempt := workflowJob.WorkflowJob.RunAttempt
+	klog.Infof("workflowName: %s\n", workflowName)
+	klog.Infof("workflowID: %d\n", workflowID)
+	klog.Infof("workflowRunNumber: %d\n", workflowRunNumber)
+	klog.Infof("WorkflowJob.RunAttempt: %d\n", workflowRunAttempt)
 
-	uniqueRunnerName := fmt.Sprintf("id-%d-%d", workflowID, workflowRunNumber)
+	uniqueRunnerName := fmt.Sprintf("id-%d-%d-%d", workflowID, workflowRunNumber, workflowRunAttempt)
 	klog.Infof("uniqueRunnerName: %s\n", uniqueRunnerName)
 
-	klog.Infof("Workflow is requested.  ID: %s, Name: %s\n", uniqueRunnerName, workflowName)
 	if create {
 		err = createRunner(uniqueRunnerName)
 		if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
After switching from the first version of the GH Actions using self-hosted runners in favor of the WebHook method for creating runners (v2), we regressed a feature that gave us unique runners per `RunAttempt` where we reused the same runner if a new `RunAttempt` was received before the self-hosted runner was deleted. This is a common occurrence especially when doing multiple subsequent pushes to your branch on the same PR. This PR now will give us a unique runner for each PR's RunAttempt.

Made a slight change to trigger the E2Es from the daily build.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
As best as I could without actually throwing this into production. I create a test binary that output in debug logs what I was expecting to happen without actually triggering the new webhook. Unfortunately, this PR needs to be merged at the same time the webhook service is replaced.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA