### PR TITLE
Automaticaly Merge Select Dependabot PRs

### DIFF
--- a/.github/workflows/build-automatically-merge-pr.yaml
+++ b/.github/workflows/build-automatically-merge-pr.yaml
@@ -1,0 +1,35 @@
+name: Build - Merge Dependabot PRs
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - assigned
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - "hack/runner/webhook/go.**"
+jobs:
+  auto-merge:
+    name: Automatically Merge PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get dependencies
+        id: ensure-deps
+        shell: bash
+        run: |
+          make ensure-deps
+      - name: Check Dependabot
+        id: check-dependabot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PACKAGING_ACCESS_TOKEN }}
+          PR_BRANCH: ${{ github.head_ref }}
+        shell: bash
+        run: |
+          if [[ "${{ github.event.pull_request.user.login }}" == "dependabot" ]]; then
+            set +x
+            echo "${GITHUB_TOKEN}" | gh auth login --with-token
+            set -x
+            gh pr merge "${PR_BRANCH}" --delete-branch --squash --admin
+          fi


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
The AWS SDK is updated daily which in turn always creates a new PR each to bump the dependency version. For select (ie only one) utility project, we should just merge the PR automatically. This code isn't used in the TCE release and only is run when the webhook service is compiled and uploaded to the webhook servers to be updated.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA