### PR TITLE
Reenable vsphere-cpi unit tests

### DIFF
--- a/addons/packages/vsphere-cpi/1.23.0-alpha.1/test/Makefile
+++ b/addons/packages/vsphere-cpi/1.23.0-alpha.1/test/Makefile
@@ -19,8 +19,7 @@ get-deps: ## Get all dependencies
 	go mod download
 
 test: ## Run unit testing suite
-	@echo "Unit tests disabled until https://github.com/vmware-tanzu/community-edition/issues/4185 is resolved"
-	#go run github.com/onsi/ginkgo/ginkgo -v .
+	go run github.com/onsi/ginkgo/ginkgo -v .
 
 e2e-test: ## Run e2e testing suite
 	@echo "TODO: implement running e2e tests"

--- a/addons/packages/vsphere-cpi/1.23.0/test/Makefile
+++ b/addons/packages/vsphere-cpi/1.23.0/test/Makefile
@@ -19,8 +19,7 @@ get-deps: ## Get all dependencies
 	go mod download
 
 test: ## Run unit testing suite
-	@echo "Unit tests disabled until https://github.com/vmware-tanzu/community-edition/issues/4185 is resolved"
-	#go run github.com/onsi/ginkgo/ginkgo -v .
+	go run github.com/onsi/ginkgo/ginkgo -v .
 
 e2e-test: ## Run e2e testing suite
 	@echo "TODO: implement running e2e tests"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

There were errors in the vsphere-cpi package's unit tests for the 1.23.0
and 1.23.0-alpha.1 package versions. These were fixed indirectly by:

https://github.com/vmware-tanzu/community-edition/pull/4135

This reenables the `test` target for those versions so unit tests are
run.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4185 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make -C addons/packages/vsphere-cpi/1.23.0-alpha.1/test test` and
`make -C addons/packages/vsphere-cpi/1.23.0/test test`, verified
tests now pass.