### PR TITLE
Add update strategy and node selector overlay to secretgen-controlle 0.8.0

### DIFF
--- a/addons/packages/secretgen-controller/0.8.0/bundle/config/overlays/update-strategy-overlay.yaml
+++ b/addons/packages/secretgen-controller/0.8.0/bundle/config/overlays/update-strategy-overlay.yaml
@@ -1,0 +1,50 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#! We are adding this overlay in the package to accomandate the need from vSphere supervisor cluster:
+#! `deployment.spec.strategy.type` is configured to `RollingUpdate`
+#! `deployment.spec.strategy.rollingUpdate.maxUnavailable` is set to `0`.
+#! `deployment.spec.strategy.rollingUpdate.maxSurge` is set to `1`.
+#! `deployment.spec.template.spec.nodeSelector`is set to target only `Nodes`
+#! `daemonset.spec.updateStrategy.type` is configured to `OnDelete`
+#! This overlay makes configuring the above parameters possible
+#! Reference: https://github.com/vmware-tanzu/tanzu-framework/issues/1850
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"Deployment"})
+---
+kind: Deployment
+spec:
+  #@ if data.values.deployment.updateStrategy != None:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: #@ data.values.deployment.updateStrategy
+    #@overlay/match missing_ok=True
+    #@ if data.values.deployment.updateStrategy == "rollingUpdate":
+    rollingUpdate:
+      #@ if/end data.values.deployment.rollingUpdate.maxUnavailable != None:
+      maxUnavailable: #@ data.values.deployment.rollingUpdate.maxUnavailable
+      #@ if/end data.values.deployment.rollingUpdate.maxSurge != None:
+      maxSurge: #@ data.values.deployment.rollingUpdate.maxSurge
+    #@ end
+  #@ end
+  #@ if data.values.nodeSelector != None:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@ for key in data.values.nodeSelector:
+        #@overlay/match missing_ok=True
+        #@yaml/text-templated-strings
+        (@= key @): #@ data.values.nodeSelector[key]
+        #@ end
+  #@ end
+
+#@overlay/match missing_ok=True,by=overlay.subset({"kind":"DaemonSet"})
+---
+kind: DaemonSet
+spec:
+  #@ if data.values.daemonset.updateStrategy:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    type: #@ data.values.daemonset.updateStrategy
+  #@ end

--- a/addons/packages/secretgen-controller/0.8.0/bundle/config/schema.yaml
+++ b/addons/packages/secretgen-controller/0.8.0/bundle/config/schema.yaml
@@ -3,6 +3,24 @@
 #@data/values-schema
 #@schema/desc "OpenAPIv3 Schema for secretgen-controller"
 ---
+#@schema/desc "NodeSelector configuration applied to all the deployments"
+#@schema/type any=True
+nodeSelector:
+deployment:
+  #@schema/desc "Update strategy of deployments"
+  #@schema/nullable
+  updateStrategy: ""
+  rollingUpdate:
+    #@schema/desc "The maxUnavailable of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy"
+    #@schema/nullable
+    maxUnavailable: 1
+    #@schema/desc "The maxSurge of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy"
+    #@schema/nullable
+    maxSurge: 0
+daemonset:
+  #@schema/desc "Update strategy of daemonsets"
+  #@schema/nullable
+  updateStrategy: ""
 #@schema/desc "Configuration for secretgen-controller"
 secretgenController:
   #@schema/desc "The namespace in which to deploy secretgen-controller"

--- a/addons/packages/secretgen-controller/0.8.0/bundle/config/values.yaml
+++ b/addons/packages/secretgen-controller/0.8.0/bundle/config/values.yaml
@@ -1,6 +1,14 @@
 #@data/values
 #@overlay/match-child-defaults missing_ok=True
 ---
+nodeSelector: null
+deployment:
+  updateStrategy: null
+  rollingUpdate:
+    maxUnavailable: null
+    maxSurge: null
+daemonset:
+  updateStrategy: null
 secretgenController:
   namespace: secretgen-controller
   createNamespace: true

--- a/addons/packages/secretgen-controller/0.8.0/package.yaml
+++ b/addons/packages/secretgen-controller/0.8.0/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/secretgen-controller@sha256:95ee2b63de1f53f5938254e567845eb8641546cf0e0fd8f0e3d5aa9ef290c017
+          image: projects.registry.vmware.com/tce/secretgen-controller@sha256:ef25443ee64e80e94132148d8e62eec5ba810b295638df2e9883933ad77525d9
       template:
       - ytt:
           paths:
@@ -29,6 +29,42 @@ spec:
       additionalProperties: false
       description: OpenAPIv3 Schema for secretgen-controller
       properties:
+        nodeSelector:
+          nullable: true
+          description: NodeSelector configuration applied to all the deployments
+          default: null
+        deployment:
+          type: object
+          additionalProperties: false
+          properties:
+            updateStrategy:
+              type: string
+              nullable: true
+              description: Update strategy of deployments
+              default: null
+            rollingUpdate:
+              type: object
+              additionalProperties: false
+              properties:
+                maxUnavailable:
+                  type: integer
+                  nullable: true
+                  description: The maxUnavailable of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy
+                  default: null
+                maxSurge:
+                  type: integer
+                  nullable: true
+                  description: The maxSurge of rollingUpdate. Applied only if rollingUpdate is used as updateStrategy
+                  default: null
+        daemonset:
+          type: object
+          additionalProperties: false
+          properties:
+            updateStrategy:
+              type: string
+              nullable: true
+              description: Update strategy of daemonsets
+              default: null
         secretgenController:
           type: object
           additionalProperties: false
@@ -36,9 +72,9 @@ spec:
           properties:
             namespace:
               type: string
-              default: secretgen-controller
               description: The namespace in which to deploy secretgen-controller
+              default: secretgen-controller
             createNamespace:
               type: boolean
-              default: true
               description: Whether to create namespace specified for secretgen-controller
+              default: true


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
We need to enforce the update strategy of all the deployment and daemonset running on Supervisor cluster. Also, add nodeSelector configuration to deployments.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: # https://github.com/vmware-tanzu/tanzu-framework/issues/1850

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Manually tested the templates

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
