### PR TITLE
Bumps compatibility file for new tkr in prep for 0.12.0 GA tag

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/hack/tce-compatibility.yaml
+++ b/cli/cmd/plugin/unmanaged-cluster/hack/tce-compatibility.yaml
@@ -2,11 +2,15 @@ version: v1
 unmanagedClusterPluginVersions:
 - version: dev
   supportedTkrVersions:
+  - image: projects.registry.vmware.com/tce/tkr:v1.22.7-2
   - image: projects.registry.vmware.com/tce/tkr:v1.22.7-1
   - image: projects.registry.vmware.com/tce/tkr:v0.17.0-dev-2
   - image: projects.registry.vmware.com/tce/tkr:v0.17.0-dev-1
   - image: projects.registry.vmware.com/tce/tkr:v0.17.0
   - image: projects.registry.vmware.com/tce/tkr:v1.22.5
+- version: v0.12.0
+  supportedTkrVersions:
+  - image: projects.registry.vmware.com/tce/tkr:v1.22.7-2
 - version: v0.12.0-rc.2
   supportedTkrVersions:
   - image: projects.registry.vmware.com/tce/tkr:v1.22.7-1

--- a/hack/release/tkr-bom.yaml
+++ b/hack/release/tkr-bom.yaml
@@ -209,7 +209,7 @@ components:
       tanzuUserPackageRepositoryImage:
         imagePath: main
         repository: projects.registry.vmware.com/tce
-        tag: 0.12.0-rc2
+        tag: 0.12.0
       vsphere-cpi.tanzu.vmware.com:
         imagePath: packages/core/vsphere-cpi
         tag: v1.22.6_vmware.1-tkg.2-tf-v0.11.4


### PR DESCRIPTION
## What this PR does / why we need it
- Updates compatibility file to `v8` which point to `v1.22.7-2` tkr for `v0.12.0` ga tag
- Updates tkr to `v1.22.7-2` which uses the new `v0.12.0` user managed repo (as part of #4074)

## Describe testing done for PR

TKr `v1.22.7-2`:
```
projects.registry.vmware.com/tce/tkr@sha256:0052d0579260ad6f65a70a5e7c8aa46361aed849c569e56fb46475b73635aa8e
```

Compatibility file `v8`:
```
projects.registry.vmware.com/tce/compatibility@sha256:4f6bab24dc97f46631f2768bf4fd1ab60ae1cdced5e50c4470eca05fbca42526
```

Used a build of `unmanaged-cluster` with success:
```
❯ ./unmanaged-cluster create life

📁 Created cluster directory

🧲 Resolving and checking Tanzu Kubernetes release (TKr) compatibility file
   projects.registry.vmware.com/tce/compatibility
   Downloaded to: /home/jmcb/.config/tanzu/tkg/unmanaged/compatibility/projects.registry.vmware.com_tce_compatibility_v8

🔧 Resolving TKr
   projects.registry.vmware.com/tce/tkr:v1.22.7-2
   Downloaded to: /home/jmcb/.config/tanzu/tkg/unmanaged/bom/projects.registry.vmware.com_tce_tkr_v1.22.7-2
   Rendered Config: /home/jmcb/.config/tanzu/tkg/unmanaged/life/config.yaml
   Bootstrap Logs: /home/jmcb/.config/tanzu/tkg/unmanaged/life/bootstrap.log
```
