### PR TITLE
UI: initialize websocket listener

### DIFF
--- a/cli/cmd/plugin/ui/server/serve.go
+++ b/cli/cmd/plugin/ui/server/serve.go
@@ -50,8 +50,7 @@ func Serve(bind, browser string, logLevel int32) error {
 	server.Host = host
 	server.Browser = browser
 
-	// TODO: Need to determine what we actually need here.
-	// ws.InitWebsocketUpgrader(server.Host)
+	handlers.InitWebsocketUpgrader(server.Host)
 
 	app := handlers.App{LogLevel: logLevel}
 	app.ConfigureHandlers(api)


### PR DESCRIPTION
This enables our websocket handler to allow backend logging to be
streamed to the UI for display.