### PR TITLE
Fixed feedback button link

### DIFF
--- a/extensions/docker-desktop/Dockerfile
+++ b/extensions/docker-desktop/Dockerfile
@@ -33,7 +33,7 @@ ARG LICENSE='Apache-2.0'
 ARG ICON_URL='https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/docs/images/logos/tce-logo-only.png'
 # ARG SCREENSHOTS_URLS='[ { "alt": "Cluster view", "url": "https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/extensions/docker-desktop/docs/img/screenshots/cluster.png" } ]'
 ARG PUBLISHER_URL='https://github.com/vmware-tanzu/community-edition'
-ARG ADDITIONAL_URLS='[ { "title": "VMware Tanzu Community Edition", "url": "https://tanzucommunityedition.io/" }, { "title": "Documentation", "url": "https://tanzucommunityedition.io/docs/latest/" }, { "title": "Support", "url": "https://github.com/vmware-tanzu/community-edition" }, { "title": "Terms of Service", "url": "https://github.com/vmware-tanzu/community-edition/blob/main/LICENSE" }, { "title": "Privacy policy", "url": "https://www.vmware.com/help/privacy.html" }]'
+ARG ADDITIONAL_URLS='[ { "title": "VMware Tanzu Community Edition", "url": "https://tanzucommunityedition.io/" }, { "title": "Documentation", "url": "https://tanzucommunityedition.io/docs/latest/" }, { "title": "Support", "url": "https://github.com/vmware-tanzu/community-edition/issues/new/choose" }, { "title": "Terms of Service", "url": "https://github.com/vmware-tanzu/community-edition/blob/main/LICENSE" }, { "title": "Privacy policy", "url": "https://www.vmware.com/help/privacy.html" }]'
 
 ARG CHANGELOG='<p>Extension changelog:</p> <ul> <li>Initial release</li> </ul>'
 

--- a/extensions/docker-desktop/ui/src/shared/constants.tsx
+++ b/extensions/docker-desktop/ui/src/shared/constants.tsx
@@ -12,6 +12,6 @@ export const TCE_KUBEAPPS_README =
   'https://tanzucommunityedition.io/docs/v0.11/package-readme-contour-1.20.1/';
 
 export const EXTENSION_REPO_ISSUES =
-  'https://github.com/vmware-tanzu/community-edition/issues/new';
+  'https://github.com/vmware-tanzu/community-edition/issues/new/choose';
 export const EXTENSION_REPO_LICENSE =
   'https://raw.githubusercontent.com/vmware-tanzu/community-edition/main/LICENSE';


### PR DESCRIPTION
## What this PR does / why we need it
Makes the feedback button point to https://github.com/vmware-tanzu/community-edition/issues/new/choose, and also the support button on the extension in the marketplace view.

<img width="975" alt="image" src="https://user-images.githubusercontent.com/78350/167018586-e2b212ef-5e2f-4115-8cd6-a43e327de41a.png">
<img width="561" alt="image" src="https://user-images.githubusercontent.com/78350/167018618-2dd73cf3-fede-4115-a903-4fda5ef9f9a3.png">


## Which issue(s) this PR fixes
Fixes: #4381 

## Describe testing done for PR
Build and click on the feedback button link

Signed-off-by: Jorge Morales Pou <jorgemoralespou@gmail.com>
