### PR TITLE
Resolve minikube image via kubernetes version

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cluster/minikube.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cluster/minikube.go
@@ -56,8 +56,6 @@ func (mkcm *MinikubeClusterManager) Create(c *config.UnmanagedClusterConfig) (*K
 	// Base start command arguments
 	args := []string{
 		"start",
-		"--driver",
-		mkcm.driver,
 		"--profile",
 		c.ClusterName,
 	}
@@ -67,11 +65,22 @@ func (mkcm *MinikubeClusterManager) Create(c *config.UnmanagedClusterConfig) (*K
 		"--log_file="+c.LogFile,
 	)
 
-	// Set the node image
+	// Set the Kubernetes version, which determines the node image
+	// the node image selected will be chosen on the basis of the driver
+	// that is set.
 	args = append(
 		args,
-		"--base-image="+c.NodeImage,
+		"--kubernetes-version="+c.NodeImage,
 	)
+
+	// Configure the driver if provider, otherwise the value of `minikube config
+	// get driver` will be used
+	if mkcm.driver != "" {
+		args = append(
+			args,
+			"--driver="+mkcm.driver,
+		)
+	}
 
 	// Configure the container container-runtime if provided
 	if mkcm.containerRuntime != "" {

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/tkr.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/tkr.go
@@ -490,10 +490,11 @@ func (tkr *Bom) GetTKRNodeImage(provider string) string {
 		tag := tkr.Components.KubernetesSigsKind[0].Images.KindNodeImage.Tag
 		return fmt.Sprintf("%s/%s:%s", repo, path, tag)
 	case "minikube":
-		repo := tkr.Components.KubernetesSigsMinikube[0].Images.MinikubeNodeImage.Repository
-		path := tkr.Components.KubernetesSigsMinikube[0].Images.MinikubeNodeImage.ImagePath
-		tag := tkr.Components.KubernetesSigsMinikube[0].Images.MinikubeNodeImage.Tag
-		return fmt.Sprintf("%s/%s:%s", repo, path, tag)
+		// TODO(joshrosso): eventually we should find a way to resolve to real image. The issue
+		// with minikube is we need to maintain a list of images for each driver. For example, the
+		// image used with the docker driver is different from the image used with the kvm2 driver.
+		version := tkr.Release.Version
+		return version
 	}
 
 	// Unsupported provider


### PR DESCRIPTION
## What this PR does / why we need it

This commit moves (back) to minikube resolution based on the kubernetes
version specified in the TKr. This is needed because there are unique
images for each driver type (e.g. kvm2 and docker).

Until we setup our TKrs to express many minikube images, we will stick
to this model and leverage default images resolved by minikube.

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/3982

## Describe testing done for PR

**:speaker: audio included**

https://user-images.githubusercontent.com/6200057/162842281-b774a074-72ee-4dd5-a912-5ec793346652.mp4

## Special notes for your reviewer

Review the video above, review the code changes, make suggestions.
