### PR TITLE
Docker desktop: add `.yarnrc` for package download timeouts

### DIFF
--- a/extensions/docker-desktop/ui/.yarnrc
+++ b/extensions/docker-desktop/ui/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 500000


### PR DESCRIPTION
## What this PR does / why we need it

Useful for during long multi-arch builds to prevent timeouts on
larger UI component libraries.

This happens occasionally in the form of the following error:
```
info There appears to be trouble with your network connection. Retrying...
An unexpected error occurred: “https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.4.4.tgz: ESOCKETTIMEDOUT
```

This issue also sheds some light on this: https://github.com/mui/material-ui/issues/12432#issuecomment-411046157

## Describe testing done for PR
No timeouts - able to do build
