### PR TITLE
package repository automation #4321

### DIFF
--- a/.github/workflows/package-generate-repository.yaml
+++ b/.github/workflows/package-generate-repository.yaml
@@ -1,0 +1,107 @@
+name: Package - Generate Package Repository
+on:
+  push:
+    branches:
+      - main
+      - release-*
+    tags-ignore:
+      - "**"
+    paths:
+      - addons/packages/**/*/package.yaml
+      - addons/packages/**/*/metadata.yaml
+      - addons/repos/main.yaml
+jobs:
+  check:
+    outputs:
+      status: ${{ steps.early.outputs.status }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'vmware-tanzu/community-edition'
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.17"
+        id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Get diff
+        id: diffs
+        run: |
+          echo "::set-output name=diffs::$(git --no-pager diff --name-only HEAD^ HEAD | tr '\n' ',' | sed 's/\(.*\),/\1 /')"
+      - name: Echo Change Set
+        env:
+          CHANGESET: ${{ steps.diffs.outputs.diffs }}
+        run: |
+          echo "Change Set: ${CHANGESET}"
+      - id: early
+        shell: bash
+        name: Early exit
+        run:
+          echo "::set-output name=status::$(./hack/workflows/gen-pkgr/check.sh ${{ steps.diffs.outputs.diffs }})"
+      - id: s2
+        shell: bash
+        if: steps.early.outputs.status == 'donotgenerate'
+        run: |
+          echo "Do not generate package repository"
+      - id: s3
+        shell: bash
+        if: steps.early.outputs.status == 'generate'
+        run: |
+          echo "Generate package repository"
+  generate-package-repository:
+    name: Generate Package Repository
+    runs-on: ubuntu-latest
+    needs: check
+    if: github.repository == 'vmware-tanzu/community-edition' && needs.check.outputs.status == 'generate'
+    steps:
+      - name: Echo Output Status
+        run: |
+          echo "output status: ${{ needs.check.outputs.status }}"
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.17"
+        id: go
+      - name: Config credentials
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PACKAGING_ACCESS_TOKEN }}
+        run: |
+          git config --global pull.rebase true
+          git config --global url."https://git:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
+          git config --global user.name github-actions
+          git config --global user.email github-actions@github.com
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Install Carvel Tools
+        uses: vmware-tanzu/carvel-setup-action@v1
+      - name: Check the versions of Carvel tools
+        run: |
+          imgpkg version && kbld version && vendir version && ytt version
+      - name: Login to Harbor with Docker
+        uses: docker/login-action@v1
+        with:
+          registry: projects-stg.registry.vmware.com
+          username: ${{ secrets.HARBOR_STAGING_USERNAME }}
+          password: ${{ secrets.HARBOR_STAGING_PASSWORD }}
+      - name: Generate the Package Repository
+        id: gen-pkgr
+        run: |
+          echo "::set-output name=repo-url::$(make --no-print-directory generate-package-repo CHANNEL=main TAG=$(git rev-parse --short "$GITHUB_SHA") REGISTRY_URL=projects-stg.registry.vmware.com/tce)"
+      - name: Echo Step
+        id: echo-step
+        env:
+          REPO_URL: ${{steps.gen-pkgr.outputs.repo-url}}
+        run: |
+          echo "The REPO_URL is ${REPO_URL}"
+      - name: Update Pull Request
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'This Pull Request contained a change that generates a new package repository. The repository is available at URL:\n`${{steps.gen-pkgr.outputs.repo-url}}`'
+            })

--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,10 @@ generate-openapischema-package: #Generate package with OpenAPI v3 schema
 	@printf "===> package.yaml has been updated with openAPIv3 schema in its valuesSchema field for $${PACKAGE}/$${VERSION}\n";
 
 generate-package-repo: check-carvel # Generate and push the package repository. Usage: make generate-package-repo CHANNEL=main TAG=0.11.0
-	cd ./hack/packages/ && $(MAKE) run
+	@cd ./hack/packages/ && $(MAKE) run
+
+check-for-um-package:
+	@cd ./hack/workflows/gen-pkgr/ && $(MAKE) run
 
 get-package-config: # Extracts the package values.yaml file. Usage: make get-package-config PACKAGE=foo VERSION=1.0.0
 	TEMP_DIR=`mktemp -d` \

--- a/hack/packages/Makefile
+++ b/hack/packages/Makefile
@@ -30,7 +30,9 @@ ifeq ($(origin CHANNEL),undefined)
 	@echo "Error! CHANNEL env var not set"
 else ifeq ($(origin TAG),undefined)
 	@echo "Error! TAG env var not set"
+else ifeq ($(origin REGISTRY_URL),undefined)
+	@echo "Error! REGISTRY_URL env var not set"
 else
-	go run generate-package-repository.go $(CHANNEL) $(TAG)
+	@go run generate-package-repository.go $(CHANNEL) $(TAG) $(REGISTRY_URL)
 endif
 

--- a/hack/packages/generate-package-repository.go
+++ b/hack/packages/generate-package-repository.go
@@ -36,7 +36,6 @@ type BundleRef struct {
 }
 
 func main() {
-	var OciRegistry = "projects.registry.vmware.com/tce"
 	var PackagesDirectoryPath = filepath.Join("..", "..", "addons", "packages")
 	var RepoDirectoryPath = filepath.Join("..", "..", "addons", "repos")
 	var GeneratedRepoDirectoryPath = filepath.Join(RepoDirectoryPath, "generated")
@@ -44,6 +43,7 @@ func main() {
 
 	channel := os.Args[1]
 	tag := os.Args[2]
+	ociRegistry := os.Args[3]
 	channelDir := filepath.Join(GeneratedRepoDirectoryPath, channel)
 	imgpkgDir := filepath.Join(channelDir, ".imgpkg")
 	packagesDir := filepath.Join(channelDir, "packages")
@@ -87,7 +87,7 @@ func main() {
 	execCommand("kbld", []string{"--file", packagesDir, "--imgpkg-lock-output", imagesLockFile})
 
 	bundleLockFilename := "output.yaml"
-	registryPathAndTag := OciRegistry + "/" + channel + ":" + tag
+	registryPathAndTag := ociRegistry + "/" + channel + ":" + tag
 	execCommand("imgpkg", []string{"push", "--tty", "--bundle", registryPathAndTag, "--file", channelDir, "--lock-output", bundleLockFilename})
 
 	bundleLockYamlFile, err := os.ReadFile(bundleLockFilename)
@@ -97,8 +97,7 @@ func main() {
 	err = yaml.Unmarshal(bundleLockYamlFile, &bundleLock)
 	check(err)
 
-	fmt.Println("Package Repository pushed to", bundleLock.Bundle.Image)
-	fmt.Println("\nInstall with:\ntanzu package repository add repo-name --namespace default --url", bundleLock.Bundle.Image)
+	fmt.Println(bundleLock.Bundle.Image)
 	os.RemoveAll(bundleLockFilename)
 }
 

--- a/hack/workflows/gen-pkgr/check-for-um-package.go
+++ b/hack/workflows/gen-pkgr/check-for-um-package.go
@@ -1,0 +1,99 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is a utility program used to check if the generate-package-repository workflow should run
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type PackageRepositoryPackage struct {
+	Name     string   `yaml:"name"`
+	Versions []string `yaml:"versions"`
+}
+
+type PackageRepository struct {
+	Packages []PackageRepositoryPackage `yaml:"packages"`
+}
+
+func main() {
+	err := mainErr()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func mainErr() error {
+	// The first argument should be a comma separated list of the modified/changed files
+	if len(os.Args) <= 1 {
+		return errors.New("no files in change set")
+	}
+
+	arg1 := os.Args[1]
+
+	// if the repo file, addons/repos/main.yaml, was updated, early exit, we want to generate the repo
+	if strings.Contains(arg1, "addons/repos/main.yaml") {
+		return nil
+	}
+
+	changeSet := strings.Split(arg1, ",")
+
+	packageUpdates := make(map[string]string)
+
+	// Go through the change set, look for package or metadata yaml files. Add matched packages to maps.
+	for _, file := range changeSet {
+		if strings.HasPrefix(file, "addons/packages") {
+			fileBits := strings.Split(file, "/")
+			if strings.HasSuffix(file, "/metadata.yaml") {
+				// split up the string, get the package, the package will be the 3rd arg
+				packageMetadata := fileBits[2] + "/metadata"
+				packageUpdates[packageMetadata] = packageMetadata
+			} else if strings.HasSuffix(file, "/package.yaml") {
+				packageVersion := fileBits[2] + "/" + fileBits[3]
+				packageUpdates[packageVersion] = packageVersion
+			}
+		}
+	}
+
+	// Read in the package repository
+	var packageRepository PackageRepository
+	packageRepositoryFile := filepath.Join("..", "..", "..", "addons", "repos", "main.yaml")
+	source, err := os.ReadFile(packageRepositoryFile)
+	check(err)
+
+	err = yaml.Unmarshal(source, &packageRepository)
+	check(err)
+
+	// if a package listed in the main.yaml repo file is in the list of files modified, run the workflow
+	for _, pkg := range packageRepository.Packages {
+		// check for the metadata file changing
+		packageMetadata := pkg.Name + "/metadata"
+		if packageUpdates[packageMetadata] != "" {
+			// package exists in the repo, need to generate new repository, early exit
+			return nil
+		}
+
+		// check for package versions
+		for _, version := range pkg.Versions {
+			packageVersion := pkg.Name + "/" + version
+			if packageUpdates[packageVersion] != "" {
+				// package exists in the repo, need to generate new repository, early exit
+				return nil
+			}
+		}
+	}
+
+	return errors.New("do not generate package repository")
+}
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}

--- a/hack/workflows/gen-pkgr/check.sh
+++ b/hack/workflows/gen-pkgr/check.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+check_if_pkgr_should_be_generated() {
+  cd hack/workflows/gen-pkgr && go run check-for-um-package.go "$1"
+  status=$?
+  if [ $status -eq 0 ]; then
+    echo "generate"
+    exit 0
+  else
+    echo "donotgenerate"
+    exit 1
+  fi
+}
+
+check_if_pkgr_should_be_generated "$1"


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds a GitHub workflow. The workflow will create a new package repository on the staging distribution Harbor instance. Pushes to Pull Requests that modify a package or metadata yaml file will trigger the workflow. After creating the package repository, the pull request will be updated with the URL of the new repo bundle.

## Which issue(s) this PR fixes

Fixes: #4321

## Describe testing done for PR

Testing is a bit complicated. The workflow has to exist on the default branch for it to trigger. In my fork I had to change the default branch to be the branch where I developed the workflow. I also added a repo file to another branch that I modified and pushed every time the workflow was updated.

The package repos are tagged with the first 8 characters of the SHA from the commit that triggers the workflow.

The easiest way to test this might be to just merge it and modify a trigger file through a PR.

## Special notes for your reviewer

The workflow required the addition of 2 secrets to the community edition repo, a username and password for the Harbor robot account. These have already been added.

Interesting caveat that I discovered while developing this - GitHub Secrets are not shared with actions for PRs that are on Forks of the repo. So, if a package change is made on a PR from a fork, this workflow will not run. It will run on PRs on the main repository or pushes to main branch.