### PR TITLE
Add common redirects for certain links already used

### DIFF
--- a/docs/designs/2730-visibility.md
+++ b/docs/designs/2730-visibility.md
@@ -343,7 +343,7 @@ bootstrap logging to aid in troubleshooting when deployments fail.
 #### Cluster API Controller Logs
 
 One common scenario we have found to work when troubleshooting deployment failures
-is to [look at the `capX-controller-manager` POD logs](https://tanzucommunityedition.io/docs/tsg-bootstrap/#troubleshooting-manually).
+is to [look at the `capX-controller-manager` POD logs](https://tanzucommunityedition.io/docs/v0.11/tsg-bootstrap/#troubleshooting-manually).
 Looking for Error level logs (log lines that start with an `E`) will often indicate
 what is failing in reconciliation that is preventing the cluster from being
 properly created.

--- a/docs/site/themes/template/layouts/index.redirects
+++ b/docs/site/themes/template/layouts/index.redirects
@@ -1,3 +1,8 @@
 {{ $latest := (cond (.Site.Params.docs_versioning) .Site.Params.docs_latest "") }}
-/docs                          /docs/{{ $latest }}     301!
-/docs/latest                   /docs/{{ $latest }}
+/docs                                   /docs/{{ $latest }}     301!
+/docs/latest                            /docs/{{ $latest }}
+/docs/package-management                /docs/{{ $latest }}/package-management
+/docs/getting-started                   /docs/{{ $latest }}/getting-started
+/docs/contribute/contributing           /docs/{{ $latest }}/contribute/contributing
+/docs/trouble-faq                       /docs/{{ $latest }}/trouble-faq
+/docs/package-creation-step-by-step     /docs/{{ $latest }}/package-creation-step-by-step


### PR DESCRIPTION
Signed-off-by: Jonas Rosland <jrosland@vmware.com>

## What this PR does / why we need it
There are multiple instances of where some common links are being used. The proper way would be to update these links to the latest versioned URLs, but with redirects we can do that automatically instead of trying to remember to edit those every time there's a new release.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4055

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
