### PR TITLE
Make unmanaged e2e test runs explicit action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,6 +507,6 @@ vsphere-management-and-workload-cluster-e2e-test:
 	BUILD_VERSION=$(BUILD_VERSION) test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
 
 unmanaged-cluster-e2e-test:
-	cd cli/cmd/plugin/unmanaged-cluster/test/e2e && BUILD_VERSION=$(BUILD_VERSION) ROOT_DIR=$(ROOT_DIR) go test -test.v -timeout 180m
+	cd cli/cmd/plugin/unmanaged-cluster && make e2e-test BUILD_VERSION=$(BUILD_VERSION)
 
 ##### E2E TESTS

--- a/cli/cmd/plugin/unmanaged-cluster/Makefile
+++ b/cli/cmd/plugin/unmanaged-cluster/Makefile
@@ -1,6 +1,8 @@
 # Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+ROOT_DIR := $(shell git rev-parse --show-toplevel)
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message
@@ -21,7 +23,7 @@ test: ## Run unit testing suite
 	echo "N/A: No unit tests for unmanaged-cluster"
 
 e2e-test: ## Run e2e testing suite
-	cd test/e2e && go test -timeout 180m
+	cd test/e2e && BUILD_VERSION=$(BUILD_VERSION) ROOT_DIR=$(ROOT_DIR) go test -tags=e2e -timeout 180m
 
 build: ## Build the executable
 	echo "N/A: Implement building"

--- a/cli/cmd/plugin/unmanaged-cluster/test/e2e/e2e_suite_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/test/e2e/e2e_suite_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/docs/site/content/docs/contribute/contributing.md
+++ b/docs/site/content/docs/contribute/contributing.md
@@ -163,7 +163,7 @@ it _is_ expected that each Makefile provide the following targets:
 
 - `make`: Displays a help message with all poosible make targets
 - `make test`: invokes unit tests
-- `make e2e-test`: invokes an E2E testing suite
+- `make e2e-test`: invokes an E2E testing suite (see note below)
 - `make lint`: invokes linting protocols for the individual module. For example, in a Go project, it should call Golangci-lint.
 - `make get-deps`: gets the necessary dependencies for running, testing, and building.  Typically is `go mod tidy` in Go modules
 - `make build`: builds the individual piece of software
@@ -183,6 +183,15 @@ make makefile
 
 to generate a makefile to stdout that can be used in your project.
 This is a good starting point for new packages and plugins integrating directly into the Tanzu Community Edition repository.
+
+**Note for plugin authors**: End-to-end tests should not be run as part of normal
+unit test runs. Place the following at the top of any e2e test files so they are
+not included by default. Use `-tags=e2e` inside the `make e2e-test` target
+so they are only included under that condition.
+
+```go
+//go:build e2e
+```
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

The current setup causes e2e tests to be run like any normal unit test,
making it difficult to quickly run unit testing.

This separates out the e2e tests so they need to be explicitly invoked
by requiring `-tags=e2e` in the invocation of `go test`.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4112 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran unit and e2e tests locally.