### PR TITLE
Designates CODEOWNERS for `vsphere-pv-csi` package

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -95,5 +95,8 @@ addons/packages/vsphere-cpi @vmware-tanzu/pkg-vsphere-cpi-owners
 ## Ownership of the vsphere-csi package
 addons/packages/vsphere-csi @vmware-tanzu/pkg-vsphere-csi-owners
 
+## Ownership of the vsphere-pv-csi package
+addons/packages/vsphere-pv-csi @vmware-tanzu/pkg-vsphere-csi-owners
+
 ## Ownership of the whereabouts package
 addons/packages/whereabouts @vmware-tanzu/pkg-whereabouts-owners


### PR DESCRIPTION
## What this PR does / why we need it

Saw there wasn't an owner over this package. Setting the @vmware-tanzu/pkg-vsphere-csi-owners - let me know if this _isn't_ the correct team to deligate

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
N/a - GitHub is saying this CODEOWNER file is valid 👍🏼 