### PR TITLE
Add go and cloning to auto merge of dependabot

### DIFF
--- a/.github/workflows/build-automatically-merge-pr.yaml
+++ b/.github/workflows/build-automatically-merge-pr.yaml
@@ -15,6 +15,13 @@ jobs:
     name: Automatically Merge PR
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.17"
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v1
       - name: Get dependencies
         id: ensure-deps
         shell: bash


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

The action for performing the automatic merge of some updates was
failing due to the environment not being fully set up. This adds
installing go and cloning the repo so the `ensure-deps` step can run.