### PR TITLE
urllint: use unbuffered async channel

### DIFF
--- a/hack/check/urllinter/pkg/lint/lint.go
+++ b/hack/check/urllinter/pkg/lint/lint.go
@@ -219,7 +219,7 @@ func (llc *LinkLintConfig) LintAll() bool {
 	linkCount := len(llc.LinkMap)
 
 	// Limit the number of GET requests so we don't get rate limited
-	results := make(chan checkResult, 2)
+	results := make(chan checkResult)
 	wg := sync.WaitGroup{}
 
 	isFatal := false


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We are seeing periodic failures checking URLs, even though these URLs
are valid, well-known sites such as sonobuoy.io. It's possible that even
with the small number of concurrent requests we make, that could be
triggering some sort of DoS protection from these sites.

This changes the async queue we use for processing results to be
unbuffered. It had been a buffered queue of 2, so we could have multiple
GET checks happening simultaneously. An unbuffered queue will block the
from moving on to the next check until the result is picked up to be
processed. Even with this unbuffered change, the speed is just over 4
seconds to check all URLs versus the original 60 second time seen when
all checks were fully sequentual.