### PR TITLE
Add utility for parallel lint execution

### DIFF
--- a/.github/workflows/check-all.yaml
+++ b/.github/workflows/check-all.yaml
@@ -52,7 +52,7 @@ jobs:
         shell: bash
         run: |
           make ensure-deps
-          make check
+          PRINT_FAILURES=1 make check
       - name: Get dependencies
         shell: bash
         run: |

--- a/Makefile
+++ b/Makefile
@@ -125,24 +125,9 @@ OCI_REGISTRY := projects.registry.vmware.com/tce
 ##### IMAGE
 
 ##### LINTING TARGETS
-.PHONY: check check-serial check-parallel lint mdlint shellcheck yamllint misspell actionlint urllint imagelint
+.PHONY: check lint mdlint shellcheck yamllint misspell actionlint urllint imagelint
 check:
-	@make_version=`make --version | grep -E "GNU Make [0-9].[0-9]+" | grep -E -o "[0-9].[0-9]+" | cut -d "." -f1`; \
-	if [ "$${make_version}" != "3" ]; then \
-		echo " "; \
-		echo "*********************************************************************************"; \
-		echo "Executing linters in parallel. Output is withheld until individual lint jobs complete."; \
-		echo "*********************************************************************************"; \
-		echo " "; \
-		$(MAKE) --jobs=$(NUMBER_OF_CORES) --output-sync=target lint mdlint shellcheck yamllint misspell actionlint urllint imagelint; \
-	else \
-		echo " "; \
-		echo "***************************************************"; \
-		echo "To speed up linting, update to the latest GNU Make."; \
-		echo "***************************************************"; \
-		echo " "; \
-		$(MAKE) lint mdlint shellcheck yamllint misspell actionlint urllint imagelint; \
-	fi;
+	go run hack/check/makerunner.go lint mdlint shellcheck yamllint misspell actionlint urllint imagelint
 
 .PHONY: check-deps-minimum-build
 check-deps-minimum-build:

--- a/hack/check/makerunner.go
+++ b/hack/check/makerunner.go
@@ -1,0 +1,136 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+	"time"
+)
+
+const (
+	Running  = string('\U0001F3C3')
+	Complete = string('\U0001F600')
+	Failed   = string('\U0001F4A5')
+)
+
+// Set a PRINT_FAILURES env variable to 1 to enable
+var printFailLogs bool
+
+type taskStatus struct {
+	status  string
+	logFile string
+	name    string
+}
+
+func printTaskStatus(tasks []taskStatus, update bool) {
+	if update {
+		// Clear the last update
+		for i := 0; i < len(tasks); i++ {
+			fmt.Print("\033[1A") // Up a line
+			fmt.Print("\033[K")  // Clear it
+		}
+	}
+
+	for _, task := range tasks {
+		outputLocation := ""
+		if task.status == Failed {
+			outputLocation = fmt.Sprintf("- %s", task.logFile)
+		}
+		fmt.Printf("%s - %s %s\n", task.status, task.name, outputLocation)
+	}
+}
+
+func main() {
+	targets := os.Args[1:]
+	if len(targets) == 0 {
+		fmt.Println("Please pass list of targets to run")
+		return
+	}
+
+	if os.Getenv("PRINT_FAILURES") == "1" {
+		printFailLogs = true
+	}
+
+	tasks := make([]taskStatus, len(targets))
+	timeStamp := time.Now().Format("20060102")
+	wg := sync.WaitGroup{}
+	guard := make(chan struct{}, runtime.NumCPU())
+	complete := make(chan bool)
+
+	fmt.Printf("Running targets: %v\n", targets)
+	for i, target := range targets {
+		wg.Add(1)
+		guard <- struct{}{}
+
+		go func(tasks []taskStatus, target string, i int) {
+			tasks[i].name = target
+			tasks[i].status = Running
+			defer wg.Done()
+
+			f, _ := os.CreateTemp("", fmt.Sprintf("%s-%s", target, timeStamp))
+			tasks[i].logFile = f.Name()
+
+			cmd := exec.Command("make", target)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				tasks[i].status = Failed
+
+				// Only capture the output for failures
+				_, _ = f.Write(out)
+				if err != nil {
+					_, _ = f.WriteString(err.Error())
+				}
+			} else {
+				tasks[i].status = Complete
+				defer os.Remove(f.Name())
+			}
+
+			<-guard
+		}(tasks, target, i)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	printTaskStatus(tasks, false)
+
+	go func() {
+		// Loop through and print out status until complete
+		for {
+			select {
+			case <-complete:
+				printTaskStatus(tasks, true)
+				return
+			default:
+				printTaskStatus(tasks, true)
+				time.Sleep(1 * time.Second)
+			}
+		}
+	}()
+
+	wg.Wait()
+	complete <- true
+
+	fmt.Println("\nAll tasks complete!")
+
+	hasFailures := false
+	for _, task := range tasks {
+		if task.status == Failed {
+			hasFailures = true
+
+			if printFailLogs {
+				contents, _ := os.ReadFile(task.logFile)
+				fmt.Printf("\n%s failure output:\n", task.name)
+				fmt.Print(string(contents))
+				fmt.Printf("\n\n")
+			}
+		}
+	}
+
+	if hasFailures {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This adds a small utility to give us more control over running multiple
lint checks in parallel, though it is flexible enough that it could be
used for any case where we have multiple make targets that we would like
to run in parallel.

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make check` and `PRINT_FAILURES=1 make check` to verify proper operation.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

We may want to think about moving some things like `imagelint` out of the default checks run as that's a very long running check.
