### PR TITLE
Adding env variable BUILD_VERSION in Unmanaged cluster e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,6 +507,6 @@ vsphere-management-and-workload-cluster-e2e-test:
 	BUILD_VERSION=$(BUILD_VERSION) test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
 
 unmanaged-cluster-e2e-test:
-	cd cli/cmd/plugin/unmanaged-cluster/test/e2e && go test -test.v -timeout 180m
+	cd cli/cmd/plugin/unmanaged-cluster/test/e2e && BUILD_VERSION=$(BUILD_VERSION) go test -test.v -timeout 180m
 
 ##### E2E TESTS


### PR DESCRIPTION
Signed-off-by: Aman Sharma <amansh@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Setting env variable BUILD_VERSION was missed in #3810 e2e test for unmanaged cluster. This PR will fix that and resolve the [failure](https://github.com/vmware-tanzu/community-edition/runs/6053108460?check_suite_focus=true#step:4:53)  

