### PR TITLE
Fixes unmanaged minikube driver not setting container-runtime or raw extra args

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cluster/minikube.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cluster/minikube.go
@@ -490,7 +490,7 @@ func (mkcm *MinikubeClusterManager) setProvierConfigs(pc map[string]interface{})
 			return fmt.Errorf("ProviderConfiguration.containerRuntime wrong type, expected string")
 		}
 
-		mkcm.driver = pc["container-runtime"].(string)
+		mkcm.containerRuntime = pc["containerRuntime"].(string)
 	}
 
 	if _, ok := pc["rawMinikubeArgs"]; ok {
@@ -498,7 +498,7 @@ func (mkcm *MinikubeClusterManager) setProvierConfigs(pc map[string]interface{})
 			return fmt.Errorf("ProviderConfiguration.rawMinikubeArgs wrong type, expected string")
 		}
 
-		mkcm.driver = pc["containerRuntime"].(string)
+		mkcm.rawMinikubeArgs = pc["rawMinikubeArgs"].(string)
 	}
 
 	return nil

--- a/docs/site/content/docs/ref-unmanaged-cluster.md
+++ b/docs/site/content/docs/ref-unmanaged-cluster.md
@@ -273,8 +273,8 @@ when `ProviderConfiguration` is used.
   Provider: minikube
   ProviderConfiguration:
     driver: vmware
-    container-runtime: auto
-    rawMinikubeArgs: --disk-size 30000mb
+    containerRuntime: docker
+    rawMinikubeArgs: --disk-size=30000mb
   Cni: calico
   CniConfiguration: {}
   PodCidr: 10.244.0.0/16


### PR DESCRIPTION
## What this PR does / why we need it
Fixes unmanaged-cluster minikube provider yaml not correctly consuming `containerRuntime` or `rawMinikubeArgs`

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
Create a new unmanaged cluster with the following config:
```yaml
ClusterName: mini-test
KubeconfigPath: ""
ExistingClusterKubeconfig: ""
NodeImage: ""
Provider: minikube
ProviderConfiguration:
  driver: kvm2
  containerRuntime: containerd
  rawMinikubeArgs: --disk-size=30000mb
Cni: calico
CniConfiguration: {}
PodCidr: 10.244.0.0/16
ServiceCidr: 10.96.0.0/16
TkrLocation: ""
AdditionalPackageRepos: []
PortsToForward: []
SkipPreflight: false
ControlPlaneNodeCount: "1"
WorkerNodeCount: "0"
Profiles: []
LogFile: ""
```

Deploy with:
```
tanzu unmanaged-cluster create -f minikube-test.yaml
```

Successfully deploys and correctly sets container-runtime:
```
❯ minikube profile list
|-----------|-----------|------------|---------------|------|---------|---------|-------|
|  Profile  | VM Driver |  Runtime   |      IP       | Port | Version | Status  | Nodes |
|-----------|-----------|------------|---------------|------|---------|---------|-------|
| mini-test | kvm2      | containerd | 192.168.39.69 | 8443 | v1.21.5 | Running |     1 |
|-----------|-----------|------------|---------------|------|---------|---------|-------|
```

And we can see this command was generated in the bootstrapping log:
```
/usr/local/bin/minikube start --profile mini-test --log_file=/home/jmcb/.config/tanzu/tkg/unmanaged/mini-test/bootstrap.log --kubernetes-version=v1.21.5 --driver=kvm2 --container-runtime=containerd --nodes=1 --extra-config kubeadm.pod-network-cidr=10.244.0.0/16 --service-cluster-ip-range 10.96.0.0/16 --disk-size=30000mb
```