### PR TITLE
supports unmanaged-cluster port forward listen address

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cluster/kind.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cluster/kind.go
@@ -169,6 +169,9 @@ func kindConfigFromClusterConfig(c *config.UnmanagedClusterConfig) ([]byte, erro
 	// If users want a more granular way to apply port mappings, they should use the rawKindConfig
 	for _, portToForward := range c.PortsToForward {
 		portMapping := kindconfig.PortMapping{}
+		if portToForward.ListenAddress != "" {
+			portMapping.ListenAddress = portToForward.ListenAddress
+		}
 		if portToForward.ContainerPort != 0 {
 			portMapping.ContainerPort = int32(portToForward.ContainerPort)
 		}

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -84,7 +84,7 @@ func init() {
 	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy; default is calico")
 	CreateCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR for Pod IP allocation; default is 10.244.0.0/16")
 	CreateCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR for Service IP allocation; default is 10.96.0.0/16")
-	CreateCmd.Flags().StringSliceVarP(&co.portMapping, "port-map", "p", []string{}, "Ports to map between container node and the host (format: '80:80/tcp' or just '80')")
+	CreateCmd.Flags().StringSliceVarP(&co.portMapping, "port-map", "p", []string{}, "Ports to map between container node and the host (format: '127.0.0.1:80:80/tcp', '80:80/tcp', '80:80', or just '80')")
 	CreateCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
 	CreateCmd.Flags().BoolVar(&co.skipPreflightChecks, "skip-preflight", false, "Skip the preflight checks; default is false")
 	CreateCmd.Flags().StringVar(&co.numContPlanes, "control-plane-node-count", "", "The number of control plane nodes to deploy; default is 1")

--- a/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
@@ -256,10 +256,37 @@ func TestSanatizeKubeconfigPath(t *testing.T) {
 	}
 }
 
+func TestParsePortMapFullStringWithListenAddr(t *testing.T) {
+	portMap, err := ParsePortMap("127.0.0.1:80:8080/tcp")
+	if err != nil {
+		t.Error("Parsing should pass")
+	}
+
+	if portMap.ListenAddress != "127.0.0.1" {
+		t.Errorf("Listen address should be 127.0.0.1, was %s", portMap.ListenAddress)
+	}
+
+	if portMap.ContainerPort != 80 {
+		t.Errorf("Container port should be 80, was %d", portMap.ContainerPort)
+	}
+
+	if portMap.HostPort != 8080 {
+		t.Errorf("Host port should be 8080, was %d", portMap.HostPort)
+	}
+
+	if portMap.Protocol != "tcp" {
+		t.Errorf("Protocol should be tcp, was %s", portMap.Protocol)
+	}
+}
+
 func TestParsePortMapFullString(t *testing.T) {
 	portMap, err := ParsePortMap("80:8080/tcp")
 	if err != nil {
 		t.Error("Parsing should pass")
+	}
+
+	if portMap.ListenAddress != "" {
+		t.Errorf("Listen address should be empty, was %s", portMap.ListenAddress)
 	}
 
 	if portMap.ContainerPort != 80 {
@@ -279,6 +306,10 @@ func TestParsePortMapContainerPort(t *testing.T) {
 	portMap, err := ParsePortMap("80")
 	if err != nil {
 		t.Error("Parsing should pass")
+	}
+
+	if portMap.ListenAddress != "" {
+		t.Errorf("Listen address should be empty, was %s", portMap.ListenAddress)
 	}
 
 	if portMap.ContainerPort != 80 {


### PR DESCRIPTION
## What this PR does / why we need it
Supports users adding a listening address to their `unmanaged-cluster` port forwards like: `listen-address:port:port/protocol`

FYI - this removes support for setting the protocol of port mappings in minikube. Reference issue: https://github.com/kubernetes/minikube/issues/13939

## Which issue(s) this PR fixes
Fixes: #3060

## Describe testing done for PR
Using the default kind provider:
```
❯ tanzu unmanaged-cluster create asdf -p 127.0.0.1:8080:8080/tcp

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Compatibility file exists at /home/jmcb/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v4

🔧 Resolving TKr
   projects.registry.vmware.com/tce/tkr:v0.17.0-dev-2
   TKr exists at /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v0.17.0-dev-2
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/asdf/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/asdf/bootstrap.log

🔧 Processing Tanzu Kubernetes Release

🎨 Selected base image
   projects.registry.vmware.com/tce/kind:v1.22.4

📦 Selected core package repository
   projects.registry.vmware.com/tce/repo-10:0.10.0

📦 Selected additional package repositories
   projects.registry.vmware.com/tce/main:0.11.0

📦 Selected kapp-controller image bundle
   projects.registry.vmware.com/tce/kapp-controller-multi-pkg:v0.30.1

🚀 Creating cluster asdf
   Cluster creation using kind!
   ❤️  Checkout this awesome project at https://kind.sigs.k8s.io
   Base image downloaded
   Cluster created
   To troubleshoot, use:

   kubectl ${COMMAND} --kubeconfig /home/jmcb/.config/tanzu/tkg/unmanaged/asdf/kube.conf

📧 Installing kapp-controller
   kapp-controller status: Running

📧 Installing package repositories
   tkg-core-repository package repo status: Reconcile succeeded

🌐 Installing CNI
   calico.community.tanzu.vmware.com:3.22.1

✅ Cluster created

🎮 kubectl context set to asdf

View available packages:
   tanzu package available list
View running pods:
   kubectl get po -A
Delete this cluster:
   tanzu unmanaged delete asdf

❯ docker ps
CONTAINER ID   IMAGE                                           COMMAND                  CREATED              STATUS              PORTS                                                 NAMES
8153de49a538   projects.registry.vmware.com/tce/kind:v1.22.4   "/usr/local/bin/entr…"   About a minute ago   Up About a minute   127.0.0.1:8080->8080/tcp, 127.0.0.1:43835->6443/tcp   asdf-control-plane
```

Using the minikube provider:
```
❯ tanzu unmanaged-cluster create asdf -p 127.0.0.1:888:888/tcp --provider minikube

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Compatibility file exists at /home/jmcb/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v4

🔧 Resolving TKr
   projects.registry.vmware.com/tce/tkr:v0.17.0-dev-2
   TKr exists at /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v0.17.0-dev-2
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/asdf/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/asdf/bootstrap.log

🔧 Processing Tanzu Kubernetes Release

🎨 Selected base image
   gcr.io/k8s-minikube/kicbase:v0.0.30@sha256:02c921df998f95e849058af14de7045efc3954d90320967418a0d1f182bbc0b2

📦 Selected core package repository
   projects.registry.vmware.com/tce/repo-10:0.10.0

📦 Selected additional package repositories
   projects.registry.vmware.com/tce/main:0.11.0

📦 Selected kapp-controller image bundle
   projects.registry.vmware.com/tce/kapp-controller-multi-pkg:v0.30.1

🚀 Creating cluster asdf
   Cluster creation using Minikube!
   Warning: the minikube provider is experimental!
   ❤️  Checkout this awesome project at https://minikube.sigs.k8s.io
   Base image downloaded
   Cluster created
   Minikube port-mappings doesn't support setting the protocol. Skipping using port-map protocol
   To troubleshoot, use:

   kubectl ${COMMAND} --kubeconfig /home/jmcb/.config/tanzu/tkg/unmanaged/asdf/kube.conf

📧 Installing kapp-controller
   kapp-controller status: Running

📧 Installing package repositories
   tkg-core-repository package repo status: Reconcile succeeded

🌐 Installing CNI
   calico.community.tanzu.vmware.com:3.22.1

✅ Cluster created

🎮 kubectl context set to asdf

View available packages:
   tanzu package available list
View running pods:
   kubectl get po -A
Delete this cluster:
   tanzu unmanaged delete asdf

❯ docker ps
CONTAINER ID   IMAGE                                 COMMAND                  CREATED          STATUS          PORTS                                                                                                                                                          NAMES
54076363ef29   gcr.io/k8s-minikube/kicbase:v0.0.30   "/usr/local/bin/entr…"   47 minutes ago   Up 47 minutes   127.0.0.1:888->888/tcp, 127.0.0.1:49167->22/tcp, 127.0.0.1:49166->2376/tcp, 127.0.0.1:49165->5000/tcp, 127.0.0.1:49164->8443/tcp, 127.0.0.1:49163->32443/tcp   asdf
```
