### PR TITLE
Fix cartographer catalog example

### DIFF
--- a/addons/packages/app-toolkit/0.2.0/README.md
+++ b/addons/packages/app-toolkit/0.2.0/README.md
@@ -31,7 +31,7 @@ Application Toolkit is currently tested with Unmanaged Clusters on any of the be
 
 | Config | Values | Description |
 |--------|--------|-------------|
-| cartographer-catalog | | [See cartographer catalog documentation](https://tanzucommunityedition.io/docs/package-readme-cartographer-catalog-0.3.0/#configuration)|
+| cartographer_catalog | | [See cartographer catalog documentation](https://tanzucommunityedition.io/docs/package-readme-cartographer-catalog-0.3.0/#configuration)|
 | cert_manager | | [See cert-manager documentation](https://tanzucommunityedition.io/docs/v0.11/package-readme-cert-manager-1.6.1/#configuration)|
 | contour | | [See contour documentation](https://tanzucommunityedition.io/docs/v0.11/package-readme-contour-1.20.1/#configuration-reference) |
 | excluded_packages  | Array of package names | Allows installers to skip deploying named packages |
@@ -84,10 +84,10 @@ kpack:
   kp_default_repository_username:
   kp_default_repository_password:
 
-cartographer-catalog:
-    registry:
-        server:
-        repository:
+cartographer_catalog:
+  registry:
+    server:
+    repository:
 
 # The namespace field below will configure the namespace for creating workloads.
 developer_namespace:  #default value is default
@@ -122,10 +122,10 @@ kpack:
   kp_default_repository_username: my-dockerhub-username
   kp_default_repository_password: my-dockerhub-password
 
-cartographer-catalog:
+cartographer_catalog:
   registry:
-      server: index.docker.io
-      repository: my-dockerhub-username
+    server: index.docker.io
+    repository: my-dockerhub-username
 ```
 
 ### Step 3: Install App-toolkit Package


### PR DESCRIPTION
## What this PR does / why we need it

The documentation for app-toolkit 0.2.0 has an error - cartographer catalog values should be under the `cartographer_catalog` key, not `cartographer-catalog`

(underscore, not dash)

## Which issue(s) this PR fixes

N/A

## Describe testing done for PR

Tested with my pre-release install. This is a doc error only - you can see correct usage in the app catalog tests here:

https://github.com/vmware-tanzu/community-edition/tree/main/addons/packages/app-toolkit/0.2.0/test

 
## Special notes for your reviewer
