### PR TITLE
fix broken image links

### DIFF
--- a/docs/site/content/docs/designs/package-management.md
+++ b/docs/site/content/docs/designs/package-management.md
@@ -35,7 +35,7 @@ APIs are as follows.
 manifests. Inclusion of a `PackageRepository` in a cluster inherently makes the
 `Package`s available. This can be visually represented as follows.
 
-![Package and Package Repository](/docs/img/tanzu-carvel-new-apis.png)
+![Package and Package Repository](../img/tanzu-carvel-new-apis.png)
 
 With the above in place, a user can see all the packages using `kubectl`.
 
@@ -55,7 +55,7 @@ referenced in the corresponding `Package` manifest. It then downloads those
 assets, renders them (e.g. `ytt`) and applies them to the cluster. This can be
 visually represented as follows.
 
-![InstalledPackage Flow](/docs/img/tanzu-carvel-installed-package.png)
+![InstalledPackage Flow](../img/tanzu-carvel-installed-package.png)
 
 ## Client Side
 
@@ -92,7 +92,7 @@ already-existent objects. Namely the following from each `Package` instance:
 
 This is visually represented as follows.
 
-![tanzu package list](/docs/img/tanzu-package-list.png)
+![tanzu package list](../img/tanzu-package-list.png)
 
 ### Package Configuration
 
@@ -284,7 +284,7 @@ In running this command, the `tanzu` client will have done the following.
 
 This is visually represented as follows.
 
-![tanzu package install](/docs/img/tanzu-package-install.png)
+![tanzu package install](../img/tanzu-package-install.png)
 
 #### Including Package Configuration
 
@@ -366,7 +366,7 @@ installed package repo
 
 The flow would look as follows.
 
-![tanzu package repo install](/docs/img/tanzu-package-repo-install.png)
+![tanzu package repo install](../img/tanzu-package-repo-install.png)
 
 ### Package Repository Deletion
 
@@ -382,7 +382,7 @@ deleted package repo
 
 The flow would look as follows.
 
-![tanzu package repo delete](/docs/img/tanzu-package-repo-delete.png)
+![tanzu package repo delete](../img/tanzu-package-repo-delete.png)
 
 ## Designed Pending Details
 

--- a/docs/site/content/docs/designs/package-process.md
+++ b/docs/site/content/docs/designs/package-process.md
@@ -38,7 +38,7 @@ For details on how these packages are discovered, deployed, and managed, see
 The following flow describes how we package user-managed packages. These steps
 are described in detail in the subsequent sections.
 
-![tanzu packaging flow](/docs/img/tanzu-packaging-flow.png)
+![tanzu packaging flow](../img/tanzu-packaging-flow.png)
 
 ### 1. Create Directory Structure
 
@@ -266,7 +266,7 @@ runtime:
 With the above in place, you can validate that overlays and templating are
 working as expected. The conceptual flow is as follows.
 
-![templating flow](/docs/img/tanzu-templating-flow.png)
+![templating flow](../img/tanzu-templating-flow.png)
 
 To run the above, you can use `ytt` as follows. If successful, the transformed manifest will be displayed,
 otherwise, an error message is displayed.
@@ -288,7 +288,7 @@ kbld is used to create a lock file, which we name `images.yml`. This file contai
 **are not mutated**. Instead, the SHA will be swapped out for the tag upon
 deployment. The relationship is as follows.
 
-![tanzu packaging flow](/docs/img/tanzu-kbld-flow.png)
+![tanzu packaging flow](../img/tanzu-kbld-flow.png)
 
 To find all container image references, create an `ImagesLock`, and ensure the
 digest's SHA is referenced, you can run `kbld` as follows.
@@ -411,7 +411,7 @@ instead the `PackageRepsoitory` bundle, containing many `Package`s is. Once
 the `PackageRepository` is in place, `kapp-controller` will make `Package` CRs
 in the cluster. This relationship can be seen as follows.
 
-![Package and Package Repository](/docs/img/tanzu-carvel-new-apis.png)
+![Package and Package Repository](../img/tanzu-carvel-new-apis.png)
 
 An example `Package` for `gatekeeper` would read as follows.
 

--- a/docs/site/content/docs/package-management.md
+++ b/docs/site/content/docs/package-management.md
@@ -10,7 +10,7 @@ package` to interact with packages.
 
 A package repository holds references to package(s). By installing a package repository into a cluster, packages become available for installation. A look at this relationship is as follows.
 
-![tanzu packaging flow](/docs/img/pkg-mgmt-repo.png)
+![tanzu packaging flow](../img/pkg-mgmt-repo.png)
 
  The PackageRepository is installed in the `default` namespace by default.
 
@@ -109,7 +109,7 @@ provides instructions for how to run the software in a cluster. Source code for
 Tanzu Community Edition's configuration bundles can be found in
 [GitHub](https://github.com/vmware-tanzu/community-edition/tree/main/addons/packages).
 
-![tanzu package install](/docs/img/pkg-mgmt-pkg.png)
+![tanzu package install](../img/pkg-mgmt-pkg.png)
 
 When running `tanzu package` commands, there are two types of resources:
 
@@ -203,7 +203,7 @@ At the point of install, there are multiple objects that may exist in different
 Kubernetes namespaces. The breakdown of how objects end up in different namespaces is as
 follows.
 
-![tanzu package namespace](/docs/img/pkg-mgmt-ns.png)
+![tanzu package namespace](../img/pkg-mgmt-ns.png)
 
 The `Package`s, or software available for install, are always available in the
 **same** namespace as the `PackageRepository`. When you run a `tanzu package
@@ -411,7 +411,7 @@ that will need to change need to be provided.
 This section covers common ways to troubleshoot packages. Before reading, review
 the following diagram that shows what is created when a package is installed.
 
-![tanzu packaging troubleshooting](/docs/img/pkg-mgt-trbl.png)
+![tanzu packaging troubleshooting](../img/pkg-mgt-trbl.png)
 
 ### Installation Troubleshooting
 

--- a/docs/site/content/docs/vSphere-ldap-config.md
+++ b/docs/site/content/docs/vSphere-ldap-config.md
@@ -67,13 +67,13 @@ This is the Root CA, which was retrieved via the Active Directory Certificate Se
 
 With all of these settings in place, the Identity Management Settings for LDAPS integration should look similar to the following:
 
-![LDAPS Identity Management Configuration](/docs/img/ldaps-im.png?raw=true)
+![LDAPS Identity Management Configuration](../img/ldaps-im.png?raw=true)
 
 ## Verify LDAP Configuration
 
 If everything has been configured correctly, and your LDAP service is working, then the `Verify LDAP Configuration` utility will run a check to ensure that it can correctly connect to your Active Directory/LDAPS service, do a BIND operation with the BIND user and credentials, and verify that it can search the user and group directories. If successful, it should report something simialr to the following. Note that an LDAP user has been added to the *Test User Name* field:
 
-![LDAPS Configuration Verification](/docs/img/ldap-verify.png?raw=true)
+![LDAPS Configuration Verification](../img/ldap-verify.png?raw=true)
 
 If there are issues, then determine which part of the verification is failing. If it is an X509 error during the Connect phase, check that the certificate is correct, and in base64 format. If it is a BIND issue, check the BIND DN and Password. If it is in the User Search or Group Search, check the Distinguished Names, Filters and Username/Name Attributues accordingly.
 
@@ -260,7 +260,7 @@ Switched to context "tanzu-cli-mgmt@mgmt".
 
 As soon as an attempt is made to query the cluster in the "non-admin" context, for example `kubectl get nodes`, the Dex portal launches in a browser window. Add the user credentials from the `ClusterRoleBinding` which was created in first step of this section, such as *chogan@rainpole.com*.
 
-![DEX LDAP Portal](/docs/img/dex-portal.png?raw=true)
+![DEX LDAP Portal](../img/dex-portal.png?raw=true)
 
 The `kubectl` command run previously to query the cluster should now complete once the authentication step with Dex has completed successfully.
 

--- a/docs/site/content/docs/vsphere-monitoring-stack.md
+++ b/docs/site/content/docs/vsphere-monitoring-stack.md
@@ -305,7 +305,7 @@ Handling connection for 9001
 
 Note that I have deliberately obfuscated the first two octets of the IP address allocated to Envoy above. Now if you point a browser to the localhost:9001, the following Envoy landing page should be displayed:
 
-![Envoy Listing](/docs/img/envoy-listings.png?raw=true)
+![Envoy Listing](../img/envoy-listings.png?raw=true)
 
 Everything is now in place to deploy Prometheus.
 
@@ -487,15 +487,15 @@ prometheus prometheus-httpproxy  prometheus.rainpole.com prometheus-tls valid  V
 
 To verify that Prometheus is working correctly, point to the Prometheus FQDN (e.g. http:// prometheus.rainpole.com). If everything has worked correctly, you should be able to see a Prometheus dashboard:
 
-![Envoy Dashboard Landing Page](/docs/img/envoy-db1.png?raw=true)
+![Envoy Dashboard Landing Page](../img/envoy-db1.png?raw=true)
 
 To do a very simple test, add a simple query, e.g. `prometheus_http_requests_total` and click Execute:
 
-![Envoy Simple Query](/docs/img/envoy-db2.png?raw=true)
+![Envoy Simple Query](../img/envoy-db2.png?raw=true)
 
 To check integration between Prometheus and Envoy, another query can be executed. When the Envoy landing page was displayed earlier, there was a section called `prometheus/stats`. These can now be queried as well, since these are the metrics that Envoy is sending to Prometheus. If we return to the Envoy landing page in the browser, and click on the prometheus/stats link and examine the metrics. one of these metrics, such as the `envoy_cluster_default_total_match`, and use it as a query in Prometheus (selecting Graph instead of Table this time):
 
-![Envoy Prometheus Metric Query](/docs/img/envoy-db3.png?raw=true)
+![Envoy Prometheus Metric Query](../img/envoy-db3.png?raw=true)
 
 If you see something similar to this, then it would appear that Prometheus is working successfully. Now let's complete the monitoring stack by provisioning Grafana, and connecting it to our Prometheus data source.
 
@@ -627,20 +627,20 @@ As mentioned, Grafana uses a Load Balancer service type by default, so it has be
 
 After adding your virtual host FQDN to your DNS, you can now connect to the Grafana dashboard using the FDQN. You connect directly to the Load Balancer IP address allocated to the Service. The login credentials are `admin/admin` initially, but you will need to change the password on first login. This is the landing page:
 
-![Grafana Landing Page](/docs/img/grafana-landing-page.png?raw=true)
+![Grafana Landing Page](../img/grafana-landing-page.png?raw=true)
 
 There is no need to add a datasource or create a dashboard - these have already been done for you.
 
 To examine the data source, click on the icon representing data sources on the left hand side (which looks like a cog). Here you can see the Prometheus data source that we placed in the data values manifest file when we deployed Grafana is already in place:
 
-![Grafana Data Source Prometheus](/docs/img/grafana-data-source.png?raw=true)
+![Grafana Data Source Prometheus](../img/grafana-data-source.png?raw=true)
 
 Now click on the dashboards icon on the left hand side (it looks like a square of 4 smaller squares), and select `Manage` from the drop-down list. This will show the existing dashboards. There are 2 existing dashboards that have been provided; one is Kubernetes monitoring and the other is TKG monitoring. These dashboards are based on the Kubernetes Grafana dashboards found on [GitHub](https://github.com/kubernetes-monitoring/kubernetes-mixin).
 
-![Grafana Dashboards Manager](/docs/img/grafana-manage-dashboards.png?raw=true)
+![Grafana Dashboards Manager](../img/grafana-manage-dashboards.png?raw=true)
 
 Finally, select the TKG dashboard which is being sent metrics via the Prometheus data source. This provides an overview of the TKG cluster:
 
-![TKG Dashboard](/docs/img/grafana-tkg-dashboard.png?raw=true)
+![TKG Dashboard](../img/grafana-tkg-dashboard.png?raw=true)
 
 The full monitoring stack of Contour/Envoy Ingress, with secure communication via Cert-Manager, alongside the Prometheus data scraper and Grafana visualization are now deployed through Tanzu Community Edition community packages. Happy monitoring/analyzing.


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
Fixes image links in docs (based on same method used to fix links in  #4177 - that is working in [main/edge ](https://tanzucommunityedition.io/docs/edge/getting-started/)


## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/4084, https://github.com/vmware-tanzu/community-edition/issues/4126

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
