### PR TITLE
UC: Raise cluster delete log level

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -371,8 +371,8 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int,
 	log.Style(outputIndent, color.FgGreen).Infof("tanzu package available list\n")
 	log.Infof("View running pods:\n")
 	log.Style(outputIndent, color.FgGreen).Infof("kubectl get po -A\n")
-	log.Infof("Delete this cluster:\n")
-	log.Style(outputIndent, color.FgGreen).Infof("tanzu unmanaged delete %s\n", scConfig.ClusterName)
+	log.V(2).Infof("Delete this cluster:\n")
+	log.V(2).Style(outputIndent, color.FgGreen).Infof("tanzu unmanaged delete %s\n", scConfig.ClusterName)
 	return returnCode, nil
 }
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

On cluster creation we print out steps explaining how to delete the
cluster. This raises the log level on those messages so they are not
printed when verbosity is set lower so things like the Docker Desktop
integration where the default instructions do not apply.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4392 