### PR TITLE
Updates `unmanaged-cluster` compatibility file to support the `v0.12.0` RC 2 release

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/hack/tce-compatibility.yaml
+++ b/cli/cmd/plugin/unmanaged-cluster/hack/tce-compatibility.yaml
@@ -2,14 +2,17 @@ version: v1
 unmanagedClusterPluginVersions:
 - version: dev
   supportedTkrVersions:
-  - image: projects.registry.vmware.com/tce/tkr:v1.22.7
+  - image: projects.registry.vmware.com/tce/tkr:v1.22.7-1
   - image: projects.registry.vmware.com/tce/tkr:v0.17.0-dev-2
   - image: projects.registry.vmware.com/tce/tkr:v0.17.0-dev-1
   - image: projects.registry.vmware.com/tce/tkr:v0.17.0
   - image: projects.registry.vmware.com/tce/tkr:v1.22.5
+- version: v0.12.0-rc.2
+  supportedTkrVersions:
+  - image: projects.registry.vmware.com/tce/tkr:v1.22.7-1
 - version: v0.12.0-rc.1
   supportedTkrVersions:
-  - image: projects.registry.vmware.com/tce/tkr:v1.22.7
+  - image: projects.registry.vmware.com/tce/tkr:v1.22.7-1
 - version: v0.11.0
   supportedTkrVersions:
   - image: projects.registry.vmware.com/tce/tkr:v0.17.0

--- a/hack/release/tkr-bom.yaml
+++ b/hack/release/tkr-bom.yaml
@@ -209,7 +209,7 @@ components:
       tanzuUserPackageRepositoryImage:
         imagePath: main
         repository: projects.registry.vmware.com/tce
-        tag: 0.12.0
+        tag: 0.12.0-rc2
       vsphere-cpi.tanzu.vmware.com:
         imagePath: packages/core/vsphere-cpi
         tag: v1.22.6_vmware.1-tkg.2-tf-v0.11.4


### PR DESCRIPTION
Signed-off-by: John McBride <jmcbride@vmware.com>

## What this PR does / why we need it

Adds missing field for `v0.12.0-rc.2` release

## Which issue(s) this PR fixes
N/a

## Describe testing done for PR
Able to build off of RC now:
```
❯ tanzu unmanaged-cluster version
v0.12.0-rc.2

❯ tanzu unmanaged-cluster create woof

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Downloaded to: /Users/jmcbride/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v7

🔧 Resolving TKr
   projects.registry.vmware.com/tce/tkr:v1.22.7-1
   Downloaded to: /Users/jmcbride/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v1.22.7-1
   Rendered Config: /Users/jmcbride/.config/tanzu/tkg/unmanaged/woof/config.yaml
   Bootstrap Logs: /Users/jmcbride/.config/tanzu/tkg/unmanaged/woof/bootstrap.log
...
```

File is already in `v7` of `projects.registry.vmware.com/tce/compatibility` and the new TKr:

```
❯ crane ls projects.registry.vmware.com/tce/compatibility | rg v7
v7

❯ crane ls projects.registry.vmware.com/tce/tkr | rg v1.22.7-1
v1.22.7-1
```