### PR TITLE
New kpack dependencies version

### DIFF
--- a/addons/packages/kpack-dependencies/0.0.22/README.md
+++ b/addons/packages/kpack-dependencies/0.0.22/README.md
@@ -43,6 +43,8 @@ You can install the kpack dependencies package using the command below:
 
 `tanzu package install kpack-dependencies --package-name kpack-dependencies.community.tanzu.vmware.com --version 0.0.1 -f kpack-deps-values.yaml`
 
+#### Verification
+
 Once the package is installed you can view the resources that have been created:
 
 **NOTE: These resources cannot be modified manually, they can only be upgraded via upgrades of the kpack dependencies package. If you wish to create custom ClusterStores, ClusterStacks, or ClusterBuilders you must create [new resources](https://github.com/pivotal/kpack/blob/main/docs/tutorial.md) and manage them manually.**
@@ -63,9 +65,21 @@ base      <some-image>   True
 default   <some-image>   True
 ```
 
+#### Troubleshooting
+
+Currently, the kpack dependencies package will not immediately fail if the installation is in a bad state.
+
+If your installation is reconciling for a long time or receives a timeout, check the status of the relevant resources:
+
+```bash
+kubectl describe clusterstore
+kubectl describe clusterstack
+kubectl describe clusterbuilder
+```
+
 ## Configuration and Usage
 
-After installing kpack dependencies dependencies do not need to be manually installed, and you can immediately create source-to-image builds.
+After installing the kpack dependencies package, ClusterStores, ClusterStacks, and ClusterBuilders do not need to be manually installed, and you can immediately create source-to-image builds.
 
 * [Creating an image using kp](#creating-an-image-using-kp-cli)
 * [Creating an image using kubectl](#creating-an-image-using-kubectl)
@@ -114,7 +128,7 @@ After installing kpack dependencies dependencies do not need to be manually inst
     ```
 
    * Make sure to replace `<IMAGE-TAG>` with the tag in the registry of the
-     secret you configured in step #5. Something like:
+     secret you configured. Something like:
      `your-name/app` or `gcr.io/your-project/app`
    * If you are using your application source, replace `--git`
      & `--git-revision`.
@@ -171,7 +185,7 @@ After installing kpack dependencies dependencies do not need to be manually inst
 
 3. Run the built application image locally.
 
-   Download the latest built OCI image available in step #6 and run it with
+   Download the latest built OCI image available and run it with
    Docker.
 
    ```bash
@@ -203,7 +217,7 @@ After installing kpack dependencies dependencies do not need to be manually inst
    > Note: You can also provide a branch or tag as the `spec.git.revision` and kpack will poll and rebuild on updates!
 
    We can simulate an update from a CI/CD tool by updating
-   the `spec.git.revision` on the Image Resource configured in step #6.
+   the `spec.git.revision` on the Image Resource.
 
    If you are using your own application please push an updated commit and use
    the new commit sha. If you are using Spring Pet Clinic you can update the
@@ -229,7 +243,7 @@ After installing kpack dependencies dependencies do not need to be manually inst
    2        BUILDING                                                    CONFIG
    ```
 
-   You can tail the logs for the Image Resource with the kp cli used in step #6.
+   You can tail the logs for the Image Resource with the kp cli.
 
    ```bash
    kp build logs tutorial-image
@@ -295,8 +309,7 @@ After installing kpack dependencies dependencies do not need to be manually inst
    An Image Resource is the specification for an OCI image that kpack should
    build and manage.
 
-   We will create a sample Image Resource that builds with the builder created
-   in step #5.
+   We will create a sample Image Resource that builds with the builder we created.
 
    The example included here utilizes
    the [Spring Pet Clinic sample app](https://github.com/spring-projects/spring-petclinic)
@@ -323,7 +336,7 @@ After installing kpack dependencies dependencies do not need to be manually inst
 
    * Replace `<DOCKER-IMAGE-TAG>` with a valid image tag that exists in the
      registry you configured with the `--docker-server` flag when creating a
-     Secret in step #1. Something like: `your-name/app`
+     Secret. Something like: `your-name/app`
      or `gcr.io/your-project/app`
    * If you are using your application source, replace `source.git.url`
      & `source.git.revision`.
@@ -375,7 +388,7 @@ After installing kpack dependencies dependencies do not need to be manually inst
 
 4. Run the built application image locally.
 
-   Download the latest OCI image available in step #6 and run it with Docker.
+   Download the latest OCI image available and run it with Docker.
 
    ```bash
    docker run -p 8080:8080 <latest-image-with-digest>
@@ -406,7 +419,7 @@ After installing kpack dependencies dependencies do not need to be manually inst
    > Note: You can also provide a branch or tag as the `spec.git.revision` and kpack will poll and rebuild on updates!
 
    We can simulate an update from a CI/CD tool by updating
-   the `spec.git.revision` on the Image Resource used in step #6.
+   the `spec.git.revision` on the Image Resource.
 
    If you are using your own application push an updated commit and use the new
    commit sha. If you are using Spring Pet Clinic you can update the revision
@@ -432,7 +445,7 @@ After installing kpack dependencies dependencies do not need to be manually inst
    tutorial-image-build-2-xsf2l                                                       Unknown
    ```
 
-   You can tail the logs for the image with the kp cli used in step #6.
+   You can tail the logs for the image with the kp cli.
 
    ```bash
    kp build logs tutorial-image -b 2

--- a/addons/packages/kpack-dependencies/0.0.22/package.yaml
+++ b/addons/packages/kpack-dependencies/0.0.22/package.yaml
@@ -1,0 +1,33 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: kpack-dependencies.community.tanzu.vmware.com.0.0.22
+spec:
+  refName: kpack-dependencies.community.tanzu.vmware.com
+  version: 0.0.22
+  capacityRequirementsDescription: Registry with > 1GB available space
+  releaseNotes: https://github.com/vmware-tanzu/package-for-kpack-dependencies/releases/tag/v0.0.22
+  valuesSchema:
+    openAPIv3:
+      title: kpack-dependencies.community.tanzu.vmware.com values schema
+      properties:
+        kp_default_repository:
+          type: string
+          description: Docker repository for builder images. The same value used during installation of kpack.
+          examples:
+          - registry.io/kpack
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/kpack/dependencies@sha256:1465f7822e9a3085f700bea1678814e69aa46dad962745b71a5923ced0b8fa32
+      template:
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
+      deploy:
+      - kapp: {}

--- a/addons/packages/kpack-dependencies/vendir.lock.yml
+++ b/addons/packages/kpack-dependencies/vendir.lock.yml
@@ -5,4 +5,9 @@ directories:
       url: https://api.github.com/repos/vmware-tanzu/package-for-kpack-dependencies/releases/64272438
     path: .
   path: 0.0.9
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/package-for-kpack-dependencies/releases/65269157
+    path: .
+  path: 0.0.22
 kind: LockConfig

--- a/addons/packages/kpack-dependencies/vendir.yml
+++ b/addons/packages/kpack-dependencies/vendir.yml
@@ -2,13 +2,23 @@ apiVersion: vendir.k14s.io/v1alpha1
 kind: Config
 minimumRequiredVersion: 0.12.0
 directories:
-  - path: 0.0.9
-    contents:
-      - path: .
-        githubRelease:
-          slug: vmware-tanzu/package-for-kpack-dependencies
-          tag: v0.0.9
-          disableAutoChecksumValidation: true
-          assetNames:
-            - "package.yaml"
-            - "README.md"
+- path: 0.0.9
+  contents:
+  - path: .
+    githubRelease:
+      slug: vmware-tanzu/package-for-kpack-dependencies
+      tag: v0.0.9
+      disableAutoChecksumValidation: true
+      assetNames:
+      - package.yaml
+      - README.md
+- path: 0.0.22
+  contents:
+  - path: .
+    githubRelease:
+      slug: vmware-tanzu/package-for-kpack-dependencies
+      tag: v0.0.22
+      disableAutoChecksumValidation: true
+      assetNames:
+      - package.yaml
+      - README.md


### PR DESCRIPTION
## What this PR does / why we need it

The kpack dependencies package has a new version to release to TCE.

New version is in commit message. See kpack-dependencies [releases](https://github.com/vmware-tanzu/package-for-kpack-dependencies/releases) for details.

## Which issue(s) this PR fixes

Kpack dependencies are released automatically on a consistent cadance or as needed for security patches.

## Describe testing done for PR

Integration testing with kpack package.

/assign @tce-owners
