### PR TITLE
Docker extension: Use `buildx` for build steps

### DIFF
--- a/extensions/docker-desktop/Dockerfile-apps-bin
+++ b/extensions/docker-desktop/Dockerfile-apps-bin
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # BUILD BACKEND GO
-FROM bitnami/golang:1.18.0
+FROM golang:1.18.1
 
 ARG TARGETARCH
 

--- a/extensions/docker-desktop/Dockerfile-client
+++ b/extensions/docker-desktop/Dockerfile-client
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # BUILD FRONTEND
-FROM bitnami/node:16.14.2
+FROM node:16.14.2
 
 ARG TARGETARCH
 

--- a/extensions/docker-desktop/Dockerfile-tanzu-cli
+++ b/extensions/docker-desktop/Dockerfile-tanzu-cli
@@ -3,7 +3,7 @@
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM bitnami/golang:1.18.0
+FROM golang:1.18.1
 
 ARG TARGETARCH
 

--- a/extensions/docker-desktop/Makefile
+++ b/extensions/docker-desktop/Makefile
@@ -19,19 +19,19 @@ NO_COLOR   = \033[m
 .DEFAULT_GOAL := extension
 
 build-tanzucli: ## Build the tanzu cli container image
-	docker build $(BUILD_ARGS) --tag=$(IMAGE)-tanzu-cli:$(TAG) -f Dockerfile-tanzu-cli .
+	docker buildx build $(BUILD_ARGS) --tag=$(IMAGE)-tanzu-cli:$(TAG) -f Dockerfile-tanzu-cli .
 .PHONY: build-tanzucli
 
 build-appsbin: ## Build the dashboard container image
-	docker build $(BUILD_ARGS) --tag=$(IMAGE)-apps-bin:$(TAG) -f Dockerfile-apps-bin .
+	docker buildx build $(BUILD_ARGS) --tag=$(IMAGE)-apps-bin:$(TAG) -f Dockerfile-apps-bin .
 .PHONY: build-appsbin
 
 build-downloader: ## Build the binary downloader container image
-	docker build $(BUILD_ARGS) --tag=$(IMAGE)-downloader:$(TAG) -f Dockerfile-downloader .
+	docker buildx build $(BUILD_ARGS) --tag=$(IMAGE)-downloader:$(TAG) -f Dockerfile-downloader .
 .PHONY: build-downloader
 
 build-client: ## Build the UI container image
-	docker build $(BUILD_ARGS) --tag=$(IMAGE)-client:$(TAG) -f Dockerfile-client .
+	docker buildx build $(BUILD_ARGS) --tag=$(IMAGE)-client:$(TAG) -f Dockerfile-client .
 .PHONY: build-client
 
 build-deps: ## Build the required images used in the extension image


### PR DESCRIPTION
## What this PR does / why we need it

- Supports multi arch development, including on M1 macbooks

The bitnami golang and node images don't have builds for arm, so this switches to using the default dockerhub images.

## Which issue(s) this PR fixes
Related: https://github.com/vmware-tanzu/community-edition/pull/4384#issuecomment-1119100092

## Describe testing done for PR
Able to run `make extension` and than `make install`. Then, able to start cluster on m1 / arm mac.

Needs validation from non arm machine.
