### PR TITLE
Enable `make test-plugins`

### DIFF
--- a/.github/workflows/check-all.yaml
+++ b/.github/workflows/check-all.yaml
@@ -62,6 +62,10 @@ jobs:
         run: |
           make ensure-deps
           make release ENVS=linux-amd64
+      - name: Plugin unit tests
+        shell: bash
+        run: |
+          make test-plugins
       - name: Install
         shell: bash
         run: |

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ ensure-deps:
 	hack/ensure-deps/ensure-dependencies.sh
 
 GO_MODULES=$(shell find . -path "*/go.mod" | xargs -I _ dirname _)
+PLUGIN_MODULES=$(shell find . -path "*/go.mod" | grep "cmd.plugin" | xargs -I _ dirname _)
 
 get-deps:
 	@for i in $(GO_MODULES); do \
@@ -426,8 +427,10 @@ build-install-plugins: build-cli-plugins install-plugins
 	@printf "CLI plugins built and installed\n"
 
 test-plugins: ## run tests on TCE plugins
-	# TODO(joshrosso): update once we get our testing strategy in place
-	@echo "No tests to run."
+	@for i in $(PLUGIN_MODULES); do \
+		echo "-- Running tests for $$i --"; \
+		make -C $$i test; \
+	done
 
 .PHONY: clean-plugin
 clean-plugin:

--- a/cli/cmd/plugin/conformance/Makefile
+++ b/cli/cmd/plugin/conformance/Makefile
@@ -16,8 +16,9 @@ else
 	$(GOLANGCI_LINT) run -v --timeout=5m
 endif
 
+.PHONY: test
 test: ## Run unit testing suite
-	echo "N/A: No unit tests for hack/packages"
+	go test ./... -coverprofile=cover.out
 
 e2e-test: ## Run e2e testing suite
 	echo "N/A: No e2e tests for hack/packages"

--- a/cli/cmd/plugin/diagnostics/Makefile
+++ b/cli/cmd/plugin/diagnostics/Makefile
@@ -16,8 +16,9 @@ else
 	$(GOLANGCI_LINT) run -v --timeout=5m
 endif
 
+.PHONY: test
 test: ## Run unit testing suite
-	echo "N/A: No unit tests for hack/packages"
+	go test ./... -coverprofile=cover.out
 
 .PHONY: test-pr-check
 test-pr-check: ## Run e2e testing suite for PR check

--- a/cli/cmd/plugin/unmanaged-cluster/Makefile
+++ b/cli/cmd/plugin/unmanaged-cluster/Makefile
@@ -17,8 +17,9 @@ else
 	$(GOLANGCI_LINT) run -v --timeout=5m
 endif
 
+.PHONY: test
 test: ## Run unit testing suite
-	echo "N/A: No unit tests for unmanaged-cluster"
+	go test ./... -coverprofile=cover.out
 
 e2e-test: ## Run e2e testing suite
 	cd test/e2e && go test -timeout 180m


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We had a placeholder target in the root Makefile for a `test-plugins`
target. This was meant to run unit test coverage for our CLI plugins.

We have since added unit test coverage for our plugins, so now is a good
time to finish wiring this up. This updates our plugins to support their
expected `make test` target, and `make test-plugins` will now invoke
this for all CLI plugins in the repo.

Also added this to the `check-all` GitHub Action so unit tests of the
CLI plugins are included as part of our comprehensive testing.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related: #3536 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make test-plugins` and verified expected behavior.