### PR TITLE
Add the option to skip cni plugins installation

### DIFF
--- a/addons/packages/calico/3.22.1/README.md
+++ b/addons/packages/calico/3.22.1/README.md
@@ -13,7 +13,12 @@ The following configuration values can be set to customize the calico installati
 | Value | Required/Optional | Description |
 |-------|-------------------|-------------|
 | `infraProvider` | Required | The infrastructure provider in use. One of: `aws`, `azure`, `vsphere`, `docker`. |
-| `ipFamily` | Optional | The IP family calico should be configured with. Defaults to `ipv4`. One of: `ipv4`, `ipv6`, `ipv4,ipv6` (IPv4-primary dualstack), or `ipv6,ipv4` (IPv6-primary dualstack) |
+| `ipFamily` | Optional | The IP family calico should be configured with. Defaults to `ipv4`. One of: `ipv4`, `ipv6`, `ipv4,ipv6` (IPv4-primary dualstack), or `ipv6,ipv4` (IPv6-primary dualstack). |
+| `nodeSelector` | Optional | NodeSelector configuration applied to all the deployments. Defaults to null. |
+| `deployment.updateStrategy` | Optional | The update strategy of deployments to overwrite. Defaults to null. |
+| `deployment.rollingUpdate.maxUnavailable` | Optional | The maxUnavailable of rollingUpdate. Applied only if RollingUpdate is used as updateStrategy. Defaults to null. |
+| `deployment.rollingUpdate.maxSurge` | Optional | The maxSurge of rollingUpdate. Applied only if RollingUpdate is used as updateStrategy. Defaults to null. |
+| `daemonset.updateStrategy` | Optional | The update strategy of daemonsets to overwrite. Defaults to null. |
 
 ### calico Configuration
 
@@ -21,6 +26,7 @@ The following configuration values can be set to customize the calico installati
 |-------|-------------------|-------------|
 | `calico.config.clusterCIDR` | Optional | The pod network CIDR. Default value is empty because it can be auto detected. |
 | `calico.config.vethMTU` | Optional | MTU size. Default is `0`, which means it will be auto detected. |
+| `calico.config.skipCNIBinaries` | Optional | Skip the cni plugin(bandwidth, flannel, host-local, loopback, portmap, tuning) binaries installation from calico to avoid the overwrite when, for some cases, the nodes already contains these cni plugins. Default to `false`|
 
 ## Usage Example
 

--- a/addons/packages/calico/3.22.1/bundle/config/overlay/calico-overlay.yaml
+++ b/addons/packages/calico/3.22.1/bundle/config/overlay/calico-overlay.yaml
@@ -27,6 +27,15 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+        #@overlay/match by=overlay.subset({"name":"install-cni"})
+        - name: install-cni
+          env:
+            #@ if hasattr(values.calico.config, 'skipCNIBinaries') and values.calico.config.skipCNIBinaries == True:
+            #@overlay/merge
+            - name: SKIP_CNI_BINARIES
+              value: "bandwidth,flannel,host-local,loopback,portmap,tuning"
+            #@ end
       containers:
         #@overlay/match by=overlay.subset({"name":"calico-node"})
         - name: calico-node

--- a/addons/packages/calico/3.22.1/bundle/config/schema.yaml
+++ b/addons/packages/calico/3.22.1/bundle/config/schema.yaml
@@ -39,6 +39,8 @@ calico:
     clusterCIDR: "192.168.0.0/16,fd00:100:96::/48"
     #@schema/desc "Maximum transmission unit setting"
     vethMTU: "0"
+    #@schema/desc "Skip the cni plugin binaries installation"
+    skipCNIBinaries: false
   #@schema/deprecated "Kept for backward compatibility"
   #@schema/desc "The image repo and its pull policy"
   #@schema/nullable

--- a/addons/packages/calico/3.22.1/bundle/config/values.yaml
+++ b/addons/packages/calico/3.22.1/bundle/config/values.yaml
@@ -16,3 +16,4 @@ calico:
     clusterCIDR: null
     #! "0" as default means MTU will be auto detected
     vethMTU: "0"
+    skipCNIBinaries: false

--- a/addons/packages/calico/3.22.1/package.yaml
+++ b/addons/packages/calico/3.22.1/package.yaml
@@ -79,6 +79,10 @@ spec:
                   type: string
                   description: Maximum transmission unit setting
                   default: "0"
+                skipCNIBinaries:
+                  type: boolean
+                  description: Skip the cni plugin binaries installation
+                  default: false
             image:
               type: object
               additionalProperties: false
@@ -164,7 +168,7 @@ spec:
       syncPeriod: 5m
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/calico@sha256:a523083d6eaf0ddbe02be35506ee16cb3f4b3471a8acfa9ababc39a1ddb5c234
+          image: projects.registry.vmware.com/tce/calico@sha256:16d7c2cac6ea761cc0fdc094ab005dcf09df9df5f55600e0f3df6b5b04152ee6
       template:
       - ytt:
           paths:


### PR DESCRIPTION
## What this PR does / why we need it
As a tce calico package developer, I would like to add the option to skip cni plugins installation for the calico 3.22.1 package.

Calico default installing `bandwidth, flannel, host-local, loopback, portmap, tuning` plugin binaries during deploying.

For some cases that the nodes itself already contains cni plugin binaries and do not want calico to overwrite, calico has a env param SKIP_CNI_BINARIES to allow skipping the cni plugin binaries installation.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/4419

## Describe testing done for PR
Added test cases for the skipCNIBinaries option and ran `make test` in 3.22.1 .

