### PR TITLE
Implements multi-arch building from amd64 or arm64 for Docker desktop extension

### DIFF
--- a/extensions/docker-desktop/Dockerfile
+++ b/extensions/docker-desktop/Dockerfile
@@ -5,8 +5,8 @@
 
 ARG REGISTRY=ghcr.io/
 ARG ORG=vmware-tanzu/
-ARG IMAGE_NAME=community-edition-extension-for-docker-desktop
-ARG TAG=main
+ARG IMAGE_NAME=community-edition
+ARG TAG=dev
 
 ARG DOWNLOADER_IMAGE=${REGISTRY}${ORG}${IMAGE_NAME}-downloader:${TAG}
 ARG TANZU_CLI_IMAGE=${REGISTRY}${ORG}${IMAGE_NAME}-tanzu-cli:${TAG}

--- a/extensions/docker-desktop/Makefile
+++ b/extensions/docker-desktop/Makefile
@@ -1,13 +1,16 @@
 # Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+PLATFORMS=linux/amd64,linux/arm64
 REGISTRY?=ghcr.io/
 ORG?=vmware-tanzu/
-IMAGE_NAME=community-edition-extension-for-dockerdesktop
+IMAGE_NAME=community-edition
 IMAGE?=$(REGISTRY)${ORG}${IMAGE_NAME}
 EXTENSION_REGISTRY?=docker.io/
 EXTENSION_IMAGE?=$(EXTENSION_REGISTRY)vmware/vmware-tanzu-community-edition-extension-for-docker-desktop
-TAG?=main
+ifndef TAG
+TAG=dev
+endif
 DEV_UI_SOURCE?=http://localhost:3000
 BUILD_ARGS=--progress=plain
 
@@ -16,64 +19,121 @@ BUILDER=buildx-multi-arch
 INFO_COLOR = \033[0;36m
 NO_COLOR   = \033[m
 
-.DEFAULT_GOAL := extension
+.DEFAULT_GOAL:=help
 
-build-tanzucli: ## Build the tanzu cli container image
+help:  # Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^\$$\([0-9A-Za-z_-]+\):.*?##/ { gsub("_","-", $$1); printf "  \033[36m%-45s\033[0m %s\n", tolower(substr($$1, 3, length($$1)-7)), $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##### BUILD-DEPS
+.PHONY: build-tanzu-cli
+build-tanzu-cli: ## Build the tanzu cli container image for local arch
 	docker buildx build $(BUILD_ARGS) --tag=$(IMAGE)-tanzu-cli:$(TAG) -f Dockerfile-tanzu-cli .
-.PHONY: build-tanzucli
 
-build-appsbin: ## Build the dashboard container image
+.PHONY: build-push-tanzu-cli-all-arch
+build-push-tanzu-cli-all-arch: ## Build and push the tanzu cli container image for all archs
+	docker buildx inspect $(BUILDER)-tanzu-cli || docker buildx create --name=$(BUILDER)-tanzu-cli --driver=docker-container --driver-opt=network=host
+	docker buildx build --push $(BUILD_ARGS) --push --builder=$(BUILDER)-tanzu-cli --tag=$(IMAGE)-tanzu-cli:$(TAG) -f Dockerfile-tanzu-cli --platform=$(PLATFORMS) .
+	docker buildx stop $(BUILDER)-tanzu-cli
+
+.PHONY: build-apps-bin
+build-apps-bin: ## Build the dashboard container image for local arch
 	docker buildx build $(BUILD_ARGS) --tag=$(IMAGE)-apps-bin:$(TAG) -f Dockerfile-apps-bin .
-.PHONY: build-appsbin
 
-build-downloader: ## Build the binary downloader container image
-	docker buildx build $(BUILD_ARGS) --tag=$(IMAGE)-downloader:$(TAG) -f Dockerfile-downloader .
+.PHONY: build-push-apps-bin-all-arch
+build-push-apps-bin-all-arch: ## Build and push the dashboard container image for all archs
+	docker buildx inspect $(BUILDER)-apps-bin || docker buildx create --name=$(BUILDER)-apps-bin --driver=docker-container --driver-opt=network=host
+	docker buildx build --push $(BUILD_ARGS) --push --builder=$(BUILDER)-apps-bin --tag=$(IMAGE)-apps-bin:$(TAG) -f Dockerfile-apps-bin --platform=$(PLATFORMS) .
+	docker buildx stop $(BUILDER)-apps-bin
+
 .PHONY: build-downloader
+build-downloader: ## Build the binary downloader container image for local arch
+	docker buildx build $(BUILD_ARGS) --tag=$(IMAGE)-downloader:$(TAG) -f Dockerfile-downloader .
 
-build-client: ## Build the UI container image
-	docker buildx build $(BUILD_ARGS) --tag=$(IMAGE)-client:$(TAG) -f Dockerfile-client .
+.PHONY: build-push-downloader-all-arch
+build-push-downloader-all-arch: ## Build and push the binary downloader container image for all archs
+	docker buildx inspect $(BUILDER)-downloader || docker buildx create --name=$(BUILDER)-downloader --driver=docker-container --driver-opt=network=host
+	docker buildx build --push $(BUILD_ARGS) --push --builder=$(BUILDER)-downloader --tag=$(IMAGE)-downloader:$(TAG) -f Dockerfile-downloader --platform=$(PLATFORMS) .
+	docker buildx stop $(BUILDER)-downloader
+
 .PHONY: build-client
+build-client: ## Build the UI container image for local arch
+	docker buildx build $(BUILD_ARGS) --tag=$(IMAGE)-client:$(TAG) -f Dockerfile-client .
 
-build-deps: ## Build the required images used in the extension image
-	make -j build-downloader build-tanzucli build-appsbin build-client
+.PHONY: build-push-client-all-arch
+build-push-client-all-arch: ## Build and push the UI container image for all archs
+	docker buildx inspect $(BUILDER)-client || docker buildx create --name=$(BUILDER)-client --driver=docker-container --driver-opt=network=host
+	docker buildx build --push $(BUILD_ARGS) --push --builder=$(BUILDER)-client --tag=$(IMAGE)-client:$(TAG) -f Dockerfile-client --platform=$(PLATFORMS) .
+	docker buildx stop $(BUILDER)-client
+##### BUILD-DEPS
+
+##### BUILD
 .PHONY: build-deps
+build-deps: ## Build the required images used in the extension image for local arch
+	make -j build-downloader build-tanzu-cli build-apps-bin build-client
 
-build-extension: ## Build the extension container image
-	docker build $(BUILD_ARGS) --tag=$(EXTENSION_IMAGE):$(TAG) --build-arg TAG=$(TAG) --build-arg REGISTRY=$(REGISTRY) --build-arg ORG=${ORG} --build-arg IMAGE_NAME=${IMAGE_NAME} .
 .PHONY: build-extension
+build-extension: build-deps ## Build the extension image for local architecture
+	docker buildx build $(BUILD_ARGS) --tag=$(EXTENSION_IMAGE):$(TAG) --build-arg TAG=$(TAG) --build-arg REGISTRY=$(REGISTRY) --build-arg ORG=${ORG} --build-arg IMAGE_NAME=${IMAGE_NAME} .
+##### BUILD
 
-extension: ## Build the extension and its dependencies
-	make build-deps build-extension
-.PHONY: extension
-
+##### DOCKER
+.PHONY: install
 install: ## Install the extension or update it if already exists
 	docker extension install $(EXTENSION_IMAGE):$(TAG) || docker extension update $(EXTENSION_IMAGE):$(TAG)
 
-update: ## Update the extension with a new image
+.PHONY: build-install 
+build-install: build-extension install ## Build extension images for local arch and install
+
+.PHONY: update
+update: ## Pull and update the extension with a new image
 	docker pull $(EXTENSION_IMAGE):$(TAG) && docker extension update $(EXTENSION_IMAGE):$(TAG)
 
+.PHONY: debug
 debug: ## Enable debug in the extension
 	docker extension dev debug $(EXTENSION_IMAGE):$(TAG)
 
-source: ## Replace the ui source of the extension
+.PHONY: source
+source: ## Replace the UI source of the extension
 	docker extension dev ui-source $(EXTENSION_IMAGE):$(TAG) $(DEV_UI_SOURCE)
 
+.PHONY: validate
 validate: ## Validate the extension
 	docker extension validate $(EXTENSION_IMAGE):$(TAG)
 
+.PHONY: dev-reset
 dev-reset: ## Reset development status of the extension
 	docker extension dev reset $(EXTENSION_IMAGE):$(TAG)
 
+.PHONY: delete
 delete: ## Remove the extension
 	docker extension rm $(EXTENSION_IMAGE):$(TAG)
+##### DOCKER
 
-prepare-buildx: ## Create buildx builder for multi-arch build, if not exists
+##### PUBLISH
+.PHONY: check-ci
+check-ci:
+	@if [[ "${TCE_CI_BUILD}" != "true" ]]; then echo "WARNING: Publishing the Docker Desktop extension is only meant to be run within GitHub Actions CI or manually with extreme caution" && exit 1; else echo "Passed CI check"; fi
+
+.PHONY: prepare-buildx
+prepare-buildx: 
 	docker buildx inspect $(BUILDER) || docker buildx create --name=$(BUILDER) --driver=docker-container --driver-opt=network=host
 
-push-extension: prepare-buildx ## Build & upload extension image to a registry
-	# Do not push if tag already exists: make push-extension tag=0.1
-	docker pull $(EXTENSION_IMAGE):$(tag) && echo "Failure: Tag already exists" || docker buildx build --push --builder=$(BUILDER) --platform=linux/amd64,linux/arm64 --build-arg TAG=${tag)} --tag=$(EXTENSION_IMAGE):$(tag) .
+.PHONY: stop-buildx
+stop-buildx:
+	docker buildx stop $(BUILDER)
 
-help: ## Show this help
-	@echo Please specify a build target. The choices are:
-	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "$(INFO_COLOR)%-30s$(NO_COLOR) %s\n", $$1, $$2}'
+.PHONY: push-extension
+push-extension:
+	# Do not push if tag already exists: TAG=0.1.0 make push-extension
+	docker manifest inspect $(EXTENSION_IMAGE):$(TAG) && echo "Failure: Tag ${TAG} already exists" || docker buildx build --push --builder=$(BUILDER) --platform=$(PLATFORMS) --build-arg TAG=$(TAG) --tag=$(EXTENSION_IMAGE):$(TAG) .
+
+.PHONY: build-push-deps-all-arch
+build-push-deps-all-arch: check-ci ## Build and push the required images used in the extension image for a multi-arch build
+	make -j build-push-downloader-all-arch build-push-tanzu-cli-all-arch build-push-apps-bin-all-arch build-push-client-all-arch
+
+.PHONY: build-push-extension
+build-push-extension: check-ci prepare-buildx push-extension stop-buildx ## For all architectures, build the extension and upload to the registry
+
+.PHONY: build-push-everything
+build-push-everything: check-ci prepare-buildx build-push-deps-all-arch push-extension stop-buildx ## For all architectures, build dependent containers, build extension, and upload all image to the registries
+##### PUBLISH

--- a/extensions/docker-desktop/README.md
+++ b/extensions/docker-desktop/README.md
@@ -36,11 +36,10 @@ to follow these steps:
 1. In Docker Desktop, go to Preferences > Extensions and make sure
    "Enable Docker Extensions" is checked.
 1. From a terminal, navigate to `$TCE_REPO/extensions/docker-desktop`.
-1. Run the following commands to build and install the local extension:
+1. Run the following command to build and install the local extension:
 
    ```sh
-   make extension
-   make install
+   make build-install
    ```
 
 1. From the Docker Dashboard you can now navigate to the Extensions section.
@@ -61,4 +60,33 @@ follow these steps to have it recognized as a CLI plugin under `docker`:
 ```sh
 mkdir -p ~/.docker/cli-plugins
 cp docker-extension ~/.docker/cli-plugins/
+```
+
+### Publishing
+
+The extension uses four "builder" containers for concurrent builds of the Tanzu CLI,
+the backend utility, the React client, etc.
+
+When building and publishing a new extension image,
+ensure you have [authenticated to the GitHub container registry (ghcr).](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry)
+This is where the multi architecture builder images are stored and pushed to.
+When building the extension image for multiple architectures,
+in order to support _building from_ multiple architectures,
+these builder images are used (and pulled from ghcr) to generate the final image
+which is then pushed to Dockerhub.
+
+To build everything with a tag, including the extension itself, use:
+
+```sh
+TCE_CI_BUILD=true TAG=1.2.3 make build-push-everything
+```
+
+Note the `TCE_CI_BUILD` env var.
+This is to ensure caution and promote only publishing from CI/CD.
+
+To use existing builder images in ghcr, without going through the processes
+of rebuilding them and pushing them to ghcr, use:
+
+```sh
+TCE_CI_BUILD=true TAG=1.2.3 make build-push-extension
 ```


### PR DESCRIPTION
## What this PR does / why we need it

This is a bit of an overhaul of the docker desktop extension's makefile to enable building and pushing multi-arch images from either amd64 or arm64 architectures. This includes:

- Points our "builder" images to `vmware-tanzu/community-edition-*`
  - _Note_: If we merge this, I will also associate those images in the vmware-tanzu org with this repository for visibility
- Building and pushing multi-arch builder images using buildx
- Building and pushing multi-arch extension images using buildx (and the images hosted in ghcr)
- Pushes extension to Dockerhub registry with the default `dev` tag

## Which issue(s) this PR fixes
Fixes: N/A

## Describe testing done for PR
Able to run
```
$ make build-push-everything
```

And multi-arch builder images tagged as `dev` show up in ghcr and the extension image shows up in Dockerhub tagged as `dev`. 

## Special notes for your reviewer
Note the images in [ghcr here](https://github.com/orgs/vmware-tanzu/packages?ecosystem=container&q=community-edition-tanzu-cli&tab=packages&ecosystem=container&q=community-edition-) and also note the `dev` image [in Dockerhub](https://hub.docker.com/repository/registry-1.docker.io/vmware/vmware-tanzu-community-edition-extension-for-docker-desktop/tags)
