### PR TITLE
Fix paths for asset util after relocation

### DIFF
--- a/hack/release/asset/asset.go
+++ b/hack/release/asset/asset.go
@@ -117,7 +117,7 @@ func main() {
 	}
 
 	darwinAMD64AssetFilename := fmt.Sprintf("tce-darwin-amd64-%s.tar.gz", tag)
-	darwinAMD64Asset := filepath.Join("..", "..", "release", darwinAMD64AssetFilename)
+	darwinAMD64Asset := filepath.Join("..", "..", "..", "release", darwinAMD64AssetFilename)
 	err = uploadToDraftRelease(draftRelease, darwinAMD64Asset)
 	if err != nil {
 		fmt.Printf("uploadToDraftRelease(darwin-amd64) failed: %v\n", err)
@@ -126,7 +126,7 @@ func main() {
 
 	// TODO: Uncomment this when cluster creation is supported on Darwin/ARM64
 	// darwinARM64AssetFilename := fmt.Sprintf("tce-darwin-arm64-%s.tar.gz", tag)
-	// darwinARM64Asset := filepath.Join("..", "..", "release", darwinARM64AssetFilename)
+	// darwinARM64Asset := filepath.Join("..", "..", "..", "release", darwinARM64AssetFilename)
 	// err = uploadToDraftRelease(draftRelease, darwinARM64Asset)
 	// if err != nil {
 	//     fmt.Printf("uploadToDraftRelease(darwin-arm64) failed: %v\n", err)
@@ -134,7 +134,7 @@ func main() {
 	//}
 
 	linuxAssetFilename := fmt.Sprintf("tce-linux-amd64-%s.tar.gz", tag)
-	linuxAsset := filepath.Join("..", "..", "release", linuxAssetFilename)
+	linuxAsset := filepath.Join("..", "..", "..", "release", linuxAssetFilename)
 	err = uploadToDraftRelease(draftRelease, linuxAsset)
 	if err != nil {
 		fmt.Printf("uploadToDraftRelease(linux) failed: %v\n", err)
@@ -142,14 +142,14 @@ func main() {
 	}
 
 	windowsAssetFilename := fmt.Sprintf("tce-windows-amd64-%s.zip", tag)
-	windowsAsset := filepath.Join("..", "..", "release", windowsAssetFilename)
+	windowsAsset := filepath.Join("..", "..", "..", "release", windowsAssetFilename)
 	err = uploadToDraftRelease(draftRelease, windowsAsset)
 	if err != nil {
 		fmt.Printf("uploadToDraftRelease(windows) failed: %v\n", err)
 		return
 	}
 
-	checksumAsset := filepath.Join("..", "..", "release", DefaultCheckSumFilename)
+	checksumAsset := filepath.Join("..", "..", "..", "release", DefaultCheckSumFilename)
 	err = uploadToDraftRelease(draftRelease, checksumAsset)
 	if err != nil {
 		fmt.Printf("uploadToDraftRelease(checksum) failed: %v\n", err)


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
I just realized that the paths need to be updated since we moved into a subfolder.

Agreed the way we handle paths needs to be improved upon at some point, but that's a battle for a different day. We should provide the root path of the repo and go from there for all these kinds of utilities that are path-dependent.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA