### PR TITLE
cartographer: bump to 0.3.0

### DIFF
--- a/addons/packages/cartographer/0.3.0/README.md
+++ b/addons/packages/cartographer/0.3.0/README.md
@@ -1,0 +1,63 @@
+# Cartographer
+
+Cartographer allows you to create secure and reusable supply chains that define
+all of your application CI and CD in one place, in cluster.
+
+## Components
+
+* cartographer
+
+## Supported Providers
+
+The following table shows the providers this package can work with.
+
+| AWS  | Azure | vSphere | Docker |
+|------|-------|---------|--------|
+| ✅   | ✅    | ✅      | ✅     |
+
+## Configuration
+
+The Cartographer package has no configurable properties.
+
+## Installation
+
+The Cartographer package requires use of cert-manager for certificate
+generation.
+
+1. Install cert-manager Package
+
+   ```shell
+   tanzu package install cert-manager \
+      --package-name cert-manager.community.tanzu.vmware.com \
+      --version ${CERT_MANAGER_PACKAGE_VERSION}
+   ```
+
+   > You can get the `${CERT_MANAGER_PACKAGE_VERSION}` from running `tanzu
+   > package available list cert-manager.community.tanzu.vmware.com`.
+   > Specifying a namespace may be required depending on where your package
+   > repository was installed.
+
+2. Install the Cartographer package
+
+   ```shell
+   tanzu package install cartographer \
+      --package-name cartographer.community.tanzu.vmware.com \
+      --version ${CARTOGRAPHER_PACKAGE_VERSION}
+   ```
+
+   > You can get the `${CARTOGRAPHER_PACKAGE_VERSION}` from running `tanzu
+   > package available list cartographer.community.tanzu.vmware.com`.
+   > Specifying a namespace may be required depending on where your package
+   > repository was installed.
+
+## Documentation
+
+For documentation specific to Cartographer, check out
+[cartographer.sh](https://cartographer.sh) and the main repository
+[vmware-tanzu/cartographer](https://github.com/vmware-tanzu/cartographer).
+
+[carvel]: https://carvel.dev/
+[Cartographer]: https://cartographer.sh
+[kapp-controller]: https://github.com/vmware-tanzu/carvel-kapp-controller
+[Tanzu CLI]: https://github.com/vmware-tanzu/tanzu-framework
+[cert-manager]: https://github.com/cert-manager/cert-manager

--- a/addons/packages/cartographer/0.3.0/package.yaml
+++ b/addons/packages/cartographer/0.3.0/package.yaml
@@ -1,0 +1,29 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: cartographer.community.tanzu.vmware.com.0.3.0
+spec:
+  refName: cartographer.community.tanzu.vmware.com
+  version: 0.3.0
+  releaseNotes: https://github.com/vmware-tanzu/cartographer/releases/tag/0.3.0
+  releasedAt: "2022-04-01T17:37:47Z"
+  valuesSchema:
+    openAPIv3:
+      title: cartographer.community.tanzu.vmware.com.0.3.0 values schema
+      properties: {}
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/cartographer@sha256:ab7af733399a6e3df736796b094339e922ba156f49fba47957cdd138d4a3f2ea
+      template:
+      - ytt:
+          ignoreUnknownComments: true
+          paths:
+          - config
+      - kbld:
+          paths:
+          - .imgpkg/images.yml
+          - '-'
+      deploy:
+      - kapp: {}

--- a/addons/packages/cartographer/vendir.lock.yml
+++ b/addons/packages/cartographer/vendir.lock.yml
@@ -5,4 +5,9 @@ directories:
       url: https://api.github.com/repos/vmware-tanzu/package-for-cartographer/releases/60735667
     path: .
   path: 0.2.2
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/package-for-cartographer/releases/63403230
+    path: .
+  path: 0.3.0
 kind: LockConfig

--- a/addons/packages/cartographer/vendir.yml
+++ b/addons/packages/cartographer/vendir.yml
@@ -5,20 +5,24 @@ directories:
   - path: 0.2.2
     contents:
       - path: .
+        includePaths:
+          - README.md
+          - package.yaml
         githubRelease:
           slug: vmware-tanzu/package-for-cartographer
-          tag: v0.2.2
           disableAutoChecksumValidation: true
-          assetNames:
-          - "package.yaml"
-          - "README.md"
+          tag: v0.2.2
+          unpackArchive:
+            path: cartographer-tce.tgz
   - path: 0.3.0
     contents:
       - path: .
+        includePaths:
+          - README.md
+          - package.yaml
         githubRelease:
           slug: vmware-tanzu/package-for-cartographer
-          tag: v0.3.0
           disableAutoChecksumValidation: true
-          assetNames:
-          - "package.yaml"
-          - "README.md"
+          tag: v0.3.0
+          unpackArchive:
+            path: cartographer-tce.tgz

--- a/addons/packages/cartographer/vendir.yml
+++ b/addons/packages/cartographer/vendir.yml
@@ -12,3 +12,13 @@ directories:
           assetNames:
           - "package.yaml"
           - "README.md"
+  - path: 0.3.0
+    contents:
+      - path: .
+        githubRelease:
+          slug: vmware-tanzu/package-for-cartographer
+          tag: v0.3.0
+          disableAutoChecksumValidation: true
+          assetNames:
+          - "package.yaml"
+          - "README.md"

--- a/test/smoke/Makefile
+++ b/test/smoke/Makefile
@@ -32,7 +32,7 @@ grafana:
 	./packages/grafana/7.5.7/grafana-test.sh
 
 cartographer:
-	./packages/cartographer/0.2.2/cartographer-test.sh
+	./packages/cartographer/0.3.0/cartographer-test.sh
 
 external-dns:
 	cd "${ROOT_DIR}"/test/e2e && ginkgo -v -- --packages="external-dns" --version="0.8.0" --guest-cluster-name="tce.public"

--- a/test/smoke/packages/cartographer/0.3.0/cartographer-test.sh
+++ b/test/smoke/packages/cartographer/0.3.0/cartographer-test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TCE_REPO_PATH="$(git rev-parse --show-toplevel)"
+# shellcheck source=test/smoke/packages/utils/smoke-tests-utils.sh
+source "${TCE_REPO_PATH}/test/smoke/packages/utils/smoke-tests-utils.sh"
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Checking package is installed or not
+tanzu package installed list | grep "cert-manager.community.tanzu.vmware.com" || {
+    version=$(tanzu package available list cert-manager.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+    tanzu package install cert-manager --package-name cert-manager.community.tanzu.vmware.com --version "${version}"
+}
+
+tanzu package installed list | grep "cartographer.community.tanzu.vmware.com" || {
+    version=$(tanzu package available list cartographer.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+    tanzu package install cartographer --package-name cartographer.community.tanzu.vmware.com --version "${version}"
+}
+
+
+NAMESPACE_SUFFIX=${RANDOM}
+NAMESPACE="cartographer-${NAMESPACE_SUFFIX}"
+kubectl create ns ${NAMESPACE}
+
+kubectl apply -n ${NAMESPACE} --filename "${MY_DIR}"/testdata.yaml
+
+for sleep_duration in {1..10}; do
+    echo "sleeping ${sleep_duration}s to wait for configmap"
+    sleep "$sleep_duration"
+
+    kubectl get configmap -n ${NAMESPACE} workload-test-basic && {
+        packageCleanup cartographer cert-manager
+        namespaceCleanup ${NAMESPACE}
+        successMessage cartographer
+        exit 0
+    }
+done
+
+packageCleanup cartographer cert-manager
+namespaceCleanup ${NAMESPACE}
+failureMessage cartographer

--- a/test/smoke/packages/cartographer/0.3.0/testdata.yaml
+++ b/test/smoke/packages/cartographer/0.3.0/testdata.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-basic
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-basic
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["*"]
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-basic
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-basic
+subjects:
+  - kind: ServiceAccount
+    name: test-basic
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: test-basic
+spec:
+  template:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: workload-$(workload.metadata.name)$
+    data: {}
+
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSupplyChain
+metadata:
+  name: test-basic
+spec:
+  selector:
+    test-basic: test-basic
+
+  resources:
+    - name: test-basic
+      templateRef:
+        kind: ClusterTemplate
+        name: test-basic
+
+
+---
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: test-basic
+  labels:
+    test-basic: test-basic
+spec:
+  serviceAccountName: test-basic


### PR DESCRIPTION
## What this PR does / why we need it

Cartographer just got [v0.3.0 released](https://github.com/vmware-tanzu/cartographer/releases/tag/v0.3.0), so, bump it here in TCE too.

in this PR, proposed changes:

- `vendir` the latest 0.3.0 release from `vmware-tanzu/package-for-cartographer`
- copy smoke tests from 0.2.2 to 0.3.0 (no change in the smoke tests)


## Which issue(s) this PR fixes

None


## Describe testing done for PR

1. brought up a kind cluster with kapp-controller installed
2. added to it the package and packagemetadata objects for both cert-manager and cartographer (from `./addons/packages/`)
3. ran the smoke test

```console
$ ./0.3.0/cartographer-test.sh
 Installing package 'cert-manager.community.tanzu.vmware.com'
...
 'PackageInstall' resource install status: ReconcileSucceeded

 Added installed package 'cert-manager'
...
 'PackageInstall' resource install status: ReconcileSucceeded

 Added installed package 'cartographer'
...

sleeping 1s to wait for configmap

NAME                  DATA   AGE
workload-test-basic   0      0s


...
Uninstalled package 'cartographer' from namespace 'default'
Uninstalled package 'cert-manager' from namespace 'default'
namespace "cartographer-12275" deleted

cartographer passed
```
