### PR TITLE
UI: add UI plugin to make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ help: #### display help
 
 ##### BUILD
 ifndef PLUGINS
-PLUGINS ?= "conformance diagnostics unmanaged-cluster"
+PLUGINS ?= "conformance diagnostics unmanaged-cluster ui"
 endif
 ifndef ifndef
 # For TF 0.17.0 or higher

--- a/hack/builder/Makefile
+++ b/hack/builder/Makefile
@@ -117,4 +117,5 @@ install-plugins: check ## Installs the compiled TCE plugins
 	cp -r "../../build/${OS}-${ARCH}-${DISCOVERY_NAME}/." "${XDG_CONFIG_HOME}/tanzu-plugins" && \
 	tanzu plugin install conformance && \
 	tanzu plugin install diagnostics && \
-	tanzu plugin install unmanaged-cluster
+	tanzu plugin install unmanaged-cluster && \
+	tanzu plugin install ui


### PR DESCRIPTION
We were missing a couple steps for the addition of the UI plugin. This
adds it so targets like `make build-install-plugins` will properly
build and install the UI plugin.