### PR TITLE
Generically allow plugins from external repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,7 @@ prep-gcp-tce-bucket:
 # Please see above
 .PHONY: prune-buckets
 prune-buckets:
+	FAKE_RELEASE=$(shell expr $(BUILD_VERSION) | grep test) \
 	TCE_SCRATCH_DIR=${TCE_SCRATCH_DIR} hack/release/prune-buckets.sh
 
 # The main target for GCP buckets. Please see above

--- a/hack/release/install.bat
+++ b/hack/release/install.bat
@@ -28,26 +28,12 @@ rmdir /Q /S %TANZU_CACHE_DIR% 2>nul
 :: For 0.11.2
 :: setup
 xcopy /Y /E /H /C /I default-local "%USERPROFILE%\.config\tanzu-plugins"
-:: install plugins
-tanzu plugin install builder
-tanzu plugin install codegen
-tanzu plugin install cluster
-tanzu plugin install kubernetes-release
-tanzu plugin install login
-tanzu plugin install management-cluster
-tanzu plugin install package
-tanzu plugin install pinniped-auth
-tanzu plugin install secret
-tanzu plugin install conformance
-tanzu plugin install diagnostics
-tanzu plugin install unmanaged-cluster
 
 :: copy uninstall.bat
 copy /B /Y uninstall.bat %TCE_DIR%
 
 :: explicit init of tanzu cli and add tce repo
-:: For TF 0.17.0 or higher
-:: tanzu init
+tanzu init
 tanzu plugin repo add --name tce --gcp-bucket-name tce-tanzu-cli-plugins --gcp-root-path artifacts
 tanzu plugin repo add --name core-admin --gcp-bucket-name tce-tanzu-cli-framework-admin --gcp-root-path artifacts-admin
 

--- a/hack/release/install.sh
+++ b/hack/release/install.sh
@@ -107,23 +107,8 @@ platformdir=$(find "${MY_DIR}" -maxdepth 1 -type d -name "*default*" -exec basen
 mkdir -p "${XDG_CONFIG_HOME}/tanzu-plugins"
 cp -r "${MY_DIR}/${platformdir}/." "${XDG_CONFIG_HOME}/tanzu-plugins"
 
-# install plugins
-tanzu plugin install builder
-tanzu plugin install codegen
-tanzu plugin install cluster
-tanzu plugin install kubernetes-release
-tanzu plugin install login
-tanzu plugin install management-cluster
-tanzu plugin install package
-tanzu plugin install pinniped-auth
-tanzu plugin install secret
-tanzu plugin install conformance
-tanzu plugin install diagnostics
-tanzu plugin install unmanaged-cluster
-
 # explicit init of tanzu cli and add tce repo
-# For TF 0.17.0 or higher
-# tanzu init
+tanzu init
 TCE_REPO="$(tanzu plugin repo list | grep tce)"
 if [[ -z "${TCE_REPO}"  ]]; then
   tanzu plugin repo add --name tce --gcp-bucket-name tce-tanzu-cli-plugins --gcp-root-path artifacts

--- a/hack/release/prune-buckets.sh
+++ b/hack/release/prune-buckets.sh
@@ -10,6 +10,7 @@ set -o xtrace
 
 TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
 TCE_SCRATCH_DIR="${TCE_SCRATCH_DIR:-""}"
+TEST_RELEASE="${TEST_RELEASE:-""}"
 
 # required input
 if [[ -z "${TCE_SCRATCH_DIR}" ]]; then
@@ -24,6 +25,11 @@ fi
 # do this on TCE
 pushd "./artifacts" || exit 1
 
+# we dont want to update the plugin.yaml if this is a test release. failing to do so,
+# would indicate to tanzu cli that you could update to this "test" release
+if [[ "${TEST_RELEASE}" != "" ]]; then
+    find ./ -type f | grep "plugin.yaml" | xargs rm 
+fi
 find ./ -type f | grep -v "yaml" | xargs rm 
 find ./ -type d | grep "test" | xargs rm -rf
 for i in $(find ./ -type d | grep "v"); do echo "empty" >> "${i}/.empty"; done
@@ -33,6 +39,11 @@ popd || exit 1
 # do this on tanzu framework
 pushd "${TCE_SCRATCH_DIR}/tanzu-framework/artifacts" || exit 1
 
+# we dont want to update the plugin.yaml if this is a test release. failing to do so,
+# would indicate to tanzu cli that you could update to this "test" release
+if [[ "${TEST_RELEASE}" != "" ]]; then
+    find ./ -type f | grep "plugin.yaml" | xargs rm 
+fi
 find ./ -type f | grep -v "yaml" | xargs rm 
 find ./ -type d | grep "test" | xargs rm -rf
 for i in $(find ./ -type d | grep "v"); do echo "empty" >> "${i}/.empty"; done
@@ -41,6 +52,11 @@ popd || exit 1
 
 pushd "${TCE_SCRATCH_DIR}/tanzu-framework/artifacts-admin/" || exit 1
 
+# we dont want to update the plugin.yaml if this is a test release. failing to do so,
+# would indicate to tanzu cli that you could update to this "test" release
+if [[ "${TEST_RELEASE}" != "" ]]; then
+    find ./ -type f | grep "plugin.yaml" | xargs rm 
+fi
 find ./ -type f | grep -v "yaml" | xargs rm 
 find ./ -type d | grep "test" | xargs rm -rf
 for i in $(find ./ -type d | grep "v"); do echo "empty" >> "${i}/.empty"; done


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
These changes are required to allow plugins to be installed from external repos. To support this, we need to:
- just use `tanzu init` to install the plugins until we update the TF to something newer that `v0.17.0`
- also to test this out, we cannot update the plugin.yaml in the GCP updates for test builds because this would indicate to tanzu cli that there is a newer update to be had

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
`make release` and did an `install.sh` to make sure all plugins are installed. this actually follows the flow used by choco in the latest release:
https://github.com/vmware-tanzu/community-edition/blob/main/hack/choco/tools/chocolateyinstall.ps1#L90-L110

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA