### PR TITLE
UI: Fix docker build of UI files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ build-cli-plugins-%: prep-build-cli
 	$(eval OS = $(word 1,$(subst -, ,$*)))
 
 	@printf "===> Building with ${OS}-${ARCH}\n";
-	@cd ./cli/cmd/plugin/ui; if [ ! -d "web/tanzu-ui/build" ]; then make ui-build-docker; fi;
+	@cd ./cli/cmd/plugin/ui; if [ ! -d "web/tanzu-ui/build/static" ]; then make ui-build-docker; fi;
 	@cd ./hack/builder/ && $(MAKE) compile OS=${OS} ARCH=${ARCH} PLUGINS=${PLUGINS} DISCOVERY_NAME=${DISCOVERY_NAME} TANZU_CORE_BUCKET="tce-tanzu-cli-framework" TKG_DEFAULT_IMAGE_REPOSITORY=${TKG_DEFAULT_IMAGE_REPOSITORY} TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH=${TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH}
 
 # This publishes all plugins so we can install them

--- a/cli/cmd/plugin/ui/Makefile
+++ b/cli/cmd/plugin/ui/Makefile
@@ -40,16 +40,14 @@ ui-build: ui-dependencies ## Install dependencies, then compile client UI for pr
 	cd $(UI_DIR); npm run build:prod
 
 ui-build-docker:
-	cd $(UI_DIR); \
-		docker run -it --rm \
-		-v "$$(pwd)":/usr/src -w /usr/src \
+	docker run -it --rm \
+		-v "$$(pwd)":/usr/src -w /usr/src/$(UI_DIR) \
 		--user $(UID):$(GID) \
 		node:16 \
 		sh -c "npm ci; npm run build:prod"
 
 .PHONY: generate-ui-swagger-api
 generate-ui-swagger-api: ## Generate swagger files for UI backend
-	# swagger generate server -t server -A TanzuUI -f api/spec.yaml --exclude-main
 	rm -fr server/models server/restapi/operations
 	${SWAGGER} generate server -A TanzuUI -t server -f api/spec.yaml --exclude-main
 	git reset HEAD server/restapi/server.go


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

With the addition of generating client code from the swagger spec, the
directory path we were mounting in the docker file to perform the site
build wasn't able to reach the swagger spec.

This changes where we mount the local directory and run the build
scripts so it includes the path to the spec.

Also fixed the logic in the root plugin build to properly recognize if
the site has been built.

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make build-tce-cli-plugins` from clean clone and made sure it was able to build the site and compile the plugin.
