### PR TITLE
Add update strategy and node selector overlay to metrics-server 0.5.1

### DIFF
--- a/addons/packages/metrics-server/0.5.1/bundle/config/overlays/update-strategy-overlay.yaml
+++ b/addons/packages/metrics-server/0.5.1/bundle/config/overlays/update-strategy-overlay.yaml
@@ -1,0 +1,50 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#! We are adding this overlay in the package to accomandate the need from vSphere supervisor cluster:
+#! `deployment.spec.strategy.type` is configured to `RollingUpdate`
+#! `deployment.spec.strategy.rollingUpdate.maxUnavailable` is set to `0`.
+#! `deployment.spec.strategy.rollingUpdate.maxSurge` is set to `1`.
+#! `deployment.spec.template.spec.nodeSelector`is set to target only `Nodes`
+#! `daemonset.spec.updateStrategy.type` is configured to `OnDelete`
+#! This overlay makes configuring the above parameters possible
+#! Reference: https://github.com/vmware-tanzu/tanzu-framework/issues/1850
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"Deployment"})
+---
+kind: Deployment
+spec:
+  #@ if data.values.deployment.updateStrategy != None:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: #@ data.values.deployment.updateStrategy
+    #@overlay/match missing_ok=True
+    #@ if data.values.deployment.updateStrategy == "rollingUpdate":
+    rollingUpdate:
+      #@ if/end data.values.deployment.rollingUpdate.maxUnavailable != None:
+      maxUnavailable: #@ data.values.deployment.rollingUpdate.maxUnavailable
+      #@ if/end data.values.deployment.rollingUpdate.maxSurge != None:
+      maxSurge: #@ data.values.deployment.rollingUpdate.maxSurge
+    #@ end
+  #@ end
+  #@ if data.values.nodeSelector != None:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@ for key in data.values.nodeSelector:
+        #@overlay/match missing_ok=True
+        #@yaml/text-templated-strings
+        (@= key @): #@ data.values.nodeSelector[key]
+        #@ end
+  #@ end
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
+---
+kind: DaemonSet
+spec:
+  #@ if data.values.daemonset.updateStrategy:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    type: #@ data.values.daemonset.updateStrategy
+  #@ end

--- a/addons/packages/metrics-server/0.5.1/bundle/config/schema.yaml
+++ b/addons/packages/metrics-server/0.5.1/bundle/config/schema.yaml
@@ -5,6 +5,24 @@
 ---
 #@schema/desc "The namespace in which metrics-server is deployed"
 namespace: kube-system
+#@schema/desc "NodeSelector configuration applied to all the deployments"
+#@schema/type any=True
+nodeSelector:
+deployment:
+  #@schema/desc "Update strategy of deployments"
+  #@schema/nullable
+  updateStrategy: ""
+  rollingUpdate:
+    #@schema/desc "The maxUnavailable of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy"
+    #@schema/nullable
+    maxUnavailable: 1
+    #@schema/desc "The maxSurge of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy"
+    #@schema/nullable
+    maxSurge: 0
+daemonset:
+  #@schema/desc "Update strategy of daemonsets"
+  #@schema/nullable
+  updateStrategy: ""
 metricsServer:
   #@schema/desc "The namespace value used by older templates, will be overwriten if top level namespace is present, kept for backward compatibility"
   #@schema/nullable

--- a/addons/packages/metrics-server/0.5.1/bundle/config/values.yaml
+++ b/addons/packages/metrics-server/0.5.1/bundle/config/values.yaml
@@ -2,6 +2,14 @@
 #@overlay/match-child-defaults missing_ok=True
 ---
 namespace: kube-system
+nodeSelector: null
+deployment:
+  updateStrategy: null
+  rollingUpdate:
+    maxUnavailable: null
+    maxSurge: null
+daemonset:
+  updateStrategy: null
 metricsServer:
   namespace: null
   createNamespace: true

--- a/addons/packages/metrics-server/0.5.1/package.yaml
+++ b/addons/packages/metrics-server/0.5.1/package.yaml
@@ -11,33 +11,69 @@ spec:
       properties:
         namespace:
           type: string
-          default: kube-system
           description: The namespace in which metrics-server is deployed
+          default: kube-system
+        nodeSelector:
+          nullable: true
+          description: NodeSelector configuration applied to all the deployments
+          default: null
+        deployment:
+          type: object
+          additionalProperties: false
+          properties:
+            updateStrategy:
+              type: string
+              nullable: true
+              description: Update strategy of deployments
+              default: null
+            rollingUpdate:
+              type: object
+              additionalProperties: false
+              properties:
+                maxUnavailable:
+                  type: integer
+                  nullable: true
+                  description: The maxUnavailable of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy
+                  default: null
+                maxSurge:
+                  type: integer
+                  nullable: true
+                  description: The maxSurge of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy
+                  default: null
+        daemonset:
+          type: object
+          additionalProperties: false
+          properties:
+            updateStrategy:
+              type: string
+              nullable: true
+              description: Update strategy of daemonsets
+              default: null
         metricsServer:
           type: object
           additionalProperties: false
           properties:
             namespace:
               type: string
-              default: null
               nullable: true
               description: The namespace value used by older templates, will be overwriten if top level namespace is present, kept for backward compatibility
+              default: null
             createNamespace:
               type: boolean
-              default: true
               description: Whether to create namespace specified for metrics-server
+              default: true
             config:
               type: object
               additionalProperties: false
               properties:
                 securePort:
                   type: integer
-                  default: 4443
                   description: The HTTPS secure port used by metrics-server
+                  default: 4443
                 updateStrategy:
                   type: string
-                  default: RollingUpdate
                   description: The update strategy of the metrics-server deployment
+                  default: RollingUpdate
                 args:
                   type: array
                   description: Arguments passed into metrics-server container
@@ -51,16 +87,16 @@ spec:
                   properties:
                     failureThreshold:
                       type: integer
-                      default: 3
                       description: Probe failureThreshold of metrics-server deployment
+                      default: 3
                     periodSeconds:
                       type: integer
-                      default: 10
                       description: Probe period of metrics-server deployment
+                      default: 10
                 apiServiceInsecureTLS:
                   type: boolean
-                  default: true
                   description: Whether to enable insecure TLS for metrics-server api service
+                  default: true
                 tolerations:
                   type: array
                   description: Metrics-server deployment tolerations
@@ -77,7 +113,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/metrics-server@sha256:32578c15a2e03423d12aacc39ff94fa6795e6dfe70cb43b13a1940d77f3cb0b8
+          image: projects.registry.vmware.com/tce/metrics-server@sha256:20638483ef09afaec9d5f034d5ff3083439ff90d6a8b02e5d9dae2f43ecefc02
       template:
       - ytt:
           paths:


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
We need to enforce the update strategy of all the deployment and daemonset running on Supervisor cluster. Also, add nodeSelector configuration to deployments.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: # https://github.com/vmware-tanzu/tanzu-framework/issues/1850

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Manually tested the templates

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
