### PR TITLE
Update Gatekeeper package version #3833

### DIFF
--- a/addons/packages/gatekeeper/3.2.3/package.yaml
+++ b/addons/packages/gatekeeper/3.2.3/package.yaml
@@ -1,14 +1,15 @@
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: gatekeeper.community.tanzu.vmware.com.1.0.0
+  name: gatekeeper.community.tanzu.vmware.com.3.2.3
 spec:
   refName: gatekeeper.community.tanzu.vmware.com
-  version: 1.0.0
+  version: 3.2.3
+  releasedAt: 2021-01-27T12:00:00Z
   releaseNotes: "gatekeeper 3.2.3 https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.2.3"
   valuesSchema:
     openAPIv3:
-      title: gatekeeper.community.tanzu.vmware.com.1.0.0 values schema
+      title: gatekeeper.community.tanzu.vmware.com.3.2.3 values schema
       properties:
         namespace:
           type: string


### PR DESCRIPTION
Gatekeeper was one of the original packages we released in January 2021. At that time we were versioning the package, not the software. So, the Gatekeeper 1.0.0 package contains the Gatekeeper 3.2.3 software.

Signed-off-by: Nicholas Seemiller <nseemiller@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3833 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
