### PR TITLE
Bumps docker desktop build to latest tag for docker desktop extension

### DIFF
--- a/extensions/docker-desktop/Dockerfile-tanzu-cli
+++ b/extensions/docker-desktop/Dockerfile-tanzu-cli
@@ -9,7 +9,7 @@ ARG TARGETARCH
 
 WORKDIR /app
 
-ARG TCE_VERSION=v0.12.0
+ARG TCE_VERSION=v0.12.1
 
 RUN curl --fail --silent -L -o /tmp/src.tar.gz https://github.com/vmware-tanzu/community-edition/archive/refs/tags/${TCE_VERSION}.tar.gz && \
     tar --strip-components 1 -xvf /tmp/src.tar.gz


### PR DESCRIPTION
## What this PR does / why we need it

Bumps to v0.12.1 for docker desktop build.

@dvonthenen 

## Which issue(s) this PR fixes
Fixes: N/a - this gets fixes for logging we had pre v0.12.0 into the build
