### PR TITLE
Doc updates for unmanaged cluster

### DIFF
--- a/docs/site/content/docs/architecture.md
+++ b/docs/site/content/docs/architecture.md
@@ -98,7 +98,7 @@ relationship end-to-end.
 
 ### Unmanaged Clusters
 
-An unmanaged cluster offers a single node, local workstation cluster suitable for a development/test environment.  It requires minimal local resources and is fast to deploy. It provides support for running multiple clusters. The default Tanzu Community Edition package repository is automatically installed when you deploy an unmanaged cluster.
+An [unmanaged cluster](glossary/#u) offers a single node, local workstation cluster suitable for a development/test environment.  It requires minimal local resources and is fast to deploy. It provides support for running multiple clusters. The default Tanzu Community Edition package repository is automatically installed when you deploy an unmanaged cluster.
 
 ## Package Management
 

--- a/docs/site/content/docs/assets/create-unmanaged-cluster.md
+++ b/docs/site/content/docs/assets/create-unmanaged-cluster.md
@@ -66,3 +66,10 @@
 1. If you have [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
    installed, you can now use it to interact with the
    cluster.
+1. Run the following command to determine the name of this cluster, you will use this if you need to change context to this cluster at a later time:
+
+   ```sh
+   kubectl config view --minify
+   ```
+
+   Note: The unmanaged cluster provider name is prepended to the cluster name.

--- a/docs/site/content/docs/assets/prereq-unmanaged-linux.md
+++ b/docs/site/content/docs/assets/prereq-unmanaged-linux.md
@@ -1,3 +1,8 @@
 | Architecture   | CPU | RAM  | Required software |
 |:---------------|:----|:-----|:------------------|
-| x86_64 / amd64 | 1   | 2 GB | [Docker engine](https://docs.docker.com/engine/install) |
+| x86_64 / amd64 | 1   | 2 GB | [Docker engine](https://docs.docker.com/engine/install), (Optional) [minikube](https://minikube.sigs.k8s.io/docs/start/)|
+
+Tanzu Community Edition supports two cluster providers for unmanaged clusters: Kind and minikube
+
+- Kind is the default cluster provider and is included as default with the unmangaged cluster binary, you just need to install Docker.
+- minikube is an alternative cluster provider, if you plan to use minikube as your cluster provider, you must first install minikube and a minikube supported container or virtual machine manager such as Docker.

--- a/docs/site/content/docs/assets/prereq-unmanaged-mac.md
+++ b/docs/site/content/docs/assets/prereq-unmanaged-mac.md
@@ -1,5 +1,10 @@
 | Architecture   | CPU | RAM  | Required software |
 |:---------------|:----|:-----|:------------------|
-| x86_64 / AMD64 / ARM64  | 1   | 2 GB | [Docker Desktop](https://www.docker.com/get-started) |
+| x86_64 / AMD64 / ARM64  | 1   | 2 GB | [Docker Desktop](https://www.docker.com/get-started), (Optional) [minikube](https://minikube.sigs.k8s.io/docs/start/) |
+
+Tanzu Community Edition supports two cluster providers for unmanaged clusters: Kind and minikube
+
+- Kind is the default cluster provider and is included as default with the unmangaged cluster binary, you just need to install Docker.
+- minikube is an alternative cluster provider, if you plan to use minikube as your cluster provider, you must first install minikube and a minikube supported container or virtual machine manager such as Docker.
 
 Note: ARM64 support is experimental. Some packages might not install due to their ARM64 image not being available.

--- a/docs/site/content/docs/assets/prereq-unmanaged-windows.md
+++ b/docs/site/content/docs/assets/prereq-unmanaged-windows.md
@@ -1,3 +1,10 @@
 | Architecture   | CPU | RAM  | Required software |
 |:---------------|:----|:-----|:------------------|
-| x86_64 / amd64 | 1   | 2 GB | [Docker Desktop](https://www.docker.com/get-started) |
+| x86_64 / amd64 | 1   | 2 GB | [Docker Desktop](https://www.docker.com/get-started), (Optional) [minikube](https://minikube.sigs.k8s.io/docs/start/) |
+
+Tanzu Community Edition supports two cluster providers for unmanaged clusters: Kind and minikube
+
+- Kind is the default cluster provider and is included as default with the unmangaged cluster binary, you just need to install Docker.
+- minikube is an alternative cluster provider, if you plan to use minikube as your cluster provider, you must first install minikube and a minikube supported container or virtual machine manager such as Docker.
+
+Note: ARM64 support is experimental. Some packages might not install due to their ARM64 image not being available.

--- a/docs/site/content/docs/assets/unmanaged-desc.md
+++ b/docs/site/content/docs/assets/unmanaged-desc.md
@@ -1,2 +1,2 @@
-Unmanaged clusters offer Tanzu environments for **development** and **experimentation**. By default, they run locally via [kind](https://kind.sigs.k8s.io) with Tanzu components installed atop. 
+Unmanaged clusters offer Tanzu environments for **development** and **experimentation**. By default, they run locally via [kind](https://kind.sigs.k8s.io) (default) or [minikube](https://minikube.sigs.k8s.io/docs/start/) with Tanzu components installed atop. 
 An unmanaged cluster offers a single node, local workstation cluster suitable for a development/test environment.  It requires minimal local resources and is fast to deploy. It provides support for running multiple clusters.

--- a/docs/site/content/docs/sample.md
+++ b/docs/site/content/docs/sample.md
@@ -10,10 +10,10 @@ You must have a workload or unmanaged cluster deployed.
 
 ## Procedure
 
-1. If you are deploying to a workload cluster, switch configuration context to the target workload cluster.
+1. Switch context to the target workload or unmanaged cluster.
 
     ```sh
-    kubectl config use-context <WORKLOAD-CLUSTER-NAME>
+    kubectl config use-context <CLUSTER-NAME>
     ```
 
     For example:
@@ -23,6 +23,8 @@ You must have a workload or unmanaged cluster deployed.
 
     Switched to context "tce-cluster-1".
     ```
+
+    Note: For unmanaged clusters, the cluster provider name is prepended to the cluster name.
 
 1. Deploy the kuard demo app.
 


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
- Adds minikube as optional prereq for unmanaged cluster
- updates the unmanaged cluster description that is used in glossary
- updates the 'Deploy a Test Workload to a Workload or Unmanaged Cluster' topic to give more detail on changing context to an unmanaged cluster


## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4115

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
