### PR TITLE
Update App-Toolkit displayName in metadata.yaml

### DIFF
--- a/addons/packages/app-toolkit/metadata.yaml
+++ b/addons/packages/app-toolkit/metadata.yaml
@@ -4,7 +4,7 @@ kind: PackageMetadata
 metadata:
   name: app-toolkit.community.tanzu.vmware.com
 spec:
-  displayName: "App-Toolkit package for TCE"
+  displayName: "App-Toolkit"
   shortDescription: "Kubernetes-native toolkit to support application lifecycle"
   longDescription: "Meta-Package to install a set of TCE packages that help users to create, iterate and manage their applications"
   providerName: "VMware"


### PR DESCRIPTION
## What this PR does / why we need it
In AppToolkit's metadata.yaml, we refer to "TCE" in the displayName field. This removes that reference

## What issue does this PR address
This resolves issue #4220 

