### PR TITLE
Remove default redirect for docs and update Hugo version

### DIFF
--- a/docs/site/netlify.toml
+++ b/docs/site/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [context.production.environment]
-HUGO_VERSION = "0.82.1"
+HUGO_VERSION = "0.97.0"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -11,20 +11,20 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.82.1"
+HUGO_VERSION = "0.97.0"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "make preview-build"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.82.1"
+HUGO_VERSION = "0.97.0"
 
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.82.1"
+HUGO_VERSION = "0.97.0"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"

--- a/docs/site/themes/template/layouts/index.redirects
+++ b/docs/site/themes/template/layouts/index.redirects
@@ -1,4 +1,3 @@
 {{ $latest := (cond (.Site.Params.docs_versioning) .Site.Params.docs_latest "") }}
 /docs                          /docs/{{ $latest }}     301!
 /docs/latest                   /docs/{{ $latest }}
-/docs/*                 /docs/{{ $latest }}/:splat


### PR DESCRIPTION
Signed-off-by: Jonas Rosland <jrosland@vmware.com>

## What this PR does / why we need it
Removes default redirect for docs, messing with edge previews. Also updates Hugo to a more modern version.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3939 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
