### PR TITLE
Remove rule to ignore *-values.yaml files #4179

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,6 @@ docs/site/resources
 .vs
 .idea
 
-# package configuration values files
-*-values.yaml
 .envrc
 
 # tar balls


### PR DESCRIPTION
## What this PR does / why we need it

Updates the .gitignore rules to remove the rule to ignore `*-values.yaml` files.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4179 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
