### PR TITLE
`unmanaged-cluster` delete command returns error code on error

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -51,7 +52,7 @@ func destroy(cmd *cobra.Command, args []string) error {
 	err := tClient.Delete(clusterName)
 	if err != nil {
 		log.Errorf("Failed delete operation. Error: %s\n", err.Error())
-		return nil
+		os.Exit(1)
 	}
 
 	log.Eventf(logger.TestTubeEmoji, "Deleted cluster: %s\n", clusterName)

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -427,10 +427,10 @@ func (t *UnmanagedCluster) Delete(name string) error {
 		log.Style(outputIndent, color.FgYellow).Warnf("Warning - could not resolve cluster config file. Error: %s\n", err.Error())
 		log.Style(outputIndent, color.FgYellow).Warnf("Cluster NOT deleted.\n")
 		log.Style(outputIndent, color.FgYellow).Warnf("Be sure to manually delete cluster\n")
-		err = os.RemoveAll(t.clusterDirectory)
-		if err != nil {
+		deleteErr := os.RemoveAll(t.clusterDirectory)
+		if deleteErr != nil {
 			log.Style(outputIndent, color.FgRed).Errorf("Failed to remove config %s. Be sure to manually delete files\n", t.clusterDirectory)
-			return err
+			return deleteErr
 		}
 
 		log.Style(outputIndent, color.Faint).Infof("Local config files directory deleted: %s\n", t.clusterDirectory)
@@ -442,10 +442,10 @@ func (t *UnmanagedCluster) Delete(name string) error {
 		log.Style(outputIndent, color.FgYellow).Warnf("Warning - could not create configuration from local config file. Error: %s\n", err.Error())
 		log.Style(outputIndent, color.FgYellow).Warnf("Cluster NOT deleted.\n")
 		log.Style(outputIndent, color.FgYellow).Warnf("Be sure to manually delete cluster\n")
-		err = os.RemoveAll(t.clusterDirectory)
-		if err != nil {
+		deleteErr := os.RemoveAll(t.clusterDirectory)
+		if deleteErr != nil {
 			log.Style(outputIndent, color.FgRed).Errorf("Failed to remove config %s. Be sure to manually delete files\n", t.clusterDirectory)
-			return err
+			return deleteErr
 		}
 
 		log.Style(outputIndent, color.Faint).Infof("Local config files directory deleted: %s\n", t.clusterDirectory)
@@ -459,13 +459,14 @@ func (t *UnmanagedCluster) Delete(name string) error {
 		log.Style(outputIndent, color.FgYellow).Warnf("Warning - could not delete cluster through provider. Be sure to manually delete cluster. Error: %s\n", err.Error())
 	}
 
-	err = os.RemoveAll(t.clusterDirectory)
-	if err != nil {
+	deleteErr := os.RemoveAll(t.clusterDirectory)
+	if deleteErr != nil {
 		log.Style(outputIndent, color.FgYellow).Warnf("Cluster deleted but failed to remove config %s. Be sure to manually delete files\n", t.clusterDirectory)
+		return deleteErr
 	}
 
 	log.Style(outputIndent, color.Faint).Infof("Local config files directory deleted: %s\n", t.clusterDirectory)
-	return nil
+	return err
 }
 
 func getUnmanagedBomPath() (path string, err error) {


### PR DESCRIPTION
- Refactors error flow to capture errors from attempting to remove
  directory and correctly exit with an error code when error found

## Which issue(s) this PR fixes
Fixes: #3883

## Describe testing done for PR

Hitting `ctrl-c` during early cluster creation creates the directory structure but _does not_ create a cluster. On delete, this error state is reflected correctly now

```
❯ tanzu unmanaged-cluster create asdf

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
^C

❯ tanzu unmanaged-cluster delete asdf

🧪 Deleting cluster: asdf
   Warning - could not resolve cluster config file. Error: failed to locate a config file at /home/jmcb/.config/tanzu/tkg/unmanaged/asdf/config.yaml
   Cluster NOT deleted.
   Be sure to manually delete cluster
   Local config files directory deleted: /home/jmcb/.config/tanzu/tkg/unmanaged/asdf
Failed delete operation. Error: failed to locate a config file at /home/jmcb/.config/tanzu/tkg/unmanaged/asdf/config.yaml

❯ echo $?
1
```
