### PR TITLE
remove aws access-key-id and secret-access-key flags 

### DIFF
--- a/test/util/aws-nuke-tear-down.sh
+++ b/test/util/aws-nuke-tear-down.sh
@@ -6,7 +6,7 @@
 function aws-nuke-tear-down {
 	echo "$1"
 	envsubst < "${TCE_REPO_PATH}"/test/aws/nuke-config-template.yml > "${TCE_REPO_PATH}"/test/aws/nuke-config.yml
-	aws-nuke -c "${TCE_REPO_PATH}"/test/aws/nuke-config.yml --access-key-id "$AWS_ACCESS_KEY_ID" --secret-access-key "$AWS_SECRET_ACCESS_KEY" --force --no-dry-run || { error "$2 CLUSTER DELETION FAILED!!!"; rm -rf "${TCE_REPO_PATH}"/test/aws/nuke-config.yml; exit 1; }
+	aws-nuke -c "${TCE_REPO_PATH}"/test/aws/nuke-config.yml --force --no-dry-run || { error "$2 CLUSTER DELETION FAILED!!!"; rm -rf "${TCE_REPO_PATH}"/test/aws/nuke-config.yml; exit 1; }
 	rm -rf "${TCE_REPO_PATH}"/test/aws/nuke-config.yml
 	echo "$2 DELETED using aws-nuke!"
 }


### PR DESCRIPTION
Signed-off-by: Priyanka Saggu <priyankasaggu11929@gmail.com>

## What this PR does / why we need it
The TCE on AWS e2e test, `aws-management-and-workload-cluster-e2e-test` is using the [aws-nuke-tear-down.sh](https://github.com/vmware-tanzu/community-edition/blob/d4b6d1ad83b9e6d8aeb9a00ebd0a1bbfecace719/test/util/aws-nuke-tear-down.sh#L6) script to nuke AWS resources at the end of the test or wherever cluster provisioning fails in the middle of the test.

Inside the [aws-nuke-tear-down.sh](https://github.com/vmware-tanzu/community-edition/blob/d4b6d1ad83b9e6d8aeb9a00ebd0a1bbfecace719/test/util/aws-nuke-tear-down.sh#L6) script, the aws-nuke command looks like following, using the  `--access-key-id` & `--secret-access-key` flags:
```
aws-nuke -c "${TCE_REPO_PATH}"/test/aws/nuke-config.yml --access-key-id "$AWS_ACCESS_KEY_ID" --secret-access-key "$AWS_SECRET_ACCESS_KEY" --force --no-dry-run 
```

At the project TCE level, [this e2e test is run through GitHub actions workflow & the secrets are made available in the runner through GitHub secrets](https://github.com/vmware-tanzu/community-edition/blob/main/.github/workflows/e2e-aws-management-and-workload-cluster.yaml#L69-L74).
 
Adding credentials as GitHub secrets prevents them from getting printed as plain text in the logs by replacing it with `*****`. This replacement is native to GitHub actions only.

But it is not the case for users utilising different platforms for executing the tests & exporting AWS credentials into the host env. All the sensitive information is therefore, printed as plain text in the logs.

## Which issue(s) this PR fixes
<!--
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/3851

## Describe testing done for PR

Observed as part of the local testing, we can drop the `--access-key-id` & `--secret-access-key` flags entirely from the script.

When the flags are not provided, the `aws-nuke` command looks for either of the two things:
- It checks whether there is a `default` profile set in the `~/.aws/credentials` file (with access_key_id & secret_access_key) in the host filesystem.
- Or if there is no default profile set, it can work if we export the following two env variables in the path:
    - `export AWS_ACCESS_KEY_ID=<value>`
    - `export AWS_SECRET_ACCESS_KEY=<value>`
    
   Which in case of TCE tests, the requirement is already satisfied [here](https://github.com/vmware-tanzu/community-edition/blob/main/.github/workflows/e2e-aws-management-and-workload-cluster.yaml#L69-L74).

Snippet from the test run:

```
Deleting the MANAGEMENT CLUSTER using AWS-NUKE...
+ envsubst
+ aws-nuke -c /home/ubuntu/test/community-edition/test/aws/nuke-config.yml --force --no-dry-run
aws-nuke version v2.15.0 - Thu Apr 15 09:54:47 UTC 2021 - <redacted>

Do you really want to nuke the account with the ID <redacted-account-id> and the alias '<redacted-account-alias>'?
Waiting 15s before continuing.

....
....
Scan complete: 78 total, 18 nukeable, 60 filtered.

Do you really want to nuke these resources on the account with the ID <redacted-account-id>  and the alias '<redacted-account-alias>'?
Waiting 15s before continuing.

....
....
Removal requested: 0 waiting, 0 failed, 60 skipped, 18 finished

Nuke complete: 0 failed, 60 skipped, 18 finished.
```

## Special notes for your reviewer

Removing the flags only address the issue for `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY`.

If the test is run using a different platform to GitHub Actions, the `AWS_ACCOUNT_ID` will still appear in the logs.