### PR TITLE
Fix reference to cert-manager values.yaml file in e2e tests #4170

### DIFF
--- a/addons/packages/cert-manager/1.7.2/test/e2e/cert_manager_suite_test.go
+++ b/addons/packages/cert-manager/1.7.2/test/e2e/cert_manager_suite_test.go
@@ -55,7 +55,7 @@ var _ = BeforeSuite(func() {
 
 	version := findPackageAvailableVersion(packageName, "1.7.2")
 
-	valuesFilename := filepath.Join("fixtures", "cert-manager-values.yaml")
+	valuesFilename := filepath.Join("fixtures", "values.yaml")
 	installPackage(packageInstallName, packageName, version, valuesFilename)
 
 	By("validating cert-manager package is reconciled")

--- a/addons/packages/cert-manager/1.7.2/test/e2e/fixtures/values.yaml
+++ b/addons/packages/cert-manager/1.7.2/test/e2e/fixtures/values.yaml
@@ -1,0 +1,1 @@
+namespace: cert-manager

--- a/addons/packages/cert-manager/1.8.0/test/e2e/cert_manager_suite_test.go
+++ b/addons/packages/cert-manager/1.8.0/test/e2e/cert_manager_suite_test.go
@@ -55,7 +55,7 @@ var _ = BeforeSuite(func() {
 
 	version := findPackageAvailableVersion(packageName, "1.8.0")
 
-	valuesFilename := filepath.Join("fixtures", "cert-manager-values.yaml")
+	valuesFilename := filepath.Join("fixtures", "values.yaml")
 	installPackage(packageInstallName, packageName, version, valuesFilename)
 
 	By("validating cert-manager package is reconciled")

--- a/addons/packages/cert-manager/1.8.0/test/e2e/fixtures/values.yaml
+++ b/addons/packages/cert-manager/1.8.0/test/e2e/fixtures/values.yaml
@@ -1,0 +1,1 @@
+namespace: cert-manager


### PR DESCRIPTION
## What this PR does / why we need it

Fix the reference to the values.yaml file for the end-to-end tests for the cert-manager package.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4170

## Describe testing done for PR

```
tanzu uc create test
tanzu package repository update projects.registry.vmware.com-tce-main-v0.11.0 -n tanzu-package-repo-global --url projects.registry.vmware.com/tce/main:0.12.0-rc4
cd addons/packages/cert-manager/1.8.0/test
make e2e-test
```

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
