### PR TITLE
Fix "dependabot[bot]" name for auto PR merge

### DIFF
--- a/.github/workflows/build-automatically-merge-pr.yaml
+++ b/.github/workflows/build-automatically-merge-pr.yaml
@@ -34,7 +34,7 @@ jobs:
           PR_BRANCH: ${{ github.head_ref }}
         shell: bash
         run: |
-          if [[ "${{ github.event.pull_request.user.login }}" == "dependabot" ]]; then
+          if [[ "${{ github.event.pull_request.user.login }}" == "dependabot[bot]" ]]; then
             set +x
             echo "${GITHUB_TOKEN}" | gh auth login --with-token
             set -x


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We added an action to automatically merge dependabot updates only for
the webhook, since that is fairly safe and happens often. There was a
small issue with the script in that the "Dependabot" account name is
actually "dependabot[bot]", causing the name not to match and the
merging to be skipped. This updates the name to match.