### PR TITLE
Fix package readme published image location

### DIFF
--- a/.github/workflows/package-copy-readmes-to-docs.yaml
+++ b/.github/workflows/package-copy-readmes-to-docs.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - addons/packages/**/*/[rR][eE][aA][dD][mM][eE].md
       - addons/repos/main.yaml
+      - hack/workflows/packages/copy-package-readmes-to-docs.go
 jobs:
   copy-to-docs:
     name: Copy to Docs

--- a/hack/workflows/packages/copy-package-readmes-to-docs.go
+++ b/hack/workflows/packages/copy-package-readmes-to-docs.go
@@ -110,7 +110,7 @@ func main() {
 				input, err := os.ReadFile(destination)
 				check(err)
 
-				fileContents := strings.Replace(string(input), "images/", "../../img/", -1)
+				fileContents := strings.Replace(string(input), "images/", "../img/", -1)
 
 				err = os.WriteFile(destination, []byte(fileContents), 0644)
 				check(err)


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

When we copy over the package READMEs into the published docs, we need
to modify the location where the images are referenced. This update was
a level off with the current versioned docs structure. This updates the
copy script to adjust these image references to the right location.

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `hugo server` locally to view changes.