### PR TITLE
Implements `unmanaged-cluster` `tkr` package tests

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/tkr/image.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/image.go
@@ -48,6 +48,11 @@ type ImageReader interface {
 	// GetDownloadPath returns the path to the local filesystem where the OCI image is/will be downloaded
 	GetDownloadPath() string
 
+	// SetDownloadPath is a useful helper method in the case that users
+	// want to bypass downloading an image and need to set the path to a local bundle
+	// that may already exist on the system
+	SetDownloadPath(string)
+
 	// SetRelativeConfigPath sets the _relative_ path for the YTT config bundle in the downloaded OCI image.
 	// Example: kapp controller stores it's YTT bundle under "config/" in it's bundle.
 	//          So therefore, this function should be called with "config/" as an argument
@@ -87,6 +92,14 @@ func NewTkrImageReader(imagePath string) (ImageReader, error) {
 
 func (t *Image) GetRegistryURL() string {
 	return t.RegistryURL
+}
+
+func (t *Image) GetDownloadPath() string {
+	return t.DownloadPath
+}
+
+func (t *Image) SetDownloadPath(p string) {
+	t.DownloadPath = p
 }
 
 // GetTags returns a list of the tags for a given registry url
@@ -145,10 +158,6 @@ func (t *Image) DownloadImage() error {
 	}
 
 	return nil
-}
-
-func (t *Image) GetDownloadPath() string {
-	return t.DownloadPath
 }
 
 func (t *Image) SetRelativeConfigPath(configPath string) {

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/image_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/image_test.go
@@ -1,0 +1,306 @@
+// Copyright 2020-2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkr
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestImageReader(t *testing.T) {
+	ir, err := NewTkrImageReader("path-to-image")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if ir == nil {
+		t.Errorf("expected image struct to not be nil. Was nil")
+	}
+
+	if regURL := ir.GetRegistryURL(); regURL != "path-to-image" {
+		t.Errorf("expected image path to be `path-to-image`. Actual: %s", regURL)
+	}
+
+	if path := ir.GetDownloadPath(); path == "" {
+		t.Errorf("expected download path to be not be empty. Was empty")
+	}
+}
+
+func TestGetTags(t *testing.T) {
+	t.Skipf("imgpkg ListTags method libraries not mocked")
+}
+
+func TestDownloadBundleImage(t *testing.T) {
+	t.Skipf("imgpkg bundle download libraries not mocked")
+}
+
+func TestDownloadImage(t *testing.T) {
+	t.Skipf("imgpkg image download libraries not mocked")
+}
+
+var imgpkgImagesFileContent = `---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: ImagesLock
+images:
+- annotations:
+    kbld.carvel.dev/id: busybox
+  image: test-registry.io/library/busybox@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a`
+
+var upstreamDeploymentFileContent = `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default-namespace-name
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: default-name
+  namespace: default-namespace-name
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: default-app-name
+  template:
+    metadata:
+      labels:
+        app: default-app-name
+    spec:
+      containers:
+        - name: default-container-name
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          command:
+            - echo hello-world`
+
+var overlayNamespaceFileContent = `#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind":"Namespace", "metadata": {"name": "default-namespace-name"}})
+---
+metadata:
+  name: #@ data.values.namespace
+
+#@overlay/match by=overlay.subset({"metadata":{"namespace": "default-namespace-name"}}), expects=1
+---
+metadata:
+  namespace: #@ data.values.namespace`
+
+var valuesFileContent = `#@data/values
+
+---
+namespace: custom-namespace-name`
+
+var expectedBundle = `
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: custom-namespace-name
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - origins:
+        - preresolved:
+            url: test-registry.io/library/busybox@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a
+        url: test-registry.io/library/busybox@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a
+  name: default-name
+  namespace: custom-namespace-name
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: default-app-name
+  template:
+    metadata:
+      labels:
+        app: default-app-name
+    spec:
+      containers:
+      - command:
+        - echo hello-world
+        image: test-registry.io/library/busybox@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a
+        imagePullPolicy: IfNotPresent
+        name: default-container-name
+`
+
+func helperSetupImageLocally() (string, error) {
+	// Simulates downloaded image directory
+	imageDir, err := ioutil.TempDir("", "tmp-img-bundle-")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	imgpkgDir := filepath.Join(imageDir, ".imgpkg")
+	configDir := filepath.Join(imageDir, "config")
+	overlaysDir := filepath.Join(configDir, "overlays")
+	upstreamDir := filepath.Join(configDir, "upstream")
+
+	println(imageDir)
+
+	err = os.Mkdir(imgpkgDir, 0755)
+	if err != nil {
+		return "", err
+	}
+
+	err = os.Mkdir(configDir, 0755)
+	if err != nil {
+		return "", err
+	}
+
+	err = os.Mkdir(overlaysDir, 0755)
+	if err != nil {
+		return "", err
+	}
+
+	err = os.Mkdir(upstreamDir, 0755)
+	if err != nil {
+		return "", err
+	}
+
+	// .imgpkg/images.yml file
+	imgpkgImagesFile, err := os.Create(filepath.Join(imgpkgDir, "images.yml"))
+	if err != nil {
+		return "", err
+	}
+
+	_, err = imgpkgImagesFile.WriteString(imgpkgImagesFileContent)
+	if err != nil {
+		return "", err
+	}
+
+	// ./config/upstream/deployment.yml file
+	deploymentFile, err := os.Create(filepath.Join(upstreamDir, "deployment.yml"))
+	if err != nil {
+		return "", err
+	}
+
+	_, err = deploymentFile.WriteString(upstreamDeploymentFileContent)
+	if err != nil {
+		return "", err
+	}
+
+	// ./config/overlays/overlay-namespace.yml file
+	overlayNamespaceFile, err := os.Create(filepath.Join(overlaysDir, "overlay-namespace.yml"))
+	if err != nil {
+		return "", err
+	}
+
+	_, err = overlayNamespaceFile.WriteString(overlayNamespaceFileContent)
+	if err != nil {
+		return "", err
+	}
+
+	// ./config/values.yml file
+	valuesFile, err := os.Create(filepath.Join(configDir, "values.yml"))
+	if err != nil {
+		return "", err
+	}
+
+	_, err = valuesFile.WriteString(valuesFileContent)
+	if err != nil {
+		return "", err
+	}
+
+	return imageDir, nil
+}
+
+func TestRenderYaml(t *testing.T) {
+	p, err := helperSetupImageLocally()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	ir, err := NewTkrImageReader(p)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	ir.SetDownloadPath(p)
+	ir.SetRelativeConfigPath("config")
+	yamls, err := ir.RenderYaml()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if string(yamls) != expectedBundle {
+		t.Errorf("Rendered yaml is not correct. Was: %s\nExpected: %s", string(yamls), expectedBundle)
+	}
+
+	os.RemoveAll(p)
+}
+
+func TestAddYttValyesByBytes(t *testing.T) {
+	p, err := helperSetupImageLocally()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// Remove the values yaml file so we can inject it via our APIs
+	os.Remove(filepath.Join(p, "config", "values.yaml"))
+
+	ir, err := NewTkrImageReader(p)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	ir.SetDownloadPath(p)
+	ir.SetRelativeConfigPath("config")
+
+	err = ir.AddYttYamlValuesBytes([]byte("---\nnamespace: custom-namespace-name"))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	yamls, err := ir.RenderYaml()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if string(yamls) != expectedBundle {
+		t.Errorf("Rendered yaml is not correct. Was: %s\nExpected: %s", string(yamls), expectedBundle)
+	}
+
+	os.RemoveAll(p)
+}
+
+func TestAddYttKVsFromYaml(t *testing.T) {
+	p, err := helperSetupImageLocally()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// Remove the values yaml file so we can inject it via our APIs
+	os.Remove(filepath.Join(p, "config", "values.yaml"))
+
+	ir, err := NewTkrImageReader(p)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	ir.SetDownloadPath(p)
+	ir.SetRelativeConfigPath("config")
+
+	ir.AddYttKVsFromYAML([]string{"namespace=custom-namespace-name"})
+
+	yamls, err := ir.RenderYaml()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if string(yamls) != expectedBundle {
+		t.Errorf("Rendered yaml is not correct. Was: %s\nExpected: %s", string(yamls), expectedBundle)
+	}
+
+	os.RemoveAll(p)
+}

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/tkr_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/tkr_test.go
@@ -1,0 +1,308 @@
+// Copyright 2020-2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package tkr
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+var (
+	none   = "none"
+	tceReg = "projects.registry.vmware.com/tce"
+	tkgReg = "projects.registry.vmware.com/tkg"
+)
+
+// This is a sample chunk of a TKR from the v0.12.0 bom.
+// Since we don't use many of the fields in the bom,
+// we can ommit them for testing purposes.
+var sampleTkrYamls = `---
+apiVersion: run.tanzu.vmware.com/v1alpha2
+release:
+  version: v1.22.7
+components:
+  kapp-controller:
+  - version: v0.30.1+vmware.1
+    images:
+      kappControllerImage:
+        imagePath: kapp-controller
+        tag: v0.30.1_vmware.1
+  kubernetes-sigs_kind:
+  - version: v1.22.7
+    images:
+      kindNodeImage:
+        imagePath: kind
+        tag: v1.22.7
+        repository: projects.registry.vmware.com/tce
+  tkg-core-packages:
+  - version: v1.22.8+vmware.1-tkg.1-tf-v0.11.4
+    images:
+      kapp-controller.tanzu.vmware.com:
+        imagePath: kapp-controller-multi-pkg
+        tag: v0.30.1
+        repository: projects.registry.vmware.com/tce
+      tanzuCorePackageRepositoryImage:
+        imagePath: repo-12
+        tag: 0.12.0
+        repository: projects.registry.vmware.com/tce
+      tanzuUserPackageRepositoryImage:
+        imagePath: main
+        repository: projects.registry.vmware.com/tce
+        tag: 0.12.0
+imageConfig:
+  imageRepository: projects.registry.vmware.com/tkg`
+
+func helperMakeNewBom() (*Bom, error) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "tkr-test-")
+	if err != nil {
+		return nil, err
+	}
+
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.Write([]byte(sampleTkrYamls))
+	if err != nil {
+		return nil, err
+	}
+
+	var bom *Bom
+	bom, err = ReadTKRBom(tmpFile.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	return bom, nil
+}
+
+func TestReadTKRBom(t *testing.T) {
+	_, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+}
+
+func TestReadTKRBomFails(t *testing.T) {
+	_, err := ReadTKRBom("file-doesnt-exist")
+	if err == nil {
+		t.Error("expected reading TKr file to fail if file doesn't exist")
+	}
+
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "tkr-test-")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.Write([]byte(" ' this is bad yamls"))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	_, err = ReadTKRBom(tmpFile.Name())
+	if err == nil {
+		t.Error("expected unmarshaling TKr file to fail if invalid yaml is provided")
+	}
+}
+
+func TestGetTKRRegistry(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	repo := b.getTKRRegistry()
+	if repo != tkgReg {
+		t.Errorf("expected TKR registry to be projects.registry.vmware.com/tkg. Actual: %s", repo)
+	}
+}
+
+func TestGetTKRNodeImageKind(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	nodeImg := b.GetTKRNodeImage("kind")
+	if nodeImg != "projects.registry.vmware.com/tce/kind:v1.22.7" {
+		t.Errorf("expected node for kind image to be projects.registry.vmware.com/tce/kind:v1.22.7. Actual: %s", nodeImg)
+	}
+}
+
+func TestGetTKRNodeImageMinikube(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	nodeImg := b.GetTKRNodeImage("minikube")
+	if nodeImg != "v1.22.7" {
+		t.Errorf("expected node for minikube image to be v1.22.7. Actual: %s", nodeImg)
+	}
+}
+
+func TestGetTKRNodeImageNone(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	nodeImg := b.GetTKRNodeImage(none)
+	if nodeImg != none {
+		t.Errorf("expected node for noop provider image to be `none`. Actual: %s", nodeImg)
+	}
+}
+
+func TestGetTKRNodeImageUnsupported(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	nodeImg := b.GetTKRNodeImage("bad-provider")
+	if nodeImg != "" {
+		t.Errorf("expected node for unsupported provider image to be an empty string. Actual: %s", nodeImg)
+	}
+}
+
+func TestGetTKRCoreRepoBundlePath(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	coreRepo := b.GetTKRCoreRepoBundlePath()
+	if coreRepo != "projects.registry.vmware.com/tce/repo-12:0.12.0" {
+		t.Errorf("expected core repo path to be projects.registry.vmware.com/tce/repo-12:0.12.0. Actual: %s", coreRepo)
+	}
+}
+
+func TestGetTKRCoreRepoBundlePathDefaultRegistry(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	b.Components.TkgCorePackages[0].Images.TanzuCorePackageRepositoryImage.Repository = ""
+
+	coreRepo := b.GetTKRCoreRepoBundlePath()
+	if coreRepo != tkgReg+"/repo-12:0.12.0" {
+		t.Errorf("expected empty core repo path to default to `projects.registry.vmware.com/tkg/repo-12:0.12.0`. Actual: %s", coreRepo)
+	}
+}
+
+func TestGetTKRUserRepoBundlePath(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	userRepo := b.GetTKRUserRepoBundlePath()
+	if userRepo != "projects.registry.vmware.com/tce/main:0.12.0" {
+		t.Errorf("expected user repo path to be projects.registry.vmware.com/tce/main:0.12.0. Actual: %s", userRepo)
+	}
+}
+
+func TestGetTKRUserRepoBundlePathDefaultRegistry(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	b.Components.TkgCorePackages[0].Images.TanzuUserPackageRepositoryImage.Repository = ""
+
+	userRepo := b.GetTKRUserRepoBundlePath()
+	if userRepo != tkgReg+"/main:0.12.0" {
+		t.Errorf("expected empty core repo path to default to `projects.registry.vmware.com/tkg/main:0.12.0`. Actual: %s", userRepo)
+	}
+}
+
+func TestGetTKRUserRepoBundlePathFail(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	b.Components.TkgCorePackages[0].Images.TanzuUserPackageRepositoryImage.ImagePath = ""
+
+	userRepo := b.GetTKRUserRepoBundlePath()
+	if userRepo != "" {
+		t.Errorf("expected empty user repo image path to result in empty full path. Actual: %s", userRepo)
+	}
+
+	b.Components.TkgCorePackages[0].Images.TanzuUserPackageRepositoryImage.Tag = ""
+
+	userRepo = b.GetTKRUserRepoBundlePath()
+	if userRepo != "" {
+		t.Errorf("expected empty user repo tag to result in empty full path. Actual: %s", userRepo)
+	}
+}
+
+func TestGetTKRKappImage(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	kappImg, err := b.GetTKRKappImage()
+	if err != nil {
+		t.Errorf("expected building kapp Image reader success. Error: %s", err.Error())
+	}
+
+	if kappImg == nil {
+		t.Errorf("Expected Kapp image reader from bom to not be nil. Was nil")
+	}
+}
+
+func TestGetTKRNodeRepository(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	nodeRepo := b.getTKRNodeRepository()
+	if nodeRepo != tceReg {
+		t.Errorf("expected node repo path to be projects.registry.vmware.com/tce. Actual: %s", nodeRepo)
+	}
+}
+
+func TestGetTKRNodeRepositoryDefaultRegistry(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	b.Components.KubernetesSigsKind[0].Images.KindNodeImage.Repository = ""
+
+	nodeRepo := b.getTKRNodeRepository()
+	if nodeRepo != tkgReg {
+		t.Errorf("expected empty node repo path to default to `projects.registry.vmware.com/tkg`. Actual: %s", nodeRepo)
+	}
+}
+
+func TestGetTKRKappRepository(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	kappRepo := b.getTKRKappRepository()
+	if kappRepo != tceReg {
+		t.Errorf("expected node repo path to be projects.registry.vmware.com/tce. Actual: %s", kappRepo)
+	}
+}
+
+func TestGetTKRKappRepositoryDefaultRegistry(t *testing.T) {
+	b, err := helperMakeNewBom()
+	if err != nil {
+		t.Errorf("expected reading TKR bom to be successful. Error: %s", err.Error())
+	}
+
+	b.Components.TkgCorePackages[0].Images.KappControllerTanzuVmwareCom.Repository = ""
+
+	kappRepo := b.getTKRKappRepository()
+	if kappRepo != tkgReg {
+		t.Errorf("expected empty kapp repo path to default to `projects.registry.vmware.com/tkg`. Actual: %s", kappRepo)
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it
Implements tkr unit tests

Increases tkr package unit tests from ~10% to ~75%

## Which issue(s) this PR fixes
Related: #3536

## Describe testing done for PR
```
❯ go test ./tkr/... -coverprofile=tkr-cover.txt
ok      github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/tkr  0.797s  coverage: 75.6% of statements
```

## Special notes for your reviewer
See cover profile here: [tkr-cover.txt](https://github.com/vmware-tanzu/community-edition/files/8522930/tkr-cover.txt)

