### PR TITLE
Update dependencies for GitHub Actions

### DIFF
--- a/.github/workflows/check-all.yaml
+++ b/.github/workflows/check-all.yaml
@@ -48,10 +48,13 @@ jobs:
           key: ${{ runner.os }}-go-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Run all checks
+      - name: Ensure dependencies installed
         shell: bash
         run: |
           make ensure-deps
+      - name: Run all checks
+        shell: bash
+        run: |
           PRINT_FAILURES=1 make check-full
       - name: Get dependencies
         shell: bash
@@ -60,7 +63,6 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          make ensure-deps
           make release ENVS=linux-amd64
       - name: Plugin unit tests
         shell: bash

--- a/.github/workflows/check-packages.yaml
+++ b/.github/workflows/check-packages.yaml
@@ -24,11 +24,10 @@ jobs:
           go-version: "1.17"
         id: go
 
-      - name: Install Carvel Tools
+      - name: Ensure dependencies installed
+        shell: bash
         run: |
-          wget -O- https://carvel.dev/install.sh > install.sh
-          sudo bash install.sh
-          ytt version
+          make ensure-deps
 
       - name: Run test-packages
         run: |

--- a/hack/ensure-deps/ensure-imgpkg.sh
+++ b/hack/ensure-deps/ensure-imgpkg.sh
@@ -12,7 +12,7 @@ set -o xtrace
 
 TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
 BUILD_OS=$(uname 2>/dev/null || echo Unknown)
-VERSION="0.12.0"
+VERSION="0.28.0"
 GOBIN=$(go env GOBIN)
 GOPATH=$(go env GOPATH)
 GOBINDIR="${GOBIN:-$GOPATH/bin}"

--- a/hack/ensure-deps/ensure-kbld.sh
+++ b/hack/ensure-deps/ensure-kbld.sh
@@ -12,7 +12,7 @@ set -o xtrace
 
 TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
 BUILD_OS=$(uname 2>/dev/null || echo Unknown)
-VERSION="0.30.0"
+VERSION="0.33.0"
 GOBIN=$(go env GOBIN)
 GOPATH=$(go env GOPATH)
 GOBINDIR="${GOBIN:-$GOPATH/bin}"

--- a/hack/ensure-deps/ensure-kind.sh
+++ b/hack/ensure-deps/ensure-kind.sh
@@ -13,7 +13,7 @@ set -o xtrace
 TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
 BUILD_OS=$(uname 2>/dev/null || echo Unknown)
 BUILD_ARCH=$(uname -m 2>/dev/null || echo Unknown)
-VERSION="0.11.1"
+VERSION="0.12.0"
 
 SUDO_CMD="sudo"
 if [[ "${TCE_CI_BUILD}" == "true" ]]; then

--- a/hack/ensure-deps/ensure-ytt.sh
+++ b/hack/ensure-deps/ensure-ytt.sh
@@ -12,7 +12,7 @@ set -o xtrace
 
 TCE_CI_BUILD="${TCE_CI_BUILD:-""}"
 BUILD_OS=$(uname 2>/dev/null || echo Unknown)
-VERSION="0.34.0"
+VERSION="0.40.1"
 GOBIN=$(go env GOBIN)
 GOPATH=$(go env GOPATH)
 GOBINDIR="${GOBIN:-$GOPATH/bin}"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We have some package unit tests failing due to an older version of ytt
being used. This updates our `ensure-deps` scripts to pull the latest
versions of ytt, imgpkg, kbld, and kind.

It also updates the check-all and check-packages actions to call `make
ensure-deps` once during the set up to make sure any expected tools are
present before running tests.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4215 