### PR TITLE
[release-0.12] UC: raise logging level for some log messages

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -58,7 +58,7 @@ func configure(cmd *cobra.Command, args []string) error {
 		clusterName = args[0]
 	}
 
-	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	portMaps, err := config.ParsePortMappings(co.portMapping)
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -58,7 +58,7 @@ func configure(cmd *cobra.Command, args []string) error {
 		clusterName = args[0]
 	}
 
-	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
 
 	portMaps, err := config.ParsePortMappings(co.portMapping)
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -109,7 +109,7 @@ func create(cmd *cobra.Command, args []string) {
 	}
 
 	// initial logger, needed for logging if something goes wrong
-	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	// Attempt to read cluster name from provided kubeconfig
 	if co.existingClusterKubeconfig != "" {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -109,7 +109,7 @@ func create(cmd *cobra.Command, args []string) {
 	}
 
 	// initial logger, needed for logging if something goes wrong
-	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
 
 	// Attempt to read cluster name from provided kubeconfig
 	if co.existingClusterKubeconfig != "" {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
@@ -45,7 +45,7 @@ func destroy(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	log.Eventf(logger.TestTubeEmoji, "Deleting cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
@@ -45,7 +45,7 @@ func destroy(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
 
 	log.Eventf(logger.TestTubeEmoji, "Deleting cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
@@ -50,7 +50,7 @@ func init() {
 
 // list outputs a list of all unmanaged clusters on the system.
 func list(cmd *cobra.Command, args []string) error {
-	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 	tClient := tanzu.New(log)
 	clusters, err := tClient.List()
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
@@ -50,7 +50,7 @@ func init() {
 
 // list outputs a list of all unmanaged clusters on the system.
 func list(cmd *cobra.Command, args []string) error {
-	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
 	tClient := tanzu.New(log)
 	clusters, err := tClient.List()
 	if err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/start.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/start.go
@@ -42,7 +42,7 @@ func start(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	log.Eventf(logger.TestTubeEmoji, "Attempting to start cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/start.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/start.go
@@ -42,7 +42,7 @@ func start(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
 
 	log.Eventf(logger.TestTubeEmoji, "Attempting to start cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/stop.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/stop.go
@@ -43,7 +43,7 @@ func stop(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	log.Eventf(logger.TestTubeEmoji, "Attempting to stop cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/stop.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/stop.go
@@ -43,7 +43,7 @@ func stop(cmd *cobra.Command, args []string) error {
 	} else if len(args) == 1 {
 		clusterName = args[0]
 	}
-	log := logger.NewLogger(TtySetting(cmd.Flags()), 0)
+	log := logger.NewLogger(TtySetting(cmd.Flags()), logger.DefaultLogLevel)
 
 	log.Eventf(logger.TestTubeEmoji, "Attempting to stop cluster: %s\n", clusterName)
 	tClient := tanzu.New(log)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/term"
 )
 
+const defaultLogVerbosity = 2
+
 // TtySetting gets the setting to use for formatted TTY output based on whether
 // the user explicitly set it with a command line argument, or if not, whether
 // there is an environment variable set. If neither of these things, it will
@@ -55,6 +57,17 @@ func SetupRootCommand(rootCmd *cobra.Command) {
 
 	rootCmd.SetUsageTemplate(usageTemplate)
 	rootCmd.SetHelpTemplate(helpTemplate)
+}
+
+// LoggingVerbosity will get the configured logging level for this command.
+func LoggingVerbosity(cmd *cobra.Command) int {
+	level, err := cmd.Flags().GetInt32("verbose")
+	if err != nil {
+		// Flag missing or read failure, use default
+		return defaultLogVerbosity
+	}
+
+	return int(level)
 }
 
 // Uses the users terminal size or width of 80 if cannot determine users width

--- a/cli/cmd/plugin/unmanaged-cluster/log/log.go
+++ b/cli/cmd/plugin/unmanaged-cluster/log/log.go
@@ -43,7 +43,7 @@ type CMDLogger struct {
 	// whether to support stylizing logging output
 	tty bool
 	// logging level to respect for this logger
-	level int
+	verbosity int
 	// log level set by a logging event
 	logLevel int
 	// instances of indentation (" ") to prepend to a long message
@@ -116,10 +116,11 @@ func NewLogger(tty bool, level int) Logger {
 	fd := int(os.Stdout.Fd())
 
 	return &CMDLogger{
-		tty:    tty,
-		level:  level,
-		output: os.Stdout,
-		termFd: fd,
+		tty:       tty,
+		verbosity: level,
+		logLevel:  DefaultLogLevel,
+		output:    os.Stdout,
+		termFd:    fd,
 	}
 }
 
@@ -134,7 +135,7 @@ func (l *CMDLogger) AddLogFile(filePath string) {
 }
 
 func (l *CMDLogger) Event(emoji, message string) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 	// when tty is off, remove emoji from output
@@ -156,7 +157,7 @@ func (l *CMDLogger) Event(emoji, message string) {
 }
 
 func (l *CMDLogger) Eventf(emoji, message string, args ...interface{}) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 	// when tty is off, remove emoji from output
@@ -178,7 +179,7 @@ func (l *CMDLogger) Eventf(emoji, message string, args ...interface{}) {
 }
 
 func (l *CMDLogger) Warn(message string) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -187,7 +188,7 @@ func (l *CMDLogger) Warn(message string) {
 }
 
 func (l *CMDLogger) Warnf(message string, args ...interface{}) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -196,7 +197,7 @@ func (l *CMDLogger) Warnf(message string, args ...interface{}) {
 }
 
 func (l *CMDLogger) Error(message string) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -205,7 +206,7 @@ func (l *CMDLogger) Error(message string) {
 }
 
 func (l *CMDLogger) Errorf(message string, args ...interface{}) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -214,7 +215,7 @@ func (l *CMDLogger) Errorf(message string, args ...interface{}) {
 }
 
 func (l *CMDLogger) Info(message string) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -223,7 +224,7 @@ func (l *CMDLogger) Info(message string) {
 }
 
 func (l *CMDLogger) Infof(message string, args ...interface{}) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -234,7 +235,7 @@ func (l *CMDLogger) Infof(message string, args ...interface{}) {
 // progressf is an internal method used to log out a specified number of dots
 // in addition to a provided message and any format string arguments
 func (l *CMDLogger) progressf(count int, message string, args ...interface{}) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -296,7 +297,7 @@ func (l *CMDLogger) progressf(count int, message string, args ...interface{}) {
 }
 
 func (l *CMDLogger) ReplaceLinef(message string, args ...interface{}) {
-	if l.logLevel > l.level {
+	if l.logLevel > l.verbosity {
 		return
 	}
 
@@ -369,9 +370,10 @@ func (l *CMDLogger) AnimateProgressWithOptions(options ...AnimatorOption) {
 
 func (l *CMDLogger) V(level int) Logger {
 	return &CMDLogger{
-		tty:      l.tty,
-		logLevel: l.level,
-		output:   l.output,
+		tty:       l.tty,
+		logLevel:  level,
+		verbosity: l.verbosity,
+		output:    l.output,
 	}
 }
 
@@ -381,12 +383,12 @@ func (l *CMDLogger) Style(indent int, c color.Attribute) Logger {
 		return l
 	}
 	return &CMDLogger{
-		tty:      l.tty,
-		level:    l.level,
-		logLevel: l.logLevel,
-		indent:   indent,
-		logColor: c,
-		output:   l.output,
+		tty:       l.tty,
+		verbosity: l.verbosity,
+		logLevel:  l.logLevel,
+		indent:    indent,
+		logColor:  c,
+		output:    l.output,
 	}
 }
 

--- a/cli/cmd/plugin/unmanaged-cluster/log/log.go
+++ b/cli/cmd/plugin/unmanaged-cluster/log/log.go
@@ -35,6 +35,9 @@ const (
 	MagnetEmoji     = "\U0001F9F2"
 )
 
+// DefaultLogLevel controls the default verbosity of log messages.
+var DefaultLogLevel = 0
+
 // CMDLogger is the logger implementation used for high-level command line logging.
 type CMDLogger struct {
 	// whether to support stylizing logging output
@@ -367,8 +370,7 @@ func (l *CMDLogger) AnimateProgressWithOptions(options ...AnimatorOption) {
 func (l *CMDLogger) V(level int) Logger {
 	return &CMDLogger{
 		tty:      l.tty,
-		level:    l.level,
-		logLevel: level,
+		logLevel: l.level,
 		output:   l.output,
 	}
 }

--- a/cli/cmd/plugin/unmanaged-cluster/main.go
+++ b/cli/cmd/plugin/unmanaged-cluster/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/cmd"
-	logging "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/log"
 )
 
 var description = `Deploy and manage single-node, static, Tanzu clusters.`
@@ -49,9 +48,6 @@ func main() {
 	)
 
 	cmd.SetupRootCommand(p.Cmd)
-
-	// Configure our logging default
-	logging.DefaultLogLevel = int(logLevel)
 
 	if err := p.Execute(); err != nil {
 		os.Exit(1)

--- a/cli/cmd/plugin/unmanaged-cluster/main.go
+++ b/cli/cmd/plugin/unmanaged-cluster/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/cmd"
+	logging "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/log"
 )
 
 var description = `Deploy and manage single-node, static, Tanzu clusters.`
@@ -35,7 +36,7 @@ func main() {
 		log.Fatal(err, "unable to initialize new plugin")
 	}
 
-	p.Cmd.PersistentFlags().Int32VarP(&logLevel, "verbose", "v", 0, "Number for the log level verbosity(0-9)")
+	p.Cmd.PersistentFlags().Int32VarP(&logLevel, "verbose", "v", 2, "Number for the log level verbosity(0-9)")
 	p.Cmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Log file path")
 
 	p.AddCommands(
@@ -48,6 +49,9 @@ func main() {
 	)
 
 	cmd.SetupRootCommand(p.Cmd)
+
+	// Configure our logging default
+	logging.DefaultLogLevel = int(logLevel)
 
 	if err := p.Execute(); err != nil {
 		os.Exit(1)

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -196,8 +196,8 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int,
 	if err != nil {
 		return ErrRenderingConfig, err
 	}
-	log.Style(outputIndent, color.Faint).Infof("Rendered Config: %s\n", configFp)
-	log.Style(outputIndent, color.Faint).Infof("Bootstrap Logs: %s\n", scConfig.LogFile)
+	log.V(2).Style(outputIndent, color.Faint).Infof("Rendered Config: %s\n", configFp)
+	log.V(2).Style(outputIndent, color.Faint).Infof("Bootstrap Logs: %s\n", scConfig.LogFile)
 
 	log.Event(logger.WrenchEmoji, "Processing Tanzu Kubernetes Release")
 	t.bom, err = parseTKRBom(bomFileName)
@@ -263,8 +263,8 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int,
 	}
 
 	kcBytes := clusterToUse.Kubeconfig
-	log.Style(outputIndent, color.Faint).Info("To troubleshoot, use:\n")
-	log.Style(outputIndent, color.Faint).Infof("kubectl ${COMMAND} --kubeconfig %s\n", scConfig.KubeconfigPath)
+	log.V(2).Style(outputIndent, color.Faint).Info("To troubleshoot, use:\n")
+	log.V(2).Style(outputIndent, color.Faint).Infof("kubectl ${COMMAND} --kubeconfig %s\n", scConfig.KubeconfigPath)
 
 	// 5. Install kapp-controller
 	kc, err := kapp.New(kcBytes)
@@ -439,32 +439,12 @@ func (t *UnmanagedCluster) Delete(name string) error {
 
 	configPath, err := resolveClusterConfig(name)
 	if err != nil {
-		log.Style(outputIndent, color.FgYellow).Warnf("Warning - could not resolve cluster config file. Error: %s\n", err.Error())
-		log.Style(outputIndent, color.FgYellow).Warnf("Cluster NOT deleted.\n")
-		log.Style(outputIndent, color.FgYellow).Warnf("Be sure to manually delete cluster\n")
-		deleteErr := os.RemoveAll(t.clusterDirectory)
-		if deleteErr != nil {
-			log.Style(outputIndent, color.FgRed).Errorf("Failed to remove config %s. Be sure to manually delete files\n", t.clusterDirectory)
-			return deleteErr
-		}
-
-		log.Style(outputIndent, color.Faint).Infof("Local config files directory deleted: %s\n", t.clusterDirectory)
-		return err
+		return t.handleDeleteFailure(err)
 	}
 
 	t.config, err = config.RenderFileToConfig(configPath)
 	if err != nil {
-		log.Style(outputIndent, color.FgYellow).Warnf("Warning - could not create configuration from local config file. Error: %s\n", err.Error())
-		log.Style(outputIndent, color.FgYellow).Warnf("Cluster NOT deleted.\n")
-		log.Style(outputIndent, color.FgYellow).Warnf("Be sure to manually delete cluster\n")
-		deleteErr := os.RemoveAll(t.clusterDirectory)
-		if deleteErr != nil {
-			log.Style(outputIndent, color.FgRed).Errorf("Failed to remove config %s. Be sure to manually delete files\n", t.clusterDirectory)
-			return deleteErr
-		}
-
-		log.Style(outputIndent, color.Faint).Infof("Local config files directory deleted: %s\n", t.clusterDirectory)
-		return err
+		return t.handleDeleteFailure(err)
 	}
 
 	cm := cluster.NewClusterManager(t.config)
@@ -480,7 +460,21 @@ func (t *UnmanagedCluster) Delete(name string) error {
 		return deleteErr
 	}
 
-	log.Style(outputIndent, color.Faint).Infof("Local config files directory deleted: %s\n", t.clusterDirectory)
+	log.V(2).Style(outputIndent, color.Faint).Infof("Local config files directory deleted: %s\n", t.clusterDirectory)
+	return err
+}
+
+func (t *UnmanagedCluster) handleDeleteFailure(err error) error {
+	log.Style(outputIndent, color.FgYellow).Warnf("Warning - could not create configuration from local config file. Error: %s\n", err.Error())
+	log.Style(outputIndent, color.FgYellow).Warnf("Cluster NOT deleted.\n")
+	log.Style(outputIndent, color.FgYellow).Warnf("Be sure to manually delete cluster\n")
+	deleteErr := os.RemoveAll(t.clusterDirectory)
+	if deleteErr != nil {
+		log.V(2).Style(outputIndent, color.FgRed).Errorf("Failed to remove config %s. Be sure to manually delete files\n", t.clusterDirectory)
+		return deleteErr
+	}
+
+	log.V(2).Style(outputIndent, color.Faint).Infof("Local config files directory deleted: %s\n", t.clusterDirectory)
 	return err
 }
 
@@ -727,7 +721,7 @@ func getCompatibilityFile() (string, error) {
 	// if the expected compatibility file is already in the config directory, don't download it again. return early
 	for _, file := range items {
 		if file.Name() == expectedCompatibilityFileName {
-			log.Style(outputIndent, color.Faint).Infof("Compatibility file exists at %s\n", filepath.Join(compatibilityPath, file.Name()))
+			log.V(2).Style(outputIndent, color.Faint).Infof("Compatibility file exists at %s\n", filepath.Join(compatibilityPath, file.Name()))
 			return file.Name(), nil
 		}
 	}
@@ -804,7 +798,7 @@ func getTkrBom(registry string) (string, error) {
 	// if the expected bom is already in the config directory, don't download it again. return early
 	for _, file := range items {
 		if file.Name() == expectedBomName {
-			log.Style(outputIndent, color.Faint).Infof("TKr exists at %s\n", filepath.Join(bomPath, file.Name()))
+			log.V(2).Style(outputIndent, color.Faint).Infof("TKr exists at %s\n", filepath.Join(bomPath, file.Name()))
 			return file.Name(), nil
 		}
 	}
@@ -911,7 +905,7 @@ func blockForImageDownload(b tkr.ImageReader, downloadpath, expectedName string)
 
 	// Once downloading is done, cancel the logging animation go routine and log completion
 	cancel()
-	log.Style(outputIndent, color.Faint).ReplaceLinef("Downloaded to: %s", f)
+	log.V(2).Style(outputIndent, color.Faint).ReplaceLinef("Downloaded to: %s", f)
 
 	return nil
 }

--- a/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
+++ b/cli/cmd/plugin/unmanaged-cluster/tanzu/tanzu.go
@@ -371,8 +371,8 @@ func (t *UnmanagedCluster) Deploy(scConfig *config.UnmanagedClusterConfig) (int,
 	log.Style(outputIndent, color.FgGreen).Infof("tanzu package available list\n")
 	log.Infof("View running pods:\n")
 	log.Style(outputIndent, color.FgGreen).Infof("kubectl get po -A\n")
-	log.Infof("Delete this cluster:\n")
-	log.Style(outputIndent, color.FgGreen).Infof("tanzu unmanaged delete %s\n", scConfig.ClusterName)
+	log.V(2).Infof("Delete this cluster:\n")
+	log.V(2).Style(outputIndent, color.FgGreen).Infof("tanzu unmanaged delete %s\n", scConfig.ClusterName)
 	return returnCode, nil
 }
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

In order to hide some log output when used in the Docker Desktop extension, this
raises the log level of some of the messages referring to local paths so they can be
skipped at a lower verbosity level in the extension.