### PR TITLE
Fix GCP Upload for Staging and Release

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -65,13 +65,14 @@ jobs:
         run: |
           make prep-gcp-tce-bucket
           make build-cli-plugins-nopublish
-      - id: auth-to-gcp-buckets
+      - name: Auth to GCP Buckets
+        id: auth-to-gcp-buckets
         uses: google-github-actions/auth@v0
         with:
           credentials_json: ${{ secrets.GCP_BUCKET_SA }}
       - name: Upload Artifacts to Staging Bucket
         id: upload-artifacts-staging
-        uses: google-github-actions/upload-cloud-storage@v0.9.0
+        uses: google-github-actions/upload-cloud-storage@v0.8.0
         with:
           path: ./artifacts
           destination: tce-cli-plugins-staging

--- a/.github/workflows/release-bucket.yaml
+++ b/.github/workflows/release-bucket.yaml
@@ -77,32 +77,33 @@ jobs:
         run: |
           make ensure-deps
           make release-buckets
-      - id: auth-to-gcp-buckets
+      - name: Auth to GCP Buckets
+        id: auth-to-gcp-buckets
         uses: google-github-actions/auth@v0
         with:
           credentials_json: ${{ secrets.GCP_BUCKET_SA }}
       - name: Upload TCE Artifacts to Staging Bucket
         id: upload-artifacts-staging
-        uses: google-github-actions/upload-cloud-storage@v0.9.0
+        uses: google-github-actions/upload-cloud-storage@v0.8.0
         with:
           path: ./artifacts
           destination: tce-cli-plugins-staging
       - name: Upload TCE Artifacts to Update Bucket
         id: upload-tce-artifacts-update
-        uses: google-github-actions/upload-cloud-storage@v0.9.0
+        uses: google-github-actions/upload-cloud-storage@v0.8.0
         with:
           path: ./artifacts
           destination: tce-cli-plugins
       - name: Upload TF Artifacts to Update Bucket
         id: upload-tf-artifacts-update
-        uses: google-github-actions/upload-cloud-storage@v0.9.0
+        uses: google-github-actions/upload-cloud-storage@v0.8.0
         with:
           path: /tmp/tce-scratch-space/tanzu-framework/artifacts
           destination: tce-framework-cli-plugins/artifacts
           parent: false
       - name: Upload TF Admin Artifacts to Update Bucket
         id: upload-tf-artifacts-admin-update
-        uses: google-github-actions/upload-cloud-storage@v0.9.0
+        uses: google-github-actions/upload-cloud-storage@v0.8.0
         with:
           path: /tmp/tce-scratch-space/tanzu-framework/artifacts-admin
           destination: tce-framework-cli-plugins-admin/artifacts-admin
@@ -114,20 +115,20 @@ jobs:
         run: make prune-buckets
       - name: Upload TCE Artifacts to Release Bucket
         id: upload-tce-artifacts-release
-        uses: google-github-actions/upload-cloud-storage@v0.9.0
+        uses: google-github-actions/upload-cloud-storage@v0.8.0
         with:
           path: ./artifacts
           destination: tce-tanzu-cli-plugins
       - name: Upload TF Artifacts to Release Bucket
         id: upload-tf-artifacts-release
-        uses: google-github-actions/upload-cloud-storage@v0.9.0
+        uses: google-github-actions/upload-cloud-storage@v0.8.0
         with:
           path: /tmp/tce-scratch-space/tanzu-framework/artifacts
           destination: tce-tanzu-cli-framework/artifacts
           parent: false
       - name: Upload TF Artifacts-Admin to Release Bucket
         id: upload-tf-artifacts-admin-release
-        uses: google-github-actions/upload-cloud-storage@v0.9.0
+        uses: google-github-actions/upload-cloud-storage@v0.8.0
         with:
           path: /tmp/tce-scratch-space/tanzu-framework/artifacts-admin
           destination: tce-tanzu-cli-framework-admin/artifacts-admin


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR does 2 things:
1) Fixes the GCP upload to the buckets found here:
https://github.com/vmware-tanzu/community-edition/runs/6040162328?check_suite_focus=true

is because of this bug:
https://github.com/google-github-actions/upload-cloud-storage/pull/251

the recommendations until merged and a new version is available is to downgrade to 0.8.0

2) Just introducing a friendly name for the GitHub Action step instead of getting the ID displayed in action runs.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA