### PR TITLE
Implements misc unmanaged cluster tests - exit codes, kubeconfig, etc.

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/kubeconfig/kubeconfig_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,167 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kubeconfig
+
+import (
+	"os"
+	"testing"
+)
+
+var stubKubeconfig = `---
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: /home/my-user/.minikube/ca.crt
+    extensions:
+    - extension:
+        last-update: Mon, 02 May 2022 13:23:44 MDT
+        provider: minikube.sigs.k8s.io
+        version: v1.25.2
+      name: cluster_info
+    server: https://192.168.49.2:8443
+  name: minikube
+contexts:
+- context:
+    cluster: minikube
+    extensions:
+    - extension:
+        last-update: Mon, 02 May 2022 13:23:44 MDT
+        provider: minikube.sigs.k8s.io
+        version: v1.25.2
+      name: context_info
+    namespace: default
+    user: minikube
+  name: my-context
+current-context: my-context
+kind: Config
+preferences: {}
+users:
+- name: minikube
+  user:
+    client-certificate: /home/my-user/.minikube/profiles/minikube/client.crt
+    client-key: /home/my-user/.minikube/profiles/minikube/client.key`
+
+func TestGetKubeconfigContext(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "kubeconfig-test-")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.Write([]byte(stubKubeconfig))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	context, err := GetKubeconfigContext(tmpFile.Name())
+	if err != nil {
+		t.Errorf("failed to get context. Error: %s", err.Error())
+	}
+
+	if context != "my-context" {
+		t.Errorf("did not get correct context. Actual context: %s", context)
+	}
+}
+
+func TestGetKubeconfigContextEmpty(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "kubeconfig-test-")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.Write([]byte("---"))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	context, err := GetKubeconfigContext(tmpFile.Name())
+	if err != nil {
+		t.Errorf("failed to get context. Error: %s", err.Error())
+	}
+
+	if context != "" {
+		t.Errorf("did not get empty context. Actual context: %s", context)
+	}
+}
+
+var testJSON = `{
+  "json": [
+    "rigid",
+    "better for data interchange"
+  ],
+  "yaml": [
+    "slim and flexible",
+    "better for configuration"
+  ],
+  "object": {
+    "key": "value",
+    "array": [
+      {
+        "null_value": null
+      },
+      {
+        "boolean": true
+      },
+      {
+        "integer": 1
+      },
+      {
+        "alias": "aliases are like variables"
+      },
+      {
+        "alias": "aliases are like variables"
+      }
+    ]
+  },
+  "paragraph": "Blank lines denote\nparagraph breaks\n",
+  "content": "Or we\ncan auto\nconvert line breaks\nto save space",
+  "alias": {
+    "bar": "baz"
+  },
+  "alias_reuse": {
+    "bar": "baz"
+  }
+}`
+
+var testYamls = `alias:
+    bar: baz
+alias_reuse:
+    bar: baz
+content: |-
+    Or we
+    can auto
+    convert line breaks
+    to save space
+json:
+    - rigid
+    - better for data interchange
+object:
+    array:
+        - null_value: null
+        - boolean: true
+        - integer: 1
+        - alias: aliases are like variables
+        - alias: aliases are like variables
+    key: value
+paragraph: |
+    Blank lines denote
+    paragraph breaks
+yaml:
+    - slim and flexible
+    - better for configuration
+`
+
+func TestJSONToYAML(t *testing.T) {
+	yamls, err := jSONToYAML([]byte(testJSON))
+	if err != nil {
+		t.Errorf("could not convert json to yaml. Error: %s", err.Error())
+	}
+
+	if string(yamls) != testYamls {
+		t.Errorf("Incorrect yaml returned. Expected ----- :\n%s\nActual ----- :\n%s\n", testYamls, string(yamls))
+	}
+}

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/codes_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/codes_test.go
@@ -1,0 +1,73 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tanzu
+
+import "testing"
+
+// This test checks that the exit codes are their expected integer.
+// These ints should not change without going through the lifecycle processes
+// since users may rely on them in their ci/cd for fallback and automation purposes
+
+//nolint:gocyclo
+func TestExitCodes(t *testing.T) {
+	if Success != 0 {
+		t.Errorf("expected success exit code to be 0. Actual: %v", Success)
+	}
+
+	if InvalidConfig != 1 {
+		t.Errorf("expected InvalidConfig exit code to be 1. Actual: %v", InvalidConfig)
+	}
+
+	if ErrCreatingClusterDirs != 2 {
+		t.Errorf("expected ErrCreatingClusterDirs exict code to be 2. Actual: %v", ErrCreatingClusterDirs)
+	}
+
+	if ErrTkrBom != 3 {
+		t.Errorf("expected ErrTkrBom exit code to be 3. Actual: %v", ErrTkrBom)
+	}
+
+	if ErrRenderingConfig != 4 {
+		t.Errorf("expected ErrRenderingConfig exit code to be 4. Actual: %v", ErrRenderingConfig)
+	}
+
+	if ErrTkrBomParsing != 5 {
+		t.Errorf("expected ErrTkrBomParsing exit code to be 5. Actual: %v", ErrTkrBomParsing)
+	}
+
+	if ErrKappBundleResolving != 6 {
+		t.Errorf("expected ErrKappBundleResolving exit code to be 6. Actual: %v", ErrKappBundleResolving)
+	}
+
+	if ErrCreateCluster != 7 {
+		t.Errorf("expected ErrCreateCluster exit code to be 7. Actual: %v", ErrCreateCluster)
+	}
+
+	if ErrExistingCluster != 8 {
+		t.Errorf("expected ErrExistingCluster exit code to be 8. Actual: %v", ErrExistingCluster)
+	}
+
+	if ErrKappInstall != 9 {
+		t.Errorf("expected ErrKappInstall exit code to be 9. Actual: %v", ErrKappInstall)
+	}
+
+	if ErrCorePackageRepoInstall != 10 {
+		t.Errorf("expected ErrCorePackageRepoInstall exit code to be 10. Actual: %v", ErrCorePackageRepoInstall)
+	}
+
+	if ErrOtherPackageRepoInstall != 11 {
+		t.Errorf("expected ErrOtherPackageRepoInstall exit code to be 11. Actual: %v", ErrOtherPackageRepoInstall)
+	}
+
+	if ErrCniInstall != 12 {
+		t.Errorf("expected ErrCniInstall exit code to be 12. Actual %v", ErrCniInstall)
+	}
+
+	if ErrKubeconfigContextSet != 13 {
+		t.Errorf("expected ErrKubeconfigContextSet exit code to be 13. Actual %v", ErrKubeconfigContextSet)
+	}
+
+	if ErrInstallPackage != 14 {
+		t.Errorf("expected ErrInstallPackage exit code to be 14. Actual %v", ErrInstallPackage)
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it
Implements a few miscellaneous unmanaged-cluster tests including:

- Getting the context from a provided kubeconfig
- JSON to YAML conversion works as expected
- Exit codes are their expected integers in the tanzu package

## Which issue(s) this PR fixes
Related #3536

## Describe testing done for PR
`go test ./...` 👍🏼 
