### PR TITLE
Warnings to user on install/uninstall for select situations

### DIFF
--- a/.github/workflows/check-all.yaml
+++ b/.github/workflows/check-all.yaml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         run: |
           cd `find ./release -type d -name "tce-linux-amd64-*" | xargs -n1 echo -n`
-          ALLOW_INSTALL_AS_ROOT=true ./install.sh
+          SILENT_MODE=true ALLOW_INSTALL_AS_ROOT=true ./install.sh
   teardown-runner:
     name: Stop self-hosted EC2 runner
     needs:

--- a/.github/workflows/check-pr-diagnostics-plugin.yaml
+++ b/.github/workflows/check-pr-diagnostics-plugin.yaml
@@ -73,7 +73,7 @@ jobs:
         shell: bash
         run: |
           cd `find ./release -type d -name "tce-linux-amd64-*" | xargs -n1 echo -n`
-          ALLOW_INSTALL_AS_ROOT=true ./install.sh
+          SILENT_MODE=true ALLOW_INSTALL_AS_ROOT=true ./install.sh
   test-diagnostics-plugin:
     name: Test Diagnostics Plugin
     needs:

--- a/.github/workflows/check-pr-docker-management.yaml
+++ b/.github/workflows/check-pr-docker-management.yaml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         run: |
           cd `find ./release -type d -name "tce-linux-amd64-*" | xargs -n1 echo -n`
-          ALLOW_INSTALL_AS_ROOT=true ./install.sh
+          SILENT_MODE=true ALLOW_INSTALL_AS_ROOT=true ./install.sh
   create-cluster:
     name: Create Cluster
     needs:

--- a/hack/release/install.bat
+++ b/hack/release/install.bat
@@ -5,6 +5,12 @@
 
 :: start copy tanzu cli
 SET TANZU_CLI_DIR=%ProgramFiles%\tanzu
+
+IF EXIST "%TANZU_CLI_DIR%\tanzu.exe" (
+	SET /P CONFIRM=A previous installation of TCE currently exists. Do you wish to overwrite it? [Y/N]: 
+	IF /I "%CONFIRM%" NEQ "Y" EXIT
+)
+
 mkdir "%TANZU_CLI_DIR%"
 copy /B /Y tanzu.exe "%TANZU_CLI_DIR%"
 

--- a/hack/release/install.sh
+++ b/hack/release/install.sh
@@ -30,6 +30,7 @@ echo " Installing Tanzu Community Edition"
 echo "===================================="
 echo
 
+SILENT_MODE="${SILENT_MODE:-""}"
 ALLOW_INSTALL_AS_ROOT="${ALLOW_INSTALL_AS_ROOT:-""}"
 if [[ "$EUID" -eq 0 && "${ALLOW_INSTALL_AS_ROOT}" != "true" ]]; then
   error_exit "Do not run this script as root"
@@ -61,6 +62,20 @@ echo_debug ""
 # check if the tanzu CLI already exists and remove it to avoid conflicts
 TANZU_BIN_PATH=$(command -v tanzu)
 if [[ -n "${TANZU_BIN_PATH}" ]]; then
+  # warn user
+  LOWER_SILENT_MODE="${SILENT_MODE,,}"
+  if [[ "${LOWER_SILENT_MODE}" != "yes" && "${LOWER_SILENT_MODE}" != "y" && 
+        "${LOWER_SILENT_MODE}" != "true" && "${LOWER_SILENT_MODE}" != "1" ]]; then
+    while true; do
+      read -r -p "A previous installation of TCE currently exists. Do you wish to overwrite it? " yn
+      case $yn in
+          [Yy]* ) break;;
+          [Nn]* ) echo "Quiting. Existing installation of TCE not replaced." && exit 1;;
+          * ) echo "Please answer yes or no.";;
+      esac
+    done
+  fi
+
   # best effort, so just ignore errors
   rm -f "${TANZU_BIN_PATH}" > /dev/null
 

--- a/test/download-or-build-tce.sh
+++ b/test/download-or-build-tce.sh
@@ -43,8 +43,8 @@ if [[ "${DAILY_BUILD}" != "" ]]; then
     tar -xvf tce-daily-build.tar.gz --one-top-level=tce-daily-build --strip-components 1
     pushd tce-daily-build || exit 1
 
-        ./uninstall.sh || { error "TCE CLEANUP (UNINSTALLATION) FAILED!"; exit 1; }
-        ALLOW_INSTALL_AS_ROOT=true ./install.sh || { error "TCE INSTALLATION FAILED!"; exit 1; }
+        SILENT_MODE=true ./uninstall.sh || { error "TCE CLEANUP (UNINSTALLATION) FAILED!"; exit 1; }
+        SILENT_MODE=true ALLOW_INSTALL_AS_ROOT=true ./install.sh || { error "TCE INSTALLATION FAILED!"; exit 1; }
 
     popd || exit 1
 
@@ -55,8 +55,8 @@ else
     TCE_FOLDER=$(find ./release -type d -name "tce-*" -print0 | tr -d '\0')
     pushd "${TCE_FOLDER}" || exit 1
 
-        ./uninstall.sh || { error "TCE CLEANUP (UNINSTALLATION) FAILED!"; exit 1; }
-        ALLOW_INSTALL_AS_ROOT=true ./install.sh || { error "TCE INSTALLATION FAILED!"; exit 1; }
+        SILENT_MODE=true ./uninstall.sh || { error "TCE CLEANUP (UNINSTALLATION) FAILED!"; exit 1; }
+        SILENT_MODE=true ALLOW_INSTALL_AS_ROOT=true ./install.sh || { error "TCE INSTALLATION FAILED!"; exit 1; }
 
     popd || exit 1
 fi


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This changes the `install` script so that if the `tanzu` cli exists in the `PATH` (aka is installed), the script will prompt the user to acknowledge that it will be overwritten.

For `uninstall`, if a management or unmanaged cluster is currently deployed, the script will prompt the user to acknowledge that it will delete access to those systems if you continue.

For both `install` and `uninstall` on Linux/Darwin, a silent mode will be available for automation.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Invoked `install` and `uninstall` on Linux and Windows to make sure we get the desired behavior.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA