### PR TITLE
Optimize url check to just use HEAD

### DIFF
--- a/hack/check/urllinter/pkg/lint/lint.go
+++ b/hack/check/urllinter/pkg/lint/lint.go
@@ -5,7 +5,6 @@ package lint
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -21,6 +20,8 @@ import (
 
 	xurls "mvdan.cc/xurls/v2"
 )
+
+const userAgent = "tce-link-checker"
 
 type LinkLintConfig struct {
 	IncludeExts       []string              `yaml:"includeExts"`
@@ -187,14 +188,30 @@ func checkURL(link string) (int, error) {
 
 	cli := &http.Client{Transport: tr}
 	ctx := context.Background()
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, link, bytes.NewBuffer([]byte("")))
-	resp, err := cli.Do(req)
 
+	// Try to just do a HEAD request since we don't actually need the content
+	req, _ := http.NewRequestWithContext(ctx, http.MethodHead, link, http.NoBody)
+	req.Header.Add("user-agent", userAgent)
+
+	resp, err := cli.Do(req)
 	if err != nil {
 		return 0, err
 	}
-
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusMethodNotAllowed {
+		// For some reason some sites, like testgrid.k8s.io, don't allow HEAD requests
+		resp.Body.Close()
+		req, _ = http.NewRequestWithContext(ctx, http.MethodGet, link, http.NoBody)
+		req.Header.Add("user-agent", userAgent)
+
+		resp, err = cli.Do(req)
+		if err != nil {
+			return 0, err
+		}
+		defer resp.Body.Close()
+	}
+
 	return resp.StatusCode, nil
 }
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Our urllinter currently performs a GET request on each URL found in the
repo. Since that will actually return the full page content of the site,
and all we need to know is if the page exists, this results in data
being sent over the wire that we just end up ignoring.

This changes the link checking to use a HEAD request instead. That will
tell us if the page exists or not, while not sending any unnecessary
data with the response.

For whatever reason, the k8s testgrid site does not allow HEAD requests
and returns a 405. This is the only site out of the list of URLs that
behaves this way. To allow us to use the more optimal HEAD request for
the majority of sites, this will detect if a 405 is returned and retry
the link check using the full GET request. This makes the checking
slightly more robust.

Also sets the user-agent on these requests so there is some indication
where all these requests are coming from in case a site operator notices
a burst of requests and wants to investigate.

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make lint` and `make urllint` locally and verified proper operation.