### PR TITLE
[release-0.12] update image paths for Getting Started page (#4177)

### DIFF
--- a/docs/site/content/docs/assets/aws-clusters.md
+++ b/docs/site/content/docs/assets/aws-clusters.md
@@ -14,11 +14,11 @@ There are some prerequisites the installation process will assume.  Refer to the
 
 1. Choose Amazon from the provider tiles.
 
-    ![kickstart amazon tile](/docs/img/kickstart-amazon-tile.png)
+    ![kickstart amazon tile](../img/kickstart-amazon-tile.png)
 
 1. Fill out the IaaS Provider section.
 
-    ![kickstart amazon iaas](/docs/img/kickstart-amazon-iaas.png)
+    ![kickstart amazon iaas](../img/kickstart-amazon-iaas.png)
 
     * `A`: Whether to use AWS named profiles or provide static
       credentials. It is **highly** recommended you use profiles. This can be
@@ -31,7 +31,7 @@ There are some prerequisites the installation process will assume.  Refer to the
 
 1. Fill out the VPC settings.
 
-    ![kickstart aws vpc](/docs/img/kickstart-amazon-vpc.png)
+    ![kickstart aws vpc](../img/kickstart-amazon-vpc.png)
 
     * `A`: Whether to create a new Virtual Private Cloud in AWS or use an existing
       one. If using an existing one, you must provide its VPC ID. For initial
@@ -42,7 +42,7 @@ There are some prerequisites the installation process will assume.  Refer to the
 
 1. Fill out the Management Cluster Settings.
 
-    ![kickstart aws management cluster settings](/docs/img/kickstart-amazon-mgmt-cluster.png)
+    ![kickstart aws management cluster settings](../img/kickstart-amazon-mgmt-cluster.png)
 
     * `A`: Choose between Development profile, with 1 control plane node or
       Production, which features a highly-available three node control plane.
@@ -77,7 +77,7 @@ There are some prerequisites the installation process will assume.  Refer to the
 
 1. Fill out the Kubernetes Network section.
 
-    ![kickstart kubernetes networking](/docs/img/kickstart-amazon-network.png)
+    ![kickstart kubernetes networking](../img/kickstart-amazon-network.png)
 
     * `A`: Set the CIDR for Kubernetes [Services (Cluster
       IPs)](https://kubernetes.io/docs/concepts/services-networking/service/).
@@ -90,7 +90,7 @@ Kubernetes.
 
 1. Fill out the Identity Management section.
 
-    ![kickstart identity management](/docs/img/kickstart-identity.png)
+    ![kickstart identity management](../img/kickstart-identity.png)
 
     * `A`: Select whether you want to enable identity management. If this is
       off, certificates (via kubeconfig) are used to authenticate users. For
@@ -101,7 +101,7 @@ Kubernetes.
 
 1. Fill out the OS Image section.
 
-    ![kickstart aws os](/docs/img/kickstart-amazon-os.png)
+    ![kickstart aws os](../img/kickstart-amazon-os.png)
 
     * `A`: The [Amazon Machine Image
       (AMI)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) to

--- a/docs/site/content/docs/assets/azure-clusters.md
+++ b/docs/site/content/docs/assets/azure-clusters.md
@@ -16,11 +16,11 @@ There are some prerequisites this process will assume. Refer to the [Prepare to 
 
 1. Choose Azure from the provider tiles.
 
-    ![kickstart azure tile](/docs/img/kickstart-azure-tile.png)
+    ![kickstart azure tile](../img/kickstart-azure-tile.png)
 
 1. Fill out the IaaS Provider section.
 
-    ![kickstart azure iaas](/docs/img/kickstart-azure-iaas.png)
+    ![kickstart azure iaas](../img/kickstart-azure-iaas.png)
 
     * `A`: Your account's Tenant ID.
     * `B`: Your Client ID.
@@ -40,7 +40,7 @@ There are some prerequisites this process will assume. Refer to the [Prepare to 
 
 1. Fill out the VNET settings.
 
-    ![kickstart azure vnet](/docs/img/kickstart-azure-vnet.png)
+    ![kickstart azure vnet](../img/kickstart-azure-vnet.png)
 
     * `A`: Whether to create a new
       [Virtual Network in Azure](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview)
@@ -65,7 +65,7 @@ There are some prerequisites this process will assume. Refer to the [Prepare to 
 
 1. Fill out the Management Cluster Settings.
 
-    ![kickstart azure management cluster settings](/docs/img/kickstart-azure-mgmt-cluster.png)
+    ![kickstart azure management cluster settings](../img/kickstart-azure-mgmt-cluster.png)
 
     * `A`: Choose between Development profile with one control plane node, or
       Production, which features a highly-available three node control plane.
@@ -85,7 +85,7 @@ There are some prerequisites this process will assume. Refer to the [Prepare to 
 
 1. Fill out the Kubernetes Network section.
 
-    ![kickstart kubernetes networking](/docs/img/kickstart-azure-network.png)
+    ![kickstart kubernetes networking](../img/kickstart-azure-network.png)
 
     * `A`: Set the CIDR for Kubernetes [Services (Cluster
       IPs)](https://kubernetes.io/docs/concepts/services-networking/service/).
@@ -98,7 +98,7 @@ Kubernetes.
 
 1. Fill out the Identity Management section.
 
-    ![kickstart identity management](/docs/img/kickstart-identity.png)
+    ![kickstart identity management](../img/kickstart-identity.png)
 
     * `A`: Select whether you want to enable identity management. If this is
       off, certificates (via kubeconfig) are used to authenticate users. For
@@ -109,7 +109,7 @@ Kubernetes.
 
 1. Fill out the OS Image section.
 
-    ![kickstart azure os](/docs/img/kickstart-azure-os.png)
+    ![kickstart azure os](../img/kickstart-azure-os.png)
 
     * `A`: The Azure image to use for Kubernetes host VMs. This list should
       populate based on known images uploaded by VMware.

--- a/docs/site/content/docs/assets/octant-install.md
+++ b/docs/site/content/docs/assets/octant-install.md
@@ -25,4 +25,4 @@ required for Tanzu Community Edition.
 
 1. Navigate the Octant UI.
 
-    ![image of octant UI](../../img/octant-home.png)
+    ![image of octant UI](../img/octant-home.png)

--- a/docs/site/content/docs/assets/vsphere-clusters.md
+++ b/docs/site/content/docs/assets/vsphere-clusters.md
@@ -16,34 +16,34 @@ VMware Customer Connect.
 
 1. Ensure you have the version selected corresponding to your installation.
 
-    ![customer connect download page](/docs/img/customer-connect-downloads.png)
+    ![customer connect download page](../img/customer-connect-downloads.png)
 
 1. Locate and download the machine image (OVA) for your desired operating system
    and Kubernetes version.
 
-    ![customer connect ova downloads](/docs/img/customer-connect-ovas.png)
+    ![customer connect ova downloads](../img/customer-connect-ovas.png)
 
 1. Log in to your vCenter instance.
 
 1. In vCenter, right-click on your datacenter and choose Deploy OVF Template.
 
-    ![vcenter deploy ovf](/docs/img/vcenter-deploy-ovf.png)
+    ![vcenter deploy ovf](../img/vcenter-deploy-ovf.png)
 
 1. Follow the prompts, browsing to the local file that is the `.ova` downloaded
    in a previous step.
 
 1. Allow the template deployment to complete.
 
-    ![vcenter deploy ovf](/docs/img/vcenter-import-ovf.png)
+    ![vcenter deploy ovf](../img/vcenter-import-ovf.png)
 
 1. Right-click on the newly imported OVF template and choose Template > Convert to Template.
 
-    ![vcenter convert to template](/docs/img/vcenter-convert-to-template.png)
+    ![vcenter convert to template](../img/vcenter-convert-to-template.png)
 
 1. Verify the template is added by selecting the VMs and Templates icon and
    locating it within your datacenter.
 
-    ![vcenter template import](/docs/img/vcenter-template-import.png)
+    ![vcenter template import](../img/vcenter-template-import.png)
 
 ### Deploy a Management Cluster
 
@@ -57,11 +57,11 @@ VMware Customer Connect.
 
 1. Choose VMware vSphere from the provider tiles.
 
-    ![kickstart vsphere tile](/docs/img/kickstart-vsphere-tile.png)
+    ![kickstart vsphere tile](../img/kickstart-vsphere-tile.png)
 
 1. Fill out the IaaS Provider section.
 
-    ![kickstart vsphere iaas](/docs/img/kickstart-vsphere-iaas.png)
+    ![kickstart vsphere iaas](../img/kickstart-vsphere-iaas.png)
 
     * `A`: The IP or DNS name pointing at your vCenter instance. This is the
       same instance you uploaded the OVA to in previous steps.
@@ -77,7 +77,7 @@ VMware Customer Connect.
 
 1. Fill out the Management Cluster Settings.
 
-    ![kickstart vsphere management cluster settings](/docs/img/kickstart-vsphere-mgmt-cluster.png)
+    ![kickstart vsphere management cluster settings](../img/kickstart-vsphere-mgmt-cluster.png)
 
     * `A`: Choose between Development profile, with 1 control plane node or
       Production, which features a highly-available three node control plane.
@@ -104,7 +104,7 @@ VMware Customer Connect.
 
 1. Fill out the Resources section.
 
-    ![kickstart vsphere resources](/docs/img/kickstart-vsphere-resources.png)
+    ![kickstart vsphere resources](../img/kickstart-vsphere-resources.png)
 
     * `A`: Set the [VM
       folder](https://docs.vmware.com/en/VMware-Workstation-Pro/16.0/com.vmware.ws.using.doc/GUID-016FF81D-4FE4-4D9E-92D6-A08E022AA6D4.html)
@@ -117,7 +117,7 @@ VMware Customer Connect.
 
 1. Fill out the Kubernetes Network section.
 
-    ![kickstart kubernetes networking](/docs/img/kickstart-network.png)
+    ![kickstart kubernetes networking](../img/kickstart-network.png)
 
     * `A`: Select the [vSphere
       network](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.networking.doc/GUID-35B40B0B-0C13-43B2-BC85-18C9C91BE2D4.html)
@@ -133,7 +133,7 @@ Kubernetes.
 
 1. Fill out the Identity Management section.
 
-    ![kickstart identity management](/docs/img/kickstart-identity.png)
+    ![kickstart identity management](../img/kickstart-identity.png)
 
     * `A`: Select whether you want to enable identity management. If this is
       off, certificates (via kubeconfig) are used to authenticate users. For
@@ -144,7 +144,7 @@ Kubernetes.
 
 1. Fill out the OS Image section.
 
-    ![kickstart vsphere os](/docs/img/kickstart-vsphere-os.png)
+    ![kickstart vsphere os](../img/kickstart-vsphere-os.png)
 
     * `A`: The OVA image to use for Kubernetes host VMs. This list should
       populate based on the OVA you uploaded in previous steps. If it's missing,


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Fixes image links broken due to versioned docs.

(cherry picked from commit 9bece027207544bb47aac45ce228dd032b158b9f)