### PR TITLE
Add troubleshooting FAQ for inotify watch issues

### DIFF
--- a/docs/site/content/docs/faq-cluster-bootstrapping.md
+++ b/docs/site/content/docs/faq-cluster-bootstrapping.md
@@ -26,3 +26,29 @@ TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY: true
 |Bootstrap platform| Windows |
 |Target platform   | Any |
 |Affected versions | v0.2.1 |
+
+## Failed to create inotify errors
+
+Occasionally there are failures during management cluster deployment. In the
+case where deployment fails at the step indicating **"Install providers on
+management cluster"**, you may see the following error in the
+cap*x*-controller-manager logs when following the
+[Troubleshoot Cluster Bootstrapping](tsg-bootstrap) instructions.
+
+```txt
+Failed to create inotify object: Too many open files
+```
+
+This can be more common when the system being used for deployment already has
+several containers running.
+
+On Linux, this issue can be resolved by increasing the inotify watch limits
+using these commands:
+
+```sh
+sysctl fs.inotify.max_user_watches=1048576
+sysctl fs.inotify.max_user_instances=8192
+```
+
+After running those commands you should be able to retry deploying a managment
+cluster.


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

There is a known issue when using CAPD where the system defaults for
inotify watch limits are too restrictive, causing deployments to
fail[0].

This adds a section to our FAQ calling this out so we have somewhere to
point folks that run into this to help them resolve the issue.

[0] https://github.com/kubernetes-sigs/cluster-api/pull/6325