### PR TITLE
Add update strategy and node selector overlay to Kapp-Controller 0.35

### DIFF
--- a/addons/packages/kapp-controller/0.35.0/bundle/config/overlays/update-strategy-overlay.yaml
+++ b/addons/packages/kapp-controller/0.35.0/bundle/config/overlays/update-strategy-overlay.yaml
@@ -1,0 +1,50 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#! We are adding this overlay in the package to accomandate the need from vSphere supervisor cluster:
+#! `deployment.spec.strategy.type` is configured to `RollingUpdate`
+#! `deployment.spec.strategy.rollingUpdate.maxUnavailable` is set to `0`.
+#! `deployment.spec.strategy.rollingUpdate.maxSurge` is set to `1`.
+#! `deployment.spec.template.spec.nodeSelector`is set to target only `Nodes`
+#! `daemonset.spec.updateStrategy.type` is configured to `OnDelete`
+#! This overlay makes configuring the above parameters possible
+#! Reference: https://github.com/vmware-tanzu/tanzu-framework/issues/1850
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"Deployment"})
+---
+kind: Deployment
+spec:
+  #@ if data.values.deployment.updateStrategy != None:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: #@ data.values.deployment.updateStrategy
+    #@overlay/match missing_ok=True
+    #@ if data.values.deployment.updateStrategy == "rollingUpdate":
+    rollingUpdate:
+      #@ if/end data.values.deployment.rollingUpdate.maxUnavailable != None:
+      maxUnavailable: #@ data.values.deployment.rollingUpdate.maxUnavailable
+      #@ if/end data.values.deployment.rollingUpdate.maxSurge != None:
+      maxSurge: #@ data.values.deployment.rollingUpdate.maxSurge
+    #@ end
+  #@ end
+  #@ if data.values.nodeSelector != None:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@ for key in data.values.nodeSelector:
+        #@overlay/match missing_ok=True
+        #@yaml/text-templated-strings
+        (@= key @): #@ data.values.nodeSelector[key]
+        #@ end
+  #@ end
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
+---
+kind: DaemonSet
+spec:
+  #@ if data.values.daemonset.updateStrategy:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    type: #@ data.values.daemonset.updateStrategy
+  #@ end

--- a/addons/packages/kapp-controller/0.35.0/bundle/config/values.yaml
+++ b/addons/packages/kapp-controller/0.35.0/bundle/config/values.yaml
@@ -2,6 +2,14 @@
 #@overlay/match-child-defaults missing_ok=True
 ---
 namespace: kapp-controller
+nodeSelector: null
+deployment:
+  updateStrategy: null
+  rollingUpdate:
+    maxUnavailable: null
+    maxSurge: null
+daemonset:
+  updateStrategy: null
 kappController:
   namespace: null
   createNamespace: true

--- a/addons/packages/kapp-controller/0.35.0/package.yaml
+++ b/addons/packages/kapp-controller/0.35.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:a1d50ac793df19737fc0783215765416d14b708f2b70496565335f90a888c0f4
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:3d6f1b0fc987714913a6d3f2673f43b9c35c4ce87d7845d0213324cbac5a4dac
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
We need to enforce the update strategy of all the deployment and daemonset running on Supervisor cluster. Also, add nodeSelector configuration to deployments.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: # https://github.com/vmware-tanzu/tanzu-framework/issues/1850

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Manually tested the templates

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
