### PR TITLE
Add `make check-full` to make `check` more useful

### DIFF
--- a/.github/workflows/check-all.yaml
+++ b/.github/workflows/check-all.yaml
@@ -52,7 +52,7 @@ jobs:
         shell: bash
         run: |
           make ensure-deps
-          PRINT_FAILURES=1 make check
+          PRINT_FAILURES=1 make check-full
       - name: Get dependencies
         shell: bash
         run: |

--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,12 @@ OCI_REGISTRY := projects.registry.vmware.com/tce
 ##### IMAGE
 
 ##### LINTING TARGETS
-.PHONY: check lint mdlint shellcheck yamllint misspell actionlint urllint imagelint
+.PHONY: check check-full lint mdlint shellcheck yamllint misspell actionlint urllint imagelint
 check:
-	go run hack/check/makerunner.go lint mdlint shellcheck yamllint misspell actionlint urllint imagelint
+	go run hack/check/makerunner.go lint mdlint shellcheck yamllint misspell urllint
+
+check-full:
+	go run hack/check/makerunner.go lint mdlint shellcheck yamllint misspell urllint actionlint imagelint
 
 .PHONY: check-deps-minimum-build
 check-deps-minimum-build:

--- a/hack/check/makerunner.go
+++ b/hack/check/makerunner.go
@@ -74,19 +74,17 @@ func main() {
 
 			f, _ := os.CreateTemp("", fmt.Sprintf("%s-%s", target, timeStamp))
 			tasks[i].logFile = f.Name()
+			defer f.Close()
 
 			cmd := exec.Command("make", target)
-			out, err := cmd.CombinedOutput()
+			cmd.Stdout = f
+			cmd.Stderr = f
+			err := cmd.Run()
 			if err != nil {
 				tasks[i].status = Failed
-
-				// Only capture the output for failures
-				_, _ = f.Write(out)
-				if err != nil {
-					_, _ = f.WriteString(err.Error())
-				}
 			} else {
 				tasks[i].status = Complete
+				// Only keep the output for failures
 				defer os.Remove(f.Name())
 			}
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

The current `make check` runs all of our linters, which is great, but
they take so long to run that it almost guarantees no one will actually
run this locally more than once. We really do want folks running the
tests before proposing PRs and then needing to address issues after the
fact. To try to make it faster and easier, and make it more likely to be
used, this separates out the checks into:

- `make check` - runs a subset of all linters for the most common things
- `make check-full` - runs all the linter checks for full coverage

Our CI will continue to run the full suite of tests, but by default a
local user can just run the tests that are most likley to uncover any
concerns in their changes.

This also changes the async lint run to stream the output immediately to
the log file. This is useful to be able to tail a log while a linter is
running to get some visiblity into what is happening.