### PR TITLE
[E2E]  Changed the way to find top dir path in `Unmanaged Cluster` e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,6 +507,6 @@ vsphere-management-and-workload-cluster-e2e-test:
 	BUILD_VERSION=$(BUILD_VERSION) test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
 
 unmanaged-cluster-e2e-test:
-	cd cli/cmd/plugin/unmanaged-cluster/test/e2e && BUILD_VERSION=$(BUILD_VERSION) go test -test.v -timeout 180m
+	cd cli/cmd/plugin/unmanaged-cluster/test/e2e && BUILD_VERSION=$(BUILD_VERSION) ROOT_DIR=$(ROOT_DIR) go test -test.v -timeout 180m
 
 ##### E2E TESTS

--- a/cli/cmd/plugin/unmanaged-cluster/test/e2e/utils/cli.go
+++ b/cli/cmd/plugin/unmanaged-cluster/test/e2e/utils/cli.go
@@ -10,18 +10,11 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"strings"
 )
 
 func InstallTCE() error {
-	wd, err := os.Getwd()
-	if err != nil {
-		log.Println("error while getting current working directory", err)
-	}
-
-	indTCE := strings.LastIndex(wd, "community-edition")
-	topDirPath := wd[0 : indTCE+17]
-	err = os.Chdir(topDirPath)
+	topDirPath := os.Getenv("ROOT_DIR")
+	err := os.Chdir(topDirPath)
 	if err != nil {
 		log.Println("error while changing directory to the top:", err)
 		return err


### PR DESCRIPTION
Signed-off-by: Aman Sharma <amansh@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR is substituting the hack in UC e2e test to find the topDirPath with a solid way by setting the env varible in Makefile and using it in Go code.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4107 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Run `make unmanaged-cluster-e2e-test`
