### PR TITLE
Fix auto merge part 5

### DIFF
--- a/.github/workflows/build-automatically-merge-pr.yaml
+++ b/.github/workflows/build-automatically-merge-pr.yaml
@@ -23,7 +23,4 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GH_PACKAGING_ACCESS_TOKEN }}
         run: |
-          set +x
-          echo "${GITHUB_TOKEN}" | gh auth login --with-token
-          set -x
           gh pr merge --delete-branch --squash --admin "$PR_URL"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
I think I finally (maybe) figured this out. Turns out the dependabot has it's own different set of secrets. Added one in the last attempt, but don't need this explicit login though which is causing the failure.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA