### PR TITLE
Adds missing `v0.12.0` to TOC dropdown in docs site

### DIFF
--- a/docs/site/config.yaml
+++ b/docs/site/config.yaml
@@ -50,6 +50,7 @@ params:
   docs_versioning: true
   docs_latest: v0.12
   docs_versions:
+    - v0.12
     - v0.11
     - v0.10
   release_latest: v0.11.0


### PR DESCRIPTION
## What this PR does / why we need it
Fixes error where user would not be able to navigate back to `v0.12.0` in TOC dropdown if they went to a different version

## Which issue(s) this PR fixes
Fixes: #4481

## Describe testing done for PR

On local `make preview-build && hugo serve`

<img width="549" alt="Screen Shot 2022-05-10 at 1 58 07 PM" src="https://user-images.githubusercontent.com/23109390/167702331-a20bc2ee-d45a-4411-a906-e5d6f833d20e.png">

cc @garrying to verify
