### PR TITLE
Docs: minikube needs to be installed to use as um cluster provider

### DIFF
--- a/docs/site/content/docs/ref-unmanaged-cluster.md
+++ b/docs/site/content/docs/ref-unmanaged-cluster.md
@@ -43,6 +43,9 @@ The following providers are supported:
 * `kind`: _Default provider._ A tool for running local Kubernetes clusters using Docker container “nodes”. [Documentation site.](https://kind.sigs.k8s.io/)
 * `minikube`: Local Kubernetes, focusing on making it easy to learn and develop for Kubernetes. Supports ontainer and virtual machine managers. [Documentation site.](https://minikube.sigs.k8s.io/docs/)
 
+_Note:_ In order to use the `minikube` provider, you first must install minikube to your system.
+[Read the minikube "Start" page](https://minikube.sigs.k8s.io/docs/start/) to learn how to install and get going with minikube.
+
 ## Deploy multi-node clusters
 
 `create` supports `--control-plane-node-count`


### PR DESCRIPTION
## What this PR does / why we need it
Fixes missing docs requirement for minikube provider needing to have it installed on your system

## Which issue(s) this PR fixes
Fixes: #4114

## Describe testing done for PR
`make mdlint`