### PR TITLE
Fixes unmanaged-cluster `kind` provider setting incorrect port protocol

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cluster/kind.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cluster/kind.go
@@ -185,7 +185,7 @@ func kindConfigFromClusterConfig(c *config.UnmanagedClusterConfig) (*kindconfig.
 			portMapping.HostPort = int32(portToForward.HostPort)
 		}
 		if portToForward.Protocol != "" {
-			portMapping.Protocol = kindconfig.PortMappingProtocol(portToForward.Protocol)
+			portMapping.Protocol = kindconfig.PortMappingProtocol(strings.ToUpper(portToForward.Protocol))
 		}
 
 		kindConfig.Nodes[0].ExtraPortMappings = append(kindConfig.Nodes[0].ExtraPortMappings, portMapping)


### PR DESCRIPTION
## What this PR does / why we need it
- Kind libraries expects port mapping protocols to be uppercase. So
  instead of "tcp" it expects "TCP"

Error:
```
Creating cluster test
   Cluster creation using kind!
   :heart:  Checkout this awesome project at https://kind.sigs.k8s.io/
   Base image downloaded
   Creating cluster..             failed to create cluster, Error: kind returned error: unknown port mapping protocol: tcp
```

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
With this patch:
```
$ tanzu unmanaged-cluster create test -p 80:80/tcp
...

$ docker ps
CONTAINER ID   IMAGE                                           COMMAND                  CREATED          STATUS          PORTS                                           NAMES
718cfb4bbe65   projects.registry.vmware.com/tce/kind:v1.22.4   "/usr/local/bin/entr…"   24 seconds ago   Up 20 seconds   0.0.0.0:80->80/tcp, 127.0.0.1:43047->6443/tcp   test-control-plane
```

## Special notes for your reviewer
Supersedes #3999 
