### PR TITLE
UI: Explicitly set edition for cluster creation

### DIFF
--- a/cli/cmd/plugin/ui/server/handlers/aws.go
+++ b/cli/cmd/plugin/ui/server/handlers/aws.go
@@ -111,6 +111,7 @@ func (app *App) CreateAWSManagementCluster(params aws.CreateAWSManagementCluster
 		Annotations:            convertedParams.Annotations,
 		Labels:                 convertedParams.Labels,
 		ClusterConfigFile:      app.getFilePathForSavingConfig(),
+		Edition:                "tce",
 	}
 	if err := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initOptions, false); err != nil {
 		return aws.NewCreateAWSManagementClusterInternalServerError().WithPayload(Err(err))

--- a/cli/cmd/plugin/ui/server/handlers/azure.go
+++ b/cli/cmd/plugin/ui/server/handlers/azure.go
@@ -122,6 +122,7 @@ func (app *App) CreateAzureManagementCluster(params azure.CreateAzureManagementC
 		Annotations:            convertedParams.Annotations,
 		Labels:                 convertedParams.Labels,
 		ClusterConfigFile:      app.getFilePathForSavingConfig(),
+		Edition:                "tce",
 	}
 
 	if err := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initOptions, false); err != nil {

--- a/cli/cmd/plugin/ui/server/handlers/docker.go
+++ b/cli/cmd/plugin/ui/server/handlers/docker.go
@@ -63,6 +63,7 @@ func (app *App) CreateDockerManagementCluster(params docker.CreateDockerManageme
 		Annotations:            params.Params.Annotations,
 		Labels:                 params.Params.Labels,
 		ClusterConfigFile:      app.getFilePathForSavingConfig(),
+		Edition:                "tce",
 	}
 
 	if err := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initOptions, false); err != nil {

--- a/cli/cmd/plugin/ui/server/handlers/vsphere.go
+++ b/cli/cmd/plugin/ui/server/handlers/vsphere.go
@@ -85,6 +85,7 @@ func (app *App) CreateVSphereManagementCluster(params vsphere.CreateVSphereManag
 		Labels:                      convertedParams.Labels,
 		ClusterConfigFile:           app.getFilePathForSavingConfig(),
 		VsphereControlPlaneEndpoint: convertedParams.ControlPlaneEndpoint,
+		Edition:                     "tce",
 	}
 
 	if err := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initOptions, false); err != nil {

--- a/cli/cmd/plugin/ui/server/handlers/workloadcluster.go
+++ b/cli/cmd/plugin/ui/server/handlers/workloadcluster.go
@@ -69,6 +69,7 @@ func (app *App) CreateCluster(params cluster.CreateWorkloadClusterParams) middle
 		ClusterType:                 tfclient.WorkloadCluster,
 		TKRVersion:                  createParams.Tkrversion,
 		NodeSizeOptions:             nodeSizeOpts,
+		Edition:                     "tce",
 	}
 
 	err = tkgClient.CreateCluster(&createOpts, false)


### PR DESCRIPTION
This sets the Edition parameter for cluster creation to be hard coded to
"TCE" for now. If this extension is moved to work with multiple editions
we will need to update this to check config settings, but for now we
know it is only going to be used with the community edition version so
we can just set it directly.