### PR TITLE
Update doc links to "edge" instead of "main"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Tanzu Community Edition
 
-Authors are expected to follow some guidelines when submitting PRs. Please see our [documentation](https://tanzucommunityedition.io/docs/main/contribute/contributing/) for details.
+Authors are expected to follow some guidelines when submitting PRs. Please see our [documentation](https://tanzucommunityedition.io/docs/edge/contribute/contributing/) for details.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ source distribution of VMware Tanzu. It can be installed and deployed in minutes
 local workstation or favorite infrastructure provider. Along with cluster
 management, powered by [Cluster API](https://github.com/kubernetes-sigs/cluster-api),
 Tanzu Community Edition enables higher-level functionality via its robust
-[package management](https://tanzucommunityedition.io/docs/main/package-management)
+[package management](https://tanzucommunityedition.io/docs/edge/package-management)
 built on top of [Carvel's kapp-controller](https://carvel.dev/kapp-controller/),
 and opinionated, yet extensible, [Carvel packages](#packages).
 
@@ -26,7 +26,7 @@ and opinionated, yet extensible, [Carvel packages](#packages).
 
 ## Getting Started
 
-* [Getting Started Guide](https://tanzucommunityedition.io/docs/main/getting-started)
+* [Getting Started Guide](https://tanzucommunityedition.io/docs/edge/getting-started)
 
 ## Installation
 
@@ -94,7 +94,7 @@ platform. Packages included, by default, in Tanzu Community Edition are:
 ## Contributing
 
 If you are ready to jump in and test, add code, or help with documentation,
-follow the instructions on our [Contribution Guidelines](https://tanzucommunityedition.io/docs/main/contribute/contributing/) to
+follow the instructions on our [Contribution Guidelines](https://tanzucommunityedition.io/docs/edge/contribute/contributing/) to
 get started and at all times, follow our [Code of
 Conduct](./CODE_OF_CONDUCT.md).
 
@@ -131,7 +131,7 @@ The following describes the key directories that make up this repository.
 If you have any questions about Tanzu Community Edition, please join [#tanzu-community-edition](https://kubernetes.slack.com/messages/tanzu-community-edition) on [Kubernetes slack](http://slack.k8s.io/).
 
 Please submit [bugs or enhancements requests](https://github.com/vmware-tanzu/community-edition/issues/new/choose) in GitHub.
-More information about troubleshooting and our triage process is available [here](https://tanzucommunityedition.io/docs/main/trouble-faq/).
+More information about troubleshooting and our triage process is available [here](https://tanzucommunityedition.io/docs/edge/trouble-faq/).
 
 Information about our roadmap is available [here](https://github.com/vmware-tanzu/community-edition/blob/main/ROADMAP.md).
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

With recent changes in the versioned docs to allow seeing locally made
changes, the "main" version of the docs are no longer published and
there is just "edge". We had a few links in our README and CONTRIBUTING
docs that referenced other documentation under this path that now fail.

This updates those links to point to their "edge" equivalents.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4322 