### PR TITLE
Implements and reconciles command flags for config options in `unmanaged-cluster`

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -28,15 +28,23 @@ var ConfigureCmd = &cobra.Command{
 	RunE:    configure,
 }
 
+//nolint:dupl
 func init() {
 	ConfigureCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "Configuration file for unmanaged cluster creation")
-	ConfigureCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider to use for cluster creation. Default is 'kind'")
+	ConfigureCmd.Flags().StringVar(&co.kubeconfigPath, "kubeconfig-path", "", "File path to where the kubeconfig will be persisted. Defaults to global user kubeconfig")
+	ConfigureCmd.Flags().StringVarP(&co.existingClusterKubeconfig, "existing-cluster-kubeconfig", "e", "", "Use an existing kubeconfig to tanzu-ify a cluster")
+	ConfigureCmd.Flags().StringVar(&co.nodeImage, "node-image", "", "The host OS image to use for kubernetes nodes")
+	ConfigureCmd.Flags().StringVar(&co.infrastructureProvider, "provider", "", "The infrastructure provider for cluster creation; default is kind")
 	ConfigureCmd.Flags().StringVarP(&co.tkrLocation, "tkr", "t", "", "The URL to the image or path to local file containing a Tanzu Kubernetes release")
-	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy. Default is 'calico'")
-	ConfigureCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR to use for Pod IP addresses. Default and format is '10.244.0.0/16'")
-	ConfigureCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR to use for Service IP addresses. Default and format is '10.96.0.0/16'")
-	ConfigureCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
 	ConfigureCmd.Flags().StringSliceVar(&co.additionalRepo, "additional-repo", []string{}, "Addresses for additional package repositories to install")
+	ConfigureCmd.Flags().StringVarP(&co.cni, "cni", "c", "", "The CNI to deploy; default is calico")
+	ConfigureCmd.Flags().StringVar(&co.podcidr, "pod-cidr", "", "The CIDR for Pod IP allocation; default is 10.244.0.0/16")
+	ConfigureCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR for Service IP allocation; default is 10.96.0.0/16")
+	ConfigureCmd.Flags().StringSliceVarP(&co.portMapping, "port-map", "p", []string{}, "Ports to map between container node and the host (format: '127.0.0.1:80:80/tcp', '80:80/tcp', '80:80', or just '80')")
+	ConfigureCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
+	ConfigureCmd.Flags().BoolVar(&co.skipPreflightChecks, "skip-preflight", false, "Skip the preflight checks; default is false")
+	ConfigureCmd.Flags().StringVar(&co.numContPlanes, "control-plane-node-count", "", "The number of control plane nodes to deploy; default is 1")
+	ConfigureCmd.Flags().StringVar(&co.numWorkers, "worker-node-count", "", "The number of worker nodes to deploy; default is 0")
 	ConfigureCmd.Flags().StringSliceVar(&co.profile, "profile", []string{}, "(experimental) A profile to install. May be specified multiple times. Profile mappings supported - profile-name:profile-version:profile-config-file. profile-name should be the fully qualified package name or a prefix to a package name found in an installed package repository. profile-version is optional and resolves to the latest semantic versioned package if not specified or `latest` is entered. package-config-file is optional and should be the path to a values yaml file in order to configure the package.")
 }
 
@@ -52,22 +60,42 @@ func configure(cmd *cobra.Command, args []string) error {
 
 	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
 
+	portMaps, err := config.ParsePortMappings(co.portMapping)
+	if err != nil {
+		log.Error(err.Error())
+	}
+
 	profiles, err := config.ParseProfileMappings(co.profile)
 	if err != nil {
 		log.Error(err.Error())
 	}
 
+	// Get the log file from the global parent flag
+	logFile, err := cmd.Parent().PersistentFlags().GetString("log-file")
+	if err != nil {
+		log.Errorf("Failed to parse log file string. Error %v\n", err)
+	}
+
 	// Determine our configuration to use
+	//nolint:dupl
 	configArgs := map[string]interface{}{
-		config.ClusterConfigFile:      co.clusterConfigFile,
-		config.ClusterName:            clusterName,
-		config.Provider:               co.infrastructureProvider,
-		config.TKRLocation:            co.tkrLocation,
-		config.Cni:                    co.cni,
-		config.PodCIDR:                co.podcidr,
-		config.ServiceCIDR:            co.servicecidr,
-		config.AdditionalPackageRepos: co.additionalRepo,
-		config.Profiles:               profiles,
+		config.ClusterConfigFile:         co.clusterConfigFile,
+		config.ClusterName:               clusterName,
+		config.KubeconfigPath:            co.kubeconfigPath,
+		config.ExistingClusterKubeconfig: co.existingClusterKubeconfig,
+		config.NodeImage:                 co.nodeImage,
+		config.Provider:                  co.infrastructureProvider,
+		config.TKRLocation:               co.tkrLocation,
+		config.Cni:                       co.cni,
+		config.PodCIDR:                   co.podcidr,
+		config.ServiceCIDR:               co.servicecidr,
+		config.ControlPlaneNodeCount:     co.numContPlanes,
+		config.WorkerNodeCount:           co.numWorkers,
+		config.AdditionalPackageRepos:    co.additionalRepo,
+		config.PortsToForward:            portMaps,
+		config.SkipPreflightChecks:       co.skipPreflightChecks,
+		config.Profiles:                  profiles,
+		config.LogFile:                   logFile,
 	}
 
 	scConfig, err := config.InitializeConfiguration(configArgs)

--- a/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
@@ -19,6 +19,7 @@ func TestInitializeConfigurationNoName(t *testing.T) {
 	}
 }
 
+//nolint:gocyclo
 func TestInitializeConfigurationDefaults(t *testing.T) {
 	args := map[string]interface{}{ClusterName: "test"}
 	config, err := InitializeConfiguration(args)
@@ -28,6 +29,18 @@ func TestInitializeConfigurationDefaults(t *testing.T) {
 
 	if config.ClusterName != "test" {
 		t.Errorf("expected ClusterName to be 'test', was actually: %q", config.ClusterName)
+	}
+
+	if config.KubeconfigPath != "" {
+		t.Errorf("expected default KubeconfigPath value, was: %q", config.KubeconfigPath)
+	}
+
+	if config.ExistingClusterKubeconfig != "" {
+		t.Errorf("expected default ExistingClusterKubeconfig value, was: %q", config.ExistingClusterKubeconfig)
+	}
+
+	if config.NodeImage != "" {
+		t.Errorf("expected default NodeImage value, was: %q", config.NodeImage)
 	}
 
 	if config.Cni != defaultConfigValues[Cni] {
@@ -50,12 +63,32 @@ func TestInitializeConfigurationDefaults(t *testing.T) {
 		t.Errorf("expected default ServiceCidr, was: %q", config.ServiceCidr)
 	}
 
+	if config.TkrLocation != "" {
+		t.Errorf("expected default TkrLocation value, was: %q", config.TkrLocation)
+	}
+
+	if len(config.PortsToForward) != 0 {
+		t.Errorf("expected default PortsToForward, was: %q", config.PortsToForward)
+	}
+
+	if config.SkipPreflightChecks != false {
+		t.Errorf("expected default SkipPreflightChecks, was: %v", config.SkipPreflightChecks)
+	}
+
 	if config.ControlPlaneNodeCount != defaultConfigValues[ControlPlaneNodeCount] {
 		t.Errorf("expected default ControlPlaneNodeCount, was: %q", config.ControlPlaneNodeCount)
 	}
 
 	if config.WorkerNodeCount != defaultConfigValues[WorkerNodeCount] {
-		t.Errorf("expected default WorkerNodeCount, was: %q", config.ControlPlaneNodeCount)
+		t.Errorf("expected default WorkerNodeCount, was: %q", config.WorkerNodeCount)
+	}
+
+	if len(config.Profiles) != 0 {
+		t.Errorf("expected default profiles, was: %q", config.Profiles)
+	}
+
+	if config.LogFile != "" {
+		t.Errorf("expected default LogFile, was: %q", config.LogFile)
 	}
 }
 
@@ -224,8 +257,8 @@ func TestInitializeConfigurationFromConfigFile(t *testing.T) {
 
 func TestGenerateDefaultConfig(t *testing.T) {
 	config := GenerateDefaultConfig()
-	if config.ClusterName != "default-config" {
-		t.Errorf("expected ClusterName to be 'test', was actually: %q", config.ClusterName)
+	if config.ClusterName != "default-name" {
+		t.Errorf("expected ClusterName to be 'default-name', was actually: %q", config.ClusterName)
 	}
 
 	if config.Cni != defaultConfigValues[Cni] {
@@ -278,95 +311,150 @@ func TestSanatizeKubeconfigPath(t *testing.T) {
 }
 
 func TestParsePortMapFullStringWithListenAddr(t *testing.T) {
-	portMap, err := ParsePortMap("127.0.0.1:80:8080/tcp")
+	portMaps, err := ParsePortMappings([]string{"127.0.0.1:80:8080/tcp"})
 	if err != nil {
 		t.Error("Parsing should pass")
 	}
 
-	if portMap.ListenAddress != "127.0.0.1" {
-		t.Errorf("Listen address should be 127.0.0.1, was %s", portMap.ListenAddress)
+	if len(portMaps) != 1 {
+		t.Errorf("Expected one port mapping. Got: %v", portMaps)
 	}
 
-	if portMap.ContainerPort != 80 {
-		t.Errorf("Container port should be 80, was %d", portMap.ContainerPort)
+	if portMaps[0].ListenAddress != "127.0.0.1" {
+		t.Errorf("Listen address should be 127.0.0.1, was %s", portMaps[0].ListenAddress)
 	}
 
-	if portMap.HostPort != 8080 {
-		t.Errorf("Host port should be 8080, was %d", portMap.HostPort)
+	if portMaps[0].ContainerPort != 80 {
+		t.Errorf("Container port should be 80, was %d", portMaps[0].ContainerPort)
 	}
 
-	if portMap.Protocol != "tcp" {
-		t.Errorf("Protocol should be tcp, was %s", portMap.Protocol)
+	if portMaps[0].HostPort != 8080 {
+		t.Errorf("Host port should be 8080, was %d", portMaps[0].HostPort)
+	}
+
+	if portMaps[0].Protocol != "tcp" {
+		t.Errorf("Protocol should be tcp, was %s", portMaps[0].Protocol)
 	}
 }
 
 func TestParsePortMapFullString(t *testing.T) {
-	portMap, err := ParsePortMap("80:8080/tcp")
+	portMaps, err := ParsePortMappings([]string{"80:8080/tcp"})
 	if err != nil {
 		t.Error("Parsing should pass")
 	}
 
-	if portMap.ListenAddress != "" {
-		t.Errorf("Listen address should be empty, was %s", portMap.ListenAddress)
+	if len(portMaps) != 1 {
+		t.Errorf("Expected one port mapping. Got: %v", portMaps)
 	}
 
-	if portMap.ContainerPort != 80 {
-		t.Errorf("Container port should be 80, was %d", portMap.ContainerPort)
+	if portMaps[0].ListenAddress != "" {
+		t.Errorf("Listen address should be empty, was %s", portMaps[0].ListenAddress)
 	}
 
-	if portMap.HostPort != 8080 {
-		t.Errorf("Host port should be 8080, was %d", portMap.HostPort)
+	if portMaps[0].ContainerPort != 80 {
+		t.Errorf("Container port should be 80, was %d", portMaps[0].ContainerPort)
 	}
 
-	if portMap.Protocol != "tcp" {
-		t.Errorf("Protocol should be tcp, was %s", portMap.Protocol)
+	if portMaps[0].HostPort != 8080 {
+		t.Errorf("Host port should be 8080, was %d", portMaps[0].HostPort)
+	}
+
+	if portMaps[0].Protocol != "tcp" {
+		t.Errorf("Protocol should be tcp, was %s", portMaps[0].Protocol)
 	}
 }
 
 func TestParsePortMapContainerPort(t *testing.T) {
-	portMap, err := ParsePortMap("80")
+	portMaps, err := ParsePortMappings([]string{"80"})
 	if err != nil {
 		t.Error("Parsing should pass")
 	}
 
-	if portMap.ListenAddress != "" {
-		t.Errorf("Listen address should be empty, was %s", portMap.ListenAddress)
+	if len(portMaps) != 1 {
+		t.Errorf("Expected one port mapping. Got: %v", portMaps)
 	}
 
-	if portMap.ContainerPort != 80 {
-		t.Errorf("Container port should be 80, was %d", portMap.ContainerPort)
+	if portMaps[0].ListenAddress != "" {
+		t.Errorf("Listen address should be empty, was %s", portMaps[0].ListenAddress)
 	}
 
-	if portMap.HostPort != 0 {
-		t.Errorf("Host port should be 0, was %d", portMap.HostPort)
+	if portMaps[0].ContainerPort != 80 {
+		t.Errorf("Container port should be 80, was %d", portMaps[0].ContainerPort)
 	}
 
-	if portMap.Protocol != "" {
-		t.Errorf("Protocol should be empty, was %s", portMap.Protocol)
+	if portMaps[0].HostPort != 0 {
+		t.Errorf("Host port should be 0, was %d", portMaps[0].HostPort)
+	}
+
+	if portMaps[0].Protocol != "" {
+		t.Errorf("Protocol should be empty, was %s", portMaps[0].Protocol)
 	}
 }
 
 func TestParsePortMapContainerPortProtocol(t *testing.T) {
-	portMap, err := ParsePortMap("80/UDP")
+	portMaps, err := ParsePortMappings([]string{"80/UDP"})
 	if err != nil {
 		t.Error("Parsing should pass")
 	}
 
-	if portMap.ContainerPort != 80 {
-		t.Errorf("Container port should be 80, was %d", portMap.ContainerPort)
+	if len(portMaps) != 1 {
+		t.Errorf("Expected one port mapping. Got: %v", portMaps)
 	}
 
-	if portMap.HostPort != 0 {
-		t.Errorf("Host port should be 0, was %d", portMap.HostPort)
+	if portMaps[0].ContainerPort != 80 {
+		t.Errorf("Container port should be 80, was %d", portMaps[0].ContainerPort)
 	}
 
-	if portMap.Protocol != "udp" {
-		t.Errorf("Protocol should be udp, was %s", portMap.Protocol)
+	if portMaps[0].HostPort != 0 {
+		t.Errorf("Host port should be 0, was %d", portMaps[0].HostPort)
+	}
+
+	if portMaps[0].Protocol != "udp" {
+		t.Errorf("Protocol should be udp, was %s", portMaps[0].Protocol)
+	}
+}
+
+func TestParseMultiplePortMaps(t *testing.T) {
+	portMaps, err := ParsePortMappings([]string{"80/UDP", "127.0.0.1:999:999/TCP"})
+	if err != nil {
+		t.Error("Parsing should pass")
+	}
+
+	if len(portMaps) != 2 {
+		t.Errorf("Expected two port mapping. Got: %v", portMaps)
+	}
+
+	if portMaps[0].ContainerPort != 80 {
+		t.Errorf("Container port should be 80, was %d", portMaps[0].ContainerPort)
+	}
+
+	if portMaps[0].HostPort != 0 {
+		t.Errorf("Host port should be 0, was %d", portMaps[0].HostPort)
+	}
+
+	if portMaps[0].Protocol != "udp" {
+		t.Errorf("Protocol should be udp, was %s", portMaps[0].Protocol)
+	}
+
+	if portMaps[1].ListenAddress != "127.0.0.1" {
+		t.Errorf("Listen address should be 127.0.0.1, was %s", portMaps[1].ListenAddress)
+	}
+
+	if portMaps[1].ContainerPort != 999 {
+		t.Errorf("Container port should be 999, was %d", portMaps[1].ContainerPort)
+	}
+
+	if portMaps[1].HostPort != 999 {
+		t.Errorf("Host port should be 999, was %d", portMaps[1].HostPort)
+	}
+
+	if portMaps[1].Protocol != "tcp" {
+		t.Errorf("Protocol should be tcp, was %s", portMaps[1].Protocol)
 	}
 }
 
 func TestParsePortMapInvalid(t *testing.T) {
-	_, err := ParsePortMap("http")
+	_, err := ParsePortMappings([]string{"http"})
 	if err == nil {
 		t.Error("Parsing should fail")
 	}


### PR DESCRIPTION
## What this PR does / why we need it

This PR reconciles missing config flags for both the `create` and `configure` commands. So now, any config option that can be used in a config file, a user can set via the CLI.

Also note:

- implements consuming port mappings via a config file and/or env var
- implements consuming skip preflight checks (boolean) via config file and/or env var
- Cleans up ordering of consts to be a bit more sensible

## Which issue(s) this PR fixes
Fixes: #3945

## Describe testing done for PR

Can set these options via config flags:
```
❯ ./unmanaged-cluster config --node-image projects.registry.vmware.com/tce/kind:v1.22.4 -p 127.0.0.1:80:80/tcp --skip-preflight test
Wrote configuration file to: test.yaml

❯ cat test.yaml
ClusterName: test
KubeconfigPath: ""
ExistingClusterKubeconfig: ""
NodeImage: projects.registry.vmware.com/tce/kind:v1.22.4
Provider: kind
ProviderConfiguration: {}
Cni: calico
CniConfiguration: {}
PodCidr: 10.244.0.0/16
ServiceCidr: 10.96.0.0/16
TkrLocation: ""
AdditionalPackageRepos: []
PortsToForward:
  - ListenAddress: 127.0.0.1
    HostPort: 80
    ContainerPort: 80
    Protocol: tcp
SkipPreflightChecks: true
ControlPlaneNodeCount: "1"
WorkerNodeCount: "0"
Profiles: []
LogFile: ""
```

Using that file:
```
❯ ./unmanaged-cluster create -f test.yaml

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Compatibility file exists at /home/jmcb/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v4

🔧 Resolving TKr
   projects.registry.vmware.com/tce/tkr:v0.17.0-dev-2
   TKr exists at /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v0.17.0-dev-2
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/test/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/test/bootstrap.log

🔧 Processing Tanzu Kubernetes Release

🎨 Selected base image
   projects.registry.vmware.com/tce/kind:v1.22.4

📦 Selected core package repository
   projects.registry.vmware.com/tce/repo-10:0.10.0

📦 Selected additional package repositories
   projects.registry.vmware.com/tce/main:0.11.0

📦 Selected kapp-controller image bundle
   projects.registry.vmware.com/tce/kapp-controller-multi-pkg:v0.30.1

🚀 Creating cluster test
   Cluster creation using kind!
   ❤️  Checkout this awesome project at https://kind.sigs.k8s.io
   Base image downloaded
   Cluster created
   To troubleshoot, use:

   kubectl ${COMMAND} --kubeconfig /home/jmcb/.config/tanzu/tkg/unmanaged/test/kube.conf

📧 Installing kapp-controller
   kapp-controller status: Running

📧 Installing package repositories
   tkg-core-repository package repo status: Reconcile succeeded

🌐 Installing CNI
   calico.community.tanzu.vmware.com:3.22.1

✅ Cluster created

🎮 kubectl context set to test

View available packages:
   tanzu package available list
View running pods:
   kubectl get po -A
Delete this cluster:
   tanzu unmanaged delete test

❯ docker ps
CONTAINER ID   IMAGE                                           COMMAND                  CREATED              STATUS              PORTS                                             NAMES
160acb8c8e5e   projects.registry.vmware.com/tce/kind:v1.22.4   "/usr/local/bin/entr…"   About a minute ago   Up About a minute   127.0.0.1:80->80/tcp, 127.0.0.1:38219->6443/tcp   test-control-plane
```