### PR TITLE
Update TCE UC to v0.12.0

### DIFF
--- a/extensions/docker-desktop/Dockerfile-tanzu-cli
+++ b/extensions/docker-desktop/Dockerfile-tanzu-cli
@@ -9,7 +9,7 @@ ARG TARGETARCH
 
 WORKDIR /app
 
-ARG TCE_VERSION=v0.12.0-rc.2
+ARG TCE_VERSION=v0.12.0
 
 RUN curl --fail --silent -L -o /tmp/src.tar.gz https://github.com/vmware-tanzu/community-edition/archive/refs/tags/${TCE_VERSION}.tar.gz && \
     tar --strip-components 1 -xvf /tmp/src.tar.gz


### PR DESCRIPTION
## What this PR does / why we need it
Updates TCE Unmanaged cluster used in the Docker Desktop extension to use v0.12.0 release.

## Which issue(s) this PR fixes
Fixes: #4405

## Describe testing done for PR
Created a cluster, and all the workflow. Compatibility_v8 was still used, but repositories where now released ones:

```
   Selected core package repository
   projects.registry.vmware.com/tce/repo-12:0.12.0
   Selected additional package repositories
   projects.registry.vmware.com/tce/main:0.12.0
```

<img width="855" alt="image" src="https://user-images.githubusercontent.com/78350/167173346-0a361ddc-bb43-47b9-8cf7-cbf785a8c621.png">



Signed-off-by: Jorge Morales Pou <jorgemoralespou@gmail.com>
