### PR TITLE
Renames `unmanaged-clsuter` profiles to install-packages

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -45,7 +45,7 @@ func init() {
 	ConfigureCmd.Flags().BoolVar(&co.skipPreflightChecks, "skip-preflight", false, "Skip the preflight checks; default is false")
 	ConfigureCmd.Flags().StringVar(&co.numContPlanes, "control-plane-node-count", "", "The number of control plane nodes to deploy; default is 1")
 	ConfigureCmd.Flags().StringVar(&co.numWorkers, "worker-node-count", "", "The number of worker nodes to deploy; default is 0")
-	ConfigureCmd.Flags().StringSliceVar(&co.profile, "profile", []string{}, "(experimental) A profile to install. May be specified multiple times. Profile mappings supported - profile-name:profile-version:profile-config-file. profile-name should be the fully qualified package name or a prefix to a package name found in an installed package repository. profile-version is optional and resolves to the latest semantic versioned package if not specified or `latest` is entered. package-config-file is optional and should be the path to a values yaml file in order to configure the package.")
+	ConfigureCmd.Flags().StringSliceVar(&co.installPackage, "install-package", []string{}, "(experimental) A package to install on bootstrapping. May be specified multiple times. install-package mappings supported - package-name:package-version:package-config-file. package-name should be the fully qualified package name or a prefix to a package name found in an installed package repository. package-version is optional and resolves to the latest semantic versioned package if not specified or latest is entered. package-config-file is optional and should be the path to a values yaml file in order to configure the package.")
 }
 
 func configure(cmd *cobra.Command, args []string) error {
@@ -65,7 +65,7 @@ func configure(cmd *cobra.Command, args []string) error {
 		log.Error(err.Error())
 	}
 
-	profiles, err := config.ParseProfileMappings(co.profile)
+	installPackages, err := config.ParseInstallPackageMappings(co.installPackage)
 	if err != nil {
 		log.Error(err.Error())
 	}
@@ -94,7 +94,7 @@ func configure(cmd *cobra.Command, args []string) error {
 		config.AdditionalPackageRepos:    co.additionalRepo,
 		config.PortsToForward:            portMaps,
 		config.SkipPreflightChecks:       co.skipPreflightChecks,
-		config.Profiles:                  profiles,
+		config.InstallPackages:           installPackages,
 		config.LogFile:                   logFile,
 	}
 

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -29,7 +29,7 @@ type createUnmanagedOpts struct {
 	portMapping               []string
 	numContPlanes             string
 	numWorkers                string
-	profile                   []string
+	installPackage            []string
 }
 
 const createDesc = `
@@ -64,7 +64,7 @@ Exit codes are provided to enhance the automation of bootstrapping and are defin
 11 - Could not install additional package repo
 12 - Could not install CNI package.
 13 - Failed to merge kubeconfig and set context
-14 - Could not install designated profile`
+14 - Could not install designated installPackage`
 
 // CreateCmd creates an unmanaged workload cluster.
 var CreateCmd = &cobra.Command{
@@ -94,7 +94,7 @@ func init() {
 	CreateCmd.Flags().BoolVar(&co.skipPreflightChecks, "skip-preflight", false, "Skip the preflight checks; default is false")
 	CreateCmd.Flags().StringVar(&co.numContPlanes, "control-plane-node-count", "", "The number of control plane nodes to deploy; default is 1")
 	CreateCmd.Flags().StringVar(&co.numWorkers, "worker-node-count", "", "The number of worker nodes to deploy; default is 0")
-	CreateCmd.Flags().StringSliceVar(&co.profile, "profile", []string{}, "(experimental) A profile to install. May be specified multiple times. Profile mappings supported - profile-name:profile-version:profile-config-file. profile-name should be the fully qualified package name or a prefix to a package name found in an installed package repository. profile-version is optional and resolves to the latest semantic versioned package if not specified or `latest` is entered. package-config-file is optional and should be the path to a values yaml file in order to configure the package.")
+	CreateCmd.Flags().StringSliceVar(&co.installPackage, "install-package", []string{}, "(experimental) A package to install on bootstrapping. May be specified multiple times. install-package mappings supported - package-name:package-version:package-config-file. package-name should be the fully qualified package name or a prefix to a package name found in an installed package repository. package-version is optional and resolves to the latest semantic versioned package if not specified or latest is entered. package-config-file is optional and should be the path to a values yaml file in order to configure the package.")
 }
 
 func create(cmd *cobra.Command, args []string) {
@@ -126,7 +126,7 @@ func create(cmd *cobra.Command, args []string) {
 		os.Exit(tanzu.ErrRenderingConfig)
 	}
 
-	profiles, err := config.ParseProfileMappings(co.profile)
+	installPackages, err := config.ParseInstallPackageMappings(co.installPackage)
 	if err != nil {
 		log.Error(err.Error())
 		os.Exit(tanzu.ErrRenderingConfig)
@@ -157,7 +157,7 @@ func create(cmd *cobra.Command, args []string) {
 		config.AdditionalPackageRepos:    co.additionalRepo,
 		config.PortsToForward:            portMaps,
 		config.SkipPreflightChecks:       co.skipPreflightChecks,
-		config.Profiles:                  profiles,
+		config.InstallPackages:           installPackages,
 		config.LogFile:                   logFile,
 	}
 	clusterConfig, err := config.InitializeConfiguration(configArgs)

--- a/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/config/config_test.go
@@ -83,8 +83,8 @@ func TestInitializeConfigurationDefaults(t *testing.T) {
 		t.Errorf("expected default WorkerNodeCount, was: %q", config.WorkerNodeCount)
 	}
 
-	if len(config.Profiles) != 0 {
-		t.Errorf("expected default profiles, was: %q", config.Profiles)
+	if len(config.InstallPackages) != 0 {
+		t.Errorf("expected default install-package, was: %q", config.InstallPackages)
 	}
 
 	if config.LogFile != "" {
@@ -460,247 +460,247 @@ func TestParsePortMapInvalid(t *testing.T) {
 	}
 }
 
-// When the user provides only a profile name:
-// --profile my.package.com
-func TestParseProfileMappingsOnlyName(t *testing.T) {
-	profileMap, err := ParseProfileMappings(
+// When the user provides only a package name:
+// --install-package my.package.com
+func TestParseInstallPackageMappingsOnlyName(t *testing.T) {
+	ipMap, err := ParseInstallPackageMappings(
 		[]string{"my.package.com"},
 	)
 
 	if err != nil {
-		t.Error("Parsing profiles should pass")
+		t.Error("Parsing installPackages should pass")
 	}
 
-	if len(profileMap) != 1 {
-		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	if len(ipMap) != 1 {
+		t.Errorf("expected 1 InstallPackage. Found %v. Actual: %v", len(ipMap), ipMap)
 	}
 
-	if profileMap[0].Name != "my.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	if ipMap[0].Name != "my.package.com" {
+		t.Errorf("expected InstallPackage with name. Found %s Expected: my.package.com", ipMap[0].Name)
 	}
 
-	if profileMap[0].Version != "" {
-		t.Errorf("expected profile with no version. Found %s Expected: empty string", profileMap[0].Version)
+	if ipMap[0].Version != "" {
+		t.Errorf("expected installPackage with no version. Found %s Expected: empty string", ipMap[0].Version)
 	}
 
-	if profileMap[0].Config != "" {
-		t.Errorf("expected profile with no config. Found %s Expected: empty string", profileMap[0].Config)
+	if ipMap[0].Config != "" {
+		t.Errorf("expected installPackage with no config. Found %s Expected: empty string", ipMap[0].Config)
 	}
 }
 
-// When the user provides multiple profile flags:
-// --profile my.profile.package.com
-// --profile my.other-profile.package.com
+// When the user provides multiple installPackage flags:
+// --install-package my.installPackage.package.com
+// --install-package my.other-installPackage.package.com
 //
 // dequeues values from flags in order they are enqueued despite order of flags
-func TestParseProfileMappingsManyNames(t *testing.T) {
-	profileMap, err := ParseProfileMappings(
-		[]string{"my.profile.package.com", "my.other-profile.package.com"},
+func TestParseInstallPackageMappingsManyNames(t *testing.T) {
+	ipMap, err := ParseInstallPackageMappings(
+		[]string{"my.installPackage.package.com", "my.other-installPackage.package.com"},
 	)
 
 	if err != nil {
-		t.Error("Parsing profiles should pass")
+		t.Error("Parsing installPackages should pass")
 	}
 
-	if len(profileMap) != 2 {
-		t.Errorf("expected 2 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	if len(ipMap) != 2 {
+		t.Errorf("expected 2 installPackage. Found %v. Actual: %v", len(ipMap), ipMap)
 	}
 
-	if profileMap[0].Name != "my.profile.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.configured.package.com", profileMap[0].Name)
+	if ipMap[0].Name != "my.installPackage.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: my.configured.package.com", ipMap[0].Name)
 	}
 
-	if profileMap[0].Version != "" {
-		t.Errorf("expected profile without version. Found %s Expected: empty string", profileMap[0].Version)
+	if ipMap[0].Version != "" {
+		t.Errorf("expected installPackage without version. Found %s Expected: empty string", ipMap[0].Version)
 	}
 
-	if profileMap[0].Config != "" {
-		t.Errorf("expected profile with no config. Found %s Expected: empty string", profileMap[0].Config)
+	if ipMap[0].Config != "" {
+		t.Errorf("expected installPackage with no config. Found %s Expected: empty string", ipMap[0].Config)
 	}
 
-	if profileMap[1].Name != "my.other-profile.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.other-profile.package.com", profileMap[1].Name)
+	if ipMap[1].Name != "my.other-installPackage.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: my.other-installPackage.package.com", ipMap[1].Name)
 	}
 
-	if profileMap[1].Version != "" {
-		t.Errorf("expected profile with no version. Found %s Expected: empty string", profileMap[1].Version)
+	if ipMap[1].Version != "" {
+		t.Errorf("expected installPackage with no version. Found %s Expected: empty string", ipMap[1].Version)
 	}
 
-	if profileMap[1].Config != "" {
-		t.Errorf("expected profile with no config. Found %s Expected: empty string", profileMap[1].Config)
+	if ipMap[1].Config != "" {
+		t.Errorf("expected installPackage with no config. Found %s Expected: empty string", ipMap[1].Config)
 	}
 }
 
-// When the user provides only a profile name:
-// --profile my.package.com:1.2.3
-func TestParseProfileMappingsNameVersion(t *testing.T) {
-	profileMap, err := ParseProfileMappings(
+// When the user provides only a installPackage name:
+// --install-package my.package.com:1.2.3
+func TestParseInstallPackageMappingsNameVersion(t *testing.T) {
+	ipMap, err := ParseInstallPackageMappings(
 		[]string{"my.package.com:1.2.3"},
 	)
 
 	if err != nil {
-		t.Error("Parsing profiles should pass")
+		t.Error("Parsing installPackages should pass")
 	}
 
-	if len(profileMap) != 1 {
-		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	if len(ipMap) != 1 {
+		t.Errorf("expected 1 installPackage. Found %v. Actual: %v", len(ipMap), ipMap)
 	}
 
-	if profileMap[0].Name != "my.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	if ipMap[0].Name != "my.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: my.package.com", ipMap[0].Name)
 	}
 
-	if profileMap[0].Version != "1.2.3" {
-		t.Errorf("expected profile with version. Found %s Expected: 1.2.3", profileMap[0].Version)
+	if ipMap[0].Version != "1.2.3" {
+		t.Errorf("expected installPackage with version. Found %s Expected: 1.2.3", ipMap[0].Version)
 	}
 
-	if profileMap[0].Config != "" {
-		t.Errorf("expected profile with no config. Found %s Expected: empty string", profileMap[0].Config)
+	if ipMap[0].Config != "" {
+		t.Errorf("expected installPackage with no config. Found %s Expected: empty string", ipMap[0].Config)
 	}
 }
 
-// When the user provides multiple profile flags with name and version:
-// --profile my.profile.package.com:1.2.3
-// --profile my.other-profile.package.com:7.8.9
-func TestParseProfileMappingsManyNameVersion(t *testing.T) {
-	profileMap, err := ParseProfileMappings(
-		[]string{"my.profile.package.com:1.2.3", "my.other-profile.package.com:7.8.9"},
+// When the user provides multiple installPackage flags with name and version:
+// --install-package my.installPackage.package.com:1.2.3
+// --install-package my.other-installPackage.package.com:7.8.9
+func TestParseInstallPackageMappingsManyNameVersion(t *testing.T) {
+	ipMap, err := ParseInstallPackageMappings(
+		[]string{"my.installPackage.package.com:1.2.3", "my.other-installPackage.package.com:7.8.9"},
 	)
 
 	if err != nil {
-		t.Error("Parsing profiles should pass")
+		t.Error("Parsing installPackages should pass")
 	}
 
-	if len(profileMap) != 2 {
-		t.Errorf("expected 2 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	if len(ipMap) != 2 {
+		t.Errorf("expected 2 installPackage. Found %v. Actual: %v", len(ipMap), ipMap)
 	}
 
-	if profileMap[0].Name != "my.profile.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.configured.package.com", profileMap[0].Name)
+	if ipMap[0].Name != "my.installPackage.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: my.configured.package.com", ipMap[0].Name)
 	}
 
-	if profileMap[0].Version != "1.2.3" {
-		t.Errorf("expected profile with version. Found %s Expected: 1.2.3", profileMap[0].Version)
+	if ipMap[0].Version != "1.2.3" {
+		t.Errorf("expected installPackage with version. Found %s Expected: 1.2.3", ipMap[0].Version)
 	}
 
-	if profileMap[0].Config != "" {
-		t.Errorf("expected profile with no config. Found %s Expected: empty string", profileMap[0].Config)
+	if ipMap[0].Config != "" {
+		t.Errorf("expected installPackage with no config. Found %s Expected: empty string", ipMap[0].Config)
 	}
 
-	if profileMap[1].Name != "my.other-profile.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.other-profile.package.com", profileMap[1].Name)
+	if ipMap[1].Name != "my.other-installPackage.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: my.other-installPackage.package.com", ipMap[1].Name)
 	}
 
-	if profileMap[1].Version != "7.8.9" {
-		t.Errorf("expected profile with version. Found %s Expected: 7.8.9", profileMap[1].Version)
+	if ipMap[1].Version != "7.8.9" {
+		t.Errorf("expected installPackage with version. Found %s Expected: 7.8.9", ipMap[1].Version)
 	}
 
-	if profileMap[1].Config != "" {
-		t.Errorf("expected profile with no config. Found %s Expected: empty string", profileMap[1].Config)
+	if ipMap[1].Config != "" {
+		t.Errorf("expected installPackage with no config. Found %s Expected: empty string", ipMap[1].Config)
 	}
 }
 
-// When the user provides a full profile mapping:
-// --profile my.package.com:4.4.4:woof-path
-func TestParseProfileMappingSingle(t *testing.T) {
-	profileMap, err := ParseProfileMappings(
+// When the user provides a full installPackage mapping:
+// --install-package my.package.com:4.4.4:woof-path
+func TestParseInstallPackageMappingSingle(t *testing.T) {
+	ipMap, err := ParseInstallPackageMappings(
 		[]string{"my.package.com:4.4.4:woof-path"},
 	)
 
 	if err != nil {
-		t.Error("Parsing profiles should pass")
+		t.Error("Parsing installPackages should pass")
 	}
 
-	if len(profileMap) != 1 {
-		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	if len(ipMap) != 1 {
+		t.Errorf("expected 1 installPackage. Found %v. Actual: %v", len(ipMap), ipMap)
 	}
 
-	if profileMap[0].Name != "my.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	if ipMap[0].Name != "my.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: my.package.com", ipMap[0].Name)
 	}
 
-	if profileMap[0].Version != "4.4.4" {
-		t.Errorf("expected profile with version. Found %s Expected: 4.4.4", profileMap[0].Version)
+	if ipMap[0].Version != "4.4.4" {
+		t.Errorf("expected installPackage with version. Found %s Expected: 4.4.4", ipMap[0].Version)
 	}
 
-	if profileMap[0].Config != "woof-path" {
-		t.Errorf("expected profile with config. Found %s Expected: woof-path", profileMap[0].Config)
+	if ipMap[0].Config != "woof-path" {
+		t.Errorf("expected installPackage with config. Found %s Expected: woof-path", ipMap[0].Config)
 	}
 }
 
-// When the user provides only a profile name, empty version, and a config path:
-// --profile my.package.com::my-config
-func TestParseProfileMappingsEmptyVersion(t *testing.T) {
-	profileMap, err := ParseProfileMappings(
+// When the user provides only a installPackage name, empty version, and a config path:
+// --install-package my.package.com::my-config
+func TestParseInstallPackageMappingsEmptyVersion(t *testing.T) {
+	ipMap, err := ParseInstallPackageMappings(
 		[]string{"my.package.com::my-config"},
 	)
 
 	if err != nil {
-		t.Error("Parsing profiles should pass")
+		t.Error("Parsing installPackages should pass")
 	}
 
-	if len(profileMap) != 1 {
-		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	if len(ipMap) != 1 {
+		t.Errorf("expected 1 installPackage. Found %v. Actual: %v", len(ipMap), ipMap)
 	}
 
-	if profileMap[0].Name != "my.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	if ipMap[0].Name != "my.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: my.package.com", ipMap[0].Name)
 	}
 
-	if profileMap[0].Version != "" {
-		t.Errorf("expected profile with no version. Found %s Expected: empty string", profileMap[0].Version)
+	if ipMap[0].Version != "" {
+		t.Errorf("expected installPackage with no version. Found %s Expected: empty string", ipMap[0].Version)
 	}
 
-	if profileMap[0].Config != "my-config" {
-		t.Errorf("expected profile with config. Found %s Expected: my-config", profileMap[0].Config)
+	if ipMap[0].Config != "my-config" {
+		t.Errorf("expected installPackage with config. Found %s Expected: my-config", ipMap[0].Config)
 	}
 }
 
-// When the user provides multiple full profile mappings in single profile flag:
-// --profile my.package.com:4.4.4:woof-path,other.package.com:1.2.3:my-config-path
-func TestParseProfileMappingsMultiple(t *testing.T) {
-	profileMap, err := ParseProfileMappings(
+// When the user provides multiple full installPackage mappings in single install-package flag:
+// --install-package my.package.com:4.4.4:woof-path,other.package.com:1.2.3:my-config-path
+func TestParseInstallPackageMappingsMultiple(t *testing.T) {
+	ipMap, err := ParseInstallPackageMappings(
 		[]string{"my.package.com:4.4.4:woof-path,other.package.com:1.2.3:my-config-path"},
 	)
 
 	if err != nil {
-		t.Error("Parsing profiles should pass")
+		t.Error("Parsing installPackages should pass")
 	}
 
-	if len(profileMap) != 2 {
-		t.Errorf("expected 1 profile. Found %v. Actual: %v", len(profileMap), profileMap)
+	if len(ipMap) != 2 {
+		t.Errorf("expected 1 installPackage. Found %v. Actual: %v", len(ipMap), ipMap)
 	}
 
-	if profileMap[0].Name != "my.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	if ipMap[0].Name != "my.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: my.package.com", ipMap[0].Name)
 	}
 
-	if profileMap[0].Version != "4.4.4" {
-		t.Errorf("expected profile with version. Found %s Expected: 4.4.4", profileMap[0].Version)
+	if ipMap[0].Version != "4.4.4" {
+		t.Errorf("expected installPackage with version. Found %s Expected: 4.4.4", ipMap[0].Version)
 	}
 
-	if profileMap[0].Config != "woof-path" {
-		t.Errorf("expected profile with config. Found %s Expected: woof-path", profileMap[0].Config)
+	if ipMap[0].Config != "woof-path" {
+		t.Errorf("expected installPackage with config. Found %s Expected: woof-path", ipMap[0].Config)
 	}
 
-	if profileMap[1].Name != "other.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	if ipMap[1].Name != "other.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: my.package.com", ipMap[0].Name)
 	}
 
-	if profileMap[1].Version != "1.2.3" {
-		t.Errorf("expected profile with version. Found %s Expected: 1.2.3", profileMap[0].Version)
+	if ipMap[1].Version != "1.2.3" {
+		t.Errorf("expected installPackage with version. Found %s Expected: 1.2.3", ipMap[0].Version)
 	}
 
-	if profileMap[1].Config != "my-config-path" {
-		t.Errorf("expected profile with config. Found %s Expected: my-config-path", profileMap[0].Config)
+	if ipMap[1].Config != "my-config-path" {
+		t.Errorf("expected installPackage with config. Found %s Expected: my-config-path", ipMap[0].Config)
 	}
 }
 
-// When the user provides multiple full profile mappings in multiple profile flags:
-// --profile my.package.com:4.4.4:woof-path,other.package.com:2.2.2:other-config
-// --profile my.other-package.com:1.2.3:my-path,my.final.package.com:7.8.9:final-config
-func TestParseProfileMappingMixedFlags(t *testing.T) {
-	profileMap, err := ParseProfileMappings(
+// When the user provides multiple full installPackage mappings in multiple install-package flags:
+// --install-package my.package.com:4.4.4:woof-path,other.package.com:2.2.2:other-config
+// --install-package my.other-package.com:1.2.3:my-path,my.final.package.com:7.8.9:final-config
+func TestParseInstallPackageMappingMixedFlags(t *testing.T) {
+	ipMap, err := ParseInstallPackageMappings(
 		[]string{
 			"my.package.com:4.4.4:woof-path,other.package.com:2.2.2:other-config",
 			"my-third.package.com:1.2.3:my-path,my-final.package.com:7.8.9:final-config",
@@ -708,66 +708,66 @@ func TestParseProfileMappingMixedFlags(t *testing.T) {
 	)
 
 	if err != nil {
-		t.Error("Parsing profiles should pass")
+		t.Error("Parsing installPackages should pass")
 	}
 
-	if len(profileMap) != 4 {
-		t.Errorf("expected 4 profiles. Found %v. Actual: %v", len(profileMap), profileMap)
+	if len(ipMap) != 4 {
+		t.Errorf("expected 4 installPackages. Found %v. Actual: %v", len(ipMap), ipMap)
 	}
 
-	if profileMap[0].Name != "my.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my.package.com", profileMap[0].Name)
+	if ipMap[0].Name != "my.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: my.package.com", ipMap[0].Name)
 	}
 
-	if profileMap[0].Version != "4.4.4" {
-		t.Errorf("expected profile with version. Found %s Expected: 4.4.4", profileMap[0].Version)
+	if ipMap[0].Version != "4.4.4" {
+		t.Errorf("expected installPackage with version. Found %s Expected: 4.4.4", ipMap[0].Version)
 	}
 
-	if profileMap[0].Config != "woof-path" {
-		t.Errorf("expected profile with config. Found %s Expected: woof-path", profileMap[0].Config)
+	if ipMap[0].Config != "woof-path" {
+		t.Errorf("expected installPackage with config. Found %s Expected: woof-path", ipMap[0].Config)
 	}
 
-	if profileMap[1].Name != "other.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: other.package.com", profileMap[1].Name)
+	if ipMap[1].Name != "other.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: other.package.com", ipMap[1].Name)
 	}
 
-	if profileMap[1].Version != "2.2.2" {
-		t.Errorf("expected profile with version. Found %s Expected: 2.2.2", profileMap[1].Version)
+	if ipMap[1].Version != "2.2.2" {
+		t.Errorf("expected installPackage with version. Found %s Expected: 2.2.2", ipMap[1].Version)
 	}
 
-	if profileMap[1].Config != "other-config" {
-		t.Errorf("expected profile with config. Found %s Expected: other-config", profileMap[1].Config)
+	if ipMap[1].Config != "other-config" {
+		t.Errorf("expected installPackage with config. Found %s Expected: other-config", ipMap[1].Config)
 	}
 
-	if profileMap[2].Name != "my-third.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: third.package.com", profileMap[2].Name)
+	if ipMap[2].Name != "my-third.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: third.package.com", ipMap[2].Name)
 	}
 
-	if profileMap[2].Version != "1.2.3" {
-		t.Errorf("expected profile with version. Found %s Expected: 1.2.3", profileMap[2].Version)
+	if ipMap[2].Version != "1.2.3" {
+		t.Errorf("expected installPackage with version. Found %s Expected: 1.2.3", ipMap[2].Version)
 	}
 
-	if profileMap[2].Config != "my-path" {
-		t.Errorf("expected profile with config. Found %s Expected: my-config-path", profileMap[2].Config)
+	if ipMap[2].Config != "my-path" {
+		t.Errorf("expected installPackage with config. Found %s Expected: my-config-path", ipMap[2].Config)
 	}
 
-	if profileMap[3].Name != "my-final.package.com" {
-		t.Errorf("expected profile with name. Found %s Expected: my-final.package.com", profileMap[3].Name)
+	if ipMap[3].Name != "my-final.package.com" {
+		t.Errorf("expected installPackage with name. Found %s Expected: my-final.package.com", ipMap[3].Name)
 	}
 
-	if profileMap[3].Version != "7.8.9" {
-		t.Errorf("expected profile with version. Found %s Expected: 7.8.9", profileMap[3].Version)
+	if ipMap[3].Version != "7.8.9" {
+		t.Errorf("expected installPackage with version. Found %s Expected: 7.8.9", ipMap[3].Version)
 	}
 
-	if profileMap[3].Config != "final-config" {
-		t.Errorf("expected profile with config. Found %s Expected: final-config", profileMap[3].Config)
+	if ipMap[3].Config != "final-config" {
+		t.Errorf("expected installPackage with config. Found %s Expected: final-config", ipMap[3].Config)
 	}
 }
 
 // When the user provides a bad formatting:
-// --profile my.package.com:4.4.4:woof-path:garbage
-func TestParseProfileMappingBadFormat(t *testing.T) {
-	_, err := ParseProfileMappings(
+// --install-package my.package.com:4.4.4:woof-path:garbage
+func TestParseInstallPackageMappingBadFormat(t *testing.T) {
+	_, err := ParseInstallPackageMappings(
 		[]string{"my.package.com:4.4.4:woof-path:garbage"},
 	)
 
@@ -777,8 +777,8 @@ func TestParseProfileMappingBadFormat(t *testing.T) {
 }
 
 // Won't errors when nothing is provided:
-func TestParseProfileNil(t *testing.T) {
-	_, err := ParseProfileMappings(
+func TestParseInstallPackageNil(t *testing.T) {
+	_, err := ParseInstallPackageMappings(
 		[]string{},
 	)
 

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/codes.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/codes.go
@@ -49,6 +49,6 @@ const (
 	// 13 - Failed to merge kubeconfig and set context
 	ErrKubeconfigContextSet
 
-	// 14 - Cound not install profile
-	ErrProfileInstall
+	// 14 - Cound not install package
+	ErrInstallPackage
 )

--- a/docs/site/content/docs/ref-unmanaged-cluster.md
+++ b/docs/site/content/docs/ref-unmanaged-cluster.md
@@ -71,70 +71,70 @@ If this config option is provided, the default package repository will not be in
 tanzu unmanaged-cluster create --additional-repo my-repo.registry-url.com/path
 ```
 
-## Installing Profiles
+## Installing packages during bootstrapping
 
-_Warning:_ Profiles is an experimental feature. Use with caution.
+_Warning:_ Installing Packages during bootstrapping is an experimental feature. Use with caution.
 
-When creating a cluster, designate `--profile` to automatically install
+When creating a cluster, designate `--install-package` to automatically install
 a package from an installed package repository.
-The name of the profile must be the fully qualified name of the package in the package repository,
+The name of the package must be the fully qualified name of the package in the package repository,
 or a prefix of the package name in the package repository.
 
 So, for example, to install `fluent-bit` during cluster creation,
 run the following
 
 ```sh
-tanzu unmanaged-cluster create my-cluster --profile fluent-bit
+tanzu unmanaged-cluster create my-cluster --install-package fluent-bit
 ```
 
 By default, the _latest_ package is installed
 and all default values are used for the package.
 
-To designate a profile version or profile values yaml file, use a profile mapping.
+To designate a package version or pacakge values yaml file, use a mapping.
 The expected format is:
 
 ```text
-profile-name:profile-version:profile-config-file
+name:version:config-file-path
 ```
 
-This is used with the `--profile` flag:
+This is used with the `--install-package` flag:
 
 ```sh
-tanzu unmanged-cluster create --profile fluent-bit:1.7.5:path-to-my-config.yaml
+tanzu unmanged-cluster create --install-package fluent-bit:1.7.5:path-to-my-config.yaml
 ```
 
-Both `profile-version` and `profile-config-file` are optional.
+Both `version` and `config-file-path` are optional.
 
-To install the most recent package, use the keyword `latest` or an empty string for the profile version
+To install the most recent package, use the keyword `latest` or an empty string for the version
 to select the most recent semantic version for the specified package. Example:
 
 ```sh
-tanzu unmanaged-cluster create my-cluster --profile external-dns:latest:path-to-my-config.yaml
+tanzu unmanaged-cluster create my-cluster --install-package external-dns:latest:path-to-my-config.yaml
 ```
 
 For further information on [packages and configuring packages, read the documentation.](package-management)
 
-## Installing multiple Profiles
+## Installing multiple packages during bootstrapping
 
-_Warning:_ Profiles is an experimental feature. Use with caution.
+_Warning:_ Installing packages during bootstrapping is an experimental feature. Use with caution.
 
-Profile mappings may be specified multiple times via multiple `--profile` flags
-or within a singule profile flag, delimitted by a comma:
+Install-pacakge mappings may be specified multiple times via multiple `--install-package` flags
+or within a single `--install-package` flag, delimitted by a comma:
 
 ```sh
-tanzu unmanaged-cluster create --profile fluent-bit:1.7.5,external-dns::path-to-my-config.yaml
+tanzu unmanaged-cluster create --install-package fluent-bit:1.7.5,external-dns::path-to-my-config.yaml
 ```
 
 The above will install the fluent-bit package at version 1.7.5 with no values yaml file
 and the external-dns package at the latest version with a values yaml file.
 
 Finally, for the most granularity and configurability,
-you may configure all profile options via a unmanaged cluster config file.
+you may configure all options via a unmanaged cluster config file.
 The following is a truncated config file and can be [generated via `tanzu unmanaged-cluster config`](#custom-configuration)
-with a `--profile` flag and profile mappings:
+with the `--install-package` flag and mappings:
 
 ```yaml
-Profiles:
+InstallPackages:
 - name: fluent-bit.community.tanzu.vmware.com
 - name: external-dns.community.tanzu.vmware.com
   config: external-values.yaml
@@ -146,17 +146,17 @@ Profiles:
 Using the above config file:
 
 ```sh
-tanzu unmanaged-cluster create -f my-config
+tanzu unmanaged-cluster create -f my-config.yaml
 ```
 
-Will create a cluster with three profiles:
+will create a cluster with three packages automatically installed:
 
 * fluent-bit at the latest version with default values
 * external-dns at version 0.10.0 with the default values
 * app-toolkit at the latest version configured with the provided values
 
 _Note:_ The above examples may fail to install the packages without proper values provided.
-Always read the documentation for the specific package and profile you are installing.
+Always read the documentation for the specific package you are installing.
 
 ## Listing clusters
 
@@ -255,7 +255,7 @@ when `ProviderConfiguration` is used.
   SkipPreflight: false
   ControlPlaneNodeCount: "1"
   WorkerNodeCount: "0"
-  Profiles: []
+  InstallPackages: []
   ```
 
 * Minikube provider:
@@ -285,7 +285,7 @@ when `ProviderConfiguration` is used.
   SkipPreflight: false
   ControlPlaneNodeCount: "1"
   WorkerNodeCount: "0"
-  Profiles: []
+  InstallPackages: []
   ```
 
   The above config file can be used with another port mapping via the `-p` CLI flag.
@@ -443,7 +443,7 @@ The exit codes are defined as follows:
 * 11 - Could not install additional package repo
 * 12 - Could not install CNI package.
 * 13 - Failed to merge kubeconfig and set context
-* 14 - Could not install designated profile
+* 14 - Could not install designated packages
 
 ## Limitations
 


### PR DESCRIPTION
## What this PR does / why we need it

Renames `profiles` to `install-packages` in unmanaged-cluster

## Which issue(s) this PR fixes
Fixes: #4040

## Describe testing done for PR
```
tanzu unmanaged-cluster create test --install-package fluent-bit

...

🌐 Installing package fluent-bit
   Selected package fluent-bit.community.tanzu.vmware.com
   Installing package without version specified. Using version 1.7.5
   Installing package with no configuration file
```
