### PR TITLE
Added open source license to image

### DIFF
--- a/extensions/docker-desktop/Dockerfile
+++ b/extensions/docker-desktop/Dockerfile
@@ -81,6 +81,7 @@ COPY logo.svg .
 COPY metadata.json .
 COPY backend backend
 COPY docker-compose.yaml .
+COPY open_source_licenses.txt .
 
 RUN mkdir /opt/kubeconfig && \
     chown 1001:100 /opt/kubeconfig

--- a/extensions/docker-desktop/NOTICE.txt
+++ b/extensions/docker-desktop/NOTICE.txt
@@ -1,0 +1,10 @@
+NOTICE
+
+tce-extension-for-docker-desktop
+
+Copyright (c) 2022 VMware, Inc. All Rights Reserved. 
+
+This product is licensed to you under the Apache License, Version 2.0 (the "License").  You may not use this product except in compliance with the License.  
+
+This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file. 
+


### PR DESCRIPTION
## What this PR does / why we need it
Adds the third party open source licenses we use to the Docker extension container image and to the repo

## Which issue(s) this PR fixes
Fixes: #4407 

## Describe testing done for PR
Installed extension and verified file is in the container

Signed-off-by: Jorge Morales Pou <jorgemoralespou@gmail.com>