### PR TITLE
Update the version chooser

### DIFF
--- a/docs/site/themes/template/layouts/_default/versions.html
+++ b/docs/site/themes/template/layouts/_default/versions.html
@@ -7,7 +7,8 @@
                     {{ $version }}
             </button>
             <div class="dropdown-menu" id="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                {{ $original_version := printf "/%s/" .CurrentSection.Params.version }}
+                {{ $version       := index (split .File.Path "/") 1 }}
+                {{ $original_version := printf "/%s/" $version }}
                 {{ $latest_url := replace .Params.url .CurrentSection.Params.version .Site.Params.docs_latest | relURL }}
                 {{ $currentUrl := .Permalink }}
                 {{ range .Site.Params.docs_versions }}


### PR DESCRIPTION
Signed-off-by: Jonas Rosland <jrosland@vmware.com>

## What this PR does / why we need it
Currently the "version chooser" in our docs doesn't work. Choosing a different version than the latest one just loops back to the latest. This change takes the version from the file path, and fixes the issue.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
