### PR TITLE
Run dependency check action

### DIFF
--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -1,0 +1,14 @@
+name: Check - Dependencies
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v1


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This adds a new job to our GitHub Actions to use
`dependency-review-action`. From that project's description:

```
This action scans your pull requests for dependency changes
and will raise an error if any new dependencies have existing
vulnerabilities.
```

This should help us catch if there are any cases where we are adding a
dependency for something with a known CVE.