### PR TITLE
Fix unmanaged cluster log verbosity enforcement

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -58,7 +58,7 @@ func configure(cmd *cobra.Command, args []string) error {
 		clusterName = args[0]
 	}
 
-	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	portMaps, err := config.ParsePortMappings(co.portMapping)
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -109,7 +109,7 @@ func create(cmd *cobra.Command, args []string) {
 	}
 
 	// initial logger, needed for logging if something goes wrong
-	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	// Attempt to read cluster name from provided kubeconfig
 	if co.existingClusterKubeconfig != "" {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
@@ -45,7 +45,7 @@ func destroy(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	log.Eventf(logger.TestTubeEmoji, "Deleting cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
@@ -50,7 +50,7 @@ func init() {
 
 // list outputs a list of all unmanaged clusters on the system.
 func list(cmd *cobra.Command, args []string) error {
-	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 	tClient := tanzu.New(log)
 	clusters, err := tClient.List()
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/start.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/start.go
@@ -42,7 +42,7 @@ func start(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	log.Eventf(logger.TestTubeEmoji, "Attempting to start cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/stop.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/stop.go
@@ -43,7 +43,7 @@ func stop(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	log.Eventf(logger.TestTubeEmoji, "Attempting to stop cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/term"
 )
 
+const defaultLogVerbosity = 2
+
 // TtySetting gets the setting to use for formatted TTY output based on whether
 // the user explicitly set it with a command line argument, or if not, whether
 // there is an environment variable set. If neither of these things, it will
@@ -55,6 +57,17 @@ func SetupRootCommand(rootCmd *cobra.Command) {
 
 	rootCmd.SetUsageTemplate(usageTemplate)
 	rootCmd.SetHelpTemplate(helpTemplate)
+}
+
+// LoggingVerbosity will get the configured logging level for this command.
+func LoggingVerbosity(cmd *cobra.Command) int {
+	level, err := cmd.Flags().GetInt32("verbose")
+	if err != nil {
+		// Flag missing or read failure, use default
+		return defaultLogVerbosity
+	}
+
+	return int(level)
 }
 
 // Uses the users terminal size or width of 80 if cannot determine users width

--- a/cli/cmd/plugin/unmanaged-cluster/log/log.go
+++ b/cli/cmd/plugin/unmanaged-cluster/log/log.go
@@ -43,7 +43,7 @@ type CMDLogger struct {
 	// whether to support stylizing logging output
 	tty bool
 	// logging level to respect for this logger
-	level int
+	verbosity int
 	// log level set by a logging event
 	logLevel int
 	// instances of indentation (" ") to prepend to a long message
@@ -116,10 +116,11 @@ func NewLogger(tty bool, level int) Logger {
 	fd := int(os.Stdout.Fd())
 
 	return &CMDLogger{
-		tty:    tty,
-		level:  level,
-		output: os.Stdout,
-		termFd: fd,
+		tty:       tty,
+		verbosity: level,
+		logLevel:  DefaultLogLevel,
+		output:    os.Stdout,
+		termFd:    fd,
 	}
 }
 
@@ -134,7 +135,7 @@ func (l *CMDLogger) AddLogFile(filePath string) {
 }
 
 func (l *CMDLogger) Event(emoji, message string) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 	// when tty is off, remove emoji from output
@@ -156,7 +157,7 @@ func (l *CMDLogger) Event(emoji, message string) {
 }
 
 func (l *CMDLogger) Eventf(emoji, message string, args ...interface{}) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 	// when tty is off, remove emoji from output
@@ -178,7 +179,7 @@ func (l *CMDLogger) Eventf(emoji, message string, args ...interface{}) {
 }
 
 func (l *CMDLogger) Warn(message string) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -187,7 +188,7 @@ func (l *CMDLogger) Warn(message string) {
 }
 
 func (l *CMDLogger) Warnf(message string, args ...interface{}) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -196,7 +197,7 @@ func (l *CMDLogger) Warnf(message string, args ...interface{}) {
 }
 
 func (l *CMDLogger) Error(message string) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -205,7 +206,7 @@ func (l *CMDLogger) Error(message string) {
 }
 
 func (l *CMDLogger) Errorf(message string, args ...interface{}) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -214,7 +215,7 @@ func (l *CMDLogger) Errorf(message string, args ...interface{}) {
 }
 
 func (l *CMDLogger) Info(message string) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -223,7 +224,7 @@ func (l *CMDLogger) Info(message string) {
 }
 
 func (l *CMDLogger) Infof(message string, args ...interface{}) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -234,7 +235,7 @@ func (l *CMDLogger) Infof(message string, args ...interface{}) {
 // progressf is an internal method used to log out a specified number of dots
 // in addition to a provided message and any format string arguments
 func (l *CMDLogger) progressf(count int, message string, args ...interface{}) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -296,7 +297,7 @@ func (l *CMDLogger) progressf(count int, message string, args ...interface{}) {
 }
 
 func (l *CMDLogger) ReplaceLinef(message string, args ...interface{}) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -369,9 +370,10 @@ func (l *CMDLogger) AnimateProgressWithOptions(options ...AnimatorOption) {
 
 func (l *CMDLogger) V(level int) Logger {
 	return &CMDLogger{
-		tty:      l.tty,
-		logLevel: l.level,
-		output:   l.output,
+		tty:       l.tty,
+		logLevel:  level,
+		verbosity: l.verbosity,
+		output:    l.output,
 	}
 }
 
@@ -381,12 +383,12 @@ func (l *CMDLogger) Style(indent int, c color.Attribute) Logger {
 		return l
 	}
 	return &CMDLogger{
-		tty:      l.tty,
-		level:    l.level,
-		logLevel: l.logLevel,
-		indent:   indent,
-		logColor: c,
-		output:   l.output,
+		tty:       l.tty,
+		verbosity: l.verbosity,
+		logLevel:  l.logLevel,
+		indent:    indent,
+		logColor:  c,
+		output:    l.output,
 	}
 }
 

--- a/cli/cmd/plugin/unmanaged-cluster/main.go
+++ b/cli/cmd/plugin/unmanaged-cluster/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/cmd"
-	logging "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/log"
 )
 
 var description = `Deploy and manage single-node, static, Tanzu clusters.`
@@ -49,9 +48,6 @@ func main() {
 	)
 
 	cmd.SetupRootCommand(p.Cmd)
-
-	// Configure our logging default
-	logging.DefaultLogLevel = int(logLevel)
 
 	if err := p.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

There were issues with the way log verbosity was being set which caused
the incorrect level to be used, resulting in some expected lines not
printing at the default log level.

This updates the handling to correctly parse and set the level from the
flag. Also some minor refactoring to make it a little easier to
understand.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4413 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

```
go run . create foo
go run . rm foo
go run . create -v 0 foo
go run . rm -v 0 foo
```