### PR TITLE
Add update strategy and node selector overlay to pinniped 0.12.1 package

### DIFF
--- a/addons/packages/pinniped/0.12.1/bundle/config/overlay/update-strategy-overlay.yaml
+++ b/addons/packages/pinniped/0.12.1/bundle/config/overlay/update-strategy-overlay.yaml
@@ -1,0 +1,50 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#! We are adding this overlay in the package to accomandate the need from vSphere supervisor cluster:
+#! `deployment.spec.strategy.type` is configured to `RollingUpdate`
+#! `deployment.spec.strategy.rollingUpdate.maxUnavailable` is set to `0`.
+#! `deployment.spec.strategy.rollingUpdate.maxSurge` is set to `1`.
+#! `deployment.spec.template.spec.nodeSelector`is set to target only `Nodes`
+#! `daemonset.spec.updateStrategy.type` is configured to `OnDelete`
+#! This overlay makes configuring the above parameters possible
+#! Reference: https://github.com/vmware-tanzu/tanzu-framework/issues/1850
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"Deployment"})
+---
+kind: Deployment
+spec:
+  #@ if data.values.deployment.updateStrategy != None:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: #@ data.values.deployment.updateStrategy
+    #@overlay/match missing_ok=True
+    #@ if data.values.deployment.updateStrategy == "rollingUpdate":
+    rollingUpdate:
+      #@ if/end data.values.deployment.rollingUpdate.maxUnavailable != None:
+      maxUnavailable: #@ data.values.deployment.rollingUpdate.maxUnavailable
+      #@ if/end data.values.deployment.rollingUpdate.maxSurge != None:
+      maxSurge: #@ data.values.deployment.rollingUpdate.maxSurge
+    #@ end
+  #@ end
+  #@ if data.values.nodeSelector != None:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@ for key in data.values.nodeSelector:
+        #@overlay/match missing_ok=True
+        #@yaml/text-templated-strings
+        (@= key @): #@ data.values.nodeSelector[key]
+        #@ end
+  #@ end
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
+---
+kind: DaemonSet
+spec:
+  #@ if data.values.daemonset.updateStrategy:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    type: #@ data.values.daemonset.updateStrategy
+  #@ end

--- a/addons/packages/pinniped/0.12.1/bundle/config/values.yaml
+++ b/addons/packages/pinniped/0.12.1/bundle/config/values.yaml
@@ -15,6 +15,14 @@ imageInfo:
       imagePath: dex
       tag: v2.27.0_vmware.1
 infrastructure_provider: null
+nodeSelector: null
+deployment:
+  updateStrategy: null
+  rollingUpdate:
+    maxUnavailable: null
+    maxSurge: null
+daemonset:
+  updateStrategy: null
 tkg_cluster_role: null
 custom_cluster_issuer: "" #! provide if user wants to use a custom ClusterIssuer for both Pinniped and Dex certificates
 custom_tls_secret: "" #! provide if user wants to use a custom TLS secret for both Pinniped and Dex, will override the ClusterIssuer above if specified, user should create secret with the same name in both "tanzu-system-auth" and "pinniped-supervisor" namespaces.

--- a/addons/packages/pinniped/0.12.1/package.yaml
+++ b/addons/packages/pinniped/0.12.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/pinniped@sha256:6116d5c41b0475b0c0f5a63e5fee23806cf1e672e161a20b1b5bce93a00434b2
+            image: projects.registry.vmware.com/tce/pinniped@sha256:9a90c6e8f9f8d53897f53fa63dc3cc8de71c99b3081e5a7ad72a1413c638878d
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
We need to enforce the update strategy of all the deployment and daemonset running on Supervisor cluster. Also, add nodeSelector configuration to deployments.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #  https://github.com/vmware-tanzu/tanzu-framework/issues/1850

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Manually tested the templates

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
