### PR TITLE
UC: raise log level for some log messages

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -58,7 +58,7 @@ func configure(cmd *cobra.Command, args []string) error {
 		clusterName = args[0]
 	}
 
-	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
 
 	portMaps, err := config.ParsePortMappings(co.portMapping)
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -109,7 +109,7 @@ func create(cmd *cobra.Command, args []string) {
 	}
 
 	// initial logger, needed for logging if something goes wrong
-	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
 
 	// Attempt to read cluster name from provided kubeconfig
 	if co.existingClusterKubeconfig != "" {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
@@ -45,7 +45,7 @@ func destroy(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
 
 	log.Eventf(logger.TestTubeEmoji, "Deleting cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
@@ -50,7 +50,7 @@ func init() {
 
 // list outputs a list of all unmanaged clusters on the system.
 func list(cmd *cobra.Command, args []string) error {
-	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
 	tClient := tanzu.New(log)
 	clusters, err := tClient.List()
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/start.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/start.go
@@ -42,7 +42,7 @@ func start(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
 
 	log.Eventf(logger.TestTubeEmoji, "Attempting to start cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/stop.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/stop.go
@@ -43,7 +43,7 @@ func stop(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
 
 	log.Eventf(logger.TestTubeEmoji, "Attempting to stop cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/unmanaged-cluster/log/log.go
+++ b/cli/cmd/plugin/unmanaged-cluster/log/log.go
@@ -35,6 +35,9 @@ const (
 	MagnetEmoji     = "\U0001F9F2"
 )
 
+// DefaultLogLevel controls the default verbosity of log messages.
+var DefaultLogLevel = 0
+
 // CMDLogger is the logger implementation used for high-level command line logging.
 type CMDLogger struct {
 	// whether to support stylizing logging output
@@ -367,8 +370,7 @@ func (l *CMDLogger) AnimateProgressWithOptions(options ...AnimatorOption) {
 func (l *CMDLogger) V(level int) Logger {
 	return &CMDLogger{
 		tty:      l.tty,
-		level:    l.level,
-		logLevel: level,
+		logLevel: l.level,
 		output:   l.output,
 	}
 }

--- a/cli/cmd/plugin/unmanaged-cluster/main.go
+++ b/cli/cmd/plugin/unmanaged-cluster/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/cmd"
+	logging "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/log"
 )
 
 var description = `Deploy and manage single-node, static, Tanzu clusters.`
@@ -35,7 +36,7 @@ func main() {
 		log.Fatal(err, "unable to initialize new plugin")
 	}
 
-	p.Cmd.PersistentFlags().Int32VarP(&logLevel, "verbose", "v", 0, "Number for the log level verbosity(0-9)")
+	p.Cmd.PersistentFlags().Int32VarP(&logLevel, "verbose", "v", 2, "Number for the log level verbosity(0-9)")
 	p.Cmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Log file path")
 
 	p.AddCommands(
@@ -48,6 +49,9 @@ func main() {
 	)
 
 	cmd.SetupRootCommand(p.Cmd)
+
+	// Configure our logging default
+	logging.DefaultLogLevel = int(logLevel)
 
 	if err := p.Execute(); err != nil {
 		os.Exit(1)

--- a/extensions/docker-desktop/apps/clustermgr/pkg/cluster/cluster.go
+++ b/extensions/docker-desktop/apps/clustermgr/pkg/cluster/cluster.go
@@ -134,7 +134,7 @@ func (c *Cluster) CreateCluster() config.Response {
 	// Create Cluster without preflight checks  --> $TCE create "${CLUSTER_NAME}" --skip-preflight -f "$HOME/cluster-config-$$.yaml"
 	// TODO: See how we can stream output of the TCE process back or write it to a file
 	//nolint:gosec
-	cmd = exec.Command(config.UnmanagedClusterBinary, "create", config.DefaultClusterName, "--skip-preflight", "-f", config.GetClusterConfigFileName())
+	cmd = exec.Command(config.UnmanagedClusterBinary, "create", "-v", "0", config.DefaultClusterName, "--skip-preflight", "-f", config.GetClusterConfigFileName())
 	if err := cmd.Run(); err != nil {
 		log.Errorf("Error while creating the cluster (%s)", err.Error())
 		return config.Response{
@@ -190,7 +190,7 @@ func (c *Cluster) DeleteCluster() config.Response {
 	if status != checks.NotExist {
 		log.Info("Deleting cluster")
 		//nolint:gosec
-		cmd := exec.Command(config.UnmanagedClusterBinary, "delete", config.DefaultClusterName)
+		cmd := exec.Command(config.UnmanagedClusterBinary, "delete", "-v", "0", config.DefaultClusterName)
 		if err := cmd.Run(); err != nil {
 			log.Errorf("Error while deleting the cluster (%s)", err.Error())
 			log.Info("Force delete non running container")


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This raises the level of some local path and other unmanaged cluster
output that we don't want emitted by default for the Docker Desktop
integration. It also raises the default verbosity of commands so even
though these are logging at a higher level, they will still be printed
in a normal run.

This allows the Docker Desktop integration to explicitly run these calls
with a lower verbosity and not include the messages.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4351 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

```
go run . create foo
go run . rm foo
go run . create -v 2 foo
go run . rm -v 2 foo
```
