### PR TITLE
Restore sudo failure handling from install script

### DIFF
--- a/hack/release/install.sh
+++ b/hack/release/install.sh
@@ -25,6 +25,11 @@ error_exit () {
     exit 1
 }
 
+handle_sudo_failure() {
+    echo "sudo access required to install to ${TANZU_BIN_PATH}"
+    exit 1
+}
+
 echo "===================================="
 echo " Installing Tanzu Community Edition"
 echo "===================================="


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

The function called when sudo commands fail was accidentally removed in
a later commit. The current installer will not correctly report and exit
when a user fails to sudo when running required commands. This restores
the function.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4549 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Run installer.