### PR TITLE
Fix update automation for choco and homebrew

### DIFF
--- a/.github/workflows/release-choco-package.yaml
+++ b/.github/workflows/release-choco-package.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-choco-package:
     name: Update Choco Package
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
     runs-on: ubuntu-latest
     steps:
       - name: Config credentials
@@ -16,9 +18,6 @@ jobs:
         run: |
           git config --global pull.rebase true
           git config --global url."https://git:${GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
-          git config --global user.name github-actions
-          git config --global user.email github-actions@github.com
-
 
       - name: Check out code
         uses: actions/checkout@v1
@@ -26,8 +25,9 @@ jobs:
       - name: Update Choco Package
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
+          ACTUAL_COMMIT_SHA: ${{ github.sha }}
+          TCE_CI_BUILD: true
         shell: bash
         run: |
-          GITHUB_REF="${{ github.ref }}"
           version=${GITHUB_REF/refs\/tags\//}
           ./hack/choco/update-choco-package.sh ${version}

--- a/.github/workflows/release-homebrew-package.yaml
+++ b/.github/workflows/release-homebrew-package.yaml
@@ -18,8 +18,6 @@ jobs:
         run: |
           git config --global pull.rebase true
           git config --global url."https://git:${GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
-          git config --global user.name github-actions
-          git config --global user.email github-actions@github.com
 
       - name: Check out code
         uses: actions/checkout@v1
@@ -27,8 +25,9 @@ jobs:
       - name: Update Homebrew Package
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
+          ACTUAL_COMMIT_SHA: ${{ github.sha }}
+          TCE_CI_BUILD: true
         shell: bash
         run: |
-          GITHUB_REF="${{ github.ref }}"
           version=${GITHUB_REF/refs\/tags\//}
           ./hack/homebrew/update-homebrew-package.sh ${version}

--- a/hack/choco/update-choco-package.sh
+++ b/hack/choco/update-choco-package.sh
@@ -1,69 +1,111 @@
 #!/bin/bash
- 
+
 # Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
- 
-set -o errexit
+
 set -o nounset
 set -o pipefail
 set -o xtrace
- 
+
 version="${1:?TCE version argument empty. Example usage: ./hack/choco/update-choco-package.sh v0.10.0}"
 : "${GITHUB_TOKEN:?GITHUB_TOKEN is not set}"
- 
- 
-temp_dir=$(mktemp -d)
- 
-pushd "${temp_dir}"
 
-TCE_REPO="https://github.com/vmware-tanzu/community-edition" 
+# we only allow this to run from GitHub CI/Action
+if [[ "${TCE_CI_BUILD}" != "true" ]]; then
+    echo "This is only meant to be run within GitHub Actions CI"
+    exit 1
+fi
+
 TCE_REPO_RELEASES_URL="https://github.com/vmware-tanzu/community-edition/releases"
 TCE_WINDOWS_ZIP_FILE="tce-windows-amd64-${version}.zip"
 TCE_CHECKSUMS_FILE="tce-checksums.txt"
- 
+
 echo "Checking if the necessary files exist for the TCE ${version} release"
- 
 wget --spider -q \
    "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_WINDOWS_ZIP_FILE}" || {
        echo "${TCE_WINDOWS_ZIP_FILE} is not accessible in TCE ${version} release"
        exit 1
    }
- 
-wget --spider -q "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_CHECKSUMS_FILE}" || {
+
+wget "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_CHECKSUMS_FILE}" || {
    echo "${TCE_CHECKSUMS_FILE} is not accessible in TCE ${version} release"
    exit 1
 }
- 
-# Use --depth 1 once https://github.com/cli/cli/issues/2979#issuecomment-780490392 get resolve
-git clone "${TCE_REPO}"
 
-cd community-edition
- 
-PR_BRANCH="update-tce-to-${version}-${RANDOM}"
- 
-# Random number in branch name in case there's already some branch for the version update,
-# though there shouldn't be one. There could be one if the other branch's PR tests failed and didn't merge
-git checkout -b "${PR_BRANCH}"
+# download checksum file
+windows_amd64_shasum=$(grep "${TCE_WINDOWS_ZIP_FILE}" "${TCE_CHECKSUMS_FILE}" | cut -d ' ' -f1)
+rm -f "${TCE_CHECKSUMS_FILE}"
+
+# setup
+git config user.name github-actions
+git config user.email github-actions@github.com
+
+# which branch did this hash/tag come from
+# get commit hash for this tag, then find which branch the hash is on
+#
+# we need to do this in two stages since we could create a tag on main and then
+# create a release branch and tag immediately on that release branch. the new tag would appear in
+# both main and this new branch because the commit is the same
+
+# first test the release branch because it gets priority
+WHICH_BRANCH=$(git branch -a --contains "${ACTUAL_COMMIT_SHA}" | grep remotes | grep -v -e detached -e HEAD | grep -E "\brelease-[0-9]+\.[0-9]+\b"  | cut -d "/" -f3)
+echo "branch: ${WHICH_BRANCH}"
+if [[ "${WHICH_BRANCH}" == "" ]]; then
+    # now try main since the release branch doesnt exist
+    WHICH_BRANCH=$(git branch -a --contains "${ACTUAL_COMMIT_SHA}" | grep remotes | grep -v -e detached -e HEAD | grep -E "\bmain\b"  | cut -d "/" -f3)
+    echo "branch: ${WHICH_BRANCH}"
+    if [[ "${WHICH_BRANCH}" == "" ]]; then
+        echo "Unable to find the branch associated with this hash."
+        exit 1
+    fi
+fi
+
+# make sure we are running on a clean state before checking out
+git reset --hard
+git fetch
+git checkout "${WHICH_BRANCH}"
+git pull origin "${WHICH_BRANCH}"
 
 
 # Replacing old version with the latest stable released version.
-# Using -i so that it works on Mac and Linux OS, so that it's useful for local development.
-sed -i -e "s/\(\$releaseVersion =\).*/\$releaseVersion = ""'${version}'""/g" hack/choco/tools/chocolateyinstall.ps1 
-rm -fv hack/choco/tools/chocolateyinstall.ps1-e
+pushd "./hack/choco" || exit 1
 
-version="${version:1}"
-sed -i -e "s/\(<version>\).*\(<\/version>\)/<version>""${version}""\<\/version>/g" hack/choco/tanzu-community-edition.nuspec
-rm -fv hack/choco/tanzu-community-edition.nuspec-e
- 
+    sed -i.bak -E "s/\\\$releaseVersion =.*/\$releaseVersion = \'${version}\'/g" tools/chocolateyinstall.ps1 && rm tools/chocolateyinstall.ps1.bak
+
+    version="${version:1}"
+    sed -i.bak -E "s/<version>.*<\/version>/<version>${version}<\/version>/g" tanzu-community-edition.nuspec && rm tanzu-community-edition.nuspec.bak
+
+    sed -i.bak -E "s/\\\$checksum64 =.*/\$checksum64 = \'${windows_amd64_shasum}\'/g" tools/chocolateyinstall.ps1 && rm tools/chocolateyinstall.ps1.bak
+
+popd || exit 1
+
+
+PR_BRANCH="automation-choco-${version}"
+
+# now that we are ready... perform the commit
+# login
+set +x
+echo "${GITHUB_TOKEN}" | gh auth login --with-token
+set -x
+
+git stash
+
+# create the branch from main or the release branch
+DOES_NEW_BRANCH_EXIST=$(git branch -a | grep remotes | grep "${PR_BRANCH}")
+echo "does branch exist: ${DOES_NEW_BRANCH_EXIST}"
+if [[ "${DOES_NEW_BRANCH_EXIST}" == "" ]]; then
+    git checkout -b "${PR_BRANCH}" "${WHICH_BRANCH}"
+else
+    git checkout "${PR_BRANCH}"
+    git rebase -Xtheirs "origin/${WHICH_BRANCH}"
+fi
+
+git stash pop
+
+# do the work
 git add hack/choco/tools/chocolateyinstall.ps1
 git add hack/choco/tanzu-community-edition.nuspec
- 
-git commit -m "auto-generated - update tce choco install scripts for version ${version}"
- 
+git commit -s -m "auto-generated - update tce choco install scripts for version ${version}"
 git push origin "${PR_BRANCH}"
- 
-gh pr create --repo ${TCE_REPO} --title "auto-generated - update tce choco install scripts for version ${version}" --body "auto-generated - update tce choco install scripts for version ${version}"
- 
-gh pr merge --repo ${TCE_REPO} "${PR_BRANCH}" --squash --delete-branch --auto
- 
-popd
+gh pr create --title "auto-generated - update tce choco install scripts for version ${version}" --body "auto-generated - update tce choco install scripts for version ${version}" --base "${WHICH_BRANCH}"
+gh pr merge "${PR_BRANCH}" --delete-branch --squash --admin

--- a/hack/homebrew/update-homebrew-package.sh
+++ b/hack/homebrew/update-homebrew-package.sh
@@ -3,7 +3,6 @@
 # Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set -o errexit
 set -o nounset
 set -o pipefail
 set -o xtrace
@@ -11,9 +10,11 @@ set -o xtrace
 version="${1:?TCE version argument empty. Example usage: ./hack/homebrew/update-homebrew-package.sh v0.10.0}"
 : "${GITHUB_TOKEN:?GITHUB_TOKEN is not set}"
 
-temp_dir=$(mktemp -d)
-
-pushd "${temp_dir}"
+# we only allow this to run from GitHub CI/Action
+if [[ "${TCE_CI_BUILD}" != "true" ]]; then
+    echo "This is only meant to be run within GitHub Actions CI"
+    exit 1
+fi
 
 TCE_REPO_RELEASES_URL="https://github.com/vmware-tanzu/community-edition/releases"
 TCE_DARWIN_TAR_BALL_FILE="tce-darwin-amd64-${version}.tar.gz"
@@ -23,13 +24,13 @@ TCE_HOMEBREW_TAP_REPO="https://github.com/vmware-tanzu/homebrew-tanzu"
 
 echo "Checking if the necessary files exist for the TCE ${version} release"
 
-curl -f -I -L \
+wget --spider -q \
     "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_DARWIN_TAR_BALL_FILE}" > /dev/null || {
         echo "${TCE_DARWIN_TAR_BALL_FILE} is not accessible in TCE ${version} release"
         exit 1
     }
 
-curl -f -I -L \
+wget --spider -q \
     "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_LINUX_TAR_BALL_FILE}" > /dev/null || {
         echo "${TCE_LINUX_TAR_BALL_FILE} is not accessible in TCE ${version} release"
         exit 1
@@ -40,44 +41,88 @@ wget "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_CHECKSUMS_FILE}" || {
     exit 1
 }
 
-darwin_amd64_shasum=$(grep "${TCE_DARWIN_TAR_BALL_FILE}" ${TCE_CHECKSUMS_FILE} | cut -d ' ' -f 1)
+darwin_amd64_shasum=$(grep "${TCE_DARWIN_TAR_BALL_FILE}" "${TCE_CHECKSUMS_FILE}" | cut -d ' ' -f1)
+linux_amd64_shasum=$(grep "${TCE_LINUX_TAR_BALL_FILE}" "${TCE_CHECKSUMS_FILE}" | cut -d ' ' -f1)
+rm -f "${TCE_CHECKSUMS_FILE}"
 
-linux_amd64_shasum=$(grep "${TCE_LINUX_TAR_BALL_FILE}" ${TCE_CHECKSUMS_FILE} | cut -d ' ' -f 1)
+# clone the homebrew repo
+rm -rf "${TCE_HOMEBREW_TAP_REPO}"
+git clone --depth 1 --branch main "${TCE_HOMEBREW_TAP_REPO}"
 
-git clone ${TCE_HOMEBREW_TAP_REPO}
+pushd "./homebrew-tanzu" || exit 1
 
-cd homebrew-tanzu
+# setup
+git config user.name github-actions
+git config user.email github-actions@github.com
 
-# make sure we are on main branch before checking out
-git checkout main
+# which branch did this hash/tag come from
+# get commit hash for this tag, then find which branch the hash is on
+#
+# we need to do this in two stages since we could create a tag on main and then
+# create a release branch and tag immediately on that release branch. the new tag would appear in
+# both main and this new branch because the commit is the same
 
-PR_BRANCH="update-tce-to-${version}-${RANDOM}"
+# first test the release branch because it gets priority
+WHICH_BRANCH=$(git branch -a --contains "${ACTUAL_COMMIT_SHA}" | grep remotes | grep -v -e detached -e HEAD | grep -E "\brelease-[0-9]+\.[0-9]+\b"  | cut -d "/" -f3)
+echo "branch: ${WHICH_BRANCH}"
+if [[ "${WHICH_BRANCH}" == "" ]]; then
+    # now try main since the release branch doesnt exist
+    WHICH_BRANCH=$(git branch -a --contains "${ACTUAL_COMMIT_SHA}" | grep remotes | grep -v -e detached -e HEAD | grep -E "\bmain\b"  | cut -d "/" -f3)
+    echo "branch: ${WHICH_BRANCH}"
+    if [[ "${WHICH_BRANCH}" == "" ]]; then
+        echo "Unable to find the branch associated with this hash."
+        exit 1
+    fi
+fi
 
-# Random number in branch name in case there's already some branch for the version update,
-# though there shouldn't be one. There could be one if the other branch's PR tests failed and didn't merge
-git checkout -b "${PR_BRANCH}"
+# make sure we are running on a clean state before checking out
+git reset --hard
+git fetch
+git checkout "${WHICH_BRANCH}"
+git pull origin "${WHICH_BRANCH}"
+
 
 # Replacing old version with the latest stable released version.
-# Using -i so that it works on Mac and Linux OS, so that it's useful for local development.
-sed -i.bak "s/version \"v.*/version \"${version}\"/" tanzu-community-edition.rb
-rm -fv tanzu-community-edition.rb.bak
-
+sed -i.bak -E "s/version \"v.*/version \"${version}\"/" tanzu-community-edition.rb && rm tanzu-community-edition.rb.bak
 # First occurrence of sha256 is for MacOS SHA sum
 awk "/sha256 \".*/{c+=1}{if(c==1){sub(\"sha256 \\\".*\",\"sha256 \\\"${darwin_amd64_shasum}\\\"\",\$0)};print}" tanzu-community-edition.rb > tanzu-community-edition-updated.rb
 mv tanzu-community-edition-updated.rb tanzu-community-edition.rb
-
 # Second occurrence of sha256 is for Linux SHA sum
 awk "/sha256 \".*/{c+=1}{if(c==2){sub(\"sha256 \\\".*\",\"sha256 \\\"${linux_amd64_shasum}\\\"\",\$0)};print}" tanzu-community-edition.rb > tanzu-community-edition-updated.rb
 mv tanzu-community-edition-updated.rb tanzu-community-edition.rb
 
+
+PR_BRANCH="automation-homebrew-${version}"
+
+# now that we are ready... perform the commit
+# login
+set +x
+echo "${GITHUB_TOKEN}" | gh auth login --with-token
+set -x
+
+git stash
+
+# create the branch from main or the release branch
+DOES_NEW_BRANCH_EXIST=$(git branch -a | grep remotes | grep "${PR_BRANCH}")
+echo "does branch exist: ${DOES_NEW_BRANCH_EXIST}"
+if [[ "${DOES_NEW_BRANCH_EXIST}" == "" ]]; then
+    git checkout -b "${PR_BRANCH}" "${WHICH_BRANCH}"
+else
+    git checkout "${PR_BRANCH}"
+    git rebase -Xtheirs "origin/${WHICH_BRANCH}"
+fi
+
+git stash pop
+
+# do the work
 git add tanzu-community-edition.rb
-
-git commit -m "auto-generated - update tce homebrew formula for version ${version}"
-
+git commit -s -m "auto-generated - update tce homebrew formula for version ${version}"
 git push origin "${PR_BRANCH}"
+gh pr create --repo "${TCE_HOMEBREW_TAP_REPO}" --title "auto-generated - update tce homebrew formula for version ${version}" --body "auto-generated - update tce homebrew formula for version ${version}"
+gh pr merge --repo "${TCE_HOMEBREW_TAP_REPO}" "${PR_BRANCH}" --squash --delete-branch --admin
 
-gh pr create --repo ${TCE_HOMEBREW_TAP_REPO} --title "auto-generated - update tce homebrew formula for version ${version}" --body "auto-generated - update tce homebrew formula for version ${version}"
+# tag the new dev release
+git tag -m "${version}" "${version}"
+git push origin "${version}"
 
-gh pr merge --repo ${TCE_HOMEBREW_TAP_REPO} "${PR_BRANCH}" --squash --delete-branch --auto
-
-popd
+popd || exit 1


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This copies a lot of what was done in this PR https://github.com/vmware-tanzu/community-edition/pull/3210/ but adds in the following:
- a check to make sure this only ever runs in CI
- adds support for handling release branches
- slight fixes to the the grep/replace functionality
- tags the homebrew repo when the release is created

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/3179
Obsoletes: https://github.com/vmware-tanzu/community-edition/pull/3210/

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested the scripts by hand to make sure the things that need to be changed are working correctly.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
A follow up to this PR needs to include in a separate PR:
- invoking the choco publish in a (existing?) workflow