### PR TITLE
Make non-paravirtual fields in CPI data values nullable.

### DIFF
--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/test/vsphere_cpi_test.go
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/test/vsphere_cpi_test.go
@@ -589,21 +589,22 @@ vsphereCPI:
 #@overlay/match-child-defaults missing_ok=True
 ---
 vsphereCPI:
-server: fake-server.com
-datacenter: dc0
-username: my-user
-password: my-password
-insecureFlag: True
-nsxt:
-podRoutingEnabled: true
-host: "test"
-routes:
-routerPath: ""
-clusterCidr: "10.0.0.0/12"
-secretName: "cloud-provider-vsphere-nsxt-credentials"
-secretNamespace: "kube-system"
-insecureFlag: "true"
-# remoteAuth: "true"`
+  server: fake-server.com
+  datacenter: dc0
+  username: my-user
+  password: my-password
+  insecureFlag: True
+  nsxt:
+    podRoutingEnabled: true
+    host: "test"
+    routes:
+      routerPath: ""
+      clusterCidr: "10.0.0.0/12"
+    secretName: "cloud-provider-vsphere-nsxt-credentials"
+    secretNamespace: "kube-system"
+    insecureFlag: "true"
+    # remoteAuth: "true"
+`
 				})
 
 				It("correctly sets the value in the INI", func() {

--- a/addons/packages/vsphere-cpi/1.23.0/bundle/.imgpkg/images.yml
+++ b/addons/packages/vsphere-cpi/1.23.0/bundle/.imgpkg/images.yml
@@ -7,5 +7,5 @@ images:
       - resolved:
           tag: v1.23.0
           url: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.23.0
-  image: gcr.io/cloud-provider-vsphere/cpi/release/manager@sha256:5e014ccad0566ab6eda7cd85833fb2981d025a9cd980015a739c31fe1d8b6f62
+  image: gcr.io/cloud-provider-vsphere/cpi/release/manager@sha256:d07abc87230eef350cbf05eee11f8c18e8936b67103723cdcf2da679c40d2854
 kind: ImagesLock

--- a/addons/packages/vsphere-cpi/1.23.0/bundle/config/schema.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0/bundle/config/schema.yaml
@@ -8,14 +8,19 @@ vsphereCPI:
   #@schema/desc "The vSphere mode. Either vsphereCPI or vsphereParavirtualCPI. Default value is vsphereCPI"
   mode: vsphereCPI
   #@schema/desc "The cryptographic thumbprint of the vSphere endpoint's certificate"
+  #@schema/nullable
   tlsThumbprint: ""
   #@schema/desc "The IP address or FQDN of the vSphere endpoint"
+  #@schema/nullable
   server: ""
   #@schema/desc "The datacenter in which VMs are created/located"
+  #@schema/nullable
   datacenter: ""
   #@schema/desc "Username used to access a vSphere endpoint"
+  #@schema/nullable
   username: ""
   #@schema/desc "Password used to access a vSphere endpoint"
+  #@schema/nullable
   password: ""
   #@schema/desc "The region used by vSphere multi-AZ feature"
   #@schema/nullable
@@ -24,6 +29,7 @@ vsphereCPI:
   #@schema/nullable
   zone: ""
   #@schema/desc "The flag that disables TLS peer verification"
+  #@schema/nullable
   insecureFlag: False
   #@schema/desc "The IP family configuration"
   #@schema/nullable
@@ -41,9 +47,11 @@ vsphereCPI:
   #@schema/nullable
   vmExcludeExternalNetworkSubnetCidr: ""
   #@schema/desc "Extra arguments for the cloud-provider-vsphere."
+  #@schema/nullable
   cloudProviderExtraArgs:
     #@schema/desc "External arguments for cloud provider"
     tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+  #@schema/nullable
   nsxt:
     #@schema/desc "A flag that enables pod routing"
     podRoutingEnabled: false
@@ -82,10 +90,13 @@ vsphereCPI:
     #@schema/desc "The namespace of secret that stores CPI configuration"
     secretNamespace: "kube-system"
   #@schema/desc "HTTP proxy setting"
+  #@schema/nullable
   http_proxy: ""
   #@schema/desc "HTTPS proxy setting"
+  #@schema/nullable
   https_proxy: ""
   #@schema/desc "No-proxy setting"
+  #@schema/nullable
   no_proxy: ""
   #@schema/desc "Used in vsphereParavirtual mode, defines the Cluster API versions. Default: cluster.x-k8s.io/v1beta1."
   clusterAPIVersion: "cluster.x-k8s.io/v1beta1"

--- a/addons/packages/vsphere-cpi/1.23.0/bundle/config/upstream/vsphere-paravirtual-cpi/03-deployment.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0/bundle/config/upstream/vsphere-paravirtual-cpi/03-deployment.yaml
@@ -32,7 +32,7 @@ spec:
               value: #@ values.vsphereCPI.supervisorMasterEndpointIP
             - name: SUPERVISOR_APISERVER_PORT
               value: #@ values.vsphereCPI.supervisorMasterPort
-          image: localhost:5000/vmware.io/cloud-provider-vsphere-manager:v1.23.0
+          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.23.0
           imagePullPolicy: IfNotPresent
           name: guest-cluster-cloud-provider
           volumeMounts:
@@ -54,6 +54,8 @@ spec:
           value: "true"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
       volumes:
         - name: ccm-config
           projected:

--- a/addons/packages/vsphere-cpi/1.23.0/bundle/config/values.star
+++ b/addons/packages/vsphere-cpi/1.23.0/bundle/config/values.star
@@ -67,6 +67,9 @@ values = data.values
 def validate():
     if data.values.vsphereCPI.mode == "vsphereCPI" or not data.values.vsphereCPI.mode:
         validate_vsphereCPI()
+        if data.values.vsphereCPI.nsxt.podRoutingEnabled:
+            validate_nsxt_config()
+        end
     elif data.values.vsphereCPI.mode == "vsphereParavirtualCPI":
         validate_vsphereParavirtualCPI()
     else:
@@ -75,6 +78,3 @@ def validate():
 end
 
 validate()
-if data.values.vsphereCPI.nsxt.podRoutingEnabled:
-validate_nsxt_config()
-end

--- a/addons/packages/vsphere-cpi/1.23.0/package.yaml
+++ b/addons/packages/vsphere-cpi/1.23.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:d8d9e5131b06e6340b71e7b4ba5366f7952525a17c0fff84eaa23e8faef33c6a
+          image: projects.registry.vmware.com/tce/vsphere-cpi@sha256:ab1047ca659a5723a31732142c8ad9f571ef645a757958031dfe91fcacbc68a9
       template:
       - ytt:
           paths:


### PR DESCRIPTION
## What this PR does / why we need it

1. Makes non-paravirtual fields optional to minimize the configurations (i.e, data values) for para-virtual mode.
2. Use upstream cloud-provider-manager image for para-virtual mode
3. Add toleration `node.kubernetes.io/not-ready ` to paravirt deployment 

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
CPI package unit test

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
