### PR TITLE
Remove use of deprecated ioutil

### DIFF
--- a/addons/packages/cert-manager/1.7.2/test/unittest/unit_test.go
+++ b/addons/packages/cert-manager/1.7.2/test/unittest/unit_test.go
@@ -4,7 +4,7 @@
 package unit_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -24,14 +24,14 @@ var _ = Describe("cert-manager Ytt Templates", func() {
 		configDir = filepath.Join(repo.RootDir(), "addons/packages/cert-manager/1.7.2/bundle/config")
 
 		ValuesFromFile = func(filename string) string {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/cert-manager/1.7.2/test/unittest/fixtures/values", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/cert-manager/1.7.2/test/unittest/fixtures/values", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			return string(data)
 		}
 
 		ExpectOutputEqualToFile = func(filename string) {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/cert-manager/1.7.2/test/unittest/fixtures/expected", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/cert-manager/1.7.2/test/unittest/fixtures/expected", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(output).To(MatchYAML(string(data)))

--- a/addons/packages/cert-manager/1.8.0/test/unittest/unit_test.go
+++ b/addons/packages/cert-manager/1.8.0/test/unittest/unit_test.go
@@ -4,7 +4,7 @@
 package unit_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -24,14 +24,14 @@ var _ = Describe("cert-manager Ytt Templates", func() {
 		configDir = filepath.Join(repo.RootDir(), "addons/packages/cert-manager/1.8.0/bundle/config")
 
 		ValuesFromFile = func(filename string) string {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/cert-manager/1.8.0/test/unittest/fixtures/values", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/cert-manager/1.8.0/test/unittest/fixtures/values", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			return string(data)
 		}
 
 		ExpectOutputEqualToFile = func(filename string) {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/cert-manager/1.8.0/test/unittest/fixtures/expected", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/cert-manager/1.8.0/test/unittest/fixtures/expected", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(output).To(MatchYAML(string(data)))

--- a/addons/packages/external-dns/0.10.0/test/unittest/externaldns_test.go
+++ b/addons/packages/external-dns/0.10.0/test/unittest/externaldns_test.go
@@ -4,7 +4,7 @@
 package externaldns_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -25,14 +25,14 @@ var _ = Describe("External DNS Ytt Templates", func() {
 		configDir = filepath.Join(repo.RootDir(), "addons/packages/external-dns/0.10.0/bundle/config")
 
 		ValuesFromFile = func(filename string) string {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/external-dns/0.10.0/test/unittest/fixtures/values", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/external-dns/0.10.0/test/unittest/fixtures/values", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			return string(data)
 		}
 
 		ExpectOutputEqualToFile = func(filename string) {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/external-dns/0.10.0/test/unittest/fixtures/expected", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/external-dns/0.10.0/test/unittest/fixtures/expected", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			//fmt.Println(output)

--- a/addons/packages/external-dns/0.11.0/test/unittest/externaldns_test.go
+++ b/addons/packages/external-dns/0.11.0/test/unittest/externaldns_test.go
@@ -4,7 +4,7 @@
 package externaldns_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -25,14 +25,14 @@ var _ = Describe("External DNS Ytt Templates", func() {
 		configDir = filepath.Join(repo.RootDir(), "addons/packages/external-dns/0.10.0/bundle/config")
 
 		ValuesFromFile = func(filename string) string {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/external-dns/0.10.0/test/unittest/fixtures/values", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/external-dns/0.10.0/test/unittest/fixtures/values", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			return string(data)
 		}
 
 		ExpectOutputEqualToFile = func(filename string) {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/external-dns/0.10.0/test/unittest/fixtures/expected", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/external-dns/0.10.0/test/unittest/fixtures/expected", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			//fmt.Println(output)

--- a/addons/packages/gatekeeper/3.7.1/test/unittest/unit_test.go
+++ b/addons/packages/gatekeeper/3.7.1/test/unittest/unit_test.go
@@ -4,7 +4,7 @@
 package unit_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -24,14 +24,14 @@ var _ = Describe("Gatekeeper Ytt Templates", func() {
 		configDir = filepath.Join(repo.RootDir(), "addons/packages/gatekeeper/3.7.1/bundle/config")
 
 		ValuesFromFile = func(filename string) string {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/gatekeeper/3.7.1/test/unittest/fixtures/values", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/gatekeeper/3.7.1/test/unittest/fixtures/values", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			return string(data)
 		}
 
 		ExpectOutputEqualToFile = func(filename string) {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/gatekeeper/3.7.1/test/unittest/fixtures/expected", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/gatekeeper/3.7.1/test/unittest/fixtures/expected", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(output).To(MatchYAML(string(data)))

--- a/addons/packages/harbor/2.2.3/test/unittest/harbor_test.go
+++ b/addons/packages/harbor/2.2.3/test/unittest/harbor_test.go
@@ -4,7 +4,7 @@
 package harbor_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -24,14 +24,14 @@ var _ = Describe("Harbor Ytt Templates", func() {
 		configDir = filepath.Join(repo.RootDir(), "addons/packages/harbor/2.2.3/bundle/config")
 
 		ValuesFromFile = func(filename string) string {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/harbor/2.2.3/test/unittest/fixtures/values", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/harbor/2.2.3/test/unittest/fixtures/values", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			return string(data)
 		}
 
 		ExpectOutputEqualToFile = func(filename string) {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/harbor/2.2.3/test/unittest/fixtures/expected", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/harbor/2.2.3/test/unittest/fixtures/expected", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(output).To(BeEquivalentTo(string(data)))

--- a/addons/packages/harbor/2.3.3/test/unittest/harbor_test.go
+++ b/addons/packages/harbor/2.3.3/test/unittest/harbor_test.go
@@ -4,7 +4,7 @@
 package harbor_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -24,14 +24,14 @@ var _ = Describe("Harbor Ytt Templates", func() {
 		configDir = filepath.Join(repo.RootDir(), "addons/packages/harbor/2.3.3/bundle/config")
 
 		ValuesFromFile = func(filename string) string {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/harbor/2.3.3/test/unittest/fixtures/values", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/harbor/2.3.3/test/unittest/fixtures/values", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			return string(data)
 		}
 
 		ExpectOutputEqualToFile = func(filename string) {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/harbor/2.3.3/test/unittest/fixtures/expected", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/harbor/2.3.3/test/unittest/fixtures/expected", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(output).To(BeEquivalentTo(string(data)))

--- a/addons/packages/harbor/2.4.2/test/unittest/harbor_test.go
+++ b/addons/packages/harbor/2.4.2/test/unittest/harbor_test.go
@@ -4,7 +4,7 @@
 package harbor_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -24,14 +24,14 @@ var _ = Describe("Harbor Ytt Templates", func() {
 		configDir = filepath.Join(repo.RootDir(), "addons/packages/harbor/2.4.2/bundle/config")
 
 		ValuesFromFile = func(filename string) string {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/harbor/2.4.2/test/unittest/fixtures/values", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/harbor/2.4.2/test/unittest/fixtures/values", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			return string(data)
 		}
 
 		ExpectOutputEqualToFile = func(filename string) {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/harbor/2.4.2/test/unittest/fixtures/expected", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/harbor/2.4.2/test/unittest/fixtures/expected", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(output).To(BeEquivalentTo(string(data)))

--- a/addons/packages/local-path-storage/0.0.22/test/unittest/unit_test.go
+++ b/addons/packages/local-path-storage/0.0.22/test/unittest/unit_test.go
@@ -4,7 +4,7 @@
 package unit_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -24,14 +24,14 @@ var _ = Describe("local-path-storage Ytt Templates", func() {
 		configDir = filepath.Join(repo.RootDir(), "addons/packages/local-path-storage/0.0.22/bundle/config")
 
 		ValuesFromFile = func(filename string) string {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/local-path-storage/0.0.22/test/unittest/fixtures/values", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/local-path-storage/0.0.22/test/unittest/fixtures/values", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			return string(data)
 		}
 
 		ExpectOutputEqualToFile = func(filename string) {
-			data, err := ioutil.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/local-path-storage/0.0.22/test/unittest/fixtures/expected", filename))
+			data, err := os.ReadFile(filepath.Join(repo.RootDir(), "addons/packages/local-path-storage/0.0.22/test/unittest/fixtures/expected", filename))
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(output).To(MatchYAML(string(data)))

--- a/addons/packages/sriov-network-device-plugin/3.3.2/test/unit/sriov_dp_test.go
+++ b/addons/packages/sriov-network-device-plugin/3.3.2/test/unit/sriov_dp_test.go
@@ -5,7 +5,6 @@ package e2e_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -50,13 +49,13 @@ var _ = Describe("SR-IOV NETWORK DEVICE PLUGIN Template Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Check if same as expected results
-			expected, err = ioutil.ReadFile(filepath.Join(expectedResultDir, v))
+			expected, err = os.ReadFile(filepath.Join(expectedResultDir, v))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(strings.Compare(renderedOutput, string(expected))).Should(BeNumerically("==", 0))
 
 			// Check if resouces can be created successfully.
 			// Just a dry-run and kubeval
-			targetFile, err = ioutil.TempFile("", "sriov-dp-base-*.yaml")
+			targetFile, err = os.CreateTemp("", "sriov-dp-base-*.yaml")
 			Expect(err).NotTo(HaveOccurred())
 			defer func() {
 				targetFile.Close()

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/compatibility_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/compatibility_test.go
@@ -5,7 +5,6 @@
 package tkr
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -34,7 +33,7 @@ func TestGetLatestCompatibilityTagFails(t *testing.T) {
 
 //nolint:gocyclo
 func TestOrderOfCompatibleTkrs(t *testing.T) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "compatibility-test-")
+	tmpFile, err := os.CreateTemp("", "compatibility-test-")
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -112,7 +111,7 @@ func TestReadCompatibilityFails(t *testing.T) {
 	}
 
 	// Should fail when there is poorly formatted yamls
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "compatibility-test-")
+	tmpFile, err := os.CreateTemp("", "compatibility-test-")
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/image_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/image_test.go
@@ -4,7 +4,6 @@
 package tkr
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -136,7 +135,7 @@ spec:
 
 func helperSetupImageLocally() (string, error) {
 	// Simulates downloaded image directory
-	imageDir, err := ioutil.TempDir("", "tmp-img-bundle-")
+	imageDir, err := os.MkdirTemp("", "tmp-img-bundle-")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cli/cmd/plugin/unmanaged-cluster/tkr/tkr_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tkr/tkr_test.go
@@ -3,7 +3,6 @@
 package tkr
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -54,7 +53,7 @@ imageConfig:
   imageRepository: projects.registry.vmware.com/tkg`
 
 func helperMakeNewBom() (*Bom, error) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "tkr-test-")
+	tmpFile, err := os.CreateTemp("", "tkr-test-")
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +87,7 @@ func TestReadTKRBomFails(t *testing.T) {
 		t.Error("expected reading TKr file to fail if file doesn't exist")
 	}
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "tkr-test-")
+	tmpFile, err := os.CreateTemp("", "tkr-test-")
 	if err != nil {
 		t.Errorf(err.Error())
 	}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Go 1.16 deprecated ioutil [0]. This replaces its usage with the
recommended replacements so we don't get errors once this deprecation is
fully enforced or it is removed.

[0] https://go.dev/doc/go1.16#ioutil

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make test-plugins` and `make test-packages`.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

Our linting jobs will error on using deprecated functions, but (I'm assuming) to be less disruptive, the Go team documented ioutil is deprecated but did not mark it deprecated in the code. So for now it will be up to code review to prevent it from being added back in.

The good news/bad news with that is it will still work if added, but as soon as they decide it's been long enough and actually mark it as deprecated or decide to completely remove it, then we will be forced to clean up any instances of it in our code. This at least reduces what is already out there and hopefully makes it a little less likely that someone will copy and paste the deprecated code into their own packages.
