### PR TITLE
docs: Add custom WSL kernel link to Docker deployment

### DIFF
--- a/docs/site/content/docs/assets/capd-clusters.md
+++ b/docs/site/content/docs/assets/capd-clusters.md
@@ -5,7 +5,7 @@ using Docker.
 
 ⚠️: Tanzu Community Edition support for Docker is **experimental** and may require troubleshooting on your system.
 
-Note: Bootstrapping a cluster to Docker from a Windows bootstrap machine is currently experimental.
+Note: Bootstrapping a cluster to Docker from a Windows bootstrap machine is currently experimental, for more information, see [Docker-based Clusters on Windows](../ref-windows-capd).
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixes #4069

Signed-off-by: Patrick Kremer <pkremer@vmware.com>

## What this PR does / why we need it

The only way you can run TCE on Docker for Windows with WSL is if you compile a custom kernel. This fairly complex process is not mentioned in https://tanzucommunityedition.io/docs/v0.11/docker-install-mgmt/ - it only mentions that support is experimental. Links to the custom WSL kernel page https://tanzucommunityedition.io/docs/v0.11/ref-windows-capd/ are found elsewhere in the site, so I just borrowed that language and added it to the docker-install-mgmt page.


## Which issue(s) this PR fixes
Fixes #4069

## Describe testing done for PR

Ran locally with Hugo