### PR TITLE
Use yaml or yml files when generating a package repo #4187

### DIFF
--- a/hack/packages/generate-package-repository.go
+++ b/hack/packages/generate-package-repository.go
@@ -74,11 +74,11 @@ func main() {
 	}()
 
 	for _, p := range repository.Packages {
-		metadataFilepath := filepath.Join(PackagesDirectoryPath, p.Name, "metadata.yaml")
+		metadataFilepath := getYamlFilepath(filepath.Join(PackagesDirectoryPath, p.Name, "metadata"))
 		copyYaml(metadataFilepath, outputFile)
 
 		for _, version := range p.Versions {
-			packageFilepath := filepath.Join(PackagesDirectoryPath, p.Name, version, "package.yaml")
+			packageFilepath := getYamlFilepath(filepath.Join(PackagesDirectoryPath, p.Name, version, "package"))
 			copyYaml(packageFilepath, outputFile)
 		}
 	}
@@ -129,6 +129,17 @@ func copyYaml(packageFilepath string, outputFile *os.File) {
 			panic(err)
 		}
 	}
+}
+
+func getYamlFilepath(filename string) string {
+	yamlFilepath := filename + ".yaml"
+	_, err := os.Stat(yamlFilepath)
+	if err != nil {
+		yamlFilepath = filename + ".yml"
+		_, err = os.Stat(yamlFilepath)
+		check(err)
+	}
+	return yamlFilepath
 }
 
 func check(e error) {


### PR DESCRIPTION
## What this PR does / why we need it

Packages can have `yaml` or `yml` files. The task to generate a package repo should check for both.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4187

## Describe testing done for PR

Created a package repository containing a package with a `package.yml` file.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
