### PR TITLE
e2e test for unmanaged-cluster

### DIFF
--- a/.github/workflows/e2e-unmanaged-cluster.yaml
+++ b/.github/workflows/e2e-unmanaged-cluster.yaml
@@ -1,0 +1,88 @@
+---
+name: E2E Test - Unamanged Cluster
+
+on:
+  repository_dispatch:
+    types: [daily-build]
+
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - cli/cmd/plugin/unmanaged-cluster
+
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - release-*
+
+    paths:
+      - "cli/cmd/plugin/unmanaged-cluster"
+      - ".github/workflows/e2e-unmanaged-cluster.yaml"
+      - "Makefile"
+
+    tags-ignore:
+      - "**"
+
+jobs:
+  setup-runner:
+    name: Start self-hosted EC2 runner
+    runs-on: ubuntu-latest
+    outputs:
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        shell: bash
+        run: |
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
+          echo "INSTANCE_NAME: ${INSTANCE_NAME}"
+          echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
+
+  e2e-unmanaged-cluster-test:
+    name: E2E Unmanaged Cluster Test
+    needs: setup-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.setup-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.17"
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Run Unamanged Cluster E2E Test
+        run: |
+          make unmanaged-cluster-e2e-test
+
+      - name: Collect tanzu diagnostics data
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: diagnostics-data
+          path: |
+            bootstrap.*.diagnostics.tar.gz
+            management-cluster.*.diagnostics.tar.gz
+            workload-cluster.*.diagnostics.tar.gz
+
+  teardown-runner:
+    name: Stop self-hosted EC2 runner
+    needs:
+      - setup-runner # required to get output from the setup-runner job
+      - e2e-unmanaged-cluster-test # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stop EC2 runner
+        id: stop-ec2-runner
+        shell: bash
+        run: |
+          echo "GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}"
+          echo "GITHUB_RUN_ATTEMPT: ${GITHUB_RUN_ATTEMPT}"
+          INSTANCE_NAME="id-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
+          echo "INSTANCE_NAME: ${INSTANCE_NAME}"

--- a/Makefile
+++ b/Makefile
@@ -515,4 +515,8 @@ docker-management-and-cluster-e2e-test:
 # vSphere Management + Workload Cluster E2E Test
 vsphere-management-and-workload-cluster-e2e-test:
 	BUILD_VERSION=$(BUILD_VERSION) test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
+
+unmanaged-cluster-e2e-test:
+	cd cli/cmd/plugin/unmanaged-cluster/test/e2e && go test -test.v -timeout 180m
+
 ##### E2E TESTS

--- a/addons/packages/external-dns/0.10.0/test/tools/tools.go
+++ b/addons/packages/external-dns/0.10.0/test/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools

--- a/addons/packages/external-dns/0.11.0/test/tools/tools.go
+++ b/addons/packages/external-dns/0.11.0/test/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools

--- a/addons/packages/harbor/2.2.3/test/tools.go
+++ b/addons/packages/harbor/2.2.3/test/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools

--- a/addons/packages/harbor/2.3.3/test/tools.go
+++ b/addons/packages/harbor/2.3.3/test/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools

--- a/addons/packages/harbor/2.4.2/test/tools.go
+++ b/addons/packages/harbor/2.4.2/test/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools

--- a/cli/cmd/plugin/unmanaged-cluster/Makefile
+++ b/cli/cmd/plugin/unmanaged-cluster/Makefile
@@ -21,7 +21,7 @@ test: ## Run unit testing suite
 	echo "N/A: No unit tests for unmanaged-cluster"
 
 e2e-test: ## Run e2e testing suite
-	echo "N/A: No e2e tests for unmanaged-cluster"
+	cd test/e2e && go test -timeout 180m
 
 build: ## Build the executable
 	echo "N/A: Implement building"

--- a/cli/cmd/plugin/unmanaged-cluster/test/e2e/Readme.md
+++ b/cli/cmd/plugin/unmanaged-cluster/test/e2e/Readme.md
@@ -1,0 +1,10 @@
+# Unmanaged cluster e2e test
+
+To run unmanaged cluster e2e-test.
+
+```bash
+#!/bin/bash
+make e2e-test
+```
+
+For now test is supporting LINUX and Mac only.

--- a/cli/cmd/plugin/unmanaged-cluster/test/e2e/e2e_suite_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/test/e2e/e2e_suite_test.go
@@ -1,0 +1,126 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"regexp"
+	"testing"
+
+	e2e "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/test/e2e/utils"
+)
+
+var clusterName string
+
+const (
+	colorReset = "\033[0m" // Reset
+	colorBlue  = "\033[34m"
+	colorRed   = "\033[31m" // Fail
+	colorGreen = "\033[32m" // Pass
+	passConst  = "GREEN"
+	failConst  = "RED"
+)
+
+// installing TCE
+func TestTCEInstallation(t *testing.T) {
+	signal := passConst
+	fmt.Println("-------------------------------", string(colorBlue), "Unmanged cluster e2e Test", string(colorReset), "---------------------------------------------")
+	err := e2e.InstallTCE()
+	if err != nil {
+		t.Errorf("Error while installing TCE: %v", err)
+		signal = failConst
+	}
+	if signal == failConst {
+		fmt.Println("-------------------------------", string(colorRed), "TCE installation Failed", string(colorReset), "---------------------------------------------")
+	} else {
+		fmt.Println("-------------------------------", string(colorGreen), "TCE installation Passed", string(colorReset), "---------------------------------------------")
+	}
+}
+
+// Installing Unmanahged cluster
+func TestUCInstallation(t *testing.T) {
+	signal := passConst
+
+	// Random Unmanged Cluster Name
+	rand, _ := rand.Int(rand.Reader, big.NewInt(1000))
+	clusterName = "uc" + rand.String() + "test"
+
+	_, err := e2e.Tanzu(nil, "unmanaged-cluster", "create", clusterName)
+	if err != nil {
+		t.Errorf("error while unmanaged cluster Creation: %v", err)
+		signal = failConst
+	}
+
+	if signal == failConst {
+		fmt.Println("-------------------------------", string(colorRed), "Unmanged Cluster creation Failed see above logs", string(colorReset), "---------------------------------------------")
+	} else {
+		fmt.Println("-------------------------------", string(colorGreen), "Unmanged Cluster created Successfully", string(colorReset), "---------------------------------------------")
+	}
+}
+
+// Checking Unmanaged cluster working
+func TestUCWorking(t *testing.T) {
+	signal := passConst
+
+	repoList, err := e2e.Tanzu(nil, "package", "repository", "list", "-A")
+	if err != nil || repoList == "" {
+		t.Errorf("error while checking for package repositories: %v", err)
+		signal = failConst
+	}
+
+	registryExist, err := regexp.MatchString("\\btanzu-package-repo-global\\b", repoList)
+	if registryExist == false || err != nil {
+		t.Errorf("Package registry not present or %v", err)
+		signal = failConst
+	}
+
+	coreRepo, err := regexp.MatchString("\\btkg-system\\b", repoList)
+	if coreRepo == false || err != nil {
+		t.Errorf("Core repository not present or %v", err)
+		signal = failConst
+	}
+
+	_, err = e2e.Kubectl(nil, "get", "pods", "-A")
+	if err != nil {
+		t.Errorf("error while checking for pods: %v", err)
+		signal = failConst
+	}
+
+	if signal == failConst {
+		fmt.Println("-------------------------------", string(colorRed), "Unmanaged Cluster is not healthy see above logs", string(colorReset), "---------------------------------------------")
+	} else {
+		fmt.Println("-------------------------------", string(colorGreen), "Unmanaged Cluster is healthy", string(colorReset), "---------------------------------------------")
+	}
+}
+
+// Deleting unmanage cluster
+func TestUCDeletion(t *testing.T) {
+	signal := passConst
+
+	_, err := e2e.Tanzu(nil, "unmanaged-cluster", "delete", clusterName)
+	if err != nil {
+		t.Errorf("error while unmanaged cluster deletion")
+		signal = failConst
+	}
+
+	ucLists, err := e2e.Tanzu(nil, "unmanaged-cluster", "list", "-q")
+	if err != nil {
+		t.Errorf("error while printing unmanaged cluster list: %v", err)
+		signal = failConst
+	}
+
+	ucExist, _ := regexp.MatchString("\\b"+clusterName+"\\b", ucLists)
+	if ucExist || err != nil {
+		t.Errorf("unmanaged cluster still present or error occurred: %v", err)
+		signal = failConst
+	}
+
+	if signal == failConst {
+		fmt.Println("-------------------------------", string(colorRed), "Unmanaged Cluster deletion Failed see above logs", string(colorReset), "---------------------------------------------")
+	} else {
+		fmt.Println("-------------------------------", string(colorGreen), "Unmanaged Cluster deleted Successfully", string(colorReset), "---------------------------------------------")
+	}
+}

--- a/cli/cmd/plugin/unmanaged-cluster/test/e2e/utils/cli.go
+++ b/cli/cmd/plugin/unmanaged-cluster/test/e2e/utils/cli.go
@@ -1,0 +1,85 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func InstallTCE() error {
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Println("error while getting current working directory", err)
+	}
+
+	indTCE := strings.LastIndex(wd, "community-edition")
+	topDirPath := wd[0 : indTCE+17]
+	err = os.Chdir(topDirPath)
+	if err != nil {
+		log.Println("error while changing directory to the top:", err)
+		return err
+	}
+
+	// installing dependencies i.e docker and kubectl
+	err = runDeployScript("hack/ensure-deps/ensure-docker.sh")
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+
+	err = runDeployScript("hack/ensure-deps/ensure-kubectl.sh")
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+
+	return runDeployScript("test/download-or-build-tce.sh")
+}
+
+func runDeployScript(filename string) error {
+	mwriter := io.MultiWriter(os.Stdout)
+	cmd := exec.Command("/bin/bash", filename)
+	cmd.Stderr = mwriter
+	cmd.Stdout = mwriter
+	err := cmd.Run() // blocks until sub process is complete
+	if err != nil {
+		log.Fatal(err)
+	}
+	return err
+}
+
+func Kubectl(input io.Reader, args ...string) (string, error) {
+	return cliRunner("kubectl", input, args...)
+}
+
+func Tanzu(input io.Reader, args ...string) (string, error) {
+	return cliRunner("tanzu", input, args...)
+}
+
+func cliRunner(name string, input io.Reader, args ...string) (string, error) {
+	var stdOut bytes.Buffer
+	mwriter := io.MultiWriter(&stdOut, os.Stderr)
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = input
+	cmd.Stdout = mwriter
+	cmd.Stderr = mwriter
+
+	err := cmd.Run()
+	if err != nil {
+		rc := -1
+		if ee, ok := err.(*exec.ExitError); ok {
+			rc = ee.ExitCode()
+		}
+
+		return "", fmt.Errorf("%s\nexit status: %d", err.Error(), rc)
+	}
+
+	return stdOut.String(), err
+}

--- a/hack/builder/builder.go
+++ b/hack/builder/builder.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // Copyright 2021 VMware, Inc. All Rights Reserved.

--- a/hack/check/tools/tools.go
+++ b/hack/check/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // Copyright 2021 VMware, Inc. All Rights Reserved.

--- a/hack/ensure-deps/ensure-docker.sh
+++ b/hack/ensure-deps/ensure-docker.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script installs dependencies needed for running build-tce.sh and deploy-tce.sh
+
+BUILD_OS=$(uname -s)
+export BUILD_OS
+# Make sure docker is installed
+echo "Checking for Docker..."
+if [[ -z "$(command -v docker)" ]]; then
+    echo "Installing Docker..."
+    if [[ "$BUILD_OS" == "Linux" ]]; then
+        curl -fsSL https://get.docker.com -o get-docker.sh
+        sh ./get-docker.sh
+    elif [[ "$(BUILD_OS)" == "Darwin" ]]; then
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+        brew cask install docker
+    fi
+else
+    echo "Found Docker!"
+fi
+
+echo "Verifying Docker..."
+if ! sudo docker run --rm hello-world > /dev/null; then
+    error "Unable to verify docker functionality, make sure docker is installed correctly"
+    exit 1
+else
+    echo "Verified Docker functionality successfully!"
+fi


### PR DESCRIPTION
Signed-off-by: Aman Sharma <amansh@vmware.com>
The changes in Harbor and external-dns is due to `gofmt -s -w` nothing core change are there.
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR is adding an e2e-test for Unmanaged-Cluster which is handling 
- TCE installation 
- then creating Unmanaged Cluster
- Checking for repository 
- Checking for Pods  
-  deleting Unmanaged cluster and checking the cluster deletion.

Assumption:
Test environment does not have TCE installed.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: [#3689](https://github.com/vmware-tanzu/community-edition/issues/3689)

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested in workflow logs are here
https://github.com/aman556/community-edition/runs/5871260779?check_suite_focus=true#step:6:2448
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
