### PR TITLE
Fixing supported kubernetes versions per v0.11.0

### DIFF
--- a/docs/site/content/docs/support-matrix.md
+++ b/docs/site/content/docs/support-matrix.md
@@ -50,4 +50,4 @@ Mac and Windows: In Docker Desktop, select Preferences > Resources > Advanced
 
 ## Supported Kubernetes Versions
 
-Tanzu Community Edition supports the following Kubernetes versions: `1.21.2, 1.20.8, 1.19.12`
+Tanzu Community Edition supports the following Kubernetes versions: `1.22.5, 1.21.8, 1.20.14`


### PR DESCRIPTION
These are the supported versions as per OVAs available in customerconnect.vmware.com

## What this PR does / why we need it
Updates kubernetes version support in tanzucommunityedition docs based on OVAs available in customerconnect.vmware.com

## Which issue(s) this PR fixes
NA

Fixes: #

## Describe testing done for PR
None

## Special notes for your reviewer
Based on feedback in TCE slack channel [here](https://kubernetes.slack.com/archives/C02GY94A8KT/p1649066668804209) that this information was correct.
