### PR TITLE
Set provider to none for existing clusters we bootstrap against

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cluster/cluster.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cluster/cluster.go
@@ -11,10 +11,6 @@ import (
 )
 
 const (
-	NoneClusterManagerProvider     = "none"
-	KindClusterManagerProvider     = "kind"
-	MinikubeClusterManagerProvider = "minikube"
-
 	// represents a provider believes the cluster is running.
 	StatusRunning = "Running"
 	// represents a provider believes the cluster is stopped.
@@ -72,11 +68,11 @@ type Manager interface {
 // NewClusterManager provides a way to dynamically get a cluster manager based on the unmanaged cluster config provider
 func NewClusterManager(c *config.UnmanagedClusterConfig) Manager {
 	switch c.Provider {
-	case KindClusterManagerProvider:
+	case config.ProviderKind:
 		return NewKindClusterManager()
-	case MinikubeClusterManagerProvider:
+	case config.ProviderMinikube:
 		return NewMinikubeClusterManager()
-	case NoneClusterManagerProvider:
+	case config.ProviderNone:
 		return NewNoopClusterManager()
 	}
 

--- a/cli/cmd/plugin/unmanaged-cluster/config/config.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config.go
@@ -43,6 +43,10 @@ const (
 	Profiles                  = "Profiles"
 	LogFile                   = "LogFile"
 	defaultName               = "default-name"
+
+	ProviderKind     = "kind"
+	ProviderMinikube = "minikube"
+	ProviderNone     = "none"
 )
 
 var defaultConfigValues = map[string]interface{}{

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -115,7 +115,12 @@ func validateConfiguration(scConfig *config.UnmanagedClusterConfig) error {
 	if scConfig.Provider == "" {
 		// Should have been validated earlier, but not an error. We can just
 		// default it to kind.
-		scConfig.Provider = cluster.KindClusterManagerProvider
+		scConfig.Provider = config.ProviderKind
+	}
+
+	// if an existing kubeconfig (cluster) was specified. The provider should be set to noop
+	if scConfig.ExistingClusterKubeconfig != "" {
+		scConfig.Provider = config.ProviderNone
 	}
 
 	return nil
@@ -242,7 +247,7 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int,
 	// 4. Create the cluster
 	var clusterToUse *cluster.KubernetesCluster
 
-	if scConfig.ExistingClusterKubeconfig != "" {
+	if scConfig.Provider == config.ProviderNone {
 		log.Eventf(logger.RocketEmoji, "Using existing cluster\n")
 		clusterToUse, err = useExistingCluster(scConfig)
 		if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/tkr.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/tkr.go
@@ -9,6 +9,8 @@ import (
 	"os"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/config"
 )
 
 // ImagePackage represents information for an image.
@@ -484,17 +486,19 @@ func (tkr *Bom) getTKRRegistry() string {
 
 func (tkr *Bom) GetTKRNodeImage(provider string) string {
 	switch provider {
-	case "kind":
+	case config.ProviderKind:
 		repo := tkr.getTKRNodeRepository()
 		path := tkr.Components.KubernetesSigsKind[0].Images.KindNodeImage.ImagePath
 		tag := tkr.Components.KubernetesSigsKind[0].Images.KindNodeImage.Tag
 		return fmt.Sprintf("%s/%s:%s", repo, path, tag)
-	case "minikube":
+	case config.ProviderMinikube:
 		// TODO(joshrosso): eventually we should find a way to resolve to real image. The issue
 		// with minikube is we need to maintain a list of images for each driver. For example, the
 		// image used with the docker driver is different from the image used with the kvm2 driver.
 		version := tkr.Release.Version
 		return version
+	case config.ProviderNone:
+		return "none"
 	}
 
 	// Unsupported provider


### PR DESCRIPTION
## What this PR does / why we need it

This will ensure the provider shows up as none in:

* `tanzu uc ls`
* The rendered config file

when the user specifies an existing kubeconfig.

Note this work also moves the provider (constants) into the `config` package so they can be accessed across packages in `unmanaged-cluster`s.

## Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/3541

## Describe testing done for PR

**:speaker: audio included**

https://user-images.githubusercontent.com/6200057/162848225-eee9ea97-fcd7-430c-8422-093c9714a9ef.mp4

## Special notes for your reviewer

See video above. review code and provide suggestions.