### PR TITLE
fix: tlsCertificateSecretName in harbor package 2.3.3

### DIFF
--- a/addons/packages/harbor/2.3.3/bundle/config/overlay/update-core.yaml
+++ b/addons/packages/harbor/2.3.3/bundle/config/overlay/update-core.yaml
@@ -104,3 +104,10 @@ spec:
             #@overlay/append
             - name: TOKEN_PRIVATE_KEY_PATH
               value: /etc/core/private-key/tls.key
+      volumes:
+      #@ if values.tlsCertificateSecretName:
+      #@overlay/match by="name"
+      - name: ca-download
+        secret:
+          secretName: #@ values.tlsCertificateSecretName
+      #@ end

--- a/addons/packages/harbor/2.3.3/package.yaml
+++ b/addons/packages/harbor/2.3.3/package.yaml
@@ -721,7 +721,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/harbor@sha256:610c0ec78afd7095eed05624976ab83bd05c41b1f926fb2ccb7cf1bdfc239f37
+            image: projects.registry.vmware.com/tce/harbor@sha256:7a5d963edb34b0c564e3cad6a5138837ef27f0d141523e2bdde86336723a683f
       template:
         - ytt:
             paths:

--- a/addons/packages/harbor/2.3.3/test/unittest/fixtures/expected/tls-certificate-secret-name.yaml
+++ b/addons/packages/harbor/2.3.3/test/unittest/fixtures/expected/tls-certificate-secret-name.yaml
@@ -208,7 +208,7 @@ spec:
           secretName: harbor-token-service
       - name: ca-download
         secret:
-          secretName: harbor-tls
+          secretName: harbor-tls-2
       - name: core-internal-certs
         secret:
           secretName: harbor-core-internal-tls


### PR DESCRIPTION
Signed-off-by: Shengwen Yu <yshengwen@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR fixes: https://github.com/vmware-tanzu/community-edition/issues/3591 in harbor package 2.3.3

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3591 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
1. ut 
```
cd addons/packages/harbor/2.3.3/test
make test
```
2. functional test 
2.1 In tce-harbor-data-values-2.3.3.yaml file, not setting `tlsCertificate`, and not setting `tlsCertificateSecretName`, then `tanzu package install harbor --package-name harbor.community.tanzu.vmware.com --version 2.3.3 -f tce-harbor-data-values-2.3.3.yaml` => harbor is up and running, we can access harbor via web ui
2.2 followed by step 2.1, update tce-harbor-data-values-2.3.3.yaml to not set `tlsCertificate`, but SETTING `tlsCertificateSecretName` to the value harbor-tls-201, then `tanzu package installed update harbor -f tce-harbor-data-values-2.3.3.yaml` => harbor is up and running, we can access harbor via web ui
2.3 In tce-harbor-data-values-2.3.3.yaml file, not setting `tlsCertificate`, but SETTING `tlsCertificateSecretName` to the value harbor-tls-201, then `tanzu package install harbor --package-name harbor.community.tanzu.vmware.com --version 2.3.3 -f tce-harbor-data-values-2.3.3.yaml` => harbor is up and running, we can access harbor via web ui

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
