### PR TITLE
Clean up configured linters in golangci-lint

### DIFF
--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -11,6 +11,7 @@ on:
       - "**.go"
       - "**/go.mod"
       - "hack/check-lint.sh"
+      - ".golangci.yaml"
 
 jobs:
   checklint:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -58,8 +58,6 @@ linters:
   enable:
     - bodyclose
     - deadcode
-    - depguard
-    - dogsled
     - dupl
     - errcheck
     - funlen
@@ -71,14 +69,12 @@ linters:
     - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
     - noctx
     - nolintlint
-    - rowserrcheck
     - revive
     - staticcheck
     - structcheck
@@ -86,27 +82,8 @@ linters:
     - typecheck
     - unconvert
     - unparam
-    - unused
     - varcheck
     - whitespace
-
-  # don't enable:
-  # - asciicheck
-  # - exhaustive
-  # - gochecknoinits
-  # - gochecknoglobals
-  # - gocognit
-  # - godot
-  # - godox
-  # - goerr113
-  # - interfacer
-  # - lll
-  # - nestif
-  # - prealloc
-  # - testpackage
-  # - revive
-  # - scopelint
-  # - wsl
 
 issues:
   exclude:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We have a long list of linters configured in our golangci-lint
configuration. Since the linting of all modules takes a noticeable
amount of time, I went through the list to see if there were any that
were redundant or of very low value to try to optimize this a little.

This removes a few of the configured linters:

- depguard - requires configuration that we are not using
- dogsled - checks for too many blank assignments (_, _ = x())
- gosimple - used to simplify code when using "fix", which we don't
- rowserrcheck - used for checking SQL query error checks
- unused - already covered by deadcode

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `time make lint` before and after removing linters. The times would
fluctuate, but I did see a few runs after the cleanup that were a little
faster. May be more noticeable on machines with less cores like our
GitHub Action runners.
