### PR TITLE
Fix vsphere-pv-csi schema validation

### DIFF
--- a/addons/packages/vsphere-pv-csi/2.4.1/bundle/config/schema.yaml
+++ b/addons/packages/vsphere-pv-csi/2.4.1/bundle/config/schema.yaml
@@ -1,8 +1,17 @@
+#! schema.yaml
+
 #@data/values-schema
+#@schema/desc "OpenAPIv3 Schema for vsphere-pv-csi"
 ---
+#@schema/desc "Configurations for vsphere-pv-csi"
 vspherePVCSI:
+  #@schema/desc: "Namespace to deploy vsphere-pv-csi"
   namespace: ""
+  #@schema/desc: "Supervisor cluster's apiserver hostname"
   supervisor_master_endpoint_hostname: ""
+  #@schema/desc: "Supervisor cluster's apiserver port"
   supervisor_master_port: 0
+  #@schema/desc: "UID of workload cluster"
   cluster_uid: ""
+  #@schema/desc: "Name of workload cluster"
   cluster_name: ""

--- a/addons/packages/vsphere-pv-csi/2.4.1/package.yaml
+++ b/addons/packages/vsphere-pv-csi/2.4.1/package.yaml
@@ -5,21 +5,47 @@ metadata:
 spec:
   refName: vsphere-pv-csi.community.tanzu.vmware.com
   version: 2.4.1
-  releaseNotes: "vsphere-csi 2.4.1 https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.4.1"
+  releaseNotes: vsphere-csi 2.4.1 https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.4.1
   licenses:
-    - "Apache 2.0"
+  - Apache 2.0
   template:
     spec:
       fetch:
-        - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-pv-csi@sha256:f8e7842e55f571c13e90439f80039511762169e480d5534773745aa15d5ce133
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/vsphere-pv-csi@sha256:7b0bf20f984709e94e27aa27995bbad3f80175e1a53979c3ae979e2243271a4a
       template:
-        - ytt:
-            paths:
-              - config/
-        - kbld:
-            paths:
-              - "-"
-              - .imgpkg/images.yml
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
       deploy:
-        - kapp: {}
+      - kapp: {}
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      description: OpenAPIv3 Schema for vsphere-pv-csi
+      properties:
+        vspherePVCSI:
+          type: object
+          additionalProperties: false
+          description: Configurations for vsphere-pv-csi
+          properties:
+            namespace:
+              type: string
+              default: ""
+            supervisor_master_endpoint_hostname:
+              type: string
+              default: ""
+            supervisor_master_port:
+              type: integer
+              default: 0
+            cluster_uid:
+              type: string
+              default: ""
+            cluster_name:
+              type: string
+              default: ""

--- a/addons/packages/vsphere-pv-csi/2.4.1/sample-values/vsphere-pv-csi.yaml
+++ b/addons/packages/vsphere-pv-csi/2.4.1/sample-values/vsphere-pv-csi.yaml
@@ -5,3 +5,5 @@ vspherePVCSI:
   namespace: "vmware-system-csi"
   supervisor_master_endpoint_hostname: "supervisor.default.svc"
   supervisor_master_port: 6443
+  cluster_uid: 33EE5E89-CA9B-43E4-82C6-6A2F21E3AD37
+  cluster_name: test


### PR DESCRIPTION
## What this PR does / why we need it
Cluster_uid and Cluster_name in vsphere-pv-csi package schema was defined as string but default value was null. That caused mismatch and ytt rendering failed with error:
```
ytt: Error: Overlaying data values (in following order: values.yaml, values.yaml):
One or more data values were invalid
====================================

values.yaml:
    |
  8 |   cluster_uid: null
    |

    = found: null
    = expected: string (by schema.yaml:15)

values.yaml:
    |
  9 |   cluster_name: null
    |

    = found: null
    = expected: string (by schema.yaml:17)

```

## Which issue(s) this PR fixes


## Describe testing done for PR
```
❯ ytt --ignore-unknown-comments -f . -f ../values.yaml
apiVersion: v1
kind: Namespace
metadata:
  name: vmware-system-csi
---
kind: ServiceAccount
apiVersion: v1
metadata:
  name: vsphere-csi-controller
  namespace: vmware-system-csi
---
kind: ServiceAccount
apiVersion: v1
metadata:
  name: vsphere-csi-node
  namespace: vmware-system-csi
---
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: vsphere-csi-controller-role
rules:
- apiGroups:
  - ""
  resources:
  - nodes
  - pods
  - configmaps
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - persistentvolumeclaims
  verbs:
  - get
  - list
  - watch
  - update
- apiGroups:
  - ""
  resources:
  - persistentvolumes
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - delete
  - patch
- apiGroups:
  - ""
  resources:
  - events
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
- apiGroups:
  - coordination.k8s.io
  resources:
  - leases
  verbs:
  - get
  - watch
  - list
  - delete
  - update
  - create
- apiGroups:
  - cns.vmware.com
  resources:
  - triggercsifullsyncs
  verbs:
  - create
  - get
  - update
  - watch
  - list
- apiGroups:
  - storage.k8s.io
  resources:
  - storageclasses
  - csinodes
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - storage.k8s.io
  resources:
  - volumeattachments
  verbs:
  - get
  - list
  - watch
  - update
  - patch
- apiGroups:
  - storage.k8s.io
  resources:
  - volumeattachments/status
  verbs:
  - patch
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - get
  - create
  - update
- apiGroups:
  - policy
  resources:
  - podsecuritypolicies
  verbs:
  - use
  resourceNames:
  - vmware-system-privileged
- apiGroups:
  - ""
  resources:
  - persistentvolumeclaims/status
  verbs:
  - update
  - patch
---
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: vsphere-csi-node-role
  namespace: vmware-system-csi
rules:
- apiGroups:
  - policy
  resources:
  - podsecuritypolicies
  verbs:
  - use
  resourceNames:
  - vmware-system-privileged
- apiGroups:
  - ""
  resources:
  - configmaps
  verbs:
  - get
  - list
  - watch
---
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: vsphere-csi-controller-binding
subjects:
- kind: ServiceAccount
  name: vsphere-csi-controller
  namespace: vmware-system-csi
roleRef:
  kind: ClusterRole
  name: vsphere-csi-controller-role
  apiGroup: rbac.authorization.k8s.io
---
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: vsphere-csi-node-binding
  namespace: vmware-system-csi
subjects:
- kind: ServiceAccount
  name: vsphere-csi-node
  namespace: vmware-system-csi
roleRef:
  kind: Role
  name: vsphere-csi-node-role
  apiGroup: rbac.authorization.k8s.io
---
kind: Deployment
apiVersion: apps/v1
metadata:
  name: vsphere-csi-controller
  namespace: vmware-system-csi
spec:
  replicas: 1
  strategy:
    type: Recreate
  selector:
    matchLabels:
      app: vsphere-csi-controller
  template:
    metadata:
      labels:
        app: vsphere-csi-controller
        role: vsphere-csi
    spec:
      serviceAccountName: vsphere-csi-controller
      nodeSelector:
        node-role.kubernetes.io/master: ""
      tolerations:
      - operator: Exists
        key: node-role.kubernetes.io/master
        effect: NoSchedule
      priorityClassName: system-node-critical
      containers:
      - name: csi-attacher
        image: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
        args:
        - --v=4
        - --timeout=300s
        - --csi-address=$(ADDRESS)
        - --leader-election
        - --kube-api-qps=100
        - --kube-api-burst=100
        imagePullPolicy: IfNotPresent
        env:
        - name: ADDRESS
          value: /csi/csi.sock
        volumeMounts:
        - mountPath: /csi
          name: socket-dir
      - name: vsphere-csi-controller
        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1
        args:
        - --supervisor-fss-name=csi-feature-states
        - --supervisor-fss-namespace=$(CSI_NAMESPACE)
        - --fss-name=internal-feature-states.csi.vsphere.vmware.com
        - --fss-namespace=$(CSI_NAMESPACE)
        imagePullPolicy: IfNotPresent
        ports:
        - containerPort: 2112
          name: prometheus
          protocol: TCP
        env:
        - name: CSI_ENDPOINT
          value: unix:///csi/csi.sock
        - name: CLUSTER_FLAVOR
          value: GUEST_CLUSTER
        - name: X_CSI_MODE
          value: controller
        - name: GC_CONFIG
          value: /etc/cloud/pvcsi-config/cns-csi.conf
        - name: PROVISION_TIMEOUT_MINUTES
          value: "4"
        - name: ATTACHER_TIMEOUT_MINUTES
          value: "4"
        - name: RESIZE_TIMEOUT_MINUTES
          value: "4"
        - name: LOGGER_LEVEL
          value: PRODUCTION
        - name: SUPERVISOR_CLIENT_QPS
          value: "50"
        - name: SUPERVISOR_CLIENT_BURST
          value: "50"
        - name: INCLUSTER_CLIENT_QPS
          value: "50"
        - name: INCLUSTER_CLIENT_BURST
          value: "50"
        - name: CSI_NAMESPACE
          value: vmware-system-csi
        - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
          value: 3m
        volumeMounts:
        - mountPath: /etc/cloud/pvcsi-provider
          name: pvcsi-provider-volume
          readOnly: true
        - mountPath: /etc/cloud/pvcsi-config
          name: pvcsi-config-volume
          readOnly: true
        - mountPath: /csi
          name: socket-dir
      - name: vsphere-syncer
        image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.1
        args:
        - --leader-election
        - --supervisor-fss-name=csi-feature-states
        - --supervisor-fss-namespace=$(CSI_NAMESPACE)
        - --fss-name=internal-feature-states.csi.vsphere.vmware.com
        - --fss-namespace=$(CSI_NAMESPACE)
        imagePullPolicy: IfNotPresent
        ports:
        - containerPort: 2113
          name: prometheus
          protocol: TCP
        env:
        - name: FULL_SYNC_INTERVAL_MINUTES
          value: "30"
        - name: GC_CONFIG
          value: /etc/cloud/pvcsi-config/cns-csi.conf
        - name: CLUSTER_FLAVOR
          value: GUEST_CLUSTER
        - name: LOGGER_LEVEL
          value: PRODUCTION
        - name: CSI_NAMESPACE
          value: vmware-system-csi
        volumeMounts:
        - mountPath: /etc/cloud/pvcsi-provider
          name: pvcsi-provider-volume
          readOnly: true
        - mountPath: /etc/cloud/pvcsi-config
          name: pvcsi-config-volume
          readOnly: true
      - name: liveness-probe
        image: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
        args:
        - --csi-address=$(ADDRESS)
        imagePullPolicy: IfNotPresent
        env:
        - name: ADDRESS
          value: /csi/csi.sock
        volumeMounts:
        - mountPath: /csi
          name: socket-dir
      - name: csi-provisioner
        image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
        args:
        - --v=4
        - --timeout=300s
        - --csi-address=$(ADDRESS)
        - --leader-election
        - --default-fstype=ext4
        - --kube-api-qps=100
        - --kube-api-burst=100
        imagePullPolicy: IfNotPresent
        env:
        - name: ADDRESS
          value: /csi/csi.sock
        volumeMounts:
        - mountPath: /csi
          name: socket-dir
      - name: csi-resizer
        image: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
        args:
        - --v=4
        - --timeout=300s
        - --handle-volume-inuse-error=false
        - --csi-address=$(ADDRESS)
        - --leader-election
        - --kube-api-qps=100
        - --kube-api-burst=100
        env:
        - name: ADDRESS
          value: /csi/csi.sock
        volumeMounts:
        - mountPath: /csi
          name: socket-dir
      volumes:
      - name: pvcsi-provider-volume
        secret:
          secretName: pvcsi-provider-creds
      - name: pvcsi-config-volume
        configMap:
          name: pvcsi-config
      - name: socket-dir
        emptyDir: {}
---
apiVersion: storage.k8s.io/v1
kind: CSIDriver
metadata:
  name: csi.vsphere.vmware.com
spec:
  attachRequired: true
  podInfoOnMount: false
---
kind: DaemonSet
apiVersion: apps/v1
metadata:
  name: vsphere-csi-node
  namespace: vmware-system-csi
spec:
  selector:
    matchLabels:
      app: vsphere-csi-node
  updateStrategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: vsphere-csi-node
        role: vsphere-csi
    spec:
      hostNetwork: true
      dnsPolicy: ClusterFirstWithHostNet
      serviceAccountName: vsphere-csi-node
      priorityClassName: system-node-critical
      containers:
      - name: node-driver-registrar
        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
        imagePullPolicy: IfNotPresent
        args:
        - --v=5
        - --csi-address=$(ADDRESS)
        - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
        - --health-port=9809
        env:
        - name: ADDRESS
          value: /csi/csi.sock
        - name: DRIVER_REG_SOCK_PATH
          value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
        volumeMounts:
        - name: plugin-dir
          mountPath: /csi
        - name: registration-dir
          mountPath: /registration
        ports:
        - containerPort: 9809
          name: healthz
        livenessProbe:
          httpGet:
            path: /healthz
            port: healthz
          initialDelaySeconds: 5
          timeoutSeconds: 5
      - name: vsphere-csi-node
        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1
        args:
        - --supervisor-fss-name=csi-feature-states
        - --supervisor-fss-namespace=$(CSI_NAMESPACE)
        - --fss-name=internal-feature-states.csi.vsphere.vmware.com
        - --fss-namespace=$(CSI_NAMESPACE)
        imagePullPolicy: IfNotPresent
        env:
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        - name: CSI_ENDPOINT
          value: unix:///csi/csi.sock
        - name: MAX_VOLUMES_PER_NODE
          value: "59"
        - name: X_CSI_MODE
          value: node
        - name: X_CSI_SPEC_REQ_VALIDATION
          value: "false"
        - name: CLUSTER_FLAVOR
          value: GUEST_CLUSTER
        - name: LOGGER_LEVEL
          value: PRODUCTION
        - name: CSI_NAMESPACE
          value: vmware-system-csi
        securityContext:
          privileged: true
          capabilities:
            add:
            - SYS_ADMIN
          allowPrivilegeEscalation: true
        volumeMounts:
        - name: plugin-dir
          mountPath: /csi
        - name: pods-mount-dir
          mountPath: /var/lib/kubelet
          mountPropagation: Bidirectional
        - name: device-dir
          mountPath: /dev
        - name: blocks-dir
          mountPath: /sys/block
        - name: sys-devices-dir
          mountPath: /sys/devices
      - name: liveness-probe
        image: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
        args:
        - --csi-address=/csi/csi.sock
        imagePullPolicy: IfNotPresent
        volumeMounts:
        - name: plugin-dir
          mountPath: /csi
      volumes:
      - name: registration-dir
        hostPath:
          path: /var/lib/kubelet/plugins_registry
          type: Directory
      - name: plugin-dir
        hostPath:
          path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/
          type: DirectoryOrCreate
      - name: pods-mount-dir
        hostPath:
          path: /var/lib/kubelet
          type: Directory
      - name: device-dir
        hostPath:
          path: /dev
      - name: blocks-dir
        hostPath:
          path: /sys/block
          type: Directory
      - name: sys-devices-dir
        hostPath:
          path: /sys/devices
          type: Directory
      tolerations:
      - effect: NoExecute
        operator: Exists
      - effect: NoSchedule
        operator: Exists
---
apiVersion: v1
data:
  cns-csi.conf: |-
    [GC]
    endpoint = supervisor.default.svc
    port = 6443
    tanzukubernetescluster-uid = test
    tanzukubernetescluster-name = test
kind: ConfigMap
metadata:
  name: pvcsi-config
  namespace: vmware-system-csi
---
apiVersion: v1
data:
  volume-extend: "true"
  volume-health: "true"
  online-volume-extend: "true"
  file-volume: "true"
  csi-sv-feature-states-replication: "false"
  block-volume-snapshot: "false"
kind: ConfigMap
metadata:
  name: internal-feature-states.csi.vsphere.vmware.com
  namespace: vmware-system-csi
---
apiVersion: v1
kind: Service
metadata:
  name: vsphere-csi-controller
  namespace: vmware-system-csi
  labels:
    app: vsphere-csi-controller
spec:
  ports:
  - name: ctlr
    port: 2112
    targetPort: 2112
    protocol: TCP
  - name: syncer
    port: 2113
    targetPort: 2113
    protocol: TCP
  selector:
    app: vsphere-csi-controller
```

## Special notes for your reviewer
Havent been able to push package due to permissions error. So this PR should be merged only after package is pushed.
```
imgpkg: Error: Writing 'projects.registry.vmware.com/tce/vsphere-pv-csi:2.4.1':
  Writing image:
    Non-retryable error:
      POST https://projects.registry.vmware.com/v2/tce/vsphere-pv-csi/blobs/uploads/:
        UNAUTHORIZED: unauthorized to access repository: tce/vsphere-pv-csi, action: push: unauthorized to access repository: tce/vsphere-pv-csi, action: push
```
