### PR TITLE
Implements unamanged-cluster local file tkr discovery

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -31,7 +31,7 @@ var ConfigureCmd = &cobra.Command{
 func init() {
 	ConfigureCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "Configuration file for unmanaged cluster creation")
 	ConfigureCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider to use for cluster creation. Default is 'kind'")
-	ConfigureCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The Tanzu Kubernetes Release location.")
+	ConfigureCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The URL to the image or path to local file containing a Tanzu Kubernetes release")
 	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'calico'")
 	ConfigureCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR to use for Pod IP addresses. Default and format is '10.244.0.0/16'")
 	ConfigureCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR to use for Service IP addresses. Default and format is '10.96.0.0/16'")

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -79,7 +79,7 @@ func init() {
 	CreateCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "A config file describing how to create the Tanzu environment")
 	CreateCmd.Flags().StringVarP(&co.existingClusterKubeconfig, "existing-cluster-kubeconfig", "e", "", "Use an existing kubeconfig to tanzu-ify a cluster")
 	CreateCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider for cluster creation; default is kind")
-	CreateCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The URL to the image containing a Tanzu Kubernetes release")
+	CreateCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The URL to the image or path to local file containing a Tanzu Kubernetes release")
 	CreateCmd.Flags().StringSliceVar(&co.additionalRepo, "additional-repo", []string{}, "Addresses for additional package repositories to install")
 	CreateCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy; default is calico")
 	CreateCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR for Pod IP allocation; default is 10.244.0.0/16")

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -468,7 +469,7 @@ func (t *UnmanagedCluster) Delete(name string) error {
 	return nil
 }
 
-func getUnmanagedBomPath() (path string, err error) {
+func getUnmanagedBomPath() (bomPath string, err error) {
 	tkgUnmanagedConfigDir, err := config.GetUnmanagedConfigPath()
 	if err != nil {
 		return "", err
@@ -477,7 +478,7 @@ func getUnmanagedBomPath() (path string, err error) {
 	return filepath.Join(tkgUnmanagedConfigDir, bomDir), nil
 }
 
-func getUnmanagedCompatibilityPath() (path string, err error) {
+func getUnmanagedCompatibilityPath() (compatPath string, err error) {
 	tkgUnmanagedConfigDir, err := config.GetUnmanagedConfigPath()
 	if err != nil {
 		return "", err
@@ -486,7 +487,7 @@ func getUnmanagedCompatibilityPath() (path string, err error) {
 	return filepath.Join(tkgUnmanagedConfigDir, compatibilityDir), nil
 }
 
-func buildFilesystemSafeBomName(bomFileName string) (path string) {
+func buildFilesystemSafeBomName(bomFileName string) string {
 	var sb strings.Builder
 	for _, char := range bomFileName {
 		if char == '/' || char == ':' {
@@ -716,6 +717,10 @@ func getCompatibilityFile() (string, error) {
 }
 
 func getTkrBom(registry string) (string, error) {
+	if isLocalTkrBom(registry) {
+		return useLocalTkrBom(registry)
+	}
+
 	log.Style(outputIndent, color.Faint).Infof("%s\n", registry)
 	expectedBomName := buildFilesystemSafeBomName(registry)
 
@@ -786,8 +791,47 @@ func getTkrBom(registry string) (string, error) {
 	return expectedBomName, nil
 }
 
-func blockForImageDownload(b tkr.ImageReader, path, expectedName string) error {
-	f := filepath.Join(path, expectedName)
+func isLocalTkrBom(p string) bool {
+	_, err := os.Stat(path.Clean(p))
+	return !os.IsNotExist(err)
+}
+
+func useLocalTkrBom(p string) (string, error) {
+	log.Style(outputIndent, color.Faint).Infof("Reading and copying local file for TKr bom at %s\n", p)
+
+	cleanPath := path.Clean(p)
+
+	// Name the bom with the `local-` prefix so there are no clashes with real tkrs/boms
+	expectedBomName := buildFilesystemSafeBomName("local-" + cleanPath)
+
+	localTkrBom, err := os.Open(cleanPath)
+	if err != nil {
+		return "", fmt.Errorf("could not open downloaded tkr bom file: %s", err)
+	}
+	defer localTkrBom.Close()
+
+	bomPath, err := getUnmanagedBomPath()
+	if err != nil {
+		return "", fmt.Errorf("failed to get tanzu stanadlone bom path: %s", err)
+	}
+
+	newBomFile, err := os.Create(filepath.Join(bomPath, expectedBomName))
+	if err != nil {
+		return "", fmt.Errorf("could not create tanzu unmanaged bom tkr file: %s", err)
+	}
+	defer newBomFile.Close()
+
+	_, err = io.Copy(newBomFile, localTkrBom)
+	if err != nil {
+		return "", fmt.Errorf("could not copy file contents: %s", err)
+	}
+
+	log.Style(outputIndent, color.Faint).Infof("Copied TKr to %s\n", newBomFile.Name())
+	return expectedBomName, nil
+}
+
+func blockForImageDownload(b tkr.ImageReader, downloadpath, expectedName string) error {
+	f := filepath.Join(downloadpath, expectedName)
 
 	// start a go routine to animate the downloading logs while the imgpkg libraries get the bom image
 	ctx, cancel := context.WithCancel(context.Background())

--- a/docs/site/content/docs/ref-unmanaged-cluster.md
+++ b/docs/site/content/docs/ref-unmanaged-cluster.md
@@ -381,6 +381,12 @@ To create a cluster with an alternative TKr, you can run:
 tanzu unmanaged-cluster create --tkr projects.registry.vmware.com/tce/tkr:v1.22.2
 ```
 
+The `--tkr` option also supports local files.
+
+```sh
+tanzu unmanaged-cluster create --tkr path-to-my-tkr-file.yaml
+```
+
 To customize a TKr, you can pull an existing one down using `imgpkg`:
 
 ```sh
@@ -399,7 +405,7 @@ modifications, you can repush it using:
 imgpkg push -f ./tkr/tkr-bom-CUSTOM.yaml -i ${YOUR_REGISTRY}:${YOUR_TAG}
 ```
 
-Once pushed, you can reference this repo using the `--tkr` flag.
+Once pushed, you can reference this repo or local file using the `--tkr` flag.
 
 ## Exit codes
 


### PR DESCRIPTION


## What this PR does / why we need it
Supports users providing a local file TKr. Attempts to resolve the provided flag as a local file. If it is a local file, attempt to use it. If not, continue as normal.

## Which issue(s) this PR fixes
Fixes: #3902

## Describe testing done for PR

Note the logs indicating a local TKr is being read / used

```
❯ crane export projects.registry.vmware.com/tce/tkr:v1.22.5 - | tar xv

❯ head tkr-bom-v1.22.5.yaml
apiVersion: run.tanzu.vmware.com/v1alpha2
release:
  version: v1.22.5+vmware.1-tkg.3-tf-v0.11.2
components:
  ako-operator:
  - version: v1.5.0+vmware.4
    images:
      akoOperatorImage:
        imagePath: ako-operator
        tag: v1.5.0_vmware.4

❯ tanzu unmanaged-cluster create test --tkr ./tkr-bom-v1.22.5.yaml

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Compatibility file exists at /home/jmcb/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v4
   Custom TKr ./tkr-bom-v1.22.5.yaml NOT found in compatibility file. Proceed with caution, the provided TKr may not work with this version of unmanaged-cluster

🔧 Resolving TKr
   Reading and copying local file for TKr bom at ./tkr-bom-v1.22.5.yaml
   Copied TKr to /home/jmcb/.config/tanzu/tkg/unmanaged/bom/local-tkr-bom-v1.22.5.yaml
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/test/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/test/bootstrap.log

🔧 Processing Tanzu Kubernetes Release

🎨 Selected base image
   projects.registry.vmware.com/tce/kind/node:v1.22.5

📦 Selected core package repository
   projects-stg.registry.vmware.com/tkg/packages/core/repo:v1.22.5_vmware.1-tkg.3-tf-v0.11.2

📦 Selected kapp-controller image bundle
   projects-stg.registry.vmware.com/tkg/packages/core/kapp-controller:v0.30.0_vmware.1-tkg.1
```
