### PR TITLE
Don't skip linting on test code

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -130,11 +130,3 @@ issues:
     - linters:
         - gocritic
       text: "unnecessaryDefer:"
-run:
-  skip-dirs:
-    - test/
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.44.2 # use the fixed version to not introduce new linters unexpectedly


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We had been skipping running linters on code in test directories. There
really isn't any reason we shouldn't make sure our test code is as good
of quality as our functional code, so this removes that skip to make
sure this is covered. Thankfully it did not uncover hidden problems, but
it will help make sure nothing is introduced going forward.

Also removes the golangci-lint version from the config file. This is now
controlled by our test tool go.mod entry, so no need to have that in the
config file.