### PR TITLE
[release-0.12] Blog: make doc links go to specific version (#4086)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Tanzu Community Edition
 
-Authors are expected to follow some guidelines when submitting PRs. Please see our [documentation](https://tanzucommunityedition.io/docs/contribute/contributing/) for details.
+Authors are expected to follow some guidelines when submitting PRs. Please see our [documentation](https://tanzucommunityedition.io/docs/main/contribute/contributing/) for details.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ source distribution of VMware Tanzu. It can be installed and deployed in minutes
 local workstation or favorite infrastructure provider. Along with cluster
 management, powered by [Cluster API](https://github.com/kubernetes-sigs/cluster-api),
 Tanzu Community Edition enables higher-level functionality via its robust
-[package management](https://tanzucommunityedition.io/docs/package-management)
+[package management](https://tanzucommunityedition.io/docs/main/package-management)
 built on top of [Carvel's kapp-controller](https://carvel.dev/kapp-controller/),
 and opinionated, yet extensible, [Carvel packages](#packages).
 
@@ -25,7 +25,7 @@ and opinionated, yet extensible, [Carvel packages](#packages).
 
 ## Getting Started
 
-* [Getting Started Guide](https://tanzucommunityedition.io/docs/getting-started)
+* [Getting Started Guide](https://tanzucommunityedition.io/docs/main/getting-started)
 
 ## Installation
 
@@ -93,7 +93,7 @@ platform. Packages included, by default, in Tanzu Community Edition are:
 ## Contributing
 
 If you are ready to jump in and test, add code, or help with documentation,
-follow the instructions on our [Contribution Guidelines](https://tanzucommunityedition.io/docs/contribute/contributing/) to
+follow the instructions on our [Contribution Guidelines](https://tanzucommunityedition.io/docs/main/contribute/contributing/) to
 get started and at all times, follow our [Code of
 Conduct](./CODE_OF_CONDUCT.md).
 
@@ -130,6 +130,6 @@ The following describes the key directories that make up this repository.
 If you have any questions about Tanzu Community Edition, please join [#tanzu-community-edition](https://kubernetes.slack.com/messages/tanzu-community-edition) on [Kubernetes slack](http://slack.k8s.io/).
 
 Please submit [bugs or enhancements requests](https://github.com/vmware-tanzu/community-edition/issues/new/choose) in GitHub.
-More information about troubleshooting and our triage process is available [here](https://tanzucommunityedition.io/docs/trouble-faq/).
+More information about troubleshooting and our triage process is available [here](https://tanzucommunityedition.io/docs/main/trouble-faq/).
 
 Information about our roadmap is available [here](https://github.com/vmware-tanzu/community-edition/blob/main/ROADMAP.md).

--- a/docs/designs/2730-visibility.md
+++ b/docs/designs/2730-visibility.md
@@ -343,7 +343,7 @@ bootstrap logging to aid in troubleshooting when deployments fail.
 #### Cluster API Controller Logs
 
 One common scenario we have found to work when troubleshooting deployment failures
-is to [look at the `capX-controller-manager` POD logs](https://tanzucommunityedition.io/docs/tsg-bootstrap/#troubleshooting-manually).
+is to [look at the `capX-controller-manager` POD logs](https://tanzucommunityedition.io/docs/v0.11/tsg-bootstrap/#troubleshooting-manually).
 Looking for Error level logs (log lines that start with an `E`) will often indicate
 what is failing in reconciliation that is preventing the cluster from being
 properly created.

--- a/docs/designs/2967-package-image-vulnerability-scanning.md
+++ b/docs/designs/2967-package-image-vulnerability-scanning.md
@@ -162,7 +162,7 @@ turtle@turtle-a01 tce-main % cat /tmp/tce-main/.imgpkg/images.yml | grep "image:
 ```
 
 These are the two packages of `harbor` which are
-supported [tanzu packages](https://tanzucommunityedition.io/docs/package-management/)
+supported [tanzu packages](https://tanzucommunityedition.io/docs/v0.11/package-management/)
 
 Let's get a list of images from one of these packages
 

--- a/docs/developer/app-toolkit.md
+++ b/docs/developer/app-toolkit.md
@@ -26,7 +26,7 @@ Configuration is deferred to the included TCE package. For instance, if end user
 
 ### Similarities and Differences to TCE Packaging of Upstream Projects
 
-TCE provides guidance about how to include other upstream projects into TCE - e.g. kpack, knative, etc., as described in the [TCE Documentation](https://tanzucommunityedition.io/docs/package-creation-step-by-step/). Principally it describes how to
+TCE provides guidance about how to include other upstream projects into TCE - e.g. kpack, knative, etc., as described in the [TCE Documentation](https://tanzucommunityedition.io/docs/v0.11/package-creation-step-by-step/). Principally it describes how to
 
 - Use Vendir to syncronize upstream content to a local directory.
 - Import/pin a version of the upstream's manifests

--- a/docs/site/content/posts/03-five-ways-to-begin.md
+++ b/docs/site/content/posts/03-five-ways-to-begin.md
@@ -71,7 +71,7 @@ workshops enable you to experience Tanzu Community Edition in this way:
 When you're ready to set up a Tanzu Community Edition cluster, you'll
 want to turn to these helpful resources:
 
-- The Tanzu Community Edition [installation instructions](https://tanzucommunityedition.io/docs/installation-planning/) detail the software download and configuration process, and the steps involved in setting up a new workload cluster.
+- The Tanzu Community Edition [installation instructions](https://tanzucommunityedition.io/docs/v0.11/installation-planning/) detail the software download and configuration process, and the steps involved in setting up a new workload cluster.
 
 - You can customize your cluster by adding capabilities that are useful to you. Check out the list of optional [packages](https://tanzucommunityedition.io/packages/) that you can install into your cluster.
 

--- a/docs/site/content/posts/07-tce-unmanaged-managed-clusters.md
+++ b/docs/site/content/posts/07-tce-unmanaged-managed-clusters.md
@@ -28,7 +28,7 @@ While the control plane and the Node can be on the same machine, typically, a Ku
 
 ## Unmanaged clusters
 
-An [unmanaged cluster](https://tanzucommunityedition.io/docs/getting-started-unmanaged/) is just a plain Kubernetes cluster spun up using your favorite tools like [kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/) or vRealize Automation. In the case of Tanzu Community Edition, you can use a [single command](https://tanzucommunityedition.io/docs/getting-started-unmanaged/) with the Tanzu CLI, and it will spin up a Kubernetes-in-Docker (*kind*) cluster on your local machine. In a kind cluster, all the pieces discussed above, including Nodes, are actually containers running in your local container engine (such as Docker Desktop).
+An [unmanaged cluster](https://tanzucommunityedition.io/docs/v0.11/getting-started-unmanaged/) is just a plain Kubernetes cluster spun up using your favorite tools like [kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/) or vRealize Automation. In the case of Tanzu Community Edition, you can use a [single command](https://tanzucommunityedition.io/docs/v0.11/getting-started-unmanaged/) with the Tanzu CLI, and it will spin up a Kubernetes-in-Docker (*kind*) cluster on your local machine. In a kind cluster, all the pieces discussed above, including Nodes, are actually containers running in your local container engine (such as Docker Desktop).
 
 !["Tanzu Community Edition Unmanaged Cluster Control Plane and Nodes in Container"](/img/Cluster-Container-img2.png)
 
@@ -63,7 +63,7 @@ With these benefits and drawbacks in mind, here are some of the typical use case
 
 ## Managed clusters
 
-[Managed clusters](https://tanzucommunityedition.io/docs/getting-started/) take all the goodness we get from declarative infrastructure, Kubernetes, [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/), and the Kubernetes [Cluster API](https://cluster-api.sigs.k8s.io/) to allow you to use Kubernetes clusters to manage the clusters. The basic idea is to create one Kubernetes cluster (a management cluster) and then use that cluster to create and manage other Kubernetes clusters where we do all work (workload clusters).
+[Managed clusters](https://tanzucommunityedition.io/docs/v0.11/getting-started/) take all the goodness we get from declarative infrastructure, Kubernetes, [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/), and the Kubernetes [Cluster API](https://cluster-api.sigs.k8s.io/) to allow you to use Kubernetes clusters to manage the clusters. The basic idea is to create one Kubernetes cluster (a management cluster) and then use that cluster to create and manage other Kubernetes clusters where we do all work (workload clusters).
 
 The management cluster uses the Kubernetes Cluster API to manage the full lifecycle of other Kubernetes clusters. The workload cluster is where you run all your applications, databases, and other containerized goodness. Typically, the management cluster is on separate machines/infrastructure from any of the workload clusters as its only job should be managing its clusters.
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

The versioned docs changed where some of the referenced links point to.
In many cases the redirect will get to the correct page, but there were
a few links in our blogs that were now resulting in 404s.

This updates the links in a couple blog posts to get to specific
versions. This fixes and link and makes sure future modifications will
not break existing posts.

(cherry picked from commit ca9c1a330feae50e8d102d59e79ff2a8756a167b)