### PR TITLE
Fix next tag to be used when cutting a release on a release branch

### DIFF
--- a/hack/release/release/release.go
+++ b/hack/release/release/release.go
@@ -131,10 +131,10 @@ func getDraftRelease(client *github.Client, tag string) (*github.RepositoryRelea
 }
 
 // update Release version
-func newRelease(current string) error {
+func newRelease(current string, relbranch bool) error {
 	fmt.Printf("tag: %s\n", current)
 
-	newVersion, err := incrementRelease(current)
+	newVersion, err := incrementRelease(current, relbranch)
 	if err != nil {
 		fmt.Printf("incrementRelease failed. Err: %v\n", err)
 		return err
@@ -187,7 +187,7 @@ func bumpRelease(current string) error {
 }
 
 // helper Release functions
-func incrementRelease(tag string) (string, error) {
+func incrementRelease(tag string, relbranch bool) (string, error) {
 	items := strings.Split(tag, ".")
 	if len(items) != NumberOfSemVerSeparators {
 		fmt.Printf("Split version failed\n")
@@ -208,7 +208,7 @@ func incrementRelease(tag string) (string, error) {
 
 	// are we on a release branch (ie vX.Y.[0-9]+)? then increment the patch version
 	// otherwise, this is a minor release and increment the minor version
-	if iPatch > 0 {
+	if relbranch {
 		iPatch++
 	} else {
 		iMinor++
@@ -344,6 +344,9 @@ func main() {
 	var skip bool
 	flag.BoolVar(&skip, "skip", false, "Skip making changes to draft release")
 
+	var relbranch bool
+	flag.BoolVar(&relbranch, "relbranch", false, "We are on a release branch")
+
 	flag.Parse()
 	// flags
 
@@ -366,7 +369,7 @@ func main() {
 			return
 		}
 
-		err = newRelease(tag)
+		err = newRelease(tag, relbranch)
 		if err != nil {
 			fmt.Printf("newRelease failed. Err: %v\n", err)
 			return
@@ -381,7 +384,7 @@ func main() {
 
 		err = bumpRelease(tag)
 		if err != nil {
-			fmt.Printf("newRelease failed. Err: %v\n", err)
+			fmt.Printf("bumpRelease failed. Err: %v\n", err)
 			return
 		}
 	}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Upon inspection of the cutting the GA release, I noticed that we didn't correct add a new dev tag for the release branches (for example `release-011`). The tag afterwards should have been `v0.11.1-dev.1`. I manually created that tag to keep the normal workflow.

The fix is all in this line right here:
https://github.com/vmware-tanzu/community-edition/pull/4361/files#diff-a2560a7f7851cbaa385bc60a1d4574a115c372df8857a19a9b9c301fbf486ecaR211

This change detects if we created the branch off a release branch then correctly bumps the patch version.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested locally....
```
[vonthd@rocky8 release]$ go run ./release.go -previous v0.10.0 -tag v0.11.0 -relbranch
Cutting GA release, so resetting
tag: v0.11.0
incrementRelease: v0.11.1
DEV_BUILD: dev.1
incrementRelease: v0.11.1-dev.1
```

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA