### PR TITLE
[E2E] Use latest stable release of tce package repository for e2e tests

### DIFF
--- a/test/add-tce-package-repo.sh
+++ b/test/add-tce-package-repo.sh
@@ -8,7 +8,7 @@ set -x
 
 echo "Adding TCE package repository..."
 REPO_NAME="tce-main-latest"
-REPO_URL="projects.registry.vmware.com/tce/main:0.9.1"
+REPO_URL="projects.registry.vmware.com/tce/main:0.11.0"
 REPO_NAMESPACE="default"
 
 # TODO: Use stable version of the tce/main repo once https://github.com/vmware-tanzu/community-edition/issues/1250 is fixed

--- a/test/gatekeeper/e2e-test.sh
+++ b/test/gatekeeper/e2e-test.sh
@@ -10,7 +10,7 @@ source "${TCE_REPO_PATH}/test/util/utils.sh"
 
 function test-gatekeeper {
     echo "Installing Gatekeeper..."
-    gatekeeper_version=$(tanzu package available list gatekeeper.community.tanzu.vmware.com -o json | jq -r '.[0].version | select(. != null)')
+    gatekeeper_version=$(tanzu package available list gatekeeper.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
     tanzu package install gatekeeper --package-name gatekeeper.community.tanzu.vmware.com --version "${gatekeeper_version}" || { error "Gatekeeper installation failed. TEST FAILED."; exit 1; }
     # Added this as it takes time to create namespace for Gatekeeper
     sleep 10s


### PR DESCRIPTION
## What this PR does / why we need it

Use latest stable release (`v0.11.0`) of TCE package repository for E2E Tests. Also update how we obtain the latest version of gatekeeper package for the gatekeeper E2E test

## Which issue(s) this PR fixes

Fixes: #3525

## Describe testing done for PR

E2E test logs - [e2e.log](https://github.com/vmware-tanzu/community-edition/files/8387566/e2e.log)

## Special notes for your reviewer

None as of now