### PR TITLE
Add make target to build UI with container

### DIFF
--- a/cli/cmd/plugin/ui/Makefile
+++ b/cli/cmd/plugin/ui/Makefile
@@ -38,3 +38,11 @@ ui-dependencies: ## Install UI dependencies (node modules)
 
 ui-build: ui-dependencies ## Install dependencies, then compile client UI for production
 	cd $(UI_DIR); npm run build:prod
+
+ui-build-docker:
+	cd $(UI_DIR); \
+		docker run -it --rm \
+		-v "$$(pwd)":/usr/src -w /usr/src \
+		--user $(shell id -u):$(shell id -g) \
+		node:16 \
+		sh -c "npm ci; npm run build:prod"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This adds a `ui-build-docker` target to our Makefile build our UI using
the node:16 container so folks without a proper UI dev environment set
up can easily build our site.