### PR TITLE
UI: fix launching browser to UI path

### DIFF
--- a/cli/cmd/plugin/ui/server/restapi/server.go
+++ b/cli/cmd/plugin/ui/server/restapi/server.go
@@ -234,7 +234,7 @@ func (s *Server) Serve() (err error) {
 		servers = append(servers, httpServer)
 		wg.Add(1)
 
-		uiURL := fmt.Sprintf("http://%s", s.httpServerL.Addr())
+		uiURL := fmt.Sprintf("http://%s/ui", s.httpServerL.Addr())
 		s.Logf("Serving UI at %s", uiURL)
 		s.OpenBrowserURL(uiURL)
 
@@ -331,7 +331,7 @@ func (s *Server) Serve() (err error) {
 		servers = append(servers, httpsServer)
 		wg.Add(1)
 
-		uiURL := fmt.Sprintf("https://%s", s.httpsServerL.Addr())
+		uiURL := fmt.Sprintf("https://%s/ui", s.httpsServerL.Addr())
 		s.Logf("Serving UI at %s", uiURL)
 		s.OpenBrowserURL(uiURL)
 

--- a/cli/cmd/plugin/ui/server/serve.go
+++ b/cli/cmd/plugin/ui/server/serve.go
@@ -101,8 +101,12 @@ func globalMiddleware(handler http.Handler) http.Handler {
 func fileServerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasPrefix(r.URL.Path, "/ui") {
-			// pass along to the next handler
-			next.ServeHTTP(w, r)
+			if r.URL.Path == "/" {
+				http.Redirect(w, r, "/ui", http.StatusMovedPermanently)
+			} else {
+				// pass along to the next handler
+				next.ServeHTTP(w, r)
+			}
 		} else {
 			w.Header().Set("Cache-Control", "no-store")
 			w.Header().Set("Pragma", "no-cache")


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

The current browser launch was opening the root server path. The
redirect to the /ui path was not working, so this meant by default a
user would get sent to a 404 page and then need to add the /ui on the
end to actually see the UI.

This fixes both the initial launch URL to go directly to the UI as well
as the redirect so if someone navigated to the root, they would actually
get redirected to the right location.

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Tested launch UI and getting directed to the right page. Edited URL in browser to go to root and verified it redirected to the right location. Performed basic API request to make sure /api path was unaffected.