### PR TITLE
addons/packages/pinniped: create pinniped-info from package

### DIFF
--- a/addons/packages/pinniped/0.12.1/bundle/config/overlay/pinniped-info-cm.yaml
+++ b/addons/packages/pinniped/0.12.1/bundle/config/overlay/pinniped-info-cm.yaml
@@ -1,0 +1,12 @@
+#@ load("@ytt:data", "data")
+
+#@ if data.values.tkg_cluster_role == "workload":
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pinniped-info
+  namespace: kube-public
+data:
+  concierge_is_cluster_scoped: "true"
+#@ end


### PR DESCRIPTION
...instead of post-deploy job. We are trying to get rid of the post-deploy
job on the workload cluster. This is one step.

Signed-off-by: Andrew Keesler <akeesler@vmware.com>

## What this PR does / why we need it

```
    addons/packages/pinniped: create pinniped-info from package

    ...instead of post-deploy job. We are trying to get rid of the post-deploy
    job on the workload cluster. This is one step.
```

## Which issue(s) this PR fixes

None

## Describe testing done for PR

* Created workload cluster to test fresh install of package
* Upgraded existing workload cluster to test upgrade of package

## Special notes for your reviewer

None