### PR TITLE
Releasing v0.21.7 of fluxcd-source-controller

### DIFF
--- a/addons/packages/fluxcd-source-controller/0.21.7/README.md
+++ b/addons/packages/fluxcd-source-controller/0.21.7/README.md
@@ -1,0 +1,193 @@
+# Fluxcd-source-controller
+
+The source-controller is a Kubernetes operator, specialised in artifacts acquisition
+from external sources such as Git, Helm repositories and S3 buckets.
+The source-controller implements the
+[source.toolkit.fluxcd.io](https://github.com/fluxcd/source-controller/tree/master/docs/spec/v1beta1) API
+and is a core component of the [GitOps toolkit](https://toolkit.fluxcd.io).
+
+## Configuration
+
+The fluxcd-source-controller package has following configurable properties.
+
+| Value           | Required/Optional |                           Description                                                |
+|-----------------|-------------------|--------------------------------------------------------------------------------------|
+| `namespace`     | Optional          | Sets namespace for k8s objects where resources of source-controller will be created. |
+| `limits_cpu`    | Optional          | Sets maximum usage of cpu for source-controller deployment.                          |
+| `limits_memory` | Optional          | Sets maximum usage of memory for source-controller deployment.                       |
+| `no_proxy`      | Optional          | Set domains for which no proxying should be performed                                |
+| `https_proxy`   | Optional          | Set secure proxy connection information                                              |
+| `http_proxy`    | Optional          | Set unsecure proxy connection information                                            |
+
+```yaml
+---
+namespace: flux-system-namespace
+limits_cpu: 1050m
+limits_memory: 2Gi
+service_port: 90
+no_proxy: ""
+https_proxy: ""
+http_proxy: ""
+```
+
+## Installation
+
+To install FluxCD source-controller from the Tanzu Application Platform package repository:
+
+1. List version information for the package by running:
+
+    ```shell
+    tanzu package available list fluxcd-source-controller.community.tanzu.vmware.com
+    ```
+
+    For example:
+
+    ```shell
+    \ Retrieving package versions for fluxcd-source-controller.community.tanzu.vmware.com...
+      NAME                                                 VERSION  RELEASED-AT
+      fluxcd-source-controller.community.tanzu.vmware.com  0.21.2   2022-02-07 06:14:08 -0500 -05
+      fluxcd-source-controller.community.tanzu.vmware.com  0.21.3   2022-02-07 06:14:08 -0500 -05
+      fluxcd-source-controller.community.tanzu.vmware.com  0.21.7   2022-02-07 06:14:08 -0500 -05
+    ```
+
+2. Install the package by running:
+
+    ```shell
+    tanzu package install fluxcd-source-controller -p fluxcd-source-controller.community.tanzu.vmware.com -v VERSION-NUMBER
+    ```
+
+    Where:
+
+    - `VERSION-NUMBER` is the version of the package listed in step 1.
+
+    For example:
+
+    ```shell
+    tanzu package install fluxcd-source-controller -p fluxcd-source-controller.community.tanzu.vmware.com -v 0.21.7
+    \ Installing package 'fluxcd-source-controller.community.tanzu.vmware.com'
+    | Getting package metadata for 'fluxcd-source-controller.community.tanzu.vmware.com'
+    | Creating service account 'fluxcd-source-controller-default-sa'
+    | Creating cluster admin role 'fluxcd-source-controller-default-cluster-role'
+    | Creating cluster role binding 'fluxcd-source-controller-default-cluster-rolebinding'
+    | Creating package resource
+    / Waiting for 'PackageInstall' reconciliation for 'fluxcd-source-controller'
+    / 'PackageInstall' resource install status: Reconciling
+
+
+     Added installed package 'fluxcd-source-controller'
+    ```
+
+3. Verify the package install by running:
+
+    ```shell
+    tanzu package installed get fluxcd-source-controller
+    ```
+
+    For example:
+
+    ```shell
+    \ Retrieving installation details for fluxcd-source-controller...
+    NAME:                    fluxcd-source-controller
+    PACKAGE-NAME:            fluxcd-source-controller.community.tanzu.vmware.com
+    PACKAGE-VERSION:         0.21.7
+    STATUS:                  Reconcile succeeded
+    CONDITIONS:              [{ReconcileSucceeded True  }]
+    USEFUL-ERROR-MESSAGE:
+    ```
+
+    Verify that `STATUS` is `Reconcile succeeded`
+
+    ```shell
+    kubectl get pods -n flux-system
+    ```
+
+    For example:
+
+    ```shell
+    $ kubectl get pods -n flux-system
+    NAME                                 READY   STATUS    RESTARTS   AGE
+    source-controller-69859f545d-ll8fj   1/1     Running   0          3m38s
+    ```
+
+    Verify that `STATUS` is `Running`
+
+## Try fluxcd-source-controller
+
+1. Verify all the objects are installed:
+
+    This package would create a new namespace where all the elements of fluxcd will be hosted called `flux-system`
+
+    you can verify the main components of `fluxcd-source-controller` were installed by running:
+
+    ```shell
+    kubectl get all -n flux-system
+    NAME                                     READY   STATUS    RESTARTS   AGE
+    pod/source-controller-7684c85659-2zfxb   1/1     Running   0          40m
+
+    NAME                        TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
+    service/source-controller   ClusterIP   10.108.138.74   <none>        80/TCP    40m
+
+    NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
+    deployment.apps/source-controller   1/1     1            1           40m
+
+    NAME                                           DESIRED   CURRENT   READY   AGE
+    replicaset.apps/source-controller-7684c85659   1         1         1       40m
+    ```
+
+    you should get something really similar!
+
+2. Verify all the CRD were installed correctly:
+
+    The way you would communicate with `fluxcd-source-controller` would be through its CRDs, this will be your main action point.
+
+    In order to check all the CRDs were installed you can run:
+
+    ```shell
+    kubectl get crds -n flux-system | grep ".fluxcd.io"
+    buckets.source.toolkit.fluxcd.io                         2022-03-07T19:20:14Z
+    gitrepositories.source.toolkit.fluxcd.io                 2022-03-07T19:20:14Z
+    helmcharts.source.toolkit.fluxcd.io                      2022-03-07T19:20:14Z
+    helmrepositories.source.toolkit.fluxcd.io                2022-03-07T19:20:14Z
+    ```
+
+3. Try one simple example:
+
+    Try one quick example yourself, so you can check everything is working as expected
+
+    - Let's consume a `GitRepository` object,
+
+      - Create the following `gitrepository-sample.yaml` file:
+
+          ```yaml
+          apiVersion: source.toolkit.fluxcd.io/v1beta1
+          kind: GitRepository
+          metadata:
+            name: gitrepository-sample
+          spec:
+            interval: 1m
+            url: https://github.com/stefanprodan/podinfo
+            ref:
+              branch: master
+          ```
+
+      - Apply the created conf
+
+          ```shell
+          kubectl apply -f gitrepository-sample.yaml
+          gitrepository.source.toolkit.fluxcd.io/gitrepository-sample created
+          ```
+
+      - Check the git-repository was fetched correctly
+
+          ```shell
+          kubectl get GitRepository
+          NAME                   URL                                       READY   STATUS                                                              AGE
+          gitrepository-sample   https://github.com/stefanprodan/podinfo   True    Fetched revision: master/132f4e719209eb10b9485302f8593fc0e680f4fc   4s
+          ```
+
+    You can find more examples checking out the samples folder on [fluxcd/source-controller/samples](https://github.com/fluxcd/source-controller/tree/main/config/samples)
+
+## Documentation
+
+For documentation specific to fluxcd-source-controller, check out the main repository
+[fluxcd/source-controller](https://github.com/fluxcd/source-controller).

--- a/addons/packages/fluxcd-source-controller/0.21.7/package.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/package.yaml
@@ -1,0 +1,51 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: fluxcd-source-controller.community.tanzu.vmware.com.0.21.7
+spec:
+  refName: fluxcd-source-controller.community.tanzu.vmware.com
+  version: 0.21.7
+  releasedAt: "2022-02-07T11:14:08Z"
+  valuesSchema:
+    openAPIv3:
+      properties:
+        namespace:
+          type: string
+          description: Deployment and service namespace
+          default: source-system
+        limits_cpu:
+          type: string
+          description: Set cpu usuage limit
+          default: 1000m
+        limits_memory:
+          type: string
+          description: Set memory usuage limit
+          default: 1Gi
+        no_proxy:
+          type: string
+          description: Set domains for which no proxying should be performed
+          default: ""
+        https_proxy:
+          type: string
+          description: Set secure proxy connection information
+          default: ""
+        http_proxy:
+          type: string
+          description: Set unsecure proxy connection information
+          default: ""
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: projects.registry.vmware.com/tce/fluxcd-source-controller-bundle@sha256:ee121262689174a0b60df3fac6450254d17f4e426765612fcfa5318567ee8698
+      template:
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
+          - config/kapp.yml
+      deploy:
+      - kapp: {}

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/e2e.sh
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/e2e.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#!/bin/sh
+#!/usr/bin/env bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+# Checking package is installed or not
+tanzu package installed list | grep "fluxcd-source-controller.community.tanzu.vmware.com" || {
+  version=$(tanzu package available list fluxcd-source-controller.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+  tanzu package install fluxcd-source-controller --package-name fluxcd-source-controller.community.tanzu.vmware.com --version "${version}"
+}
+
+
+function cleanup(){
+    EXIT_CODE="$?"
+
+    # only dump all logs if an error has occurred
+    if [ ${EXIT_CODE} -ne 0 ]; then
+        kubectl -n kube-system describe pods
+        kubectl -n flux-system describe pods
+        kubectl -n flux-system get gitrepositories -oyaml
+        kubectl -n flux-system get helmrepositories -oyaml
+        kubectl -n flux-system get helmcharts -oyaml
+        kubectl -n flux-system get all
+        kubectl -n flux-system logs deploy/source-controller
+        kubectl -n minio get all
+        kubectl -n minio describe pods
+    else
+        echo "All E2E tests passed!"
+    fi
+    exit ${EXIT_CODE}
+}
+trap cleanup EXIT
+
+echo "Run smoke tests"
+kubectl -n flux-system apply -f "flux-source-controller/config/samples"
+kubectl -n flux-system rollout status deploy/source-controller --timeout=1m
+kubectl -n flux-system wait gitrepository/gitrepository-sample --for=condition=ready --timeout=1m
+kubectl -n flux-system wait helmrepository/helmrepository-sample --for=condition=ready --timeout=1m
+kubectl -n flux-system wait helmchart/helmchart-sample --for=condition=ready --timeout=1m
+kubectl -n flux-system delete -f "flux-source-controller/config/samples"
+
+echo "Run HelmChart values file tests"
+kubectl -n flux-system apply -f "flux-source-controller/config/testdata/helmchart-valuesfile"
+kubectl -n flux-system wait helmchart/podinfo --for=condition=ready --timeout=5m
+kubectl -n flux-system wait helmchart/podinfo-git --for=condition=ready --timeout=5m
+kubectl -n flux-system delete -f "flux-source-controller/config/testdata/helmchart-valuesfile"
+
+# Deleting package
+tanzu package installed list | grep "fluxcd-source-controller.community.tanzu.vmware.com" || {
+  version=$(tanzu package available list fluxcd-source-controller.community.tanzu.vmware.com | tail -n 1 | awk '{print $2}')
+  tanzu package installed delete fluxcd-source-controller -y
+}

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/samples/source_v1beta1_bucket.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/samples/source_v1beta1_bucket.yaml
@@ -1,0 +1,11 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: Bucket
+metadata:
+  name: bucket-sample
+spec:
+  interval: 1m
+  provider: generic
+  bucketName: podinfo
+  endpoint: minio.minio.svc.cluster.local:9000
+  region: us-east-1
+  insecure: true

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/samples/source_v1beta1_gitrepository.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/samples/source_v1beta1_gitrepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: gitrepository-sample
+spec:
+  interval: 1m
+  url: https://github.com/stefanprodan/podinfo
+  ref:
+    branch: master

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/samples/source_v1beta1_helmchart_gitrepository.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/samples/source_v1beta1_helmchart_gitrepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmChart
+metadata:
+  name: helmchart-git-sample
+spec:
+  chart: charts/podinfo
+  sourceRef:
+    kind: GitRepository
+    name: gitrepository-sample
+  interval: 1m

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/samples/source_v1beta1_helmchart_helmrepository.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/samples/source_v1beta1_helmchart_helmrepository.yaml
@@ -1,0 +1,11 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmChart
+metadata:
+  name: helmchart-sample
+spec:
+  chart: podinfo
+  version: '>=2.0.0 <3.0.0'
+  sourceRef:
+    kind: HelmRepository
+    name: helmrepository-sample
+  interval: 1m

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/samples/source_v1beta1_helmrepository.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/samples/source_v1beta1_helmrepository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: helmrepository-sample
+spec:
+  interval: 1m
+  url: https://stefanprodan.github.io/podinfo

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/bucket/source.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/bucket/source.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: Bucket
+metadata:
+  name: podinfo
+spec:
+  interval: 1m
+  provider: generic
+  bucketName: podinfo
+  endpoint: minio.minio.svc.cluster.local:9000
+  region: us-east-1
+  insecure: true
+  secretRef:
+    name: minio-credentials

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/git/large-repo.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/git/large-repo.yaml
@@ -1,0 +1,29 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: large-repo-go-git
+spec:
+  gitImplementation: go-git
+  interval: 10m
+  timeout: 2m
+  url: https://github.com/hashgraph/hedera-mirror-node.git
+  ref:
+    branch: main
+  ignore: |
+    /*
+    !/charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: large-repo-libgit2
+spec:
+  gitImplementation: libgit2
+  interval: 10m
+  timeout: 2m
+  url: https://github.com/hashgraph/hedera-mirror-node.git
+  ref:
+    branch: main
+  ignore: |
+    /*
+    !/charts

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/helmchart-from-bucket/source.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/helmchart-from-bucket/source.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: Bucket
+metadata:
+  name: charts
+spec:
+  interval: 1m
+  provider: generic
+  bucketName: charts
+  endpoint: minio.minio.svc.cluster.local:9000
+  region: us-east-1
+  insecure: true
+  secretRef:
+    name: minio-credentials
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmChart
+metadata:
+  name: helmchart-bucket
+spec:
+  chart: ./helmchart
+  sourceRef:
+    kind: Bucket
+    name: charts
+  interval: 1m

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/helmchart-valuesfile/gitrepository.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/helmchart-valuesfile/gitrepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: podinfo
+spec:
+  interval: 5m
+  url: https://github.com/stefanprodan/podinfo
+  ref:
+    branch: v5.x
+  ignore:
+    /*
+    !/charts/

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/helmchart-valuesfile/helmchart_gitrepository.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/helmchart-valuesfile/helmchart_gitrepository.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmChart
+metadata:
+  name: podinfo-git
+spec:
+  interval: 1m
+  sourceRef:
+    kind: GitRepository
+    name: podinfo
+  chart: charts/podinfo
+  valuesFile: charts/podinfo/values.yaml
+  valuesFiles:
+    - charts/podinfo/values-prod.yaml

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/helmchart-valuesfile/helmchart_helmrepository.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/helmchart-valuesfile/helmchart_helmrepository.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmChart
+metadata:
+  name: podinfo
+spec:
+  interval: 1m
+  sourceRef:
+    kind: HelmRepository
+    name: podinfo
+  chart: podinfo
+  valuesFile: values.yaml
+  valuesFiles:
+    - values-prod.yaml

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/helmchart-valuesfile/helmrepository.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/helmchart-valuesfile/helmrepository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: podinfo
+spec:
+  interval: 5m
+  url: https://stefanprodan.github.io/podinfo

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/minio/manifests/namespace/namespace.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/minio/manifests/namespace/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio-test

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/minio/manifests/namespace/role.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/minio/manifests/namespace/role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gotk-reconciler
+  namespace: minio-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: gotk:minio-test:reconciler

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/minio/manifests/podinfo/deployment.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/minio/manifests/podinfo/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podinfo
+  namespace: minio-test
+spec:
+  minReadySeconds: 3
+  revisionHistoryLimit: 5
+  progressDeadlineSeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: podinfo
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9797"
+      labels:
+        app: podinfo
+    spec:
+      containers:
+      - name: podinfod
+        image: stefanprodan/podinfo:4.0.6
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 9898
+          protocol: TCP
+        - name: http-metrics
+          containerPort: 9797
+          protocol: TCP
+        - name: grpc
+          containerPort: 9999
+          protocol: TCP
+        command:
+        - ./podinfo
+        - --port=9898
+        - --port-metrics=9797
+        - --grpc-port=9999
+        - --grpc-service-name=podinfo
+        - --level=info
+        - --random-delay=false
+        - --random-error=false
+        env:
+        - name: PODINFO_UI_COLOR
+          value: "#34577c"
+        livenessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/readyz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/minio/manifests/podinfo/service.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/minio/manifests/podinfo/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: podinfo
+  namespace: minio-test
+spec:
+  type: ClusterIP
+  selector:
+    app: podinfo
+  ports:
+    - name: http
+      port: 9898
+      protocol: TCP
+      targetPort: http
+    - port: 9999
+      targetPort: grpc
+      protocol: TCP
+      name: grpc

--- a/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/minio/secret.yaml
+++ b/addons/packages/fluxcd-source-controller/0.21.7/test/flux-source-controller/config/testdata/minio/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+data:
+  accesskey: bXlhY2Nlc3NrZXk=
+  secretkey: bXlzZWNyZXRrZXk=

--- a/addons/packages/fluxcd-source-controller/vendir.lock.yml
+++ b/addons/packages/fluxcd-source-controller/vendir.lock.yml
@@ -10,4 +10,9 @@ directories:
       url: https://api.github.com/repos/vmware-tanzu/package-for-source-controller/releases/64883267
     path: .
   path: 0.21.5
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/package-for-source-controller/releases/66181222
+    path: .
+  path: 0.21.7
 kind: LockConfig

--- a/addons/packages/fluxcd-source-controller/vendir.yml
+++ b/addons/packages/fluxcd-source-controller/vendir.yml
@@ -22,3 +22,13 @@ directories:
           assetNames:
           - "package.yaml"
           - "README.md"
+  - path: 0.21.7
+    contents:
+      - path: .
+        githubRelease:
+          slug: vmware-tanzu/package-for-source-controller
+          tag: v0.21.7
+          disableAutoChecksumValidation: true
+          assetNames:
+          - "package.yaml"
+          - "README.md"


### PR DESCRIPTION
## What this PR does / why we need it

- Adding `http_proxy` param to fluxcd-source-controller

| Value           | Required/Optional |                           Description                                                |
|-----------------|-------------------|--------------------------------------------------------------------------------------|
| `namespace`     | Optional          | Sets namespace for k8s objects where resources of source-controller will be created. |
| `limits_cpu`    | Optional          | Sets maximum usage of cpu for source-controller deployment.                          |
| `limits_memory` | Optional          | Sets maximum usage of memory for source-controller deployment.                       |
| `no_proxy`      | Optional          | Set domains for which no proxying should be performed                                |
| `https_proxy`   | Optional          | Set secure proxy connection information                                              |
| `http_proxy`    | Optional          | Set unsecure proxy connection information                                            |

## Describe testing done for PR

1. Create a cluster provisioned with kapp-controller and cert-manager
2. Submit the metadata.yaml and 0.21.7/package.yaml files
3. Install the package using the tanzu cli

```text
tanzu package install fluxcd-source-controller -p fluxcd-source-controller.community.tanzu.vmware.com -v 0.21.5
\ Installing package 'fluxcd-source-controller.community.tanzu.vmware.com'
| Getting package metadata for 'fluxcd-source-controller.community.tanzu.vmware.com'
| Creating service account 'fluxcd-source-controller-default-sa'
| Creating cluster admin role 'fluxcd-source-controller-default-cluster-role'
| Creating cluster role binding 'fluxcd-source-controller-default-cluster-rolebinding'
| Creating package resource
/ Waiting for 'PackageInstall' reconciliation for 'fluxcd-source-controller'
| 'PackageInstall' resource install status: Reconciling


 Added installed package 'fluxcd-source-controller'
```
run the smoke test that you will find inside the **0.21.7** folder


you can also see more deeper tests executed on our pipeline:

- [test-installation](https://runway-ci.eng.vmware.com/teams/tce-fluxcd-source-controller/pipelines/flux-pipeline-0-21-2-build-x/jobs/test/builds/4#L626c4161:39:49)
- [test-smoke](https://runway-ci.eng.vmware.com/teams/tce-fluxcd-source-controller/pipelines/flux-pipeline-0-21-2-build-x/jobs/test/builds/4#L626c4162:37:142)

## Special notes for your reviewer

Now you can install fluxcd-source-controller with some custom params, in order to test it you can have a value.yml file:

```yaml
---
namespace: flux-system-namespace
limits_cpu: 1050m
limits_memory: 2Gi
service_port: 90
no_proxy: ""
https_proxy: ""
http_proxy: ""
```

and install the package adding the `-f values.yml` flag, it would look something like this

`tanzu package install fluxcd-source-controller -p fluxcd-source-controller.community.tanzu.vmware.com -v 0.21.7 -f values.yml`