### PR TITLE
🍒 [release-0.12] cherry-pick: Add App Toolkit 0.2.0 package (#4124)

### DIFF
--- a/addons/packages/app-toolkit/0.2.0/README.md
+++ b/addons/packages/app-toolkit/0.2.0/README.md
@@ -1,0 +1,245 @@
+# (Experimental) Application Toolkit
+
+Application Toolkit package is a package that installs a set of packages for creating, iterating and managing applications.
+
+For a simple tutorial on how to use Application Toolkit, please refer to the "Getting Started with Creating a Tanzu Workload" guide.
+
+## Supported Providers
+
+Application Toolkit is currently tested with Unmanaged Clusters on any of the below providers.
+
+| Unmanaged Clusters| AWS | Azure | vSphere | Docker |
+|-------------------|-----|-------|---------|--------|
+| ✅                | ✅   | ✅     | ✅       | ✅      |
+
+## Components
+
+### App Toolkit 0.2.0
+
+| Name                                                                                                                     | Description                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| [Cartographer](https://tanzucommunityedition.io/docs/v0.11/package-readme-cartographer-0.3.0/)                           | Cartographer allows you to create secure and reusable supply chains that define all of your application CI and CD in one place, in cluster. | 0.3.0   |
+| [Cartographer-Catalog](https://tanzucommunityedition.io/docs/v0.11/package-readme-cartographer-catalog-0.3.0/)           | Reusable Cartographer Supply Chains and templates for driving workloads from source code to running Knative service in a cluster.           | 0.3.0   |
+| [cert-manager](https://tanzucommunityedition.io/docs/v0.11/package-readme-cert-manager-1.6.1/)                           | Cert Manager provides certificate management functionality.                                                                                 | 1.6.1   |
+| [Contour](https://tanzucommunityedition.io/docs/v0.11/package-readme-contour-1.20.1/)                                    | Contour provides Ingress capabilities for Kubernetes clusters                                                                               | 1.20.1  |
+| [Flux CD Source Controller](https://tanzucommunityedition.io/docs/v0.11/package-readme-fluxcd-source-controller-0.21.2/) | FluxCD Source specialises in artifact acquisition from external sources such as Git, Helm repositories and S3 buckets.                      | 0.21.2  |
+| [Knative Serving](https://tanzucommunityedition.io/docs/v0.11/package-readme-knative-serving-1.0.0/)                     | Knative Serving provides the ability for users to create serverless workloads from OCI images                                                                                                 | 1.0.0   |
+| [kpack](https://tanzucommunityedition.io/docs/v0.11/package-readme-kpack-0.5.2/)                                         | kpack provides a platform for building OCI images from source code.
+| [kpack-dependencies](https://tanzucommunityedition.io/docs/v0.11/package-readme-kpack-dependencies-0.0.9/)               | kpack-dependencies provides a curated set of buildpacks and stacks required by kpack.                                                       | 0.0.9   |
+
+## Configuration
+
+| Config | Values | Description |
+|--------|--------|-------------|
+| cartographer-catalog | | [See cartographer catalog documentation](https://tanzucommunityedition.io/docs/package-readme-cartographer-catalog-0.3.0/#configuration)|
+| cert_manager | | [See cert-manager documentation](https://tanzucommunityedition.io/docs/package-readme-cert-manager-1.6.1/#configuration)|
+| contour | | [See contour documentation](https://tanzucommunityedition.io/docs/package-readme-contour-1.20.1/#configuration-reference) |
+| excluded_packages  | Array of package names | Allows installers to skip deploying named packages |
+| knative_serving | | [See knative documentation](https://tanzucommunityedition.io/docs/package-readme-knative-serving-1.0.0/#configuration) |
+| kpack | | [See kpack documentation](https://tanzucommunityedition.io/docs/package-readme-kpack-0.5.2/#kpack-configuration) |
+| kpack-dependencies | | [See kpack dependencies documentation](https://tanzucommunityedition.io/docs/package-readme-kpack-dependencies-0.0.9/#kpack-dependencies-configuration) |
+| developer-namespace | (default value is `default`) | Configures the namespace with the required secret, service binding and role binding to create Tanzu workloads |
+
+## Installing the App Toolkit Package
+
+### Before you begin
+
+* Ensure the Tanzu CLI is installed, see [Getting Started](https://tanzucommunityedition.io/docs/v0.12/getting-started/#install-tanzu-cli).
+* Ensure you have created an unmanaged cluster.
+* An OCI Compliant Container registry credentials to be used in kpack, kpack-dependencies, cartographer-catalog package configuration and for secret creation.
+* A Load Balancer or Ingress configuration to be used in conjunction with Contour and Knative-Serving
+
+### Step 1: Create the registry secret
+
+ 1. Install `secretgen-controller` based on the version in the secretgen-controller package docs. For example, if the version is 0.8.0
+
+    ```shell
+    tanzu package install secretgen-controller --package-name secretgen-controller.community.tanzu.vmware.com --version 0.8.0
+    ```
+
+ 1. Create a registry secret `registry-credentials` using the below command
+
+    ```shell
+    tanzu secret registry add registry-credentials --server REGISTRY_URL --username REGISTRY_USER --password REGISTRY_PASS --export-to-all-namespaces`
+    ```
+
+      * `REGISTRY_URL` - URL for the registry you plan to upload your builds to.
+        * For Dockerhub, it would be <https://index.docker.io/v1/>
+        * For GCR, it would be <gcr.io>
+        * For Harbor, it would be <myharbor.example.com>
+      * `REGISTRY_USER`: the username for the account with write access to the registry specified with `REGISTRY_URL`
+      * `REGISTRY_PASS`: the password for the same account. If you have special characters in your password, you'll want to double check that the credential is populated correctly. You can also use the `--pasword-env-var`, `--password-file`, or `--password-stdin` options to provide your password if you prefer
+
+### Step 2: Prepare an app-toolkit-values.yaml
+
+As mentioned in the pre-requisite, ensure you provide the image registry configuration and ingress configuration while installing App-Toolkit package.
+
+```yaml
+contour:
+
+knative_serving:
+
+kpack:
+  kp_default_repository:
+  kp_default_repository_username:
+  kp_default_repository_password:
+
+cartographer-catalog:
+    registry:
+        server:
+        repository:
+
+# The namespace field below will configure the namespace for creating workloads.
+developer_namespace:  #default value is default
+
+# The excluded_packages field consists of packages you do not want to install.
+# Below is an example of how you can provide the packages you want to exclude.
+
+excluded_packages:
+   # - contour.community.tanzu.vmware.com
+   # - cert-manager.community.tanzu.vmwware.com
+```
+
+#### Example App Toolkit Configuration
+
+In the following example, we will deploy our traffic ingress mechanism, Contour, with a ClusterIP configuration, and Knative to serve as localhost. You will add these configurations to a `app-toolkit-values.yaml` file, and add a Docker registry for kpack to store buildpacks on.
+
+```yaml
+contour:
+  envoy:
+    service:
+      type: ClusterIP
+    hostPorts:
+      enable: true
+
+knative_serving:
+  domain:
+    type: real
+    name: 127-0-0-1.sslip.io
+
+kpack:
+  kp_default_repository: docker.io/my-dockerhub-username/my-repo
+  kp_default_repository_username: my-dockerhub-username
+  kp_default_repository_password: my-dockerhub-password
+
+cartographer-catalog:
+  registry:
+      server: index.docker.io
+      repository: my-dockerhub-username
+```
+
+### Step 3: Install App-toolkit Package
+
+1. Install the 0.2.0 version of Application Toolkit.
+
+```shell
+tanzu package install app-toolkit --package-name app-toolkit.community.tanzu.vmware.com --version 0.2.0 -f app-toolkit-values.yaml -n tanzu-package-repo-global
+```
+
+1. You can validate this by checking that all the packages have successfully reconciled using the command:
+
+```shell
+tanzu package installed list -A
+```
+
+You should see output consisting of the below packages among other packages you may have installed.
+
+```shell
+NAME                      PACKAGE-NAME                                         PACKAGE-VERSION  STATUS               NAMESPACE
+  secretgen-controller      secretgen-controller.community.tanzu.vmware.com      0.8.0            Reconcile succeeded  default
+  app-toolkit               app-toolkit.community.tanzu.vmware.com               0.2.0            Reconcile succeeded  tanzu-package-repo-global
+  cartographer              cartographer.community.tanzu.vmware.com              0.3.0            Reconcile succeeded  tanzu-package-repo-global
+  cartographer-catalog      cartographer-catalog.community.tanzu.vmware.com      0.3.0            Reconcile succeeded  tanzu-package-repo-global
+  cert-manager              cert-manager.community.tanzu.vmware.com              1.6.1            Reconcile succeeded  tanzu-package-repo-global
+  contour                   contour.community.tanzu.vmware.com                   1.20.1           Reconcile succeeded  tanzu-package-repo-global
+  fluxcd-source-controller  fluxcd-source-controller.community.tanzu.vmware.com  0.21.2           Reconcile succeeded  tanzu-package-repo-global
+  knative-serving           knative-serving.community.tanzu.vmware.com           1.0.0            Reconcile succeeded  tanzu-package-repo-global
+  kpack                     kpack.community.tanzu.vmware.com                     0.5.2            Reconcile succeeded  tanzu-package-repo-global
+  kpack-dependencies        kpack-dependencies.community.tanzu.vmware.com        0.0.9            Reconcile succeeded  tanzu-package-repo-global
+  cni                       calico.community.tanzu.vmware.com                    3.22.1           Reconcile succeeded  tkg-system
+```
+
+## Usage
+
+1. Ensure you have followed the steps for Installing the App Toolkit Package.
+
+2. In case you want to create applications in a namespace different than the one you configured during App Toolkit installation, please complete the "Set-up the Developer Namespace" before proceeding to create the Tanzu workload.
+
+3. Please create a workload.yaml with the minimal information as provided below:
+
+4. Create a Tanzu workload using the `tanzu apps workload create` command. You can supply your own git repo, or use the sample git repo below.
+
+    ```shell
+    tanzu apps workload create hello-world \
+                --git-repo GIT-URL-TO-PROJECT-REPO \
+                --git-branch main \
+                --type web \
+                --label app.kubernetes.io/part-of=hello-world \
+                --yes \
+                -n YOUR-DEVELOPER-NAMESPACE
+    ```
+
+    where GIT-URL-TO-PROJECT-REPO is your git repositoryand YOUR-DEVELOPER-NAMESPACE is the namespace configured while installing the package.
+
+5. Watch the logs of the workload to see it build and deploy. You'll know it's complete when you see `Build successful`
+
+    ```shell
+    tanzu apps workload tail hello-world -n YOUR-DEVELOPER-NAMESPACE
+    ```
+
+6. After the workload is built and running, you can get the URL of the workload by running the command below.
+
+    ```shell
+    tanzu apps workload get hello-world --namespace YOUR-DEVELOPER-NAMESPACE
+    ```
+
+### Set-up the Developer Namespace
+
+In case you want to create workloads in additional namespaces, follow the below procedure to set-up each developer namespace.
+
+1. Ensure you have access to kubectl.
+
+2. Create the additional namespace using the below command
+
+    ```shell
+    kubectl create namespace YOUR-DEVELOPER-NAMESPACE
+    ```
+
+3. Create the secret, a service account and a role binding in the developer namespace using the below kubectl command
+
+    ```shell
+    cat <<EOF | kubectl -n YOUR-DEVELOPER-NAMESPACE create -f -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: registry-credentials
+      annotations:
+        secretgen.carvel.dev/image-pull-secret: ""
+    type: kubernetes.io/dockerconfigjson
+    data:
+      .dockerconfigjson: e30K
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: workload-user-sa
+    secrets:
+    - name: registry-credentials
+    imagePullSecrets:
+    - name: registry-credentials
+    ```
+
+## Troubleshooting
+
+### Insufficient CPU or Memory Error
+
+* Make sure the environment you're running your cluster in has enough resources allocated. You can find TCE's unmanaged-cluster specifications [here](https://tanzucommunityedition.io/docs/v0.11/support-matrix/)
+
+### Sample App deploy fails with MissingValueAtPath error
+
+* Double check the formatting for the registry credentials provided in [Usage Example](#usage-example). Different registry types expect different formats for each of the fields.
+
+### Error when you curl the `tanzu-simple-web-app` url
+
+* The service can sometimes take a minute or two to setup, even after the build shows a success with `tanzu app workload tail tanzu-simple-web-app`
+* You can also double check that the knative service for the tanzu-simple-web-app was created and is running by checking `kubectl get ksvc`

--- a/addons/packages/app-toolkit/0.2.0/bundle/.imgpkg/bundle.yml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/.imgpkg/bundle.yml
@@ -1,0 +1,9 @@
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: Bundle
+metadata:
+  name: app-toolkit
+authors:
+- name: Ryan Kilroy
+  email: rycollins@vmware.com
+websites:
+- url: https://github.com/vmware-tanzu/community-edition/

--- a/addons/packages/app-toolkit/0.2.0/bundle/.imgpkg/images.yml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/.imgpkg/images.yml
@@ -1,0 +1,3 @@
+---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: ImagesLock

--- a/addons/packages/app-toolkit/0.2.0/bundle/config/_exclusions.star
+++ b/addons/packages/app-toolkit/0.2.0/bundle/config/_exclusions.star
@@ -1,0 +1,10 @@
+load("@ytt:data", "data")
+load("@ytt:struct", "struct")
+
+def _is_pkg_enabled(name):
+    return (name not in data.values.excluded_packages)
+end
+
+exclusions = struct.make(
+    is_pkg_enabled=_is_pkg_enabled,
+)

--- a/addons/packages/app-toolkit/0.2.0/bundle/config/cartographer-catalog.yaml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/config/cartographer-catalog.yaml
@@ -1,0 +1,33 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("_exclusions.star", "exclusions")
+
+#@ if exclusions.is_pkg_enabled("cartographer-catalog.community.tanzu.vmware.com"):
+
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: cartographer-catalog
+  namespace: tanzu-package-repo-global
+  annotations:
+    kapp.k14s.io/change-rule.cartographer: upsert after upserting cartographer
+spec:
+  serviceAccountName: app-toolkit-install-sa
+  packageRef:
+    refName: cartographer-catalog.community.tanzu.vmware.com
+    versionSelection:
+      constraints: 0.3.0
+  values:
+    - secretRef:
+        name: cartographer-catalog-values
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cartographer-catalog-values
+  namespace: tanzu-package-repo-global
+stringData:
+  values.yaml: #@ yaml.encode(data.values.cartographer_catalog)
+
+#@ end

--- a/addons/packages/app-toolkit/0.2.0/bundle/config/cartographer.yaml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/config/cartographer.yaml
@@ -1,0 +1,21 @@
+#@ load("_exclusions.star", "exclusions")
+
+#@ if exclusions.is_pkg_enabled("cartographer.community.tanzu.vmware.com"):
+
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: cartographer
+  namespace: tanzu-package-repo-global
+  annotations:
+    kapp.k14s.io/change-group: cartographer
+    kapp.k14s.io/change-rule.cert-manager: upsert after upserting cert-manager
+spec:
+  serviceAccountName: app-toolkit-install-sa
+  packageRef:
+    refName: cartographer.community.tanzu.vmware.com
+    versionSelection:
+      constraints: 0.3.0
+
+#@ end

--- a/addons/packages/app-toolkit/0.2.0/bundle/config/cert-manager.yaml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/config/cert-manager.yaml
@@ -1,0 +1,22 @@
+#@ load("_exclusions.star", "exclusions")
+
+#@ if exclusions.is_pkg_enabled("cert-manager.community.tanzu.vmware.com"):
+
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: cert-manager
+  namespace: tanzu-package-repo-global
+  annotations:
+    kapp.k14s.io/change-group: cert-manager
+    kapp.k14s.io/change-rule.serviceaccount: delete before deleting serviceaccount
+spec:
+  serviceAccountName: app-toolkit-install-sa
+  packageRef:
+    refName: cert-manager.community.tanzu.vmware.com
+    versionSelection:
+      constraints: 1.6.1
+      prereleases: {}
+
+#@ end

--- a/addons/packages/app-toolkit/0.2.0/bundle/config/contour.yaml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/config/contour.yaml
@@ -1,0 +1,34 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("_exclusions.star", "exclusions")
+
+#@ if exclusions.is_pkg_enabled("contour.community.tanzu.vmware.com"):
+
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: contour
+  namespace: tanzu-package-repo-global
+  annotations:
+    kapp.k14s.io/change-group: contour
+    kapp.k14s.io/change-rule.serviceaccount: delete before deleting serviceaccount
+spec:
+  serviceAccountName: app-toolkit-install-sa
+  packageRef:
+    refName: contour.community.tanzu.vmware.com
+    versionSelection:
+      constraints: 1.20.1
+  values:
+    - secretRef:
+        name: contour-values
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: contour-values
+  namespace: tanzu-package-repo-global
+stringData:
+  values.yaml: #@ yaml.encode(data.values.contour)
+
+#@ end

--- a/addons/packages/app-toolkit/0.2.0/bundle/config/developer-namespace.yaml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/config/developer-namespace.yaml
@@ -1,0 +1,48 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+
+#@ if/end data.values.developer_namespace != "default":
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: #@ data.values.developer_namespace
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-credentials
+  namespace: #@ data.values.developer_namespace
+  annotations:
+    secretgen.carvel.dev/image-pull-secret: ""
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: e30K
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: #@ data.values.developer_namespace
+  annotations:
+    kapp.k14s.io/create-strategy: fallback-on-update
+secrets:
+- name: registry-credentials
+imagePullSecrets:
+- name: registry-credentials
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ootb-supply-chain-source-to-url-workload
+  namespace: #@ data.values.developer_namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ootb-supply-chain-source-to-url-workload
+subjects:
+  - kind: ServiceAccount
+    name: default

--- a/addons/packages/app-toolkit/0.2.0/bundle/config/fluxcd-source-controller.yaml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/config/fluxcd-source-controller.yaml
@@ -1,0 +1,20 @@
+#@ load("_exclusions.star", "exclusions")
+
+#@ if exclusions.is_pkg_enabled("fluxcd.source.controller.tanzu.vmware.com"):
+
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: fluxcd-source-controller
+  namespace: tanzu-package-repo-global
+  annotations:
+    kapp.k14s.io/change-rule.serviceaccount: delete before deleting serviceaccount
+spec:
+  serviceAccountName: app-toolkit-install-sa
+  packageRef:
+    refName: fluxcd-source-controller.community.tanzu.vmware.com
+    versionSelection:
+      constraints: 0.21.2
+
+#@ end

--- a/addons/packages/app-toolkit/0.2.0/bundle/config/knative-serving.yaml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/config/knative-serving.yaml
@@ -1,0 +1,33 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("_exclusions.star", "exclusions")
+
+#@ if exclusions.is_pkg_enabled("knative-serving.community.tanzu.vmware.com"):
+
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: knative-serving
+  namespace: tanzu-package-repo-global
+  annotations:
+    kapp.k14s.io/change-rule.serviceaccount: delete before deleting serviceaccount
+spec:
+  serviceAccountName: app-toolkit-install-sa
+  packageRef:
+    refName: knative-serving.community.tanzu.vmware.com
+    versionSelection:
+      constraints: 1.0.0
+  values:
+    - secretRef:
+        name: knative-serving-values
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: knative-serving-values
+  namespace: tanzu-package-repo-global
+stringData:
+  values.yaml: #@ yaml.encode(data.values.knative_serving)
+
+#@ end

--- a/addons/packages/app-toolkit/0.2.0/bundle/config/kpack-dependencies.yaml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/config/kpack-dependencies.yaml
@@ -1,0 +1,35 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("_exclusions.star", "exclusions")
+
+#@ if exclusions.is_pkg_enabled("kpack-dependencies.community.tanzu.vmware.com"):
+
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: kpack-dependencies
+  namespace: tanzu-package-repo-global
+  annotations:
+    kapp.k14s.io/change-rule.service-account: delete before deleting serviceaccount
+    kapp.k14s.io/change-rule.kpack-dependencies: upsert after upserting kpack
+spec:
+  serviceAccountName: app-toolkit-install-sa
+  packageRef:
+    refName: kpack-dependencies.community.tanzu.vmware.com
+    versionSelection:
+      constraints: 0.0.9
+      prereleases: {}
+  values:
+  - secretRef:
+      name: kpack-dependencies-values
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kpack-dependencies-values
+  namespace: tanzu-package-repo-global
+stringData:
+  values.yaml: #@ "kp_default_repository: " + data.values.kpack.kp_default_repository
+
+#@ end

--- a/addons/packages/app-toolkit/0.2.0/bundle/config/kpack.yaml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/config/kpack.yaml
@@ -1,0 +1,35 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("_exclusions.star", "exclusions")
+
+#@ if exclusions.is_pkg_enabled("kpack.community.tanzu.vmware.com"):
+
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: kpack
+  namespace: tanzu-package-repo-global
+  annotations:
+    kapp.k14s.io/change-group: kpack
+    kapp.k14s.io/change-rule.service-account: delete before deleting serviceaccount
+spec:
+  serviceAccountName: app-toolkit-install-sa
+  packageRef:
+    refName: kpack.community.tanzu.vmware.com
+    versionSelection:
+      constraints: 0.5.2
+      prereleases: {}
+  values:
+  - secretRef:
+      name: kpack-values
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kpack-values
+  namespace: tanzu-package-repo-global
+stringData:
+  values.yaml: #@ yaml.encode(data.values.kpack)
+
+#@ end

--- a/addons/packages/app-toolkit/0.2.0/bundle/config/rbac/cluster-admin.yaml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/config/rbac/cluster-admin.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: app-toolkit-install-cluster-admin-role
+  annotations:
+    kapp.k14s.io/change-group: serviceaccount
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: app-toolkit-install-cluster-admin-role-binding
+  annotations:
+    kapp.k14s.io/change-group: serviceaccount
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: app-toolkit-install-cluster-admin-role
+subjects:
+  - kind: ServiceAccount
+    name: app-toolkit-install-sa
+    namespace: tanzu-package-repo-global
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app-toolkit-install-sa
+  namespace: tanzu-package-repo-global
+  annotations:
+    kapp.k14s.io/change-group: serviceaccount

--- a/addons/packages/app-toolkit/0.2.0/bundle/config/values.yaml
+++ b/addons/packages/app-toolkit/0.2.0/bundle/config/values.yaml
@@ -1,0 +1,9 @@
+#@data/values
+---
+excluded_packages: []
+contour: {}
+cert_manager: {}
+cartographer_catalog: {}
+developer_namespace: default
+kpack: {}
+knative_serving: {}

--- a/addons/packages/app-toolkit/0.2.0/package.yaml
+++ b/addons/packages/app-toolkit/0.2.0/package.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: app-toolkit.community.tanzu.vmware.com.0.2.0
+spec:
+  refName: app-toolkit.community.tanzu.vmware.com
+  version: 0.2.0
+  releasedAt: 2022-04-21T18:59:24Z
+  licenses:
+    - "Apache 2.0"
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects.registry.vmware.com/tce/app-toolkit@sha256:0a36b5d0039193baf902ad86a5a175a3f062b3ceae0eb6d211e2afa3f569442d
+      template:
+        - ytt:
+            paths:
+              - config/
+        - kbld:
+            paths:
+              - "-"
+              - .imgpkg/images.yml
+      deploy:
+        - kapp: {}
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      properties:
+        excluded_packages:
+          type: array
+          default: []
+          items:
+            type: string
+          description:
+            "A list of package refs that should be excluded from app-toolkit"
+        contour:
+          type: object
+          default: {}
+          description: "contour values"
+        cartographer_catalog:
+          type: object
+          default: {}
+          description: "cartographer_catalog values"
+        developer_namespace:
+          type: string
+          default: default
+          description: "namespace to populate registry-credentials for"
+        kpack:
+          type: object
+          default: {}
+          description: "kpack values"
+        knative_serving:
+          type: object
+          default: {}
+          description: "knative-serving values"
+        cert_manager:
+          type: object
+          default: {}

--- a/addons/packages/app-toolkit/0.2.0/test/Makefile
+++ b/addons/packages/app-toolkit/0.2.0/test/Makefile
@@ -1,0 +1,18 @@
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+.DEFAULT_GOAL:=help
+
+help: ## Display this help message
+	# Inspired by Cluster-API Makefile
+	# Any target that has '## ' append to it will be included in the help message
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+test: ## Run unit testing suite
+	@echo "TODO: implement running unit tests"
+
+e2e-test: ## Run e2e testing suite
+	./app-toolkit-test.sh
+
+build: ## Build the executable
+	@echo "TODO: implement building"

--- a/addons/packages/app-toolkit/0.2.0/test/README.md
+++ b/addons/packages/app-toolkit/0.2.0/test/README.md
@@ -1,0 +1,46 @@
+# Test Execution Prerequisites
+
+- A `app-toolkit-values.yaml` file containing the following information:
+
+  ```yaml
+  contour:
+    envoy:
+      service:
+        type: ClusterIP
+      hostPorts:
+        enable: true
+  
+  cartographer_catalog:
+    registry:
+      server: [REGISTRY_SERVER]
+      repository: [REGISTRY_REPOSITORY]
+
+  developer_namespace: dev-test
+  
+  knative_serving:
+    domain:
+      type: real
+      name: 127-0-0-1.sslip.io
+
+  kpack:
+    # name of registry secret where build artifacts are stored
+    kp_default_repository: [DEFAULT_REGISTRY_URL]
+    kp_default_repository_username: [DEFAULT_REGISTRY_USERNAME]
+    kp_default_repository_password: [DEFAULT_REGISTRY_PASSWORD]
+
+  # Below is used for testing, but is not part of the intended App Toolkit flow
+  #
+  # if using DockerHub, provide it in the format "https://index.docker.io/v1/"
+  # registry.server: [REGISTRY_SERVER_SECRET]
+  # registry.username: [REGISTRY_USERNAME_SECRET]
+  # registry.password: [REGISTRY_PASSWORD_SECRET]
+  ```
+
+  Where:
+  - `REGISTRY_SERVER` and `DEFAULT_REGISTRY_URL` are valid OCI registries to store kpack images, like `https://index.docker.io/v1/`
+  - `REGISTRY_REPOSITORY` is the repository name (i.e., on Dockerhub, this is likely your username)
+  - `DEFAULT_REGISTRY_USERNAME` and `DEFAULT_REGISTRY_PASSWORD` are the credentials for the specified registry.
+  - `REGISTRY_<FOOBAR>_SECRET` are the values that appear in your `~/.docker/config.json` for your registry login
+
+After creating the file with the required fields, you can start the actual test execution with this command: `./app-toolkit-test.sh`
+You can also provide a `PackageRepo` url to the script and it will use that repository for the tests.

--- a/addons/packages/app-toolkit/0.2.0/test/app-toolkit-test.sh
+++ b/addons/packages/app-toolkit/0.2.0/test/app-toolkit-test.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+# Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eo pipefail
+
+existingPackageRepo='projects.registry.vmware.com-tce-main-v0.11.0'
+packageRepoUrl=$1
+
+registryServer=$(grep 'registry.server:' app-toolkit-values.yaml | awk '{print $NF}')
+registryUser=$(grep 'registry.username:' app-toolkit-values.yaml | awk '{print $NF}')
+registryPass=$(grep 'registry.password:' app-toolkit-values.yaml | awk '{print $NF}')
+developerNamespace=$(grep 'developer_namespace:' app-toolkit-values.yaml | awk '{print $NF}')
+workloadURL="http://tanzu-simple-web-app.${developerNamespace}.127-0-0-1.sslip.io/"
+
+function main() {
+	echo -e "=== APP TOOLKIT TEST - START ===\n"
+
+	deleteExistingCluster
+	createCluster
+	checkExecutables
+	updatePackageRepository
+	setupSecrets
+	installPackage
+	createWorkload
+	checkWorkload
+
+	echo -e "\n=== APP TOOLKIT TEST - PASSED! ===\n"
+}
+
+function deleteExistingCluster {
+	validateCommand "tanzu uc" "unmanaged-cluster"
+  tanzu uc list | grep -q app-toolkit-test
+	retcode=$?
+
+	if [ $retcode -eq 0 ]; then
+		echo "Existing 'app-toolkit-test' cluster found"
+		tanzu uc delete app-toolkit-test
+		echo "'app-toolkit-test' cluster deleted"
+	fi
+}
+
+function createCluster {
+	tanzu uc create app-toolkit-test -p 80:80 -p 443:443
+}
+
+function checkExecutables() {
+	echo -e "\n--- Executables Check : Start ---\n"
+
+	validateCommand "tanzu" "Tanzu CLI"
+	validateCommand "tanzu apps" "Applications on Kubernetes"
+	validateCommand "tanzu secret" "Tanzu secret management"
+	validateCommand "tanzu package" "Tanzu package management"
+	validateCommand "kubectl" "kubectl controls the Kubernetes cluster manager"
+	validateCommand "docker" "A self-sufficient runtime for containers"
+
+	echo -e "\n--- Executables Check : OK! ---\n"
+}
+
+function updatePackageRepository() {
+	if [ "$packageRepoUrl" != "" ]; then
+		echo "Updating '$existingPackageRepo' to use '$packageRepoUrl'"
+		tanzu package repository update "$existingPackageRepo" -n tanzu-package-repo-global --url "$packageRepoUrl"
+	else
+		echo "Using standard PackageRepo found in $existingPackageRepo"
+	fi
+}
+
+function setupSecrets() {
+	echo -e "\n--- Setting Up Secrets : Start ---\n"
+
+	tanzu package install secretgen-controller --package-name secretgen-controller.community.tanzu.vmware.com --version 0.8.0
+	tanzu secret registry add registry-credentials --server "$registryServer" --username "$registryUser" --password "$registryPass" --export-to-all-namespaces --yes
+
+	validateCommand "tanzu secret registry list" "registry-credentials"
+
+	echo -e "\n--- Setting Up Secrets : OK! ---\n"
+}
+
+function installPackage() {
+	echo -e "\n--- Installing App Toolkit : Start ---\n"
+
+	tanzu package install app-toolkit -p app-toolkit.community.tanzu.vmware.com -v 0.2.0 -n tanzu-package-repo-global -f app-toolkit-values.yaml --verbose 3
+	validateCommand "tanzu package installed get app-toolkit -n tanzu-package-repo-global" "ReconcileSucceeded"
+
+	echo -e "\n--- Installing App Toolkit : OK! ---\n"
+}
+
+function createWorkload(){
+	echo -e "\n--- Creating the Workload : Start ---\n"
+
+	tanzu apps workload create tanzu-simple-web-app --git-repo https://github.com/cgsamp/tanzu-simple-web-app --git-branch main --type=web --app tanzu-simple-web-app --yes -n "$developerNamespace"
+
+	echo -e "\n--- Creating the Workload : OK! ---\n"
+}
+
+function checkWorkload(){
+	echo -e "\n--- Checking the Workload : Start ---\n"
+	
+	pollCommand "tanzu apps workload list -n ${developerNamespace}" "Ready" 5
+	pollCommand "curl $workloadURL" "Hello" 1
+
+	echo -e "\n--- Checking the Workload : OK! ---\n"
+}
+
+function validateCommand() {
+	cmd=$1
+	match=$2
+	echo "Validating '$cmd'"
+	output=$($cmd 2>&1)
+	echo "$output" | grep -q "${match}"
+	retcode=$?
+	
+	if [ $retcode -ne 0 ]; then
+		fail "'$match' not found after executing '$cmd'"
+	fi
+}
+
+function pollCommand() {
+	cmd=$1
+	match=$2
+	timeout=$3
+	duration=5
+	count=0
+	flag=1
+	echo "Polling '$cmd' until it contains '$match'"
+
+	while [ $flag -ne 0 ] ; do
+		set +e
+		output=$($cmd 2>&1)
+		echo "${output}" | grep "${match}"
+		flag=$?
+		set -e
+		minutes=$(( count / 60 ))
+		if [[ "$minutes" -ge "$timeout" ]]; then
+			fail "Timeout exceeded polling for '$cmd' to return expected result"
+		fi
+		sleep $duration
+		count=$((count+duration))
+	done
+	minutes=$(( count / 60 ))
+	seconds=$(( count % 60 ))
+	echo "Result returned after ${minutes}m${seconds}s"
+}
+
+function fail() {
+	echo -e "\n=== APP TOOLKIT TEST - FAILED! ===\n"
+	echo "$1"
+	exit 1
+}
+
+main
+exit 0

--- a/addons/packages/app-toolkit/metadata.yaml
+++ b/addons/packages/app-toolkit/metadata.yaml
@@ -11,7 +11,7 @@ spec:
   maintainers:
     - name: "Glenio Borges"
     - name: "Kris Applegate"
-    - name: "Christopher Samp"
+    - name: "Ryan Kilroy"
   supportDescription: "For help go to #tanzu-community-edition in the kubernetes slack workspace."
   categories:
     - "application lifecycle"

--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -3,6 +3,7 @@ packages:
   - name: app-toolkit
     versions:
       - 0.1.0
+      - 0.2.0
   - name: cartographer
     versions:
       - 0.2.2


### PR DESCRIPTION
* Add App Toolkit 0.2.0 package

- Use kpack-dependencies 0.0.9
- Use cartographer-catalog 0.3.0
- Bump to cartographer 0.3.0
- Add developer-namespace feature and requirement on secretgen-controller
- Switch App Toolkit Testing framework from go to bash
- Update Readme

* Correct linting errors
* Remove unneccessary kpack_dependencies configs and doc updates
* Fix kpack-dependencies docs link

(cherry picked from commit 2453d2ad3f11e5d96ec953a7f8a53f4de28b558e)
