### PR TITLE
[release-0.12] Add timeout to cache restore in Actions (#4225)

### DIFF
--- a/.github/workflows/build-daily.yaml
+++ b/.github/workflows/build-daily.yaml
@@ -55,6 +55,8 @@ jobs:
           echo "::set-output name=date::$(date -u "+%Y-%m")"
       - name: Restore Go Cache
         uses: actions/cache@v3
+        timeout-minutes: 10
+        continue-on-error: true
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -51,6 +51,8 @@ jobs:
           echo "::set-output name=date::$(date -u "+%Y-%m")"
       - name: Restore Go Cache
         uses: actions/cache@v3
+        timeout-minutes: 10
+        continue-on-error: true
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/check-all.yaml
+++ b/.github/workflows/check-all.yaml
@@ -43,6 +43,8 @@ jobs:
           echo "::set-output name=date::$(date -u "+%Y-%m")"
       - name: Restore Go Cache
         uses: actions/cache@v3
+        timeout-minutes: 10
+        continue-on-error: true
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Restore Lint Cache
         uses: actions/cache@v3
+        timeout-minutes: 10
+        continue-on-error: true
         with:
           path: ${{ runner.temp }}/lint_cache
           key: ${{ runner.os }}-lint-cache-${{ steps.get-date.outputs.date }}

--- a/.github/workflows/check-pr-diagnostics-plugin.yaml
+++ b/.github/workflows/check-pr-diagnostics-plugin.yaml
@@ -55,6 +55,8 @@ jobs:
           echo "::set-output name=date::$(date -u "+%Y-%m")"
       - name: Restore Go Cache
         uses: actions/cache@v3
+        timeout-minutes: 10
+        continue-on-error: true
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/check-pr-docker-management.yaml
+++ b/.github/workflows/check-pr-docker-management.yaml
@@ -52,6 +52,8 @@ jobs:
           echo "::set-output name=date::$(date -u "+%Y-%m")"
       - name: Restore Go Cache
         uses: actions/cache@v3
+        timeout-minutes: 10
+        continue-on-error: true
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-aws-management-and-workload-cluster.yaml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Restore Go Cache
         uses: actions/cache@v3
+        timeout-minutes: 10
+        continue-on-error: true
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-azure-management-and-workload-cluster.yaml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Restore Go Cache
         uses: actions/cache@v3
+        timeout-minutes: 10
+        continue-on-error: true
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/e2e-vsphere-management-and-workload-cluster.yaml
+++ b/.github/workflows/e2e-vsphere-management-and-workload-cluster.yaml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Restore Go Cache
         uses: actions/cache@v3
+        timeout-minutes: 10
+        continue-on-error: true
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/release-bucket.yaml
+++ b/.github/workflows/release-bucket.yaml
@@ -59,6 +59,8 @@ jobs:
           echo "::set-output name=date::$(date -u "+%Y-%m")"
       - name: Restore Go Cache
         uses: actions/cache@v3
+        timeout-minutes: 10
+        continue-on-error: true
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,8 @@ jobs:
           echo "::set-output name=date::$(date -u "+%Y-%m")"
       - name: Restore Go Cache
         uses: actions/cache@v3
+        timeout-minutes: 10
+        continue-on-error: true
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
We have been seeing the restore of cache files basically hang during the
restore process, causing it to eventually timeout after 6 hours of
inactivity. This fails the entire job which then needs to be rerun.

This change sets a 10 minute timeout for the cache restore. Under normal
conditions, the restore is fairly quick. So if it's taken 5 minutes, we
know something isn't quite right.

It also sets the flag to tell the action to continue on this step
failure. It's better to have decreased performance from cache misses
than to fail if it's not present.

(cherry picked from commit 5d18b8c976c4a493851efddf89f6eb521d02f8cd)