### PR TITLE
Updates compatibility file to reflect v0.12.0 rc release

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/hack/tce-compatibility.yaml
+++ b/cli/cmd/plugin/unmanaged-cluster/hack/tce-compatibility.yaml
@@ -2,9 +2,14 @@ version: v1
 unmanagedClusterPluginVersions:
 - version: dev
   supportedTkrVersions:
+  - image: projects.registry.vmware.com/tce/tkr:v1.22.7
+  - image: projects.registry.vmware.com/tce/tkr:v0.17.0-dev-2
   - image: projects.registry.vmware.com/tce/tkr:v0.17.0-dev-1
   - image: projects.registry.vmware.com/tce/tkr:v0.17.0
   - image: projects.registry.vmware.com/tce/tkr:v1.22.5
+- version: v0.12.0-rc.1
+  supportedTkrVersions:
+  - image: projects.registry.vmware.com/tce/tkr:v1.22.7
 - version: v0.11.0
   supportedTkrVersions:
   - image: projects.registry.vmware.com/tce/tkr:v0.17.0


### PR DESCRIPTION
## What this PR does / why we need it

Updates the compatibility file (which has already been pushed) to reflect the v0.12.0 rc release

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
Build local binaries and used new TKr / compatibility file during `create`:
```
$ tanzu unmanaged-cluster create life

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Downloaded to: /home/jmcb/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v5

🔧 Resolving TKr
   projects.registry.vmware.com/tce/tkr:v1.22.7
   Downloaded to: /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v1.22.7
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/life/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/life/bootstrap.log

...
```
