### PR TITLE
On release, push to homebrew and chocolatey

### DIFF
--- a/.github/workflows/release-choco-package.yaml
+++ b/.github/workflows/release-choco-package.yaml
@@ -6,10 +6,35 @@ on:
       - released
 
 jobs:
-  update-choco-package:
-    name: Update Choco Package
+  e2e-choco-update:
+    name: E2E - Choco Upgrade
     # Only run this job if we're in the main repo, not a fork.
     if: github.repository == 'vmware-tanzu/community-edition'
+    runs-on: windows-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: Get the Tag
+        id: get_version
+        shell: bash
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Test Choco Upgrade
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+          ACTUAL_COMMIT_SHA: ${{ github.sha }}
+          TCE_CI_BUILD: true
+        shell: powershell
+        run: |
+          $env:BUILD_VERSION='${{ steps.get_version.outputs.VERSION }}'
+          cd ./hack/choco
+          ./test/choco-upgrade-test.ps1
+          $env:BUILD_VERSION=''
+  update-choco-package:
+    name: Update Choco Metadata
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    needs:
+      - e2e-choco-update # required test run before making changes
     runs-on: ubuntu-latest
     steps:
       - name: Config credentials
@@ -18,16 +43,38 @@ jobs:
         run: |
           git config --global pull.rebase true
           git config --global url."https://git:${GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
-
       - name: Check out code
         uses: actions/checkout@v1
-
-      - name: Update Choco Package
+      - name: Commit Choco Metadata
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
           ACTUAL_COMMIT_SHA: ${{ github.sha }}
           TCE_CI_BUILD: true
         shell: bash
         run: |
-          version=${GITHUB_REF/refs\/tags\//}
-          ./hack/choco/update-choco-package.sh ${version}
+          BUILD_VERSION=${GITHUB_REF/refs\/tags\//} ./hack/choco/update-choco-metadata.sh
+  publish-choco:
+    name: Update Choco Package
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    needs:
+      - e2e-choco-update # required test run before making changes
+      - update-choco-package # required to make chcoc metadata changes before publish
+    runs-on: windows-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: Get the Tag
+        id: get_version
+        shell: bash
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Push to Chocolatey
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+          ACTUAL_COMMIT_SHA: ${{ github.sha }}
+          TCE_CI_BUILD: true
+        shell: powershell
+        run: |
+          $env:BUILD_VERSION='${{ steps.get_version.outputs.VERSION }}'
+          ./hack/choco/update-choco-package.ps1
+          $env:BUILD_VERSION=''

--- a/.github/workflows/release-homebrew-package.yaml
+++ b/.github/workflows/release-homebrew-package.yaml
@@ -6,6 +6,20 @@ on:
       - released
 
 jobs:
+  e2e-homebrew-update:
+    name: E2E - Homebrew Upgrade
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/community-edition'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: Test Homebrew Upgrade
+        env:
+          TCE_CI_BUILD: true
+        shell: bash
+        run: |
+          BUILD_VERSION=${GITHUB_REF/refs\/tags\//} ./hack/homebrew/update-homebrew-test.sh
   update-homebrew-package:
     name: Update Homebrew Package
     # Only run this job if we're in the main repo, not a fork.
@@ -18,10 +32,8 @@ jobs:
         run: |
           git config --global pull.rebase true
           git config --global url."https://git:${GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
-
       - name: Check out code
         uses: actions/checkout@v1
-
       - name: Update Homebrew Package
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_ACCESS_TOKEN }}
@@ -29,5 +41,4 @@ jobs:
           TCE_CI_BUILD: true
         shell: bash
         run: |
-          version=${GITHUB_REF/refs\/tags\//}
-          ./hack/homebrew/update-homebrew-package.sh ${version}
+          BUILD_VERSION=${GITHUB_REF/refs\/tags\//} ./hack/homebrew/update-homebrew-package.sh

--- a/hack/choco/test/e2e-test.ps1
+++ b/hack/choco/test/e2e-test.ps1
@@ -19,12 +19,11 @@ Invoke-Command -ScriptBlock $packAndPushScriptBlock
 
 choco install tanzu-community-edition --source $HOME\tce-pkg -y
 
-tanzu
-
+# TODO: this needs to dynamically pick up on these things
 tanzu version
-
 tanzu conformance version
-
 tanzu diagnostics version
+tanzu unmanaged-cluster version
+# TODO: end
 
 choco uninstall tanzu-community-edition --source $HOME\tce-pkg -y

--- a/hack/choco/update-choco-metadata.sh
+++ b/hack/choco/update-choco-metadata.sh
@@ -7,8 +7,10 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-version="${1:?TCE version argument empty. Example usage: ./hack/choco/update-choco-package.sh v0.10.0}"
-: "${GITHUB_TOKEN:?GITHUB_TOKEN is not set}"
+if [[ -z "${BUILD_VERSION}" ]]; then
+    echo "BUILD_VERSION is not set"
+    exit 1
+fi
 
 # we only allow this to run from GitHub CI/Action
 if [[ "${TCE_CI_BUILD}" != "true" ]]; then
@@ -17,18 +19,18 @@ if [[ "${TCE_CI_BUILD}" != "true" ]]; then
 fi
 
 TCE_REPO_RELEASES_URL="https://github.com/vmware-tanzu/community-edition/releases"
-TCE_WINDOWS_ZIP_FILE="tce-windows-amd64-${version}.zip"
+TCE_WINDOWS_ZIP_FILE="tce-windows-amd64-${BUILD_VERSION}.zip"
 TCE_CHECKSUMS_FILE="tce-checksums.txt"
 
-echo "Checking if the necessary files exist for the TCE ${version} release"
+echo "Checking if the necessary files exist for the TCE ${BUILD_VERSION} release"
 wget --spider -q \
-   "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_WINDOWS_ZIP_FILE}" || {
-       echo "${TCE_WINDOWS_ZIP_FILE} is not accessible in TCE ${version} release"
+   "${TCE_REPO_RELEASES_URL}/download/${BUILD_VERSION}/${TCE_WINDOWS_ZIP_FILE}" || {
+       echo "${TCE_WINDOWS_ZIP_FILE} is not accessible in TCE ${BUILD_VERSION} release"
        exit 1
    }
 
-wget "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_CHECKSUMS_FILE}" || {
-   echo "${TCE_CHECKSUMS_FILE} is not accessible in TCE ${version} release"
+wget "${TCE_REPO_RELEASES_URL}/download/${BUILD_VERSION}/${TCE_CHECKSUMS_FILE}" || {
+   echo "${TCE_CHECKSUMS_FILE} is not accessible in TCE ${BUILD_VERSION} release"
    exit 1
 }
 
@@ -70,17 +72,17 @@ git pull origin "${WHICH_BRANCH}"
 # Replacing old version with the latest stable released version.
 pushd "./hack/choco" || exit 1
 
-    sed -i.bak -E "s/\\\$releaseVersion =.*/\$releaseVersion = \'${version}\'/g" tools/chocolateyinstall.ps1 && rm tools/chocolateyinstall.ps1.bak
+    sed -i.bak -E "s/\\\$releaseVersion =.*/\$releaseVersion = \'${BUILD_VERSION}\'/g" tools/chocolateyinstall.ps1 && rm tools/chocolateyinstall.ps1.bak
 
-    version="${version:1}"
-    sed -i.bak -E "s/<version>.*<\/version>/<version>${version}<\/version>/g" tanzu-community-edition.nuspec && rm tanzu-community-edition.nuspec.bak
+    BUILD_VERSION="${BUILD_VERSION:1}"
+    sed -i.bak -E "s/<version>.*<\/version>/<version>${BUILD_VERSION}<\/version>/g" tanzu-community-edition.nuspec && rm tanzu-community-edition.nuspec.bak
 
     sed -i.bak -E "s/\\\$checksum64 =.*/\$checksum64 = \'${windows_amd64_shasum}\'/g" tools/chocolateyinstall.ps1 && rm tools/chocolateyinstall.ps1.bak
 
 popd || exit 1
 
 
-PR_BRANCH="automation-choco-${version}"
+PR_BRANCH="automation-choco-${BUILD_VERSION}"
 
 # now that we are ready... perform the commit
 # login
@@ -105,7 +107,7 @@ git stash pop
 # do the work
 git add hack/choco/tools/chocolateyinstall.ps1
 git add hack/choco/tanzu-community-edition.nuspec
-git commit -s -m "auto-generated - update tce choco install scripts for version ${version}"
+git commit -s -m "auto-generated - update tce choco install scripts for version ${BUILD_VERSION}"
 git push origin "${PR_BRANCH}"
-gh pr create --title "auto-generated - update tce choco install scripts for version ${version}" --body "auto-generated - update tce choco install scripts for version ${version}" --base "${WHICH_BRANCH}"
+gh pr create --title "auto-generated - update tce choco install scripts for version ${BUILD_VERSION}" --body "auto-generated - update tce choco install scripts for version ${BUILD_VERSION}" --base "${WHICH_BRANCH}"
 gh pr merge "${PR_BRANCH}" --delete-branch --squash --admin

--- a/hack/choco/update-choco-package.ps1
+++ b/hack/choco/update-choco-package.ps1
@@ -1,0 +1,26 @@
+# Copyright 2021-2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+$ErrorActionPreference = 'Stop';
+
+if ((Test-Path env:BUILD_VERSION) -eq $False) {
+  throw "BUILD_VERSION environment variable is not set"
+}
+if ((Test-Path env:TCE_CI_BUILD) -eq $False) {
+  throw "TCE_CI_BUILD environment variable is not set"
+}
+if ((Test-Path env:CHOCO_API_KEY) -eq $False) {
+  throw "CHOCO_API_KEY environment variable is not set"
+}
+
+if ($env:BUILD_VERSION -like '*-*') {
+      Write-Host 'Do not commit any RC, Beta, Alpha type release'
+      Exit 0
+}
+
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+# push choco
+choco apikey -k $env:CHOCO_API_KEY -s https://push.chocolatey.org/
+choco pack
+choco push --source https://push.chocolatey.org/ --api-key $env:CHOCO_API_KEY

--- a/hack/homebrew/update-homebrew-package.sh
+++ b/hack/homebrew/update-homebrew-package.sh
@@ -7,8 +7,10 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-version="${1:?TCE version argument empty. Example usage: ./hack/homebrew/update-homebrew-package.sh v0.10.0}"
-: "${GITHUB_TOKEN:?GITHUB_TOKEN is not set}"
+if [[ -z "${BUILD_VERSION}" ]]; then
+    echo "BUILD_VERSION is not set"
+    exit 1
+fi
 
 # we only allow this to run from GitHub CI/Action
 if [[ "${TCE_CI_BUILD}" != "true" ]]; then
@@ -17,27 +19,27 @@ if [[ "${TCE_CI_BUILD}" != "true" ]]; then
 fi
 
 TCE_REPO_RELEASES_URL="https://github.com/vmware-tanzu/community-edition/releases"
-TCE_DARWIN_TAR_BALL_FILE="tce-darwin-amd64-${version}.tar.gz"
-TCE_LINUX_TAR_BALL_FILE="tce-linux-amd64-${version}.tar.gz"
+TCE_DARWIN_TAR_BALL_FILE="tce-darwin-amd64-${BUILD_VERSION}.tar.gz"
+TCE_LINUX_TAR_BALL_FILE="tce-linux-amd64-${BUILD_VERSION}.tar.gz"
 TCE_CHECKSUMS_FILE="tce-checksums.txt"
 TCE_HOMEBREW_TAP_REPO="https://github.com/vmware-tanzu/homebrew-tanzu"
 
-echo "Checking if the necessary files exist for the TCE ${version} release"
+echo "Checking if the necessary files exist for the TCE ${BUILD_VERSION} release"
 
 wget --spider -q \
-    "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_DARWIN_TAR_BALL_FILE}" > /dev/null || {
-        echo "${TCE_DARWIN_TAR_BALL_FILE} is not accessible in TCE ${version} release"
+    "${TCE_REPO_RELEASES_URL}/download/${BUILD_VERSION}/${TCE_DARWIN_TAR_BALL_FILE}" > /dev/null || {
+        echo "${TCE_DARWIN_TAR_BALL_FILE} is not accessible in TCE ${BUILD_VERSION} release"
         exit 1
     }
 
 wget --spider -q \
-    "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_LINUX_TAR_BALL_FILE}" > /dev/null || {
-        echo "${TCE_LINUX_TAR_BALL_FILE} is not accessible in TCE ${version} release"
+    "${TCE_REPO_RELEASES_URL}/download/${BUILD_VERSION}/${TCE_LINUX_TAR_BALL_FILE}" > /dev/null || {
+        echo "${TCE_LINUX_TAR_BALL_FILE} is not accessible in TCE ${BUILD_VERSION} release"
         exit 1
     }
 
-wget "${TCE_REPO_RELEASES_URL}/download/${version}/${TCE_CHECKSUMS_FILE}" || {
-    echo "${TCE_CHECKSUMS_FILE} is not accessible in TCE ${version} release"
+wget "${TCE_REPO_RELEASES_URL}/download/${BUILD_VERSION}/${TCE_CHECKSUMS_FILE}" || {
+    echo "${TCE_CHECKSUMS_FILE} is not accessible in TCE ${BUILD_VERSION} release"
     exit 1
 }
 
@@ -51,78 +53,86 @@ git clone --depth 1 --branch main "${TCE_HOMEBREW_TAP_REPO}"
 
 pushd "./homebrew-tanzu" || exit 1
 
-# setup
-git config user.name github-actions
-git config user.email github-actions@github.com
+    # setup
+    git config user.name github-actions
+    git config user.email github-actions@github.com
 
-# which branch did this hash/tag come from
-# get commit hash for this tag, then find which branch the hash is on
-#
-# we need to do this in two stages since we could create a tag on main and then
-# create a release branch and tag immediately on that release branch. the new tag would appear in
-# both main and this new branch because the commit is the same
+    # which branch did this hash/tag come from
+    # get commit hash for this tag, then find which branch the hash is on
+    #
+    # we need to do this in two stages since we could create a tag on main and then
+    # create a release branch and tag immediately on that release branch. the new tag would appear in
+    # both main and this new branch because the commit is the same
 
-# first test the release branch because it gets priority
-WHICH_BRANCH=$(git branch -a --contains "${ACTUAL_COMMIT_SHA}" | grep remotes | grep -v -e detached -e HEAD | grep -E "\brelease-[0-9]+\.[0-9]+\b"  | cut -d "/" -f3)
-echo "branch: ${WHICH_BRANCH}"
-if [[ "${WHICH_BRANCH}" == "" ]]; then
-    # now try main since the release branch doesnt exist
-    WHICH_BRANCH=$(git branch -a --contains "${ACTUAL_COMMIT_SHA}" | grep remotes | grep -v -e detached -e HEAD | grep -E "\bmain\b"  | cut -d "/" -f3)
+    # first test the release branch because it gets priority
+    WHICH_BRANCH=$(git branch -a --contains "${ACTUAL_COMMIT_SHA}" | grep remotes | grep -v -e detached -e HEAD | grep -E "\brelease-[0-9]+\.[0-9]+\b"  | cut -d "/" -f3)
     echo "branch: ${WHICH_BRANCH}"
     if [[ "${WHICH_BRANCH}" == "" ]]; then
-        echo "Unable to find the branch associated with this hash."
-        exit 1
+        # now try main since the release branch doesnt exist
+        WHICH_BRANCH=$(git branch -a --contains "${ACTUAL_COMMIT_SHA}" | grep remotes | grep -v -e detached -e HEAD | grep -E "\bmain\b"  | cut -d "/" -f3)
+        echo "branch: ${WHICH_BRANCH}"
+        if [[ "${WHICH_BRANCH}" == "" ]]; then
+            echo "Unable to find the branch associated with this hash."
+            exit 1
+        fi
     fi
-fi
 
-# make sure we are running on a clean state before checking out
-git reset --hard
-git fetch
-git checkout "${WHICH_BRANCH}"
-git pull origin "${WHICH_BRANCH}"
+    # make sure we are running on a clean state before checking out
+    git reset --hard
+    git fetch
+    git checkout "${WHICH_BRANCH}"
+    git pull origin "${WHICH_BRANCH}"
+
+    # unstable (non-GA) homebrew file
+    HOMEBREW_FILE="tanzu-community-edition.rb"
+    if [[ "${BUILD_VERSION}" == *"-"* ]]; then
+        HOMEBREW_FILE="tanzu-community-edition-unstable.rb"
+    fi
+
+    # Replacing old version with the latest stable released version.
+    sed -i.bak -E "s/version \"v.*/version \"${BUILD_VERSION}\"/" "${HOMEBREW_FILE}" && rm "${HOMEBREW_FILE}.bak"
+    # First occurrence of sha256 is for MacOS SHA sum
+    awk "/sha256 \".*/{c+=1}{if(c==1){sub(\"sha256 \\\".*\",\"sha256 \\\"${darwin_amd64_shasum}\\\"\",\$0)};print}" "${HOMEBREW_FILE}" > "tmp-${HOMEBREW_FILE}"
+    mv "tmp-${HOMEBREW_FILE}" "${HOMEBREW_FILE}"
+    # Second occurrence of sha256 is for Linux SHA sum
+    awk "/sha256 \".*/{c+=1}{if(c==2){sub(\"sha256 \\\".*\",\"sha256 \\\"${linux_amd64_shasum}\\\"\",\$0)};print}" "${HOMEBREW_FILE}" > "tmp-${HOMEBREW_FILE}"
+    mv "tmp-${HOMEBREW_FILE}" "${HOMEBREW_FILE}"
 
 
-# Replacing old version with the latest stable released version.
-sed -i.bak -E "s/version \"v.*/version \"${version}\"/" tanzu-community-edition.rb && rm tanzu-community-edition.rb.bak
-# First occurrence of sha256 is for MacOS SHA sum
-awk "/sha256 \".*/{c+=1}{if(c==1){sub(\"sha256 \\\".*\",\"sha256 \\\"${darwin_amd64_shasum}\\\"\",\$0)};print}" tanzu-community-edition.rb > tanzu-community-edition-updated.rb
-mv tanzu-community-edition-updated.rb tanzu-community-edition.rb
-# Second occurrence of sha256 is for Linux SHA sum
-awk "/sha256 \".*/{c+=1}{if(c==2){sub(\"sha256 \\\".*\",\"sha256 \\\"${linux_amd64_shasum}\\\"\",\$0)};print}" tanzu-community-edition.rb > tanzu-community-edition-updated.rb
-mv tanzu-community-edition-updated.rb tanzu-community-edition.rb
+    PR_BRANCH="automation-homebrew-${BUILD_VERSION}"
 
+    # now that we are ready... perform the commit
+    # login
+    set +x
+    echo "${GITHUB_TOKEN}" | gh auth login --with-token
+    set -x
 
-PR_BRANCH="automation-homebrew-${version}"
+    git stash
 
-# now that we are ready... perform the commit
-# login
-set +x
-echo "${GITHUB_TOKEN}" | gh auth login --with-token
-set -x
+    # create the branch from main or the release branch
+    DOES_NEW_BRANCH_EXIST=$(git branch -a | grep remotes | grep "${PR_BRANCH}")
+    echo "does branch exist: ${DOES_NEW_BRANCH_EXIST}"
+    if [[ "${DOES_NEW_BRANCH_EXIST}" == "" ]]; then
+        git checkout -b "${PR_BRANCH}" "${WHICH_BRANCH}"
+    else
+        git checkout "${PR_BRANCH}"
+        git rebase -Xtheirs "origin/${WHICH_BRANCH}"
+    fi
 
-git stash
+    git stash pop
 
-# create the branch from main or the release branch
-DOES_NEW_BRANCH_EXIST=$(git branch -a | grep remotes | grep "${PR_BRANCH}")
-echo "does branch exist: ${DOES_NEW_BRANCH_EXIST}"
-if [[ "${DOES_NEW_BRANCH_EXIST}" == "" ]]; then
-    git checkout -b "${PR_BRANCH}" "${WHICH_BRANCH}"
-else
-    git checkout "${PR_BRANCH}"
-    git rebase -Xtheirs "origin/${WHICH_BRANCH}"
-fi
+    # do the work
+    git add tanzu-community-edition.rb
+    git commit -s -m "auto-generated - update tce homebrew formula for version ${BUILD_VERSION}"
+    git push origin "${PR_BRANCH}"
+    gh pr create --repo "${TCE_HOMEBREW_TAP_REPO}" --title "auto-generated - update tce homebrew formula for version ${BUILD_VERSION}" --body "auto-generated - update tce homebrew formula for version ${BUILD_VERSION}"
+    gh pr merge --repo "${TCE_HOMEBREW_TAP_REPO}" "${PR_BRANCH}" --squash --delete-branch --admin
 
-git stash pop
-
-# do the work
-git add tanzu-community-edition.rb
-git commit -s -m "auto-generated - update tce homebrew formula for version ${version}"
-git push origin "${PR_BRANCH}"
-gh pr create --repo "${TCE_HOMEBREW_TAP_REPO}" --title "auto-generated - update tce homebrew formula for version ${version}" --body "auto-generated - update tce homebrew formula for version ${version}"
-gh pr merge --repo "${TCE_HOMEBREW_TAP_REPO}" "${PR_BRANCH}" --squash --delete-branch --admin
-
-# tag the new dev release
-git tag -m "${version}" "${version}"
-git push origin "${version}"
+    # tag the new dev release
+    git tag -m "${BUILD_VERSION}" "${BUILD_VERSION}"
+    git push origin "${BUILD_VERSION}"
 
 popd || exit 1
+
+# clean up
+rm -rf ./homebrew-tanzu

--- a/hack/homebrew/update-homebrew-test.sh
+++ b/hack/homebrew/update-homebrew-test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+if [[ -z "${BUILD_VERSION}" ]]; then
+    echo "BUILD_VERSION is not set"
+    exit 1
+fi
+
+# we only allow this to run from GitHub CI/Action
+if [[ "${TCE_CI_BUILD}" != "true" ]]; then
+    echo "This is only meant to be run within GitHub Actions CI"
+    exit 1
+fi
+
+TCE_HOMEBREW_TAP_REPO="https://github.com/vmware-tanzu/homebrew-tanzu"
+
+# clone the homebrew repo
+rm -rf ./homebrew-tanzu
+git clone --depth 1 --branch main "${TCE_HOMEBREW_TAP_REPO}"
+
+pushd "./homebrew-tanzu" || exit 1
+
+    # This will do a check on current version before adding it to main.
+    BUILD_VERSION="${BUILD_VERSION}" ./test/check-homebrew-upgrade.sh
+
+popd || exit 1
+
+# clean up
+rm -rf ./homebrew-tanzu


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This requires this PR to be merged first https://github.com/vmware-tanzu/homebrew-tanzu/pull/33

This PR adds the following:
- Performs an upgrade test for both choco and homebrew before updating/merging the changes required for both
- Performs the actual update to choco and homebrew so that after the release is published, choco pack is submitted to chocolatey and a user can homebrew the new version
- Homebrew supports an "unstable" homebrew formula which contains RCs, etc outside of the path/formula for GA. This is useful to know that non-GA homebrew can go through the same update process and is usable/testable

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/community-edition/issues/3722 https://github.com/vmware-tanzu/community-edition/issues/3178 https://github.com/vmware-tanzu/community-edition/issues/3174 https://github.com/vmware-tanzu/community-edition/issues/1663

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
TODO

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
Need to see if chocolatey supports publishing RC types packages. Until then, for choco non-GA releases... we dont push to chocolatey repo:
https://github.com/vmware-tanzu/community-edition/pull/4523/files#diff-f79c0c134b5b71887ff2ef6873fba2b15adae4787f2fd2638d50a0d4fe6579bbR16-R19