### PR TITLE
Fix GCP upload to use the latest upload provider (auth change)

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -65,13 +65,16 @@ jobs:
         run: |
           make prep-gcp-tce-bucket
           make build-cli-plugins-nopublish
+      - id: auth-to-gcp-buckets
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_BUCKET_SA }}
       - name: Upload Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@v0.9.0
         with:
           path: ./artifacts
           destination: tce-cli-plugins-staging
-          credentials: ${{ secrets.GCP_BUCKET_SA }}
   teardown-runner:
     name: Stop self-hosted EC2 runner
     # Only run this job if we're in the main repo, not a fork.

--- a/.github/workflows/release-bucket.yaml
+++ b/.github/workflows/release-bucket.yaml
@@ -77,27 +77,28 @@ jobs:
         run: |
           make ensure-deps
           make release-buckets
+      - id: auth-to-gcp-buckets
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_BUCKET_SA }}
       - name: Upload TCE Artifacts to Staging Bucket
         id: upload-artifacts-staging
         uses: google-github-actions/upload-cloud-storage@v0.9.0
         with:
           path: ./artifacts
           destination: tce-cli-plugins-staging
-          credentials: ${{ secrets.GCP_BUCKET_SA }}
       - name: Upload TCE Artifacts to Update Bucket
         id: upload-tce-artifacts-update
         uses: google-github-actions/upload-cloud-storage@v0.9.0
         with:
           path: ./artifacts
           destination: tce-cli-plugins
-          credentials: ${{ secrets.GCP_BUCKET_SA }}
       - name: Upload TF Artifacts to Update Bucket
         id: upload-tf-artifacts-update
         uses: google-github-actions/upload-cloud-storage@v0.9.0
         with:
           path: /tmp/tce-scratch-space/tanzu-framework/artifacts
           destination: tce-framework-cli-plugins/artifacts
-          credentials: ${{ secrets.GCP_BUCKET_SA }}
           parent: false
       - name: Upload TF Admin Artifacts to Update Bucket
         id: upload-tf-artifacts-admin-update
@@ -105,7 +106,6 @@ jobs:
         with:
           path: /tmp/tce-scratch-space/tanzu-framework/artifacts-admin
           destination: tce-framework-cli-plugins-admin/artifacts-admin
-          credentials: ${{ secrets.GCP_BUCKET_SA }}
           parent: false
       - name: Prune Buckets
         env:
@@ -118,14 +118,12 @@ jobs:
         with:
           path: ./artifacts
           destination: tce-tanzu-cli-plugins
-          credentials: ${{ secrets.GCP_BUCKET_SA }}
       - name: Upload TF Artifacts to Release Bucket
         id: upload-tf-artifacts-release
         uses: google-github-actions/upload-cloud-storage@v0.9.0
         with:
           path: /tmp/tce-scratch-space/tanzu-framework/artifacts
           destination: tce-tanzu-cli-framework/artifacts
-          credentials: ${{ secrets.GCP_BUCKET_SA }}
           parent: false
       - name: Upload TF Artifacts-Admin to Release Bucket
         id: upload-tf-artifacts-admin-release
@@ -133,7 +131,6 @@ jobs:
         with:
           path: /tmp/tce-scratch-space/tanzu-framework/artifacts-admin
           destination: tce-tanzu-cli-framework-admin/artifacts-admin
-          credentials: ${{ secrets.GCP_BUCKET_SA }}
           parent: false
   teardown-runner:
     name: Stop self-hosted EC2 runner


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
The way you auth to the GCP buckets has changed and dependabot is going to keep forcing us to look at this so... you have this PR. It requires an explicit auth step and removes all auth tokens from subsequent steps.

More info here:
https://github.com/google-github-actions/upload-cloud-storage#authorization

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA