### PR TITLE
addons/packages/pinniped/0.12.1: fix template error when idp_type:none results in no render

### DIFF
--- a/addons/packages/pinniped/0.12.1/package.yaml
+++ b/addons/packages/pinniped/0.12.1/package.yaml
@@ -23,4 +23,5 @@ spec:
               - kbld-config.yaml
               - .imgpkg/images.yml
       deploy:
-        - kapp: {}
+        - kapp:
+            rawOptions: ["--dangerous-allow-empty-list-of-resources=true"]


### PR DESCRIPTION
Signed-off-by: Benjamin A. Petersen <ben@benjaminapetersen.me>

## What this PR does / why we need it

There is currently a template rendering error which is a safety mechanism of `kapp`:

```
kapp: Error: Trying to apply empty set of resources will result in deletion of resources on cluster. Refusing to continue unless --dangerous-allow-empty-list-of-resources is specified.
```
however, when `identity_management_type: none` we explicitly want an empty render set. 

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
