### PR TITLE
Add updateStrategy and nodeSelector overlay to vsphere-cpi 1.23.0

### DIFF
--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/overlays/update-strategy-overlay.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/overlays/update-strategy-overlay.yaml
@@ -1,0 +1,50 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#! We are adding this overlay in the package to accommodate the need from vSphere supervisor cluster:
+#! `deployment.spec.strategy.type` is configured to `RollingUpdate`
+#! `deployment.spec.strategy.rollingUpdate.maxUnavailable` is set to `0`.
+#! `deployment.spec.strategy.rollingUpdate.maxSurge` is set to `1`.
+#! `deployment.spec.template.spec.nodeSelector`is set to target only `Nodes`
+#! `daemonset.spec.updateStrategy.type` is configured to `OnDelete`
+#! This overlay makes configuring the above parameters possible
+#! Reference: https://github.com/vmware-tanzu/tanzu-framework/issues/1850
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"Deployment"})
+---
+kind: Deployment
+spec:
+  #@ if data.values.deployment.updateStrategy != None:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: #@ data.values.deployment.updateStrategy
+    #@overlay/match missing_ok=True
+    #@ if data.values.deployment.updateStrategy == "rollingUpdate":
+    rollingUpdate:
+      #@ if/end data.values.deployment.rollingUpdate.maxUnavailable != None:
+      maxUnavailable: #@ data.values.deployment.rollingUpdate.maxUnavailable
+      #@ if/end data.values.deployment.rollingUpdate.maxSurge != None:
+      maxSurge: #@ data.values.deployment.rollingUpdate.maxSurge
+    #@ end
+  #@ end
+  #@ if data.values.nodeSelector != None:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@ for key in data.values.nodeSelector:
+        #@overlay/match missing_ok=True
+        #@yaml/text-templated-strings
+        (@= key @): #@ data.values.nodeSelector[key]
+        #@ end
+  #@ end
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
+---
+kind: DaemonSet
+spec:
+  #@ if data.values.daemonset.updateStrategy:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    type: #@ data.values.daemonset.updateStrategy
+  #@ end

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/schema.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/schema.yaml
@@ -3,6 +3,24 @@
 #@data/values-schema
 #@schema/desc "OpenAPIv3 Schema for vsphere-cpi"
 ---
+#@schema/desc "NodeSelector configuration applied to all the deployments"
+#@schema/type any=True
+nodeSelector:
+deployment:
+  #@schema/desc "Update strategy of deployments"
+  #@schema/nullable
+  updateStrategy: ""
+  rollingUpdate:
+    #@schema/desc "The maxUnavailable of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy"
+    #@schema/nullable
+    maxUnavailable: 1
+    #@schema/desc "The maxSurge of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy"
+    #@schema/nullable
+    maxSurge: 0
+daemonset:
+  #@schema/desc "Update strategy of daemonsets"
+  #@schema/nullable
+  updateStrategy: ""
 #@schema/desc "Configurations for vsphere-cpi"
 vsphereCPI:
   #@schema/desc "The vSphere mode. Either vsphereCPI or vsphereParavirtualCPI. Default value is vsphereCPI"

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/values.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/bundle/config/values.yaml
@@ -2,6 +2,14 @@
 #@overlay/match-child-defaults missing_ok=True
 
 ---
+nodeSelector: null
+deployment:
+  updateStrategy: null
+  rollingUpdate:
+    maxUnavailable: null
+    maxSurge: null
+daemonset:
+  updateStrategy: null
 vsphereCPI:
   mode: vsphereCPI
   tlsThumbprint: ""

--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/package.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:7894ffd9b9fca6a53f2277159304b5966fa9bd1dcc1f416f74dfb7ebfe95d96c
+          image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:a864df70d1f88aff1c7aa6c6fc24dde9e37bfc9704a33028eb4ac4bcfdd686b2
       template:
       - ytt:
           paths:
@@ -29,6 +29,42 @@ spec:
       additionalProperties: false
       description: OpenAPIv3 Schema for vsphere-cpi
       properties:
+        nodeSelector:
+          nullable: true
+          description: NodeSelector configuration applied to all the deployments
+          default: null
+        deployment:
+          type: object
+          additionalProperties: false
+          properties:
+            updateStrategy:
+              type: string
+              nullable: true
+              description: Update strategy of deployments
+              default: null
+            rollingUpdate:
+              type: object
+              additionalProperties: false
+              properties:
+                maxUnavailable:
+                  type: integer
+                  nullable: true
+                  description: The maxUnavailable of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy
+                  default: null
+                maxSurge:
+                  type: integer
+                  nullable: true
+                  description: The maxSurge of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy
+                  default: null
+        daemonset:
+          type: object
+          additionalProperties: false
+          properties:
+            updateStrategy:
+              type: string
+              nullable: true
+              description: Update strategy of daemonsets
+              default: null
         vsphereCPI:
           type: object
           additionalProperties: false
@@ -36,67 +72,67 @@ spec:
           properties:
             mode:
               type: string
-              default: vsphereCPI
               description: The vSphere mode. Either vsphereCPI or vsphereParavirtualCPI. Default value is vsphereCPI
+              default: vsphereCPI
             tlsThumbprint:
               type: string
-              default: ""
               description: The cryptographic thumbprint of the vSphere endpoint's certificate
+              default: ""
             server:
               type: string
-              default: ""
               description: The IP address or FQDN of the vSphere endpoint
+              default: ""
             datacenter:
               type: string
-              default: ""
               description: The datacenter in which VMs are created/located
+              default: ""
             username:
               type: string
-              default: ""
               description: Username used to access a vSphere endpoint
+              default: ""
             password:
               type: string
-              default: ""
               description: Password used to access a vSphere endpoint
+              default: ""
             region:
               type: string
-              default: null
               nullable: true
               description: The region used by vSphere multi-AZ feature
+              default: null
             zone:
               type: string
-              default: null
               nullable: true
               description: The zone used by vSphere multi-AZ feature
+              default: null
             insecureFlag:
               type: boolean
-              default: false
               description: The flag that disables TLS peer verification
+              default: false
             ipFamily:
               type: string
-              default: null
               nullable: true
               description: The IP family configuration
+              default: null
             vmInternalNetwork:
               type: string
-              default: null
               nullable: true
               description: Internal VM network name
+              default: null
             vmExternalNetwork:
               type: string
-              default: null
               nullable: true
               description: External VM network name
+              default: null
             vmExcludeInternalNetworkSubnetCidr:
               type: string
-              default: null
               nullable: true
               description: Comma separated list of internal network subnets to exclude from node IP selection.
+              default: null
             vmExcludeExternalNetworkSubnetCidr:
               type: string
-              default: null
               nullable: true
               description: Comma separated list of external network subnets to exclude from node IP selection.
+              default: null
             cloudProviderExtraArgs:
               type: object
               additionalProperties: false
@@ -104,142 +140,142 @@ spec:
               properties:
                 tls-cipher-suites:
                   type: string
-                  default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
                   description: External arguments for cloud provider
+                  default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
             nsxt:
               type: object
               additionalProperties: false
               properties:
                 podRoutingEnabled:
                   type: boolean
-                  default: false
                   description: A flag that enables pod routing
+                  default: false
                 routes:
                   type: object
                   additionalProperties: false
                   properties:
                     routerPath:
                       type: string
-                      default: ""
                       description: NSX-T T0/T1 logical router path
+                      default: ""
                     clusterCidr:
                       type: string
-                      default: ""
                       description: Cluster CIDR
+                      default: ""
                 username:
                   type: string
-                  default: ""
                   description: The username used to access NSX-T
+                  default: ""
                 password:
                   type: string
-                  default: ""
                   description: The password used to access NSX-T
+                  default: ""
                 host:
                   type: string
-                  default: null
                   nullable: true
                   description: The NSX-T server
+                  default: null
                 insecureFlag:
                   type: string
-                  default: "false"
                   description: (Deprecated. For backward compatibiility. Will be replaced by insecure. If both set, result is insecureFlag || insecure) InsecureFlag is to be set to true if NSX-T uses self-signed cert
+                  default: "false"
                 remoteAuth:
                   type: string
-                  default: "false"
                   description: (Deprecated. For backward compatibiility. Will be replaced by removeAuthEnabled. If both set, result is remoteAuth || remoteAuthEnabled). RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)
+                  default: "false"
                 insecure:
                   type: boolean
-                  default: false
                   description: Insecure is to be set to true if NSX-T uses self-signed cert
+                  default: false
                 remoteAuthEnabled:
                   type: boolean
-                  default: false
                   description: RemoteAuthEnabled is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)
+                  default: false
                 vmcAccessToken:
                   type: string
-                  default: ""
                   description: VMCAccessToken is VMC access token for token based authentification
+                  default: ""
                 vmcAuthHost:
                   type: string
-                  default: ""
                   description: VMCAuthHost is VMC verification host for token based authentification
+                  default: ""
                 clientCertKeyData:
                   type: string
-                  default: ""
                   description: Client certificate key for NSX-T
+                  default: ""
                 clientCertData:
                   type: string
-                  default: ""
                   description: Client certificate data for NSX-T
+                  default: ""
                 rootCAData:
                   type: string
-                  default: ""
                   description: The certificate authority for the server certificate for locally signed certificates
+                  default: ""
                 secretName:
                   type: string
-                  default: cloud-provider-vsphere-nsxt-credentials
                   description: The name of secret that stores CPI configuration
+                  default: cloud-provider-vsphere-nsxt-credentials
                 secretNamespace:
                   type: string
-                  default: kube-system
                   description: The namespace of secret that stores CPI configuration
+                  default: kube-system
             http_proxy:
               type: string
-              default: ""
               description: HTTP proxy setting
+              default: ""
             https_proxy:
               type: string
-              default: ""
               description: HTTPS proxy setting
+              default: ""
             no_proxy:
               type: string
-              default: ""
               description: No-proxy setting
+              default: ""
             clusterAPIVersion:
               type: string
-              default: cluster.x-k8s.io/v1beta1
               description: 'Used in vsphereParavirtual mode, defines the Cluster API versions. Default: cluster.x-k8s.io/v1beta1.'
+              default: cluster.x-k8s.io/v1beta1
             clusterKind:
               type: string
-              default: Cluster
               description: 'Used in vsphereParavirtual mode, defines the Cluster kind. Default: Cluster.'
+              default: Cluster
             clusterName:
               type: string
-              default: ""
               description: 'Used in vsphereParavirtual mode, defines the Cluster name. Default: ''''.'
+              default: ""
             clusterUID:
               type: string
-              default: ""
               description: 'Used in vsphereParavirtual mode, defines the Cluster UID. Default: '''''
+              default: ""
             supervisorMasterEndpointIP:
               type: string
-              default: ""
               description: 'Used in vsphereParavirtual mode, the endpoint IP of supervisor cluster''s API server. Default: '''''
+              default: ""
             supervisorMasterPort:
               type: string
-              default: ""
               description: 'Used in vsphereParavirtual mode, the endpoint port of supervisor cluster''s API server port. Default: '''''
+              default: ""
             antreaNSXPodRoutingEnabled:
               type: boolean
-              default: false
               description: Enable pod routing with Antrea NSX
+              default: false
             image:
               type: object
               additionalProperties: false
               properties:
                 repository:
                   type: string
-                  default: ""
                   description: The repository of CPI image
+                  default: ""
                 path:
                   type: string
-                  default: ""
                   description: The path of image
+                  default: ""
                 tag:
                   type: string
-                  default: ""
                   description: The image tag
+                  default: ""
                 pullPolicy:
                   type: string
-                  default: ""
                   description: The pull policy of image
+                  default: ""

--- a/addons/packages/vsphere-cpi/1.23.0/bundle/config/overlays/update-strategy-overlay.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0/bundle/config/overlays/update-strategy-overlay.yaml
@@ -1,0 +1,50 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#! We are adding this overlay in the package to accommodate the need from vSphere supervisor cluster:
+#! `deployment.spec.strategy.type` is configured to `RollingUpdate`
+#! `deployment.spec.strategy.rollingUpdate.maxUnavailable` is set to `0`.
+#! `deployment.spec.strategy.rollingUpdate.maxSurge` is set to `1`.
+#! `deployment.spec.template.spec.nodeSelector`is set to target only `Nodes`
+#! `daemonset.spec.updateStrategy.type` is configured to `OnDelete`
+#! This overlay makes configuring the above parameters possible
+#! Reference: https://github.com/vmware-tanzu/tanzu-framework/issues/1850
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"Deployment"})
+---
+kind: Deployment
+spec:
+  #@ if data.values.deployment.updateStrategy != None:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: #@ data.values.deployment.updateStrategy
+    #@overlay/match missing_ok=True
+    #@ if data.values.deployment.updateStrategy == "rollingUpdate":
+    rollingUpdate:
+      #@ if/end data.values.deployment.rollingUpdate.maxUnavailable != None:
+      maxUnavailable: #@ data.values.deployment.rollingUpdate.maxUnavailable
+      #@ if/end data.values.deployment.rollingUpdate.maxSurge != None:
+      maxSurge: #@ data.values.deployment.rollingUpdate.maxSurge
+    #@ end
+  #@ end
+  #@ if data.values.nodeSelector != None:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@ for key in data.values.nodeSelector:
+        #@overlay/match missing_ok=True
+        #@yaml/text-templated-strings
+        (@= key @): #@ data.values.nodeSelector[key]
+        #@ end
+  #@ end
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
+---
+kind: DaemonSet
+spec:
+  #@ if data.values.daemonset.updateStrategy:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    type: #@ data.values.daemonset.updateStrategy
+  #@ end

--- a/addons/packages/vsphere-cpi/1.23.0/bundle/config/schema.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0/bundle/config/schema.yaml
@@ -3,6 +3,24 @@
 #@data/values-schema
 #@schema/desc "OpenAPIv3 Schema for vsphere-cpi"
 ---
+#@schema/desc "NodeSelector configuration applied to all the deployments"
+#@schema/type any=True
+nodeSelector:
+deployment:
+  #@schema/desc "Update strategy of deployments"
+  #@schema/nullable
+  updateStrategy: ""
+  rollingUpdate:
+    #@schema/desc "The maxUnavailable of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy"
+    #@schema/nullable
+    maxUnavailable: 1
+    #@schema/desc "The maxSurge of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy"
+    #@schema/nullable
+    maxSurge: 0
+daemonset:
+  #@schema/desc "Update strategy of daemonsets"
+  #@schema/nullable
+  updateStrategy: ""
 #@schema/desc "Configurations for vsphere-cpi"
 vsphereCPI:
   #@schema/desc "The vSphere mode. Either vsphereCPI or vsphereParavirtualCPI. Default value is vsphereCPI"

--- a/addons/packages/vsphere-cpi/1.23.0/bundle/config/values.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0/bundle/config/values.yaml
@@ -2,6 +2,14 @@
 #@overlay/match-child-defaults missing_ok=True
 
 ---
+nodeSelector: null
+deployment:
+  updateStrategy: null
+  rollingUpdate:
+    maxUnavailable: null
+    maxSurge: null
+daemonset:
+  updateStrategy: null
 vsphereCPI:
   mode: vsphereCPI
   tlsThumbprint: ""

--- a/addons/packages/vsphere-cpi/1.23.0/package.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:ab1047ca659a5723a31732142c8ad9f571ef645a757958031dfe91fcacbc68a9
+          image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:0f0841b35780820e07f5760a89a1351ffb2f7a8caeda9c674b95f7b82b5249b8
       template:
       - ytt:
           paths:
@@ -29,6 +29,42 @@ spec:
       additionalProperties: false
       description: OpenAPIv3 Schema for vsphere-cpi
       properties:
+        nodeSelector:
+          nullable: true
+          description: NodeSelector configuration applied to all the deployments
+          default: null
+        deployment:
+          type: object
+          additionalProperties: false
+          properties:
+            updateStrategy:
+              type: string
+              nullable: true
+              description: Update strategy of deployments
+              default: null
+            rollingUpdate:
+              type: object
+              additionalProperties: false
+              properties:
+                maxUnavailable:
+                  type: integer
+                  nullable: true
+                  description: The maxUnavailable of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy
+                  default: null
+                maxSurge:
+                  type: integer
+                  nullable: true
+                  description: The maxSurge of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy
+                  default: null
+        daemonset:
+          type: object
+          additionalProperties: false
+          properties:
+            updateStrategy:
+              type: string
+              nullable: true
+              description: Update strategy of daemonsets
+              default: null
         vsphereCPI:
           type: object
           additionalProperties: false
@@ -36,210 +72,221 @@ spec:
           properties:
             mode:
               type: string
-              default: vsphereCPI
               description: The vSphere mode. Either vsphereCPI or vsphereParavirtualCPI. Default value is vsphereCPI
+              default: vsphereCPI
             tlsThumbprint:
               type: string
-              default: ""
+              nullable: true
               description: The cryptographic thumbprint of the vSphere endpoint's certificate
+              default: null
             server:
               type: string
-              default: ""
+              nullable: true
               description: The IP address or FQDN of the vSphere endpoint
+              default: null
             datacenter:
               type: string
-              default: ""
+              nullable: true
               description: The datacenter in which VMs are created/located
+              default: null
             username:
               type: string
-              default: ""
+              nullable: true
               description: Username used to access a vSphere endpoint
+              default: null
             password:
               type: string
-              default: ""
+              nullable: true
               description: Password used to access a vSphere endpoint
+              default: null
             region:
               type: string
-              default: null
               nullable: true
               description: The region used by vSphere multi-AZ feature
+              default: null
             zone:
               type: string
-              default: null
               nullable: true
               description: The zone used by vSphere multi-AZ feature
+              default: null
             insecureFlag:
               type: boolean
-              default: false
+              nullable: true
               description: The flag that disables TLS peer verification
+              default: null
             ipFamily:
               type: string
-              default: null
               nullable: true
               description: The IP family configuration
+              default: null
             vmInternalNetwork:
               type: string
-              default: null
               nullable: true
               description: Internal VM network name
+              default: null
             vmExternalNetwork:
               type: string
-              default: null
               nullable: true
               description: External VM network name
+              default: null
             vmExcludeInternalNetworkSubnetCidr:
               type: string
-              default: null
               nullable: true
               description: Comma separated list of internal network subnets to exclude from node IP selection.
+              default: null
             vmExcludeExternalNetworkSubnetCidr:
               type: string
-              default: null
               nullable: true
               description: Comma separated list of external network subnets to exclude from node IP selection.
+              default: null
             cloudProviderExtraArgs:
               type: object
               additionalProperties: false
+              nullable: true
               description: Extra arguments for the cloud-provider-vsphere.
               properties:
                 tls-cipher-suites:
                   type: string
-                  default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
                   description: External arguments for cloud provider
+                  default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
             nsxt:
               type: object
               additionalProperties: false
+              nullable: true
               properties:
                 podRoutingEnabled:
                   type: boolean
-                  default: false
                   description: A flag that enables pod routing
+                  default: false
                 routes:
                   type: object
                   additionalProperties: false
                   properties:
                     routerPath:
                       type: string
-                      default: ""
                       description: NSX-T T0/T1 logical router path
+                      default: ""
                     clusterCidr:
                       type: string
-                      default: ""
                       description: Cluster CIDR
+                      default: ""
                 username:
                   type: string
-                  default: ""
                   description: The username used to access NSX-T
+                  default: ""
                 password:
                   type: string
-                  default: ""
                   description: The password used to access NSX-T
+                  default: ""
                 host:
                   type: string
-                  default: null
                   nullable: true
                   description: The NSX-T server
+                  default: null
                 insecureFlag:
                   type: string
-                  default: "false"
                   description: (Deprecated. For backward compatibiility. Will be replaced by insecure. If both set, result is insecureFlag || insecure) InsecureFlag is to be set to true if NSX-T uses self-signed cert
+                  default: "false"
                 remoteAuth:
                   type: string
-                  default: "false"
                   description: (Deprecated. For backward compatibiility. Will be replaced by removeAuthEnabled. If both set, result is remoteAuth || remoteAuthEnabled). RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)
+                  default: "false"
                 insecure:
                   type: boolean
-                  default: false
                   description: Insecure is to be set to true if NSX-T uses self-signed cert
+                  default: false
                 remoteAuthEnabled:
                   type: boolean
-                  default: false
                   description: RemoteAuthEnabled is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM)
+                  default: false
                 vmcAccessToken:
                   type: string
-                  default: ""
                   description: VMCAccessToken is VMC access token for token based authentification
+                  default: ""
                 vmcAuthHost:
                   type: string
-                  default: ""
                   description: VMCAuthHost is VMC verification host for token based authentification
+                  default: ""
                 clientCertKeyData:
                   type: string
-                  default: ""
                   description: Client certificate key for NSX-T
+                  default: ""
                 clientCertData:
                   type: string
-                  default: ""
                   description: Client certificate data for NSX-T
+                  default: ""
                 rootCAData:
                   type: string
-                  default: ""
                   description: The certificate authority for the server certificate for locally signed certificates
+                  default: ""
                 secretName:
                   type: string
-                  default: cloud-provider-vsphere-nsxt-credentials
                   description: The name of secret that stores CPI configuration
+                  default: cloud-provider-vsphere-nsxt-credentials
                 secretNamespace:
                   type: string
-                  default: kube-system
                   description: The namespace of secret that stores CPI configuration
+                  default: kube-system
             http_proxy:
               type: string
-              default: ""
+              nullable: true
               description: HTTP proxy setting
+              default: null
             https_proxy:
               type: string
-              default: ""
+              nullable: true
               description: HTTPS proxy setting
+              default: null
             no_proxy:
               type: string
-              default: ""
+              nullable: true
               description: No-proxy setting
+              default: null
             clusterAPIVersion:
               type: string
-              default: cluster.x-k8s.io/v1beta1
               description: 'Used in vsphereParavirtual mode, defines the Cluster API versions. Default: cluster.x-k8s.io/v1beta1.'
+              default: cluster.x-k8s.io/v1beta1
             clusterKind:
               type: string
-              default: Cluster
               description: 'Used in vsphereParavirtual mode, defines the Cluster kind. Default: Cluster.'
+              default: Cluster
             clusterName:
               type: string
-              default: ""
               description: 'Used in vsphereParavirtual mode, defines the Cluster name. Default: ''''.'
+              default: ""
             clusterUID:
               type: string
-              default: ""
               description: 'Used in vsphereParavirtual mode, defines the Cluster UID. Default: '''''
+              default: ""
             supervisorMasterEndpointIP:
               type: string
-              default: ""
               description: 'Used in vsphereParavirtual mode, the endpoint IP of supervisor cluster''s API server. Default: '''''
+              default: ""
             supervisorMasterPort:
               type: string
-              default: ""
               description: 'Used in vsphereParavirtual mode, the endpoint port of supervisor cluster''s API server port. Default: '''''
+              default: ""
             antreaNSXPodRoutingEnabled:
               type: boolean
-              default: false
               description: Enable pod routing with Antrea NSX
+              default: false
             image:
               type: object
               additionalProperties: false
               properties:
                 repository:
                   type: string
-                  default: ""
                   description: The repository of CPI image
+                  default: ""
                 path:
                   type: string
-                  default: ""
                   description: The path of image
+                  default: ""
                 tag:
                   type: string
-                  default: ""
                   description: The image tag
+                  default: ""
                 pullPolicy:
                   type: string
-                  default: ""
                   description: The pull policy of image
+                  default: ""


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
We need to enforce the update strategy of all the deployment and daemonset running on Supervisor cluster. Also, add nodeSelector configuration to deployments.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: # https://github.com/vmware-tanzu/tanzu-framework/issues/1850

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Manually tested the templates

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
