### PR TITLE
Fixing `Unmanaged Cluster` e2e test failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,6 +515,6 @@ vsphere-management-and-workload-cluster-e2e-test:
 	BUILD_VERSION=$(BUILD_VERSION) test/vsphere/run-tce-vsphere-management-and-workload-cluster.sh
 
 unmanaged-cluster-e2e-test:
-	cd cli/cmd/plugin/unmanaged-cluster && make e2e-test BUILD_VERSION=$(BUILD_VERSION)
+	cd cli/cmd/plugin/unmanaged-cluster && BUILD_VERSION=$(BUILD_VERSION) make e2e-test
 
 ##### E2E TESTS


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
The reason for failure is that BUILD_VERSION was
passed after the make caommand which got override
with TCE_BUILD_VERSION [here](https://github.com/vmware-tanzu/community-edition/blob/main/Makefile#:~:text=make%20e2e%2Dtest-,BUILD_VERSION%3D%24(BUILD_VERSION),-%23%23%23%23%23%20E2E%20TESTS)

Signed-off-by: Aman Sharma <amansh@vmware.com>



## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4214 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
```
Run make unmanaged-cluster-e2e-test
```
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
