### PR TITLE
Implements `unmanaged-cluster` profiles

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -37,9 +37,7 @@ func init() {
 	ConfigureCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR to use for Service IP addresses. Default and format is '10.96.0.0/16'")
 	ConfigureCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
 	ConfigureCmd.Flags().StringSliceVar(&co.additionalRepo, "additional-repo", []string{}, "Addresses for additional package repositories to install")
-	ConfigureCmd.Flags().StringSliceVar(&co.profile, "profile", []string{}, "(experimental) A profile to install. May be specified multiple times. Should be the fully qualified package name or a prefix to a package name found in an installed package repository. Profile mappings supported - profile-name:profile-version:profile-config-file")
-	ConfigureCmd.Flags().StringSliceVar(&co.profileConfigPath, "profile-config-file", []string{}, "(experimental) Optional: path to a profile values yaml file. Uses default values (when available) if not provided. May be specified multiple times. Strings given via this flag are ordered in a queue and are enqueud in the order they are specified and dequeud when missing profile configs are encountered.")
-	ConfigureCmd.Flags().StringSliceVar(&co.profileVersion, "profile-version", []string{}, "(experimental) Optional: the version of a profile to install. Uses the latest version if not provided. May be specified multiple times. Installs latest if not provided. May be specified multiple times. Values specified via this flag are ordered in a queue and are enqueud in the order they are specified and dequeud when missing profile versions are encountered.")
+	ConfigureCmd.Flags().StringSliceVar(&co.profile, "profile", []string{}, "(experimental) A profile to install. May be specified multiple times. Profile mappings supported - profile-name:profile-version:profile-config-file. profile-name should be the fully qualified package name or a prefix to a package name found in an installed package repository. profile-version is optional and resolves to the latest semantic versioned package if not specified or `latest` is entered. package-config-file is optional and should be the path to a values yaml file in order to configure the package.")
 }
 
 func configure(cmd *cobra.Command, args []string) error {
@@ -54,7 +52,7 @@ func configure(cmd *cobra.Command, args []string) error {
 
 	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
 
-	profiles, err := config.ParseProfileMappings(co.profile, co.profileVersion, co.profileConfigPath)
+	profiles, err := config.ParseProfileMappings(co.profile)
 	if err != nil {
 		log.Error(err.Error())
 	}

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -27,6 +27,9 @@ type createUnmanagedOpts struct {
 	portMapping               []string
 	numContPlanes             string
 	numWorkers                string
+	profile                   string
+	profileConfigPath         string
+	profileVersion            string
 }
 
 const createDesc = `
@@ -59,8 +62,9 @@ Exit codes are provided to enhance the automation of bootstrapping and are defin
 9  - Could not install kapp controller to cluster.
 10 - Could not install core package repo to cluster.
 11 - Could not install additional package repo
-12 - Could not install CNI package.
-13 - Failed to merge kubeconfig and set context`
+12 - Could not install designated profile
+13 - Could not install CNI package.
+14 - Failed to merge kubeconfig and set context`
 
 // CreateCmd creates an unmanaged workload cluster.
 var CreateCmd = &cobra.Command{
@@ -87,6 +91,9 @@ func init() {
 	CreateCmd.Flags().BoolVar(&co.skipPreflightChecks, "skip-preflight", false, "Skip the preflight checks; default is false")
 	CreateCmd.Flags().StringVar(&co.numContPlanes, "control-plane-node-count", "", "The number of control plane nodes to deploy; default is 1")
 	CreateCmd.Flags().StringVar(&co.numWorkers, "worker-node-count", "", "The number of worker nodes to deploy; default is 0")
+	CreateCmd.Flags().StringVar(&co.profile, "profile", "", "A profile to install. Should be the fully qualified package name found in the package repository")
+	CreateCmd.Flags().StringVar(&co.profileConfigPath, "profile-config-file", "", "Optional: path to a profile config values yaml file. Uses pacakges defaults (if available) if not provided")
+	CreateCmd.Flags().StringVar(&co.profileVersion, "profile-version", "", "Optional: the version of a profile to install. Installs latest if not provided")
 }
 
 func create(cmd *cobra.Command, args []string) {
@@ -125,6 +132,9 @@ func create(cmd *cobra.Command, args []string) {
 		config.ControlPlaneNodeCount:     co.numContPlanes,
 		config.WorkerNodeCount:           co.numWorkers,
 		config.AdditionalPackageRepos:    co.additionalRepo,
+		config.Profile:                   co.profile,
+		config.ProfileConfig:             co.profileConfigPath,
+		config.ProfileVersion:            co.profileVersion,
 	}
 	clusterConfig, err := config.InitializeConfiguration(configArgs)
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -27,9 +27,9 @@ type createUnmanagedOpts struct {
 	portMapping               []string
 	numContPlanes             string
 	numWorkers                string
-	profile                   string
-	profileConfigPath         string
-	profileVersion            string
+	profile                   []string
+	profileConfigPath         []string
+	profileVersion            []string
 }
 
 const createDesc = `
@@ -62,9 +62,9 @@ Exit codes are provided to enhance the automation of bootstrapping and are defin
 9  - Could not install kapp controller to cluster.
 10 - Could not install core package repo to cluster.
 11 - Could not install additional package repo
-12 - Could not install designated profile
-13 - Could not install CNI package.
-14 - Failed to merge kubeconfig and set context`
+12 - Could not install CNI package.
+13 - Failed to merge kubeconfig and set context
+14 - Could not install designated profile`
 
 // CreateCmd creates an unmanaged workload cluster.
 var CreateCmd = &cobra.Command{
@@ -91,9 +91,9 @@ func init() {
 	CreateCmd.Flags().BoolVar(&co.skipPreflightChecks, "skip-preflight", false, "Skip the preflight checks; default is false")
 	CreateCmd.Flags().StringVar(&co.numContPlanes, "control-plane-node-count", "", "The number of control plane nodes to deploy; default is 1")
 	CreateCmd.Flags().StringVar(&co.numWorkers, "worker-node-count", "", "The number of worker nodes to deploy; default is 0")
-	CreateCmd.Flags().StringVar(&co.profile, "profile", "", "A profile to install. Should be the fully qualified package name found in the package repository")
-	CreateCmd.Flags().StringVar(&co.profileConfigPath, "profile-config-file", "", "Optional: path to a profile config values yaml file. Uses pacakges defaults (if available) if not provided")
-	CreateCmd.Flags().StringVar(&co.profileVersion, "profile-version", "", "Optional: the version of a profile to install. Installs latest if not provided")
+	CreateCmd.Flags().StringSliceVar(&co.profile, "profile", []string{}, "(experimental) A profile to install. Should be the fully qualified package name found in the package repository")
+	CreateCmd.Flags().StringSliceVar(&co.profileConfigPath, "profile-config-file", []string{}, "Optional: path to a profile config values yaml file. Uses pacakges defaults (if available) if not provided")
+	CreateCmd.Flags().StringSliceVar(&co.profileVersion, "profile-version", []string{}, "Optional: the version of a profile to install. Installs latest if not provided")
 }
 
 func create(cmd *cobra.Command, args []string) {
@@ -119,6 +119,12 @@ func create(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	profiles, err := config.ParseProfileMappings(co.profile, co.profileVersion, co.profileConfigPath)
+	if err != nil {
+		log.Error(err.Error())
+		os.Exit(tanzu.ErrRenderingConfig)
+	}
+
 	// Determine our configuration to use
 	configArgs := map[string]interface{}{
 		config.ClusterConfigFile:         co.clusterConfigFile,
@@ -132,9 +138,7 @@ func create(cmd *cobra.Command, args []string) {
 		config.ControlPlaneNodeCount:     co.numContPlanes,
 		config.WorkerNodeCount:           co.numWorkers,
 		config.AdditionalPackageRepos:    co.additionalRepo,
-		config.Profile:                   co.profile,
-		config.ProfileConfig:             co.profileConfigPath,
-		config.ProfileVersion:            co.profileVersion,
+		config.Profiles:                  profiles,
 	}
 	clusterConfig, err := config.InitializeConfiguration(configArgs)
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -28,8 +28,6 @@ type createUnmanagedOpts struct {
 	numContPlanes             string
 	numWorkers                string
 	profile                   []string
-	profileConfigPath         []string
-	profileVersion            []string
 }
 
 const createDesc = `
@@ -91,9 +89,7 @@ func init() {
 	CreateCmd.Flags().BoolVar(&co.skipPreflightChecks, "skip-preflight", false, "Skip the preflight checks; default is false")
 	CreateCmd.Flags().StringVar(&co.numContPlanes, "control-plane-node-count", "", "The number of control plane nodes to deploy; default is 1")
 	CreateCmd.Flags().StringVar(&co.numWorkers, "worker-node-count", "", "The number of worker nodes to deploy; default is 0")
-	CreateCmd.Flags().StringSliceVar(&co.profile, "profile", []string{}, "(experimental) A profile to install. May be specified multiple times. Should be the fully qualified package name or a prefix to a package name found in an installed package repository. Profile mappings supported - profile-name:profile-version:profile-config-file")
-	CreateCmd.Flags().StringSliceVar(&co.profileConfigPath, "profile-config-file", []string{}, "(experimental) Optional: path to a profile values yaml file. Uses default values (when available) if not provided. May be specified multiple times. Strings given via this flag are ordered in a queue and are enqueud in the order they are specified and dequeud when missing profile configs are encountered.")
-	CreateCmd.Flags().StringSliceVar(&co.profileVersion, "profile-version", []string{}, "(experimental) Optional: the version of a profile to install. Uses the latest version if not provided. May be specified multiple times. Installs latest if not provided. May be specified multiple times. Values specified via this flag are ordered in a queue and are enqueud in the order they are specified and dequeud when missing profile versions are encountered.")
+	CreateCmd.Flags().StringSliceVar(&co.profile, "profile", []string{}, "(experimental) A profile to install. May be specified multiple times. Profile mappings supported - profile-name:profile-version:profile-config-file. profile-name should be the fully qualified package name or a prefix to a package name found in an installed package repository. profile-version is optional and resolves to the latest semantic versioned package if not specified or `latest` is entered. package-config-file is optional and should be the path to a values yaml file in order to configure the package.")
 }
 
 func create(cmd *cobra.Command, args []string) {
@@ -119,7 +115,7 @@ func create(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	profiles, err := config.ParseProfileMappings(co.profile, co.profileVersion, co.profileConfigPath)
+	profiles, err := config.ParseProfileMappings(co.profile)
 	if err != nil {
 		log.Error(err.Error())
 		os.Exit(tanzu.ErrRenderingConfig)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -91,9 +91,9 @@ func init() {
 	CreateCmd.Flags().BoolVar(&co.skipPreflightChecks, "skip-preflight", false, "Skip the preflight checks; default is false")
 	CreateCmd.Flags().StringVar(&co.numContPlanes, "control-plane-node-count", "", "The number of control plane nodes to deploy; default is 1")
 	CreateCmd.Flags().StringVar(&co.numWorkers, "worker-node-count", "", "The number of worker nodes to deploy; default is 0")
-	CreateCmd.Flags().StringSliceVar(&co.profile, "profile", []string{}, "(experimental) A profile to install. Should be the fully qualified package name found in the package repository")
-	CreateCmd.Flags().StringSliceVar(&co.profileConfigPath, "profile-config-file", []string{}, "Optional: path to a profile config values yaml file. Uses pacakges defaults (if available) if not provided")
-	CreateCmd.Flags().StringSliceVar(&co.profileVersion, "profile-version", []string{}, "Optional: the version of a profile to install. Installs latest if not provided")
+	CreateCmd.Flags().StringSliceVar(&co.profile, "profile", []string{}, "(experimental) A profile to install. May be specified multiple times. Should be the fully qualified package name or a prefix to a package name found in an installed package repository. Profile mappings supported - profile-name:profile-version:profile-config-file")
+	CreateCmd.Flags().StringSliceVar(&co.profileConfigPath, "profile-config-file", []string{}, "(experimental) Optional: path to a profile values yaml file. Uses default values (when available) if not provided. May be specified multiple times. Strings given via this flag are ordered in a queue and are enqueud in the order they are specified and dequeud when missing profile configs are encountered.")
+	CreateCmd.Flags().StringSliceVar(&co.profileVersion, "profile-version", []string{}, "(experimental) Optional: the version of a profile to install. Uses the latest version if not provided. May be specified multiple times. Installs latest if not provided. May be specified multiple times. Values specified via this flag are ordered in a queue and are enqueud in the order they are specified and dequeud when missing profile versions are encountered.")
 }
 
 func create(cmd *cobra.Command, args []string) {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-
 	"golang.org/x/term"
 )
 

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
@@ -8,7 +8,10 @@ import (
 	"runtime"
 	"strconv"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"golang.org/x/term"
 )
 
 // TtySetting gets the setting to use for formatted TTY output based on whether
@@ -46,3 +49,55 @@ func TtySetting(flags *pflag.FlagSet) bool {
 	}
 	return result
 }
+
+// SetupRootCommand ensures the root cobra command is setup with our customization
+func SetupRootCommand(rootCmd *cobra.Command) {
+	cobra.AddTemplateFunc("wrappedFlagUsages", wrappedFlagUsages)
+
+	rootCmd.SetUsageTemplate(usageTemplate)
+	rootCmd.SetHelpTemplate(helpTemplate)
+}
+
+// Uses the users terminal size or width of 80 if cannot determine users width
+func wrappedFlagUsages(cmd *pflag.FlagSet) string {
+	fd := int(os.Stdout.Fd())
+	width := 80
+
+	// Get the terminal width and dynamically set
+	termWidth, _, err := term.GetSize(fd)
+	if err == nil {
+		width = termWidth
+	}
+
+	return cmd.FlagUsagesWrapped(width - 1)
+}
+
+// Identical to the default cobra usage template,
+// but utilizes wrappedFlagUsages to ensure flag usages don't wrap around
+var usageTemplate = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{wrappedFlagUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{wrappedFlagUsages .InheritedFlags | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+
+var helpTemplate = `
+{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`

--- a/cli/cmd/plugin/unmanaged-cluster/config/config.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config.go
@@ -40,6 +40,9 @@ const (
 	ProtocolSCTP              = "sctp"
 	ControlPlaneNodeCount     = "ControlPlaneNodeCount"
 	WorkerNodeCount           = "WorkerNodeCount"
+	Profile                   = "Profile"
+	ProfileConfig             = "ProfileConfig"
+	ProfileVersion            = "ProfileVersion"
 )
 
 var defaultConfigValues = map[string]interface{}{
@@ -106,6 +109,15 @@ type UnmanagedClusterConfig struct {
 	// WorkerNodeCount is the number of worker nodes to deploy for the cluster.
 	// Default is 0
 	WorkerNodeCount string `yaml:"WorkerNodeCount"`
+	// Profile is the name of a profile to install.
+	// It should directly correspond to the name of a package in an installed package repository
+	Profile string `yaml:"Profile"`
+	// ProfileConfig is the path to a config values yaml file that is to be consumed by the profile
+	// Optional: will default to an empty string on package install
+	ProfileConfig string `yaml:"ProfileConfig"`
+	// ProfileVersion is the version of the profile to install
+	// Optional: defaults to the first package found that matches name, which should be latest
+	ProfileVersion string `yaml:"ProfileVersion"`
 }
 
 // KubeConfigPath gets the full path to the KubeConfig for this unmanaged cluster.

--- a/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
@@ -319,3 +319,226 @@ func TestParsePortMapInvalid(t *testing.T) {
 		t.Error("Parsing should fail")
 	}
 }
+
+// When the user provides:
+// --profile my.package.com
+// --profile-version 1.2.3
+// --profile-config my-config-path
+func TestParseProfileMappingsOnlyFlags(t *testing.T) {
+	profileMap, err := ParseProfileMappings(
+		[]string{"my.package.com"},
+		[]string{"1.2.3"},
+		[]string{"my-config-path"},
+	)
+
+	if err != nil {
+		t.Error("Parsing profiles should pass")
+	}
+
+	if len(profileMap) != 1 {
+		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	}
+
+	if profileMap[0].Name != "my.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	}
+
+	if profileMap[0].Version != "1.2.3" {
+		t.Errorf("expected profile with version. Found %s Expected: 1.2.3", profileMap[0].Version)
+	}
+
+	if profileMap[0].Config != "my-config-path" {
+		t.Errorf("expected profile with config. Found %s Expected: my-config-path", profileMap[0].Config)
+	}
+}
+
+// When the user provides:
+// --profile my.package.com:4.4.4:woof-path,other.package.com:1.2.3:my-config-path
+func TestParseProfileMappings(t *testing.T) {
+	profileMap, err := ParseProfileMappings(
+		[]string{"my.package.com:4.4.4:woof-path,other.package.com:1.2.3:my-config-path"},
+		[]string{},
+		[]string{},
+	)
+
+	if err != nil {
+		t.Error("Parsing profiles should pass")
+	}
+
+	if len(profileMap) != 2 {
+		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	}
+
+	if profileMap[0].Name != "my.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	}
+
+	if profileMap[0].Version != "4.4.4" {
+		t.Errorf("expected profile with version. Found %s Expected: 4.4.4", profileMap[0].Version)
+	}
+
+	if profileMap[0].Config != "woof-path" {
+		t.Errorf("expected profile with config. Found %s Expected: woof-path", profileMap[0].Config)
+	}
+
+	if profileMap[1].Name != "other.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	}
+
+	if profileMap[1].Version != "1.2.3" {
+		t.Errorf("expected profile with version. Found %s Expected: 1.2.3", profileMap[0].Version)
+	}
+
+	if profileMap[1].Config != "my-config-path" {
+		t.Errorf("expected profile with config. Found %s Expected: my-config-path", profileMap[0].Config)
+	}
+}
+
+// When the user provides:
+// --profile my.package.com:4.4.4:woof-path
+// --profile other.package.com
+// --profile-version 1.2.3
+// --profile-config my-config-path
+func TestParseProfileMappingAndFlags(t *testing.T) {
+	profileMap, err := ParseProfileMappings(
+		[]string{"my.package.com:4.4.4:woof-path", "other.package.com"},
+		[]string{"1.2.3"},
+		[]string{"my-config-path"},
+	)
+
+	if err != nil {
+		t.Error("Parsing profiles should pass")
+	}
+
+	if len(profileMap) != 2 {
+		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	}
+
+	if profileMap[0].Name != "my.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	}
+
+	if profileMap[0].Version != "4.4.4" {
+		t.Errorf("expected profile with version. Found %s Expected: 4.4.4", profileMap[0].Version)
+	}
+
+	if profileMap[0].Config != "woof-path" {
+		t.Errorf("expected profile with config. Found %s Expected: woof-path", profileMap[0].Config)
+	}
+
+	if profileMap[1].Name != "other.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	}
+
+	if profileMap[1].Version != "1.2.3" {
+		t.Errorf("expected profile with version. Found %s Expected: 1.2.3", profileMap[0].Version)
+	}
+
+	if profileMap[1].Config != "my-config-path" {
+		t.Errorf("expected profile with config. Found %s Expected: my-config-path", profileMap[0].Config)
+	}
+}
+
+// When the user provides a big mix:
+// --profile my.package.com:4.4.4:woof-path,other.package.com:2.2.2
+// --profile-config other-config
+// --profile third.package.com
+// --profile-version 1.2.3
+// --profile-config my-config-path
+func TestParseProfileMappingMixedFlags(t *testing.T) {
+	profileMap, err := ParseProfileMappings(
+		[]string{"my.package.com:4.4.4:woof-path,other.package.com:2.2.2", "third.package.com"},
+		[]string{"1.2.3"},
+		[]string{"other-config", "my-config-path"},
+	)
+
+	if err != nil {
+		t.Error("Parsing profiles should pass")
+	}
+
+	if len(profileMap) != 3 {
+		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	}
+
+	if profileMap[0].Name != "my.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	}
+
+	if profileMap[0].Version != "4.4.4" {
+		t.Errorf("expected profile with version. Found %s Expected: 4.4.4", profileMap[0].Version)
+	}
+
+	if profileMap[0].Config != "woof-path" {
+		t.Errorf("expected profile with config. Found %s Expected: woof-path", profileMap[0].Config)
+	}
+
+	if profileMap[1].Name != "other.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: other.package.com", profileMap[1].Name)
+	}
+
+	if profileMap[1].Version != "2.2.2" {
+		t.Errorf("expected profile with version. Found %s Expected: 2.2.2", profileMap[1].Version)
+	}
+
+	if profileMap[1].Config != "other-config" {
+		t.Errorf("expected profile with config. Found %s Expected: other-config", profileMap[1].Config)
+	}
+
+	if profileMap[2].Name != "third.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: third.package.com", profileMap[2].Name)
+	}
+
+	if profileMap[2].Version != "1.2.3" {
+		t.Errorf("expected profile with version. Found %s Expected: 1.2.3", profileMap[2].Version)
+	}
+
+	if profileMap[2].Config != "my-config-path" {
+		t.Errorf("expected profile with config. Found %s Expected: my-config-path", profileMap[2].Config)
+	}
+}
+
+// When the user provides a bad formatting:
+// --profile my.package.com:4.4.4:woof-path:garbage
+func TestParseProfileMappingBadFormat(t *testing.T) {
+	_, err := ParseProfileMappings(
+		[]string{"my.package.com:4.4.4:woof-path:garbage"},
+		[]string{},
+		[]string{},
+	)
+
+	if err == nil {
+		t.Error("Parsing should fail")
+	}
+}
+
+// Errors when the user provides too many version flags:
+// --profile my.package.com
+// --profile-version 1.2.3
+// --profile-version 4.5.6
+func TestParseProfileMappingTooManyVersions(t *testing.T) {
+	_, err := ParseProfileMappings(
+		[]string{"my.package.com"},
+		[]string{"1.2.3", "4.5.6"},
+		[]string{},
+	)
+
+	if err == nil {
+		t.Error("Parsing should fail")
+	}
+}
+
+// Errors when the user provides too many version flags:
+// --profile my.package.com
+// --profile-config my-config.yaml
+// --profile-config my-other-config.yaml
+func TestParseProfileMappingTooManyConfigs(t *testing.T) {
+	_, err := ParseProfileMappings(
+		[]string{"my.package.com"},
+		[]string{},
+		[]string{"my-config.yaml", "my-other-config.yaml"},
+	)
+
+	if err == nil {
+		t.Error("Parsing should fail")
+	}
+}

--- a/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
@@ -320,13 +320,11 @@ func TestParsePortMapInvalid(t *testing.T) {
 	}
 }
 
-// When the user provides:
+// When the user provides only a profile name:
 // --profile my.package.com
 func TestParseProfileMappingsOnlyName(t *testing.T) {
 	profileMap, err := ParseProfileMappings(
 		[]string{"my.package.com"},
-		[]string{},
-		[]string{},
 	)
 
 	if err != nil {
@@ -350,15 +348,54 @@ func TestParseProfileMappingsOnlyName(t *testing.T) {
 	}
 }
 
-// When the user provides all flags:
-// --profile my.package.com
-// --profile-version 1.2.3
-// --profile-config my-config-path
-func TestParseProfileMappingsOnlyFlags(t *testing.T) {
+// When the user provides multiple profile flags:
+// --profile my.profile.package.com
+// --profile my.other-profile.package.com
+//
+// dequeues values from flags in order they are enqueued despite order of flags
+func TestParseProfileMappingsManyNames(t *testing.T) {
 	profileMap, err := ParseProfileMappings(
-		[]string{"my.package.com"},
-		[]string{"1.2.3"},
-		[]string{"my-config-path"},
+		[]string{"my.profile.package.com", "my.other-profile.package.com"},
+	)
+
+	if err != nil {
+		t.Error("Parsing profiles should pass")
+	}
+
+	if len(profileMap) != 2 {
+		t.Errorf("expected 2 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	}
+
+	if profileMap[0].Name != "my.profile.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: my.configured.package.com", profileMap[0].Name)
+	}
+
+	if profileMap[0].Version != "" {
+		t.Errorf("expected profile without version. Found %s Expected: empty string", profileMap[0].Version)
+	}
+
+	if profileMap[0].Config != "" {
+		t.Errorf("expected profile with no config. Found %s Expected: empty string", profileMap[0].Config)
+	}
+
+	if profileMap[1].Name != "my.other-profile.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: my.other-profile.package.com", profileMap[1].Name)
+	}
+
+	if profileMap[1].Version != "" {
+		t.Errorf("expected profile with no version. Found %s Expected: empty string", profileMap[1].Version)
+	}
+
+	if profileMap[1].Config != "" {
+		t.Errorf("expected profile with no config. Found %s Expected: empty string", profileMap[1].Config)
+	}
+}
+
+// When the user provides only a profile name:
+// --profile my.package.com:1.2.3
+func TestParseProfileMappingsNameVersion(t *testing.T) {
+	profileMap, err := ParseProfileMappings(
+		[]string{"my.package.com:1.2.3"},
 	)
 
 	if err != nil {
@@ -377,23 +414,17 @@ func TestParseProfileMappingsOnlyFlags(t *testing.T) {
 		t.Errorf("expected profile with version. Found %s Expected: 1.2.3", profileMap[0].Version)
 	}
 
-	if profileMap[0].Config != "my-config-path" {
-		t.Errorf("expected profile with config. Found %s Expected: my-config-path", profileMap[0].Config)
+	if profileMap[0].Config != "" {
+		t.Errorf("expected profile with no config. Found %s Expected: empty string", profileMap[0].Config)
 	}
 }
 
-// When the user provides multiple flags with missing fields:
-// --profile my.configured.package.com
-// --profile my.non-configured.package.com
-// --profile-version 1.2.3
-// --profile-config my-config-path
-//
-// dequeues values from flags in order they are enqueued despite order of flags
-func TestParseProfileQueue(t *testing.T) {
+// When the user provides multiple profile flags with name and version:
+// --profile my.profile.package.com:1.2.3
+// --profile my.other-profile.package.com:7.8.9
+func TestParseProfileMappingsManyNameVersion(t *testing.T) {
 	profileMap, err := ParseProfileMappings(
-		[]string{"my.configured.package.com", "my.non-configured.package.com"},
-		[]string{"1.2.3"},
-		[]string{"my-config-path"},
+		[]string{"my.profile.package.com:1.2.3", "my.other-profile.package.com:7.8.9"},
 	)
 
 	if err != nil {
@@ -404,7 +435,7 @@ func TestParseProfileQueue(t *testing.T) {
 		t.Errorf("expected 2 profile. Found %v. Actual: %v", len(profileMap), profileMap)
 	}
 
-	if profileMap[0].Name != "my.configured.package.com" {
+	if profileMap[0].Name != "my.profile.package.com" {
 		t.Errorf("expected profile with name. Found %s Expected: my.configured.package.com", profileMap[0].Name)
 	}
 
@@ -412,16 +443,16 @@ func TestParseProfileQueue(t *testing.T) {
 		t.Errorf("expected profile with version. Found %s Expected: 1.2.3", profileMap[0].Version)
 	}
 
-	if profileMap[0].Config != "my-config-path" {
-		t.Errorf("expected profile with config. Found %s Expected: my-config-path", profileMap[0].Config)
+	if profileMap[0].Config != "" {
+		t.Errorf("expected profile with no config. Found %s Expected: empty string", profileMap[0].Config)
 	}
 
-	if profileMap[1].Name != "my.non-configured.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.non-configured.package.com", profileMap[1].Name)
+	if profileMap[1].Name != "my.other-profile.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: my.other-profile.package.com", profileMap[1].Name)
 	}
 
-	if profileMap[1].Version != "" {
-		t.Errorf("expected profile with no version. Found %s Expected: empty string", profileMap[1].Version)
+	if profileMap[1].Version != "7.8.9" {
+		t.Errorf("expected profile with version. Found %s Expected: 7.8.9", profileMap[1].Version)
 	}
 
 	if profileMap[1].Config != "" {
@@ -429,13 +460,67 @@ func TestParseProfileQueue(t *testing.T) {
 	}
 }
 
-// When the user provides profile mappings:
+// When the user provides a full profile mapping:
+// --profile my.package.com:4.4.4:woof-path
+func TestParseProfileMappingSingle(t *testing.T) {
+	profileMap, err := ParseProfileMappings(
+		[]string{"my.package.com:4.4.4:woof-path"},
+	)
+
+	if err != nil {
+		t.Error("Parsing profiles should pass")
+	}
+
+	if len(profileMap) != 1 {
+		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	}
+
+	if profileMap[0].Name != "my.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	}
+
+	if profileMap[0].Version != "4.4.4" {
+		t.Errorf("expected profile with version. Found %s Expected: 4.4.4", profileMap[0].Version)
+	}
+
+	if profileMap[0].Config != "woof-path" {
+		t.Errorf("expected profile with config. Found %s Expected: woof-path", profileMap[0].Config)
+	}
+}
+
+// When the user provides only a profile name, empty version, and a config path:
+// --profile my.package.com::my-config
+func TestParseProfileMappingsEmptyVersion(t *testing.T) {
+	profileMap, err := ParseProfileMappings(
+		[]string{"my.package.com::my-config"},
+	)
+
+	if err != nil {
+		t.Error("Parsing profiles should pass")
+	}
+
+	if len(profileMap) != 1 {
+		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	}
+
+	if profileMap[0].Name != "my.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	}
+
+	if profileMap[0].Version != "" {
+		t.Errorf("expected profile with no version. Found %s Expected: empty string", profileMap[0].Version)
+	}
+
+	if profileMap[0].Config != "my-config" {
+		t.Errorf("expected profile with config. Found %s Expected: my-config", profileMap[0].Config)
+	}
+}
+
+// When the user provides multiple full profile mappings in single profile flag:
 // --profile my.package.com:4.4.4:woof-path,other.package.com:1.2.3:my-config-path
-func TestParseProfileMappings(t *testing.T) {
+func TestParseProfileMappingsMultiple(t *testing.T) {
 	profileMap, err := ParseProfileMappings(
 		[]string{"my.package.com:4.4.4:woof-path,other.package.com:1.2.3:my-config-path"},
-		[]string{},
-		[]string{},
 	)
 
 	if err != nil {
@@ -471,70 +556,23 @@ func TestParseProfileMappings(t *testing.T) {
 	}
 }
 
-// When the user provides mappings and flags:
-// --profile my.package.com:4.4.4:woof-path
-// --profile other.package.com
-// --profile-version 1.2.3
-// --profile-config my-config-path
-func TestParseProfileMappingAndFlags(t *testing.T) {
-	profileMap, err := ParseProfileMappings(
-		[]string{"my.package.com:4.4.4:woof-path", "other.package.com"},
-		[]string{"1.2.3"},
-		[]string{"my-config-path"},
-	)
-
-	if err != nil {
-		t.Error("Parsing profiles should pass")
-	}
-
-	if len(profileMap) != 2 {
-		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
-	}
-
-	if profileMap[0].Name != "my.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
-	}
-
-	if profileMap[0].Version != "4.4.4" {
-		t.Errorf("expected profile with version. Found %s Expected: 4.4.4", profileMap[0].Version)
-	}
-
-	if profileMap[0].Config != "woof-path" {
-		t.Errorf("expected profile with config. Found %s Expected: woof-path", profileMap[0].Config)
-	}
-
-	if profileMap[1].Name != "other.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
-	}
-
-	if profileMap[1].Version != "1.2.3" {
-		t.Errorf("expected profile with version. Found %s Expected: 1.2.3", profileMap[0].Version)
-	}
-
-	if profileMap[1].Config != "my-config-path" {
-		t.Errorf("expected profile with config. Found %s Expected: my-config-path", profileMap[0].Config)
-	}
-}
-
-// When the user provides a big mix of mappings and flags:
-// --profile my.package.com:4.4.4:woof-path,other.package.com:2.2.2
-// --profile-config other-config
-// --profile third.package.com
-// --profile-version 1.2.3
-// --profile-config my-config-path
+// When the user provides multiple full profile mappings in multiple profile flags:
+// --profile my.package.com:4.4.4:woof-path,other.package.com:2.2.2:other-config
+// --profile my.other-package.com:1.2.3:my-path,my.final.package.com:7.8.9:final-config
 func TestParseProfileMappingMixedFlags(t *testing.T) {
 	profileMap, err := ParseProfileMappings(
-		[]string{"my.package.com:4.4.4:woof-path,other.package.com:2.2.2", "third.package.com"},
-		[]string{"1.2.3"},
-		[]string{"other-config", "my-config-path"},
+		[]string{
+			"my.package.com:4.4.4:woof-path,other.package.com:2.2.2:other-config",
+			"my-third.package.com:1.2.3:my-path,my-final.package.com:7.8.9:final-config",
+		},
 	)
 
 	if err != nil {
 		t.Error("Parsing profiles should pass")
 	}
 
-	if len(profileMap) != 3 {
-		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	if len(profileMap) != 4 {
+		t.Errorf("expected 4 profiles. Found %v. Actual: %v", len(profileMap), profileMap)
 	}
 
 	if profileMap[0].Name != "my.package.com" {
@@ -561,7 +599,7 @@ func TestParseProfileMappingMixedFlags(t *testing.T) {
 		t.Errorf("expected profile with config. Found %s Expected: other-config", profileMap[1].Config)
 	}
 
-	if profileMap[2].Name != "third.package.com" {
+	if profileMap[2].Name != "my-third.package.com" {
 		t.Errorf("expected profile with name. Found %s Expected: third.package.com", profileMap[2].Name)
 	}
 
@@ -569,8 +607,20 @@ func TestParseProfileMappingMixedFlags(t *testing.T) {
 		t.Errorf("expected profile with version. Found %s Expected: 1.2.3", profileMap[2].Version)
 	}
 
-	if profileMap[2].Config != "my-config-path" {
+	if profileMap[2].Config != "my-path" {
 		t.Errorf("expected profile with config. Found %s Expected: my-config-path", profileMap[2].Config)
+	}
+
+	if profileMap[3].Name != "my-final.package.com" {
+		t.Errorf("expected profile with name. Found %s Expected: my-final.package.com", profileMap[3].Name)
+	}
+
+	if profileMap[3].Version != "7.8.9" {
+		t.Errorf("expected profile with version. Found %s Expected: 7.8.9", profileMap[3].Version)
+	}
+
+	if profileMap[3].Config != "final-config" {
+		t.Errorf("expected profile with config. Found %s Expected: final-config", profileMap[3].Config)
 	}
 }
 
@@ -579,8 +629,6 @@ func TestParseProfileMappingMixedFlags(t *testing.T) {
 func TestParseProfileMappingBadFormat(t *testing.T) {
 	_, err := ParseProfileMappings(
 		[]string{"my.package.com:4.4.4:woof-path:garbage"},
-		[]string{},
-		[]string{},
 	)
 
 	if err == nil {
@@ -588,47 +636,13 @@ func TestParseProfileMappingBadFormat(t *testing.T) {
 	}
 }
 
-// Errors when the user provides too many version flags:
-// --profile my.package.com
-// --profile-version 1.2.3
-// --profile-version 4.5.6
-func TestParseProfileMappingTooManyVersions(t *testing.T) {
-	_, err := ParseProfileMappings(
-		[]string{"my.package.com"},
-		[]string{"1.2.3", "4.5.6"},
-		[]string{},
-	)
-
-	if err == nil {
-		t.Error("Parsing should fail")
-	}
-}
-
-// Errors when the user provides too many config flags:
-// --profile my.package.com
-// --profile-config my-config.yaml
-// --profile-config my-other-config.yaml
-func TestParseProfileMappingTooManyConfigs(t *testing.T) {
-	_, err := ParseProfileMappings(
-		[]string{"my.package.com"},
-		[]string{},
-		[]string{"my-config.yaml", "my-other-config.yaml"},
-	)
-
-	if err == nil {
-		t.Error("Parsing should fail")
-	}
-}
-
-// Won't errors when the nothin provided:
+// Won't errors when nothing is provided:
 func TestParseProfileNil(t *testing.T) {
 	_, err := ParseProfileMappings(
-		[]string{},
-		[]string{},
 		[]string{},
 	)
 
 	if err != nil {
-		t.Error("Parsing should fail")
+		t.Error("Parsing shouldn't fail")
 	}
 }

--- a/cli/cmd/plugin/unmanaged-cluster/main.go
+++ b/cli/cmd/plugin/unmanaged-cluster/main.go
@@ -44,6 +44,9 @@ func main() {
 		cmd.DeleteCmd,
 		cmd.ListCmd,
 	)
+
+	cmd.SetupRootCommand(p.Cmd)
+
 	if err := p.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cli/cmd/plugin/unmanaged-cluster/packages/packages.go
+++ b/cli/cmd/plugin/unmanaged-cluster/packages/packages.go
@@ -91,6 +91,10 @@ type PackageManager interface {
 	// referencing the cluster-admin CluterRole. This essentially provides full admin access to anything
 	// referencing this service account. Upon success, it returns the created ServiceAccount.
 	CreateRootServiceAccount(ns, name string) (*v1.ServiceAccount, error)
+	// GetRootServiceAccount returns the root service account
+	// given a namespace and the name of the service account
+	// Fails if service account doesn't exist
+	GetRootServiceAccount(ns, name string) (*v1.ServiceAccount, error)
 	// GetRepositoryStatus outputs the status of a repository based on the namespace and repository name
 	// requested. It provides details on kapp-controller process such as "Reconciling" and "Reconcile Succeeded"
 	GetRepositoryStatus(ns, name string) (string, error)
@@ -317,6 +321,15 @@ func (am *PackageClient) CreateRootServiceAccount(ns, name string) (*v1.ServiceA
 	}
 
 	return createdSa, nil
+}
+
+func (am *PackageClient) GetRootServiceAccount(ns, name string) (*v1.ServiceAccount, error) {
+	sa, err := am.clientSet.CoreV1().ServiceAccounts(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return sa, nil
 }
 
 func (am *PackageClient) ListPackagesInNamespace(ns string) ([]datapackaging.Package, error) {

--- a/cli/cmd/plugin/unmanaged-cluster/packages/packages.go
+++ b/cli/cmd/plugin/unmanaged-cluster/packages/packages.go
@@ -93,7 +93,7 @@ type PackageManager interface {
 	CreateRootServiceAccount(ns, name string) (*v1.ServiceAccount, error)
 	// GetRootServiceAccount returns the root service account
 	// given a namespace and the name of the service account
-	// Fails if service account doesn't exist
+	// Returns nil if service account does not exist
 	GetRootServiceAccount(ns, name string) (*v1.ServiceAccount, error)
 	// GetRepositoryStatus outputs the status of a repository based on the namespace and repository name
 	// requested. It provides details on kapp-controller process such as "Reconciling" and "Reconcile Succeeded"

--- a/cli/cmd/plugin/unmanaged-cluster/semver/semver.go
+++ b/cli/cmd/plugin/unmanaged-cluster/semver/semver.go
@@ -1,0 +1,317 @@
+//nolint
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Package semver implements comparison of semantic version strings.
+// It has been modified from go source code to accept a string without a leading `v`
+// and does not include unneeded helper functions like `Max` or `Build`
+//
+// The general form of a semantic version string accepted by this package is
+//
+//	MAJOR[.MINOR[.PATCH[-PRERELEASE][+BUILD]]]
+//
+// where square brackets indicate optional parts of the syntax;
+// MAJOR, MINOR, and PATCH are decimal integers without extra leading zeros;
+// PRERELEASE and BUILD are each a series of non-empty dot-separated identifiers
+// using only alphanumeric characters and hyphens; and
+// all-numeric PRERELEASE identifiers must not have leading zeros.
+//
+// This package follows Semantic Versioning 2.0.0 (see semver.org)
+// with one exception: it recognizes
+// MAJOR and MAJOR.MINOR (with no prerelease or build suffixes)
+// as shorthands for MAJOR.0.0 and MAJOR.MINOR.0.
+
+//nolint // This is go source code copied and litely modified, but not for linting
+package semver
+
+import "sort"
+
+// parsed returns the parsed form of a semantic version string.
+type parsed struct {
+	major      string
+	minor      string
+	patch      string
+	short      string
+	prerelease string
+	build      string
+}
+
+// Compare returns an integer comparing two versions according to
+// semantic version precedence.
+// The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
+//
+// An invalid semantic version string is considered less than a valid one.
+// All invalid semantic version strings compare equal to each other.
+func Compare(v, w string) int {
+	pv, ok1 := parse(v)
+	pw, ok2 := parse(w)
+	if !ok1 && !ok2 {
+		return 0
+	}
+	if !ok1 {
+		return -1
+	}
+	if !ok2 {
+		return +1
+	}
+	if c := compareInt(pv.major, pw.major); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.minor, pw.minor); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.patch, pw.patch); c != 0 {
+		return c
+	}
+	return comparePrerelease(pv.prerelease, pw.prerelease)
+}
+
+// ByVersion implements sort.Interface for sorting semantic version strings.
+type ByVersion []string
+
+func (vs ByVersion) Len() int      { return len(vs) }
+func (vs ByVersion) Swap(i, j int) { vs[i], vs[j] = vs[j], vs[i] }
+func (vs ByVersion) Less(i, j int) bool {
+	cmp := Compare(vs[i], vs[j])
+	if cmp != 0 {
+		return cmp < 0
+	}
+	return vs[i] < vs[j]
+}
+
+// Sort sorts a list of semantic version strings using ByVersion.
+func Sort(list []string) {
+	sort.Sort(ByVersion(list))
+}
+
+func parse(v string) (p parsed, ok bool) {
+	p.major, v, ok = parseInt(v)
+	if !ok {
+		return
+	}
+	if v == "" {
+		p.minor = "0"
+		p.patch = "0"
+		p.short = ".0.0"
+		return
+	}
+	if v[0] != '.' {
+		ok = false
+		return
+	}
+	p.minor, v, ok = parseInt(v[1:])
+	if !ok {
+		return
+	}
+	if v == "" {
+		p.patch = "0"
+		p.short = ".0"
+		return
+	}
+	if v[0] != '.' {
+		ok = false
+		return
+	}
+	p.patch, v, ok = parseInt(v[1:])
+	if !ok {
+		return
+	}
+	if len(v) > 0 && v[0] == '-' {
+		p.prerelease, v, ok = parsePrerelease(v)
+		if !ok {
+			return
+		}
+	}
+	if len(v) > 0 && v[0] == '+' {
+		p.build, v, ok = parseBuild(v)
+		if !ok {
+			return
+		}
+	}
+	if v != "" {
+		ok = false
+		return
+	}
+	ok = true
+	return
+}
+
+func parseInt(v string) (t, rest string, ok bool) {
+	if v == "" {
+		return
+	}
+	if v[0] < '0' || '9' < v[0] {
+		return
+	}
+	i := 1
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	if v[0] == '0' && i != 1 {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parsePrerelease(v string) (t, rest string, ok bool) {
+	// "A pre-release version MAY be denoted by appending a hyphen and
+	// a series of dot separated identifiers immediately following the patch version.
+	// Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-].
+	// Identifiers MUST NOT be empty. Numeric identifiers MUST NOT include leading zeroes."
+	if v == "" || v[0] != '-' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) && v[i] != '+' {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i || isBadNum(v[start:i]) {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i || isBadNum(v[start:i]) {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parseBuild(v string) (t, rest string, ok bool) {
+	if v == "" || v[0] != '+' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func isIdentChar(c byte) bool {
+	return 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' || c == '-'
+}
+
+func isBadNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v) && i > 1 && v[0] == '0'
+}
+
+func isNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v)
+}
+
+func compareInt(x, y string) int {
+	if x == y {
+		return 0
+	}
+	if len(x) < len(y) {
+		return -1
+	}
+	if len(x) > len(y) {
+		return +1
+	}
+	if x < y {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+func comparePrerelease(x, y string) int {
+	// "When major, minor, and patch are equal, a pre-release version has
+	// lower precedence than a normal version.
+	// Example: 1.0.0-alpha < 1.0.0.
+	// Precedence for two pre-release versions with the same major, minor,
+	// and patch version MUST be determined by comparing each dot separated
+	// identifier from left to right until a difference is found as follows:
+	// identifiers consisting of only digits are compared numerically and
+	// identifiers with letters or hyphens are compared lexically in ASCII
+	// sort order. Numeric identifiers always have lower precedence than
+	// non-numeric identifiers. A larger set of pre-release fields has a
+	// higher precedence than a smaller set, if all of the preceding
+	// identifiers are equal.
+	// Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta <
+	// 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0."
+	if x == y {
+		return 0
+	}
+	if x == "" {
+		return +1
+	}
+	if y == "" {
+		return -1
+	}
+	for x != "" && y != "" {
+		x = x[1:] // skip - or .
+		y = y[1:] // skip - or .
+		var dx, dy string
+		dx, x = nextIdent(x)
+		dy, y = nextIdent(y)
+		if dx != dy {
+			ix := isNum(dx)
+			iy := isNum(dy)
+			if ix != iy {
+				if ix {
+					return -1
+				} else {
+					return +1
+				}
+			}
+			if ix {
+				if len(dx) < len(dy) {
+					return -1
+				}
+				if len(dx) > len(dy) {
+					return +1
+				}
+			}
+			if dx < dy {
+				return -1
+			} else {
+				return +1
+			}
+		}
+	}
+	if x == "" {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+func nextIdent(x string) (dx, rest string) {
+	i := 0
+	for i < len(x) && x[i] != '.' {
+		i++
+	}
+	return x[:i], x[i:]
+}

--- a/cli/cmd/plugin/unmanaged-cluster/semver/semver_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/semver/semver_test.go
@@ -1,0 +1,88 @@
+//nolint
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// A slightly modified version of the golang/x/mod/semver package tests
+// that removes the leading `v`
+
+package semver
+
+import (
+	"math/rand"
+	"sort"
+	"strings"
+	"testing"
+)
+
+var tests = []struct {
+	in  string
+	out string
+}{
+	{"bad", ""},
+	{"1-alpha.beta.gamma", ""},
+	{"1-pre", ""},
+	{"1+meta", ""},
+	{"1-pre+meta", ""},
+	{"1.2-pre", ""},
+	{"1.2+meta", ""},
+	{"1.2-pre+meta", ""},
+	{"1.0.0-alpha", "1.0.0-alpha"},
+	{"1.0.0-alpha.1", "1.0.0-alpha.1"},
+	{"1.0.0-alpha.beta", "1.0.0-alpha.beta"},
+	{"1.0.0-beta", "1.0.0-beta"},
+	{"1.0.0-beta.2", "1.0.0-beta.2"},
+	{"1.0.0-beta.11", "1.0.0-beta.11"},
+	{"1.0.0-rc.1", "1.0.0-rc.1"},
+	{"1", "1.0.0"},
+	{"1.0", "1.0.0"},
+	{"1.0.0", "1.0.0"},
+	{"1.2", "1.2.0"},
+	{"1.2.0", "1.2.0"},
+	{"1.2.3-456", "1.2.3-456"},
+	{"1.2.3-456.789", "1.2.3-456.789"},
+	{"1.2.3-456-789", "1.2.3-456-789"},
+	{"1.2.3-456a", "1.2.3-456a"},
+	{"1.2.3-pre", "1.2.3-pre"},
+	{"1.2.3-pre+meta", "1.2.3-pre"},
+	{"1.2.3-pre.1", "1.2.3-pre.1"},
+	{"1.2.3-zzz", "1.2.3-zzz"},
+	{"1.2.3", "1.2.3"},
+	{"1.2.3+meta", "1.2.3"},
+	{"1.2.3+meta-pre", "1.2.3"},
+	{"1.2.3+meta-pre.sha.256a", "1.2.3"},
+}
+
+func TestCompare(t *testing.T) {
+	for i, ti := range tests {
+		for j, tj := range tests {
+			cmp := Compare(ti.in, tj.in)
+			var want int
+			if ti.out == tj.out {
+				want = 0
+			} else if i < j {
+				want = -1
+			} else {
+				want = +1
+			}
+			if cmp != want {
+				t.Errorf("Compare(%q, %q) = %d, want %d", ti.in, tj.in, cmp, want)
+			}
+		}
+	}
+}
+
+func TestSort(t *testing.T) {
+	versions := make([]string, len(tests))
+	for i, test := range tests {
+		versions[i] = test.in
+	}
+	rand.Shuffle(len(versions), func(i, j int) { versions[i], versions[j] = versions[j], versions[i] })
+	Sort(versions)
+	if !sort.IsSorted(ByVersion(versions)) {
+		t.Errorf("list is not sorted:\n%s", strings.Join(versions, "\n"))
+	}
+}

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/codes.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/codes.go
@@ -43,12 +43,12 @@ const (
 	// 11 - Could not install additional package repo
 	ErrOtherPackageRepoInstall
 
-	// 12 - Cound not install profile
-	ErrProfileInstall
-
-	// 13 - Could not install CNI package
+	// 12 - Could not install CNI package
 	ErrCniInstall
 
-	// 14 - Failed to merge kubeconfig and set context
+	// 13 - Failed to merge kubeconfig and set context
 	ErrKubeconfigContextSet
+
+	// 14 - Cound not install profile
+	ErrProfileInstall
 )

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/codes.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/codes.go
@@ -43,9 +43,12 @@ const (
 	// 11 - Could not install additional package repo
 	ErrOtherPackageRepoInstall
 
-	// 12 - Could not install CNI package
+	// 12 - Cound not install profile
+	ErrProfileInstall
+
+	// 13 - Could not install CNI package
 	ErrCniInstall
 
-	// 13 - Failed to merge kubeconfig and set context
+	// 14 - Failed to merge kubeconfig and set context
 	ErrKubeconfigContextSet
 )

--- a/docs/site/content/docs/ref-unmanaged-cluster.md
+++ b/docs/site/content/docs/ref-unmanaged-cluster.md
@@ -67,34 +67,7 @@ tanzu unmanaged-cluster create my-cluster --profile fluent-bit
 By default, the _latest_ package is installed
 and all default values are used for the package.
 
-To designate a profile version, use the `--profile-version` flag:
-
-```sh
-tanzu unmanaged-cluster create my-cluster --profile fluent-bit --profile-version 1.7.5
-```
-
-To designate a profile values yaml file, use the `--profile-config-file` flag:
-
-```sh
-tanzu unmanaged-cluster create my-cluster --profile fluent-bit --profile-version 1.7.5 --profile-config-file path-to-my-values.yaml
-```
-
-For further information on [packages and configuring packages, read the documentation.](package-management)
-
-## Installing multiple Profiles
-
-_Warning:_ Profiles is an experimental feature. Use with caution.
-
-To install multiple profiles, use the various profile flags multiple times in a single command.
-
-_Note:_ the profile flags act as queues. Values are enqueued in the order they are given in the command.
-Profile fields to build profile intalls are dequeued
-when there are missing fields. This means that the _order_ flags are provided
-does not have any precedence to which profile install options are being built.
-For complicated, multiple profile installs, it is recommended
-to use more advanced configurations:
-
-A special profile mapping may be used instead of multiple flags.
+To designate a profile version or profile values yaml file, use a profile mapping.
 The expected format is:
 
 ```text
@@ -107,19 +80,35 @@ This is used with the `--profile` flag:
 tanzu unmanged-cluster create --profile fluent-bit:1.7.5:path-to-my-config.yaml
 ```
 
-Profile mappings may also be specified multiple times via multiple `--profile` flags
-or within a singular profile flag, delimitted by a comma:
+Both `profile-version` and `profile-config-file` are optional.
+
+To install the most recent package, use the keyword `latest` or an empty string for the profile version
+to select the most recent semantic version for the specified package. Example:
 
 ```sh
-tanzu unmanaged-cluster create --profile fluent-bit:1.7.5,external-dns:0.10.0:path-to-my-config.yaml
+tanzu unmanaged-cluster create my-cluster --profile external-dns:latest:path-to-my-config.yaml
+```
+
+For further information on [packages and configuring packages, read the documentation.](package-management)
+
+## Installing multiple Profiles
+
+_Warning:_ Profiles is an experimental feature. Use with caution.
+
+Profile mappings may be specified multiple times via multiple `--profile` flags
+or within a singule profile flag, delimitted by a comma:
+
+```sh
+tanzu unmanaged-cluster create --profile fluent-bit:1.7.5,external-dns::path-to-my-config.yaml
 ```
 
 The above will install the fluent-bit package at version 1.7.5 with no values yaml file
-and the external-dns package at version 0.10.0 with a values yaml file.
+and the external-dns package at the latest version with a values yaml file.
 
 Finally, for the most granularity and configurability,
-you may configure all of this via the unmanaged cluster config file.
+you may configure all profile options via a unmanaged cluster config file.
 The following is a truncated config file and can be [generated via `tanzu unmanaged-cluster config`](#custom-configuration)
+with a `--profile` flag and profile mappings:
 
 ```yaml
 Profiles:


### PR DESCRIPTION
- Users can specify --profile via flag or config to automatically
  install a profile from an installed package repo.
- Users can set the --profile-version to install a specific version.
  This is optional and will default the the latest semver if not
  specified
- Users can set the --profile-config-file for a values yaml to be
  consumed by the installed profile
- Also includes a change to logging of packages being reconciled
  so the name is visible to users when reconciling them
- Updates our usage function for cobra so a nicely formatted line break
  for long flag messages don't wrap around

## Which issue(s) this PR fixes
Fixes: #3537

## Describe testing done for PR

Install a profile by name:

```
$ tanzu unmanaged-cluster create test --profile fluent-bit.community.tanzu.vmware.com

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Compatibility file exists at /home/jmcb/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v3

🔧 Resolving TKr
   projects.registry.vmware.com/tce/tkr:v0.17.0-dev-1
   TKr exists at /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v0.17.0-dev-1
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/test/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/test/bootstrap.log

🔧 Processing Tanzu Kubernetes Release

🎨 Selected base image
   projects.registry.vmware.com/tce/kind:v1.22.4

📦 Selected core package repository
   projects.registry.vmware.com/tce/repo-10:0.10.0

📦 Selected additional package repositories
   projects.registry.vmware.com/tce/main:0.11.0

📦 Selected kapp-controller image bundle
   projects.registry.vmware.com/tce/kapp-controller-multi-pkg:v0.30.1

🚀 Creating cluster test
   Cluster creation using kind!
   ❤️  Checkout this awesome project at https://kind.sigs.k8s.io
   Base image downloaded
   Cluster created
   To troubleshoot, use:

   kubectl ${COMMAND} --kubeconfig /home/jmcb/.config/tanzu/tkg/unmanaged/test/kube.conf

📧 Installing kapp-controller
   kapp-controller status: Running

📧 Installing package repositories
   tkg-core-repository package repo status: Reconcile succeeded
   projects.registry.vmware.com-tce-main-0.11.0 package repo status: Reconcile succeeded

🌐 Installing CNI
   calico.community.tanzu.vmware.com:3.22.1

🌐 Installing Profile fluent-bit.community.tanzu.vmware.com
   Installing profile without version specified. Using version 1.7.5
   Installing profile with no configuration file

✅ Cluster created

🎮 kubectl context set to test

View available packages:
   tanzu package available list
View running pods:
   kubectl get po -A
Delete this cluster:
   tanzu unmanaged delete test

$ k get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
fluent-bit           fluent-bit-k8xq6                             0/1     Running   0          51s
kube-system          calico-kube-controllers-556b886dc8-4zc4q     1/1     Running   0          48s
kube-system          calico-node-94s4j                            1/1     Running   0          48s
kube-system          coredns-78fcd69978-cxzbd                     1/1     Running   0          95s
kube-system          coredns-78fcd69978-hkknt                     1/1     Running   0          95s
kube-system          etcd-test-control-plane                      1/1     Running   0          108s
kube-system          kube-apiserver-test-control-plane            1/1     Running   0          108s
kube-system          kube-controller-manager-test-control-plane   1/1     Running   0          108s
kube-system          kube-proxy-hj9ns                             1/1     Running   0          95s
kube-system          kube-scheduler-test-control-plane            1/1     Running   0          108s
local-path-storage   local-path-provisioner-85494db59d-bf9ws      1/1     Running   0          95s
tkg-system           kapp-controller-779d9777dc-k8xm7             1/1     Running   0          95s

$ k get packageinstalls -n tkg-system
NAME                                    PACKAGE NAME                            PACKAGE VERSION   DESCRIPTION           AGE
cni                                     calico.community.tanzu.vmware.com       3.22.1            Reconcile succeeded   64s
fluent-bit.community.tanzu.vmware.com   fluent-bit.community.tanzu.vmware.com   1.7.5             Reconcile succeeded   64s
```

Users may also provide _just_ the prefix of the package name and the install will do a best effort to match the prefix of a package:
```
$ tanzu unmanaged-cluster create --profile fluent-bit
...

🌐 Installing Profile fluent-bit
   Installing profile without version specified. Using version 1.7.5
   Installing profile with no configuration file

...

❯ k get packageinstalls -A
NAMESPACE    NAME         PACKAGE NAME                            PACKAGE VERSION   DESCRIPTION   AGE
tkg-system   cni          calico.community.tanzu.vmware.com       3.22.1            Reconciling   15s
tkg-system   fluent-bit   fluent-bit.community.tanzu.vmware.com   1.7.5             Reconciling   15s
```

Install a profile and specify the version in the profile mapping:
```
$ tanzu unmanaged-cluster create test --profile external-dns.community.tanzu.vmware.com:0.8.0
...

🌐 Installing Profile external-dns.community.tanzu.vmware.com
   Using profile version 0.8.0
   Installing profile with no configuration file

...
```

Selects the latest version if no version tag specified. (note, this includes some code from golang/x/mod/semver to parse semantic versions)
```
$ tanzu unmanaged-cluster create test --profile external-dns.community.tanzu.vmware.com
...

🌐 Installing Profile external-dns.community.tanzu.vmware.com
   Installing profile without version specified. Using version 0.10.0
   Installing profile with no configuration file

...
```

The `latest` keyword is also reserved and will select the latest semver tag
```
$ tanzu unmanaged-cluster create test --profile external-dns.community.tanzu.vmware.com:latest
...

🌐 Installing Profile external-dns.community.tanzu.vmware.com
   Installing profile without version specified. Using version 0.10.0
   Installing profile with no configuration file

...
```


If also using a config, users can use `::` to skip defining a version and select the latest one (or the `latest` keyword)
```
$ tanzu unmanaged-cluster create test --profile external-dns.community.tanzu.vmware.com::my-config.yaml
...

🌐 Installing Profile external-dns.community.tanzu.vmware.com
   Installing profile without version specified. Using version 0.10.0
   Using config my-config.yaml

...
```

Include a values yaml file to be consumed by the package profile. [Using external DNS as an example here](https://github.com/vmware-tanzu/community-edition/tree/main/addons/packages/external-dns/0.10.0)
```yaml
---
#! The namespace in which to deploy ExternalDNS.
namespace: my-cool-namespace

#! Deployment related configuration
deployment:
  args:
  - --source=service
  - --source=contour-httpproxy
  - --txt-owner-id=k8s
  - --domain-filter=k8s.example.org
  - --namespace=my-services-ns
  - --provider=rfc2136
  - --rfc2136-host=100.69.97.77
  - --rfc2136-port=53
  - --rfc2136-zone=k8s.example.org
  - --rfc2136-tsig-secret=MTlQs3NNU=
  - --rfc2136-tsig-secret-alg=hmac-sha256
  - --rfc2136-tsig-keyname=externaldns-key
  - --rfc2136-tsig-axfr
  env: []
  securityContext: []
  volumeMounts: []
  volumes: []

#! Service account related configuration
serviceaccount:
  annotations:
    key: value
```

Using the values yaml file:
```
$ tanzu unmanaged-cluster create test \
  --profile external-dns.community.tanzu.vmware.com:0.10.0:values.yaml

...

🌐 Installing Profile external-dns.community.tanzu.vmware.com
   Using profile version 0.10.0
   Using config values.yaml

...

$ k get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS      AGE
kube-system          calico-kube-controllers-6849b5c7d-c5w9z      1/1     Running   0             6m5s
kube-system          calico-node-cht4q                            1/1     Running   0             6m5s
kube-system          coredns-78fcd69978-4csnt                     1/1     Running   0             6m55s
kube-system          coredns-78fcd69978-tjsng                     1/1     Running   0             6m55s
kube-system          etcd-test-control-plane                      1/1     Running   0             7m8s
kube-system          kube-apiserver-test-control-plane            1/1     Running   0             7m8s
kube-system          kube-controller-manager-test-control-plane   1/1     Running   0             7m8s
kube-system          kube-proxy-wrrfk                             1/1     Running   0             6m55s
kube-system          kube-scheduler-test-control-plane            1/1     Running   0             7m8s
local-path-storage   local-path-provisioner-85494db59d-c9nj5      1/1     Running   0             6m55s
my-cool-namespace    external-dns-557c9c6487-7d9q5                1/1     Running   4 (50s ago)   6m8s
tkg-system           kapp-controller-779d9777dc-sq6pb             1/1     Running   0             6m55s

$ k get packageinstalls -n tkg-system
NAME                                      PACKAGE NAME                              PACKAGE VERSION   DESCRIPTION           AGE
cni                                       calico.community.tanzu.vmware.com         3.22.1            Reconcile succeeded   6m33s
external-dns.community.tanzu.vmware.com   external-dns.community.tanzu.vmware.com   0.10.0            Reconcile succeeded   6m33s
```

Users can specify multiple profiles via multiple flags
```
$ tanzu unmanaged-cluster create test --profile external-dns.community.tanzu.vmware.com --profile fluent-bit.community.tanzu.vmware.com

...

🌐 Installing Profile external-dns.community.tanzu.vmware.com
   Using profile version 0.10.0
   Using config values.yaml

🌐 Installing Profile fluent-bit.community.tanzu.vmware.com
   Installing profile without version specified. Using version 1.7.5
   Installing profile with no configuration file
```

Users can use a multiple profile mappings delimitted by a `,`
```shell
# this will generate 3 profiles:
# - external-dns version 0.10.0 using the external-values.yaml file
# - a fluent-bit profile at the latest version with no config file
# - the app toolkit, version 0.1.0 with the values.yaml file
# Each profile is delimited by a `,` and each value is delimited by `:`
$ tanzu unmanaged-cluster create test \
  --profile external-dns.community.tanzu.vmware.com:0.10.0:external-values.yaml,fluent-bit.community.tanzu.vmware.com,app-toolkit.community.tanzu.vmware.com:0.1.0:values.yaml
```
results in:
```
🌐 Installing Profile external-dns.community.tanzu.vmware.com
   Using profile version 0.10.0
   Using config external-values.yaml

🌐 Installing Profile fluent-bit.community.tanzu.vmware.com
   Installing profile without version specified. Using version 1.7.5
   Installing profile with no configuration file

🌐 Installing Profile app-toolkit.community.tanzu.vmware.com
   Using profile version 0.1.0
   Using config values.yaml
```

Users can specify profiles in their config file:
```yaml
ClusterName: test
KubeconfigPath: ""
ExistingClusterKubeconfig: ""
NodeImage: ""
Provider: kind
ProviderConfiguration: {}
Cni: calico
CniConfiguration: {}
PodCidr: 10.244.0.0/16
ServiceCidr: 10.96.0.0/16
TkrLocation: ""
AdditionalPackageRepos: []
PortsToForward: []
SkipPreflight: false
ControlPlaneNodeCount: "1"
WorkerNodeCount: "0"
Profiles:
- name: fluent-bit.community.tanzu.vmware.com
- name: external-dns.community.tanzu.vmware.com
  config: external-values.yaml
  version: 0.10.0
- name: app-toolkit.community.tanzu.vmware.com
  config: values.yaml
```
and during deploy:
```
$ tanzu unmanaged-cluster create -f test.yaml
...

🌐 Installing Profile fluent-bit.community.tanzu.vmware.com
   Installing profile without version specified. Using version 1.7.5
   Installing profile with no configuration file

🌐 Installing Profile external-dns.community.tanzu.vmware.com
   Using profile version 0.10.0
   Using config external-values.yaml

🌐 Installing Profile app-toolkit.community.tanzu.vmware.com
   Installing profile without version specified. Using version 0.1.0
   Using config values.yaml
```

Bigger example installing app toolkit:
```
$ tanzu unmanaged-cluster create test --profile app-toolkit.projects.registry.vmware.com::values.yaml
...

🌐 Installing Profile app-toolkit.community.tanzu.vmware.com
   Installing profile without version specified. Using version 0.1.0
   Using config values.yaml

...

$ k get packageinstalls -A
NAMESPACE                   NAME                                     PACKAGE NAME                                          PACKAGE VERSION   DESCRIPTION           AGE
tanzu-package-repo-global   cartographer                             cartographer.community.tanzu.vmware.com               0.2.2             Reconcile succeeded   65s
tanzu-package-repo-global   cert-manager                             cert-manager.community.tanzu.vmware.com               1.6.1             Reconcile succeeded   99s
tanzu-package-repo-global   contour                                  contour.community.tanzu.vmware.com                    1.19.1            Reconcile succeeded   99s
tanzu-package-repo-global   fluxcd-source-controller                 fluxcd-source-controller.community.tanzu.vmware.com   0.21.2            Reconcile succeeded   99s
tanzu-package-repo-global   knative-serving                          knative-serving.community.tanzu.vmware.com            1.0.0             Reconcile succeeded   99s
tanzu-package-repo-global   kpack                                    kpack.community.tanzu.vmware.com                      0.5.1             Reconcile succeeded   99s
tkg-system                  app-toolkit.community.tanzu.vmware.com   app-toolkit.community.tanzu.vmware.com                0.1.0             Reconcile succeeded   109s
tkg-system                  cni                                      calico.community.tanzu.vmware.com                     3.22.1            Reconcile succeeded   109s


$ k get pods -A
NAMESPACE             NAME                                          READY   STATUS      RESTARTS   AGE
cartographer-system   cartographer-controller-86996bbb9-72gnz       1/1     Running     0          46s
cert-manager          cert-manager-56d644484c-8hz72                 1/1     Running     0          103s
cert-manager          cert-manager-cainjector-c77cb865-pwzm4        1/1     Running     0          103s
cert-manager          cert-manager-webhook-d7c4c8dc9-dsllw          1/1     Running     0          103s
flux-system           source-controller-5cfc8d5f94-jdn2g            1/1     Running     0          54s
knative-serving       activator-5d89dc486f-tmwgx                    1/1     Running     0          70s
knative-serving       autoscaler-7c7d7bb749-sz2k6                   1/1     Running     0          69s
knative-serving       controller-8c878f645-xd87v                    1/1     Running     0          70s
knative-serving       domain-mapping-544594f79b-5cs6v               1/1     Running     0          68s
knative-serving       domainmapping-webhook-5c56fcf66-5dk2s         1/1     Running     0          68s
knative-serving       net-certmanager-controller-8657b7f5dc-pxrn6   1/1     Running     0          70s
knative-serving       net-certmanager-webhook-765c755c57-l6lrx      1/1     Running     0          70s
knative-serving       net-contour-controller-59b89f9594-qhhzg       1/1     Running     0          70s
knative-serving       webhook-84679d6476-jxjst                      1/1     Running     0          68s
kpack                 kpack-controller-8b84485dc-pf7wh              1/1     Running     0          70s
kpack                 kpack-webhook-7674b5447-dttg5                 1/1     Running     0          70s
kube-system           calico-kube-controllers-6487584b54-tcsgt      1/1     Running     0          113s
kube-system           calico-node-tjvs2                             1/1     Running     0          113s
kube-system           coredns-78fcd69978-4x2qt                      1/1     Running     0          3m5s
kube-system           coredns-78fcd69978-qcljl                      1/1     Running     0          3m5s
kube-system           etcd-test-control-plane                       1/1     Running     0          3m21s
kube-system           kube-apiserver-test-control-plane             1/1     Running     0          3m18s
kube-system           kube-controller-manager-test-control-plane    1/1     Running     0          3m19s
kube-system           kube-proxy-jkkqx                              1/1     Running     0          3m5s
kube-system           kube-scheduler-test-control-plane             1/1     Running     0          3m18s
local-path-storage    local-path-provisioner-85494db59d-q6qdw       1/1     Running     0          3m5s
projectcontour        contour-6bc54547c4-5sclw                      1/1     Running     0          105s
projectcontour        contour-6bc54547c4-q7lv4                      1/1     Running     0          105s
projectcontour        contour-certgen-v1.19.1--1-gx458              0/1     Completed   0          105s
projectcontour        envoy-q9d97                                   2/2     Running     0          98s
tkg-system            kapp-controller-779d9777dc-qvnbk              1/1     Running     0          2m43s
```

Users can drop in the profile flag and mappings into the `config` command:
```
$ tanzu unmanaged-cluster config --profile fluent-bit:1.7.5:values.yaml test
Wrote configuration file to: test.yaml

$ cat test.yaml
ClusterName: test
KubeconfigPath: ""
ExistingClusterKubeconfig: ""
NodeImage: ""
Provider: kind
ProviderConfiguration: {}
Cni: calico
CniConfiguration: {}
PodCidr: 10.244.0.0/16
ServiceCidr: 10.96.0.0/16
TkrLocation: ""
AdditionalPackageRepos: []
PortsToForward: []
SkipPreflight: false
ControlPlaneNodeCount: "1"
WorkerNodeCount: "0"
Profiles:
  - name: fluent-bit
    config: values.yaml
    version: 1.7.5
```