### PR TITLE
Fix links in v0.10. docs

### DIFF
--- a/docs/site/content/docs/edge/_index.md
+++ b/docs/site/content/docs/edge/_index.md
@@ -7,7 +7,7 @@ cascade:
 ---
 
 <!-- markdownlint-disable MD041 -->
-![TCE logo](/docs/img/tce-logo.png)
+![TCE logo](../img/tce-logo.png)
 
 VMware Tanzu Community Edition is a full-featured, easy to manage Kubernetes
 platform for learners and users. It is a freely available, community supported,

--- a/docs/site/content/docs/edge/architecture.md
+++ b/docs/site/content/docs/edge/architecture.md
@@ -64,7 +64,7 @@ to be installed in machine's path. Each subcommand (binary) is expected to be
 installed in `${XDG_DATA_HOME}/tanzu-cli`. This relationship is demonstrated
 below.
 
-![CLI Architecture](../../img/cli-arch.png)
+![CLI Architecture](../img/cli-arch.png)
 
 > [Click here to see where $XDG_DATA_HOME resolves
 > to.](https://github.com/adrg/xdg#xdg-base-directory)
@@ -85,7 +85,7 @@ There are two different types of clusters that can be deployed using the `tanzu 
 Managed clusters are deployed and managed by a Tanzu management cluster (originally deployed using `tanzu management-cluster`. This is the primary deployment model for clusters in the Tanzu ecosystem and is recommended for production scenarios. To bootstrap managed clusters, you first
 need a management cluster.  This is done using the `tanzu management-cluster create` command. When running this command, a bootstrap cluster is created locally and is used to then create the management cluster. The following diagram shows this flow.
 
-![Bootstrap cluster create](../../img/bootstrap-cluster-create.png)
+![Bootstrap cluster create](../img/bootstrap-cluster-create.png)
 
 Once the management cluster has been created, the bootstrap cluster will perform
 a move (aka pivot) of all management objects to the management cluster. From
@@ -94,7 +94,7 @@ and any new clusters you create. These new clusters, managed by the management
 cluster, are referred to as workload clusters. The following diagram shows this
 relationship end-to-end.
 
-![Management cluster bootstrapping](../../img/management-cluster-flow.png)
+![Management cluster bootstrapping](../img/management-cluster-flow.png)
 
 ### Unmanaged Clusters
 
@@ -114,7 +114,7 @@ package repositories. When a cluster is told about this package repository
 down that repository and make all the packages available to the cluster. This
 relationship is shown below.
 
-![kapp-controller repo read](../../img/tanzu-carvel-new-apis.png)
+![kapp-controller repo read](../img/tanzu-carvel-new-apis.png)
 
 With the packages available in the cluster, users of `tanzu` can install various
 packages. Within the cluster, a
@@ -122,6 +122,6 @@ packages. Within the cluster, a
 resource is created and it instructs `kapp-controller` to download the package
 and install the software in your cluster. This flow is shown below.
 
-![tanzu package install](../../img/tanzu-package-install-2.png)
+![tanzu package install](../img/tanzu-package-install-2.png)
 
 Note: If you deploy an unmanaged cluster, the default Tanzu Community Edition package repository 'tce-repo' is automatically installed.

--- a/docs/site/content/docs/edge/assets/aws-clusters.md
+++ b/docs/site/content/docs/edge/assets/aws-clusters.md
@@ -14,11 +14,11 @@ There are some prerequisites the installation process will assume.  Refer to the
 
 1. Choose Amazon from the provider tiles.
 
-    ![kickstart amazon tile](/docs/img/kickstart-amazon-tile.png)
+    ![kickstart amazon tile](../img/kickstart-amazon-tile.png)
 
 1. Fill out the IaaS Provider section.
 
-    ![kickstart amazon iaas](/docs/img/kickstart-amazon-iaas.png)
+    ![kickstart amazon iaas](../img/kickstart-amazon-iaas.png)
 
     * `A`: Whether to use AWS named profiles or provide static
       credentials. It is **highly** recommended you use profiles. This can be
@@ -31,7 +31,7 @@ There are some prerequisites the installation process will assume.  Refer to the
 
 1. Fill out the VPC settings.
 
-    ![kickstart aws vpc](/docs/img/kickstart-amazon-vpc.png)
+    ![kickstart aws vpc](../img/kickstart-amazon-vpc.png)
 
     * `A`: Whether to create a new Virtual Private Cloud in AWS or use an existing
       one. If using an existing one, you must provide its VPC ID. For initial
@@ -42,7 +42,7 @@ There are some prerequisites the installation process will assume.  Refer to the
 
 1. Fill out the Management Cluster Settings.
 
-    ![kickstart aws management cluster settings](/docs/img/kickstart-amazon-mgmt-cluster.png)
+    ![kickstart aws management cluster settings](../img/kickstart-amazon-mgmt-cluster.png)
 
     * `A`: Choose between Development profile, with 1 control plane node or
       Production, which features a highly-available three node control plane.
@@ -77,7 +77,7 @@ There are some prerequisites the installation process will assume.  Refer to the
 
 1. Fill out the Kubernetes Network section.
 
-    ![kickstart kubernetes networking](/docs/img/kickstart-amazon-network.png)
+    ![kickstart kubernetes networking](../img/kickstart-amazon-network.png)
 
     * `A`: Set the CIDR for Kubernetes [Services (Cluster
       IPs)](https://kubernetes.io/docs/concepts/services-networking/service/).
@@ -90,7 +90,7 @@ Kubernetes.
 
 1. Fill out the Identity Management section.
 
-    ![kickstart identity management](/docs/img/kickstart-identity.png)
+    ![kickstart identity management](../img/kickstart-identity.png)
 
     * `A`: Select whether you want to enable identity management. If this is
       off, certificates (via kubeconfig) are used to authenticate users. For
@@ -101,7 +101,7 @@ Kubernetes.
 
 1. Fill out the OS Image section.
 
-    ![kickstart aws os](/docs/img/kickstart-amazon-os.png)
+    ![kickstart aws os](../img/kickstart-amazon-os.png)
 
     * `A`: The [Amazon Machine Image
       (AMI)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) to

--- a/docs/site/content/docs/edge/assets/azure-clusters.md
+++ b/docs/site/content/docs/edge/assets/azure-clusters.md
@@ -16,11 +16,11 @@ There are some prerequisites this process will assume. Refer to the [Prepare to 
 
 1. Choose Azure from the provider tiles.
 
-    ![kickstart azure tile](/docs/img/kickstart-azure-tile.png)
+    ![kickstart azure tile](../img/kickstart-azure-tile.png)
 
 1. Fill out the IaaS Provider section.
 
-    ![kickstart azure iaas](/docs/img/kickstart-azure-iaas.png)
+    ![kickstart azure iaas](../img/kickstart-azure-iaas.png)
 
     * `A`: Your account's Tenant ID.
     * `B`: Your Client ID.
@@ -40,7 +40,7 @@ There are some prerequisites this process will assume. Refer to the [Prepare to 
 
 1. Fill out the VNET settings.
 
-    ![kickstart azure vnet](/docs/img/kickstart-azure-vnet.png)
+    ![kickstart azure vnet](..img/kickstart-azure-vnet.png)
 
     * `A`: Whether to create a new
       [Virtual Network in Azure](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview)
@@ -65,7 +65,7 @@ There are some prerequisites this process will assume. Refer to the [Prepare to 
 
 1. Fill out the Management Cluster Settings.
 
-    ![kickstart azure management cluster settings](/docs/img/kickstart-azure-mgmt-cluster.png)
+    ![kickstart azure management cluster settings](..img/kickstart-azure-mgmt-cluster.png)
 
     * `A`: Choose between Development profile with one control plane node, or
       Production, which features a highly-available three node control plane.
@@ -85,7 +85,7 @@ There are some prerequisites this process will assume. Refer to the [Prepare to 
 
 1. Fill out the Kubernetes Network section.
 
-    ![kickstart kubernetes networking](/docs/img/kickstart-azure-network.png)
+    ![kickstart kubernetes networking](..img/kickstart-azure-network.png)
 
     * `A`: Set the CIDR for Kubernetes [Services (Cluster
       IPs)](https://kubernetes.io/docs/concepts/services-networking/service/).
@@ -98,7 +98,7 @@ Kubernetes.
 
 1. Fill out the Identity Management section.
 
-    ![kickstart identity management](/docs/img/kickstart-identity.png)
+    ![kickstart identity management](..img/kickstart-identity.png)
 
     * `A`: Select whether you want to enable identity management. If this is
       off, certificates (via kubeconfig) are used to authenticate users. For
@@ -109,7 +109,7 @@ Kubernetes.
 
 1. Fill out the OS Image section.
 
-    ![kickstart azure os](/docs/img/kickstart-azure-os.png)
+    ![kickstart azure os](..img/kickstart-azure-os.png)
 
     * `A`: The Azure image to use for Kubernetes host VMs. This list should
       populate based on known images uploaded by VMware.

--- a/docs/site/content/docs/edge/assets/package-installation.md
+++ b/docs/site/content/docs/edge/assets/package-installation.md
@@ -10,9 +10,9 @@ For detailed instruction on package management, see [Work with Packages](../pack
 
 - Before you install packages, you should have the following cluster configurations running:
 
-  - A [management cluster](https://tanzucommunityedition.io/docs/latest/glossary/#management-cluster) and a [workload cluster](https://tanzucommunityedition.io/docs/latest/glossary/#workload-cluster).
+  - A [management cluster](glossary/#management-cluster) and a [workload cluster](glossary/#workload-cluster).
 
-For more information, see [Planning Your Installation](https://tanzucommunityedition.io/docs/latest/installation-planning/).
+For more information, see [Planning Your Installation](../installation-planning/).
 
 ### Procedure
 

--- a/docs/site/content/docs/edge/assets/prereq-pkg-creation.md
+++ b/docs/site/content/docs/edge/assets/prereq-pkg-creation.md
@@ -1,4 +1,4 @@
 
-* Tanzu Community Edition is installed and a cluster is running, see [Planning your Installation](../latest/installation-planning.md) or our [Getting Started Guide](../latest/getting-started.md).
+* Tanzu Community Edition is installed and a cluster is running, see [Planning your Installation](../installation-planning.md) or our [Getting Started Guide](../getting-started.md).
 * The [Carvel](https://carvel.dev/) suite of tools is installed. Before you begin the package creation process you should be familiar with the following Carvel tools: [ytt](../glossary/#ytt), [imgpkg](../glossary/#imgpkg), [vendir](../glossary/#vendir), and [kbld](../glossary/#kbld).
 * You have access to an [OCI registry](../glossary/#oci-registry), and you have authenticated locally so that you can push images.

--- a/docs/site/content/docs/edge/assets/vsphere-clusters.md
+++ b/docs/site/content/docs/edge/assets/vsphere-clusters.md
@@ -16,34 +16,34 @@ VMware Customer Connect.
 
 1. Ensure you have the version selected corresponding to your installation.
 
-    ![customer connect download page](/docs/img/customer-connect-downloads.png)
+    ![customer connect download page](../img/customer-connect-downloads.png)
 
 1. Locate and download the machine image (OVA) for your desired operating system
    and Kubernetes version.
 
-    ![customer connect ova downloads](/docs/img/customer-connect-ovas.png)
+    ![customer connect ova downloads](../img/customer-connect-ovas.png)
 
 1. Log in to your vCenter instance.
 
 1. In vCenter, right-click on your datacenter and choose Deploy OVF Template.
 
-    ![vcenter deploy ovf](/docs/img/vcenter-deploy-ovf.png)
+    ![vcenter deploy ovf](../img/vcenter-deploy-ovf.png)
 
 1. Follow the prompts, browsing to the local file that is the `.ova` downloaded
    in a previous step.
 
 1. Allow the template deployment to complete.
 
-    ![vcenter deploy ovf](/docs/img/vcenter-import-ovf.png)
+    ![vcenter deploy ovf](../img/vcenter-import-ovf.png)
 
 1. Right-click on the newly imported OVF template and choose Template > Convert to Template.
 
-    ![vcenter convert to template](/docs/img/vcenter-convert-to-template.png)
+    ![vcenter convert to template](../img/vcenter-convert-to-template.png)
 
 1. Verify the template is added by selecting the VMs and Templates icon and
    locating it within your datacenter.
 
-    ![vcenter template import](/docs/img/vcenter-template-import.png)
+    ![vcenter template import](../img/vcenter-template-import.png)
 
 ### Deploy a Management Cluster
 
@@ -57,11 +57,11 @@ VMware Customer Connect.
 
 1. Choose VMware vSphere from the provider tiles.
 
-    ![kickstart vsphere tile](/docs/img/kickstart-vsphere-tile.png)
+    ![kickstart vsphere tile](../img/kickstart-vsphere-tile.png)
 
 1. Fill out the IaaS Provider section.
 
-    ![kickstart vsphere iaas](/docs/img/kickstart-vsphere-iaas.png)
+    ![kickstart vsphere iaas](../img/kickstart-vsphere-iaas.png)
 
     * `A`: The IP or DNS name pointing at your vCenter instance. This is the
       same instance you uploaded the OVA to in previous steps.
@@ -77,7 +77,7 @@ VMware Customer Connect.
 
 1. Fill out the Management Cluster Settings.
 
-    ![kickstart vsphere management cluster settings](/docs/img/kickstart-vsphere-mgmt-cluster.png)
+    ![kickstart vsphere management cluster settings](../img/kickstart-vsphere-mgmt-cluster.png)
 
     * `A`: Choose between Development profile, with 1 control plane node or
       Production, which features a highly-available three node control plane.
@@ -104,7 +104,7 @@ VMware Customer Connect.
 
 1. Fill out the Resources section.
 
-    ![kickstart vsphere resources](/docs/img/kickstart-vsphere-resources.png)
+    ![kickstart vsphere resources](../img/kickstart-vsphere-resources.png)
 
     * `A`: Set the [VM
       folder](https://docs.vmware.com/en/VMware-Workstation-Pro/16.0/com.vmware.ws.using.doc/GUID-016FF81D-4FE4-4D9E-92D6-A08E022AA6D4.html)
@@ -117,7 +117,7 @@ VMware Customer Connect.
 
 1. Fill out the Kubernetes Network section.
 
-    ![kickstart kubernetes networking](/docs/img/kickstart-network.png)
+    ![kickstart kubernetes networking](../img/kickstart-network.png)
 
     * `A`: Select the [vSphere
       network](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.networking.doc/GUID-35B40B0B-0C13-43B2-BC85-18C9C91BE2D4.html)
@@ -133,7 +133,7 @@ Kubernetes.
 
 1. Fill out the Identity Management section.
 
-    ![kickstart identity management](/docs/img/kickstart-identity.png)
+    ![kickstart identity management](../img/kickstart-identity.png)
 
     * `A`: Select whether you want to enable identity management. If this is
       off, certificates (via kubeconfig) are used to authenticate users. For
@@ -144,7 +144,7 @@ Kubernetes.
 
 1. Fill out the OS Image section.
 
-    ![kickstart vsphere os](/docs/img/kickstart-vsphere-os.png)
+    ![kickstart vsphere os](../img/kickstart-vsphere-os.png)
 
     * `A`: The OVA image to use for Kubernetes host VMs. This list should
       populate based on the OVA you uploaded in previous steps. If it's missing,

--- a/docs/site/content/docs/edge/designs/package-management.md
+++ b/docs/site/content/docs/edge/designs/package-management.md
@@ -35,7 +35,7 @@ APIs are as follows.
 manifests. Inclusion of a `PackageRepository` in a cluster inherently makes the
 `Package`s available. This can be visually represented as follows.
 
-![Package and Package Repository](/docs/img/tanzu-carvel-new-apis.png)
+![Package and Package Repository](../../img/tanzu-carvel-new-apis.png)
 
 With the above in place, a user can see all the packages using `kubectl`.
 
@@ -55,7 +55,7 @@ referenced in the corresponding `Package` manifest. It then downloads those
 assets, renders them (e.g. `ytt`) and applies them to the cluster. This can be
 visually represented as follows.
 
-![InstalledPackage Flow](/docs/img/tanzu-carvel-installed-package.png)
+![InstalledPackage Flow](../../img/tanzu-carvel-installed-package.png)
 
 ## Client Side
 
@@ -92,7 +92,7 @@ already-existent objects. Namely the following from each `Package` instance:
 
 This is visually represented as follows.
 
-![tanzu package list](/docs/img/tanzu-package-list.png)
+![tanzu package list](../../img/tanzu-package-list.png)
 
 ### Package Configuration
 
@@ -284,7 +284,7 @@ In running this command, the `tanzu` client will have done the following.
 
 This is visually represented as follows.
 
-![tanzu package install](/docs/img/tanzu-package-install.png)
+![tanzu package install](../../img/tanzu-package-install.png)
 
 #### Including Package Configuration
 
@@ -366,7 +366,7 @@ installed package repo
 
 The flow would look as follows.
 
-![tanzu package repo install](/docs/img/tanzu-package-repo-install.png)
+![tanzu package repo install](../../img/tanzu-package-repo-install.png)
 
 ### Package Repository Deletion
 
@@ -382,7 +382,7 @@ deleted package repo
 
 The flow would look as follows.
 
-![tanzu package repo delete](/docs/img/tanzu-package-repo-delete.png)
+![tanzu package repo delete](../../img/tanzu-package-repo-delete.png)
 
 ## Designed Pending Details
 

--- a/docs/site/content/docs/edge/designs/package-process.md
+++ b/docs/site/content/docs/edge/designs/package-process.md
@@ -31,14 +31,14 @@ $ tanzu package install gatekeeper --package-name gatekeeper.community.tanzu.vmw
 > This experience is specific to user-managed packages.
 
 For details on how these packages are discovered, deployed, and managed, see
-[Package Management](/docs/package-management.md).
+[Package Management](../package-management).
 
 ### Packaging Workflow
 
 The following flow describes how we package user-managed packages. These steps
 are described in detail in the subsequent sections.
 
-![tanzu packaging flow](/docs/img/tanzu-packaging-flow.png)
+![tanzu packaging flow](../../img/tanzu-packaging-flow.png)
 
 ### 1. Create Directory Structure
 
@@ -266,7 +266,7 @@ runtime:
 With the above in place, you can validate that overlays and templating are
 working as expected. The conceptual flow is as follows.
 
-![templating flow](/docs/img/tanzu-templating-flow.png)
+![templating flow](../../img/tanzu-templating-flow.png)
 
 To run the above, you can use `ytt` as follows. If successful, the transformed manifest will be displayed,
 otherwise, an error message is displayed.
@@ -288,7 +288,7 @@ kbld is used to create a lock file, which we name `images.yml`. This file contai
 **are not mutated**. Instead, the SHA will be swapped out for the tag upon
 deployment. The relationship is as follows.
 
-![tanzu packaging flow](/docs/img/tanzu-kbld-flow.png)
+![tanzu packaging flow](/../../img/tanzu-kbld-flow.png)
 
 To find all container image references, create an `ImagesLock`, and ensure the
 digest's SHA is referenced, you can run `kbld` as follows.
@@ -411,7 +411,7 @@ instead the `PackageRepsoitory` bundle, containing many `Package`s is. Once
 the `PackageRepository` is in place, `kapp-controller` will make `Package` CRs
 in the cluster. This relationship can be seen as follows.
 
-![Package and Package Repository](/docs/img/tanzu-carvel-new-apis.png)
+![Package and Package Repository](../../img/tanzu-carvel-new-apis.png)
 
 An example `Package` for `gatekeeper` would read as follows.
 

--- a/docs/site/content/docs/edge/docker-monitoring-stack.md
+++ b/docs/site/content/docs/edge/docker-monitoring-stack.md
@@ -16,7 +16,7 @@ The metallb deployment can be considered a three step process if deploying via m
 
 Deployment of the Tanzu Community Edition cluster and metallb are beyond the scope of this document.
 
-It is also recommended that readers familiarise themselves with the [working with packages](/docs/latest/package-management.md) documentation as we will be using packages extensively in this procedure.
+It is also recommended that readers familiarise themselves with the [working with packages](package-management) documentation as we will be using packages extensively in this procedure.
 
 ## Add the Tanzu Community Edition Package Repository
 
@@ -288,7 +288,7 @@ Handling connection for 9001
 
 Now if you point a browser to the `localhost:9001`, the following Envoy landing page should be displayed:
 
-![Envoy Listing](/docs/img/envoy-listings.png?raw=true)
+![Envoy Listing](../img/envoy-listings.png?raw=true)
 
 Note the stats/prometheus link. This will be useful to reference when testing Prometheus in a later step.
 
@@ -580,15 +580,15 @@ Forwarding from [::1]:52119 -> 9090
 
 Now open a browser on your host, and connect to `localhost:52119` (or whatever port was chosen on your host). The Prometheus dashboard should be visible.
 
-![Prometheus Dashboard Landing Page](/docs/img/prometheus-standalone1.png?raw=true)
+![Prometheus Dashboard Landing Page](../img/prometheus-standalone1.png?raw=true)
 
 To do a very simple test, add a simple query, e.g. `prometheus_http_requests_total` and click Execute:
 
-![Prometheus Simple Query](/docs/img/prometheus-standalone2.png?raw=true)
+![Prometheus Simple Query](../img/prometheus-standalone2.png?raw=true)
 
 To check integration between Prometheus and Envoy, another query can be executed. When the Envoy landing page was displayed earlier, there was a section called `prometheus/stats`. These can now be queried as well, since these are the metrics that Envoy is sending to Prometheus. If we return to the Envoy landing page in the browser, and click on the prometheus/stats link and examine one of these metrics, such as the `envoy_cluster_default_total_match`, and use it as a query in Prometheus (selecting Graph instead of Table this time):
 
-![Envoy Prometheus Metric Query](/docs/img/prometheus-standalone3.png?raw=true)
+![Envoy Prometheus Metric Query](../img/prometheus-standalone3.png?raw=true)
 
 If this metric is also visible, then it would appear that Prometheus is working successfully. Now let's complete the monitoring stack by provisioning Grafana, and connecting it to our Prometheus data source.
 
@@ -717,20 +717,20 @@ Forwarding from [::1]:52533 -> 3000
 
 Now connect to `localhost:52533`, or whichever port was chosen by kubectl on your system, you should see the Grafana UI. The login credentials are admin/admin initially, but you will need to change the password on first login. This is the landing page:
 
-![Grafana Landing Page](/docs/img/grafana-landing-standalone.png?raw=true)
+![Grafana Landing Page](../img/grafana-landing-standalone.png?raw=true)
 
 There is no need to add a datasource or create a dashboard - these have already been done for you.
 
 To examine the data source, click on the icon representing datas sources on the left hand side (which looks like a cog). Here you can see the Prometheus data source is already in place:
 
-![Grafana Data Source Prometheus](/docs/img/grafana-data-source-standalone.png?raw=true)
+![Grafana Data Source Prometheus](../img/grafana-data-source-standalone.png?raw=true)
 
 Now click on the dashboards icon on the left hand side (it looks like a square of 4 smaller squares), and select `Manage` from the drop-down list. This will show the existing dashboards. There are 2 existing dashboards that have been provided; one is Kubernetes monitoring and the other is TKG monitoring. These dashboards are based on the Kubernetes Grafana dashboards found on [GitHub](https://github.com/kubernetes-monitoring/kubernetes-mixin).
 
-![Grafana Dashboards Manager](/docs/img/grafana-manage-dashboards-standalone.png?raw=true)
+![Grafana Dashboards Manager](../img/grafana-manage-dashboards-standalone.png?raw=true)
 
 Finally, select the TKG dashboard which is being sent metrics via the Prometheus data source. This provides an overview of the TKG cluster:
 
-![TKG Dashboard](/docs/img/grafana-dashboard-standalone.png?raw=true)
+![TKG Dashboard](../img/grafana-dashboard-standalone.png?raw=true)
 
 The full monitoring stack of Contour/Envoy Ingress, with secure communication via Cert-Manager, local storage provided by local-path-storage, alongside the Prometheus data scraper and Grafana visualization are now deployed through Tanzu Community Edition community packages onto a cluster running in Docker. Happy monitoring/analyzing.

--- a/docs/site/content/docs/edge/getting-started-unmanaged.md
+++ b/docs/site/content/docs/edge/getting-started-unmanaged.md
@@ -87,4 +87,4 @@ Choose your operating system below for guidance on installation.
 
 ## Next Steps
 
-* [Unmanaged Clusters Reference Documentation](/docs/latest/ref-unmanaged-cluster)
+* [Unmanaged Clusters Reference Documentation](ref-unmanaged-cluster)

--- a/docs/site/content/docs/edge/headless-install.md
+++ b/docs/site/content/docs/edge/headless-install.md
@@ -59,7 +59,7 @@ changes. At the bottom of this page, there is a
 box labeled "CLI Command Equivalent" that shows the command line that can be
 used to perform the second step of kicking off the deployment.
 
-![cli command equivalent](../../img/wizard-cli-command.png)
+![cli command equivalent](../img/wizard-cli-command.png)
 
 Note the file path of the generated YAML file (the path is listed after the
 `--file` argument). In this case, the file path is:

--- a/docs/site/content/docs/edge/solutions-opinionated-install-package.md
+++ b/docs/site/content/docs/edge/solutions-opinionated-install-package.md
@@ -10,7 +10,7 @@ You’re going to follow the [same workflow](/docs/designs/package-process/#pack
 
 First thing you will do is to create a package that will contain all the additional resources that are created in your opinionated environment. This package will be named `my-opinionated-config`. Then, we will create a package that will instantiate the four packages used: contour, cert-manager, external-dns and my-opinionated-config. This is actually the one that will trigger all the installations on your environment. You will name this package `my-opinionated-package`.
 
-![Opinionated package](/docs/img/opinionated-package.png)
+![Opinionated package](../img/opinionated-package.png)
 
 ## Opinionated configuration and additional resources
 
@@ -230,7 +230,7 @@ We will see the yaml resource files that the package will install on the cluster
 
 Now it’s time to package all the files up into a [Carvel imgpkg bundle](https://carvel.dev/imgpkg/docs/latest/resources/#bundle). For this we will still need to add some files, and we will need to have an OCI Registry (container registry) to push the generated bundle to, so that we can then test it in the cluster. For the purpose of this guide we will use an [Anonymous & ephemeral Docker image registry called ttl.sh](https://ttl.sh/) so that we don’t need to care about the registry. In a real world environment you should use your own registry.
 
-The first step in creating the bundle is to make sure that it is `complete` which means that if it references images within the descriptors used, those images are properly defined in an [imgpkg lock file](https://carvel.dev/imgpkg/docs/latest/resources/#imageslock-configuration). To do this, we need a folder `.imgpkg` in our package where that file will be generated. Create that folder and the run `[kbld](/docs/designs/package-process/#5-resolve-and-reference-image-digests)` to search on your files for images references to be inventoried.
+The first step in creating the bundle is to make sure that it is `complete` which means that if it references images within the descriptors used, those images are properly defined in an [imgpkg lock file](https://carvel.dev/imgpkg/docs/latest/resources/#imageslock-configuration). To do this, we need a folder `.imgpkg` in our package where that file will be generated. Create that folder and the run `[kbld](../designs/package-process/#5-resolve-and-reference-image-digests)` to search on your files for images references to be inventoried.
 
 ```shell
 kbld --file config --imgpkg-lock-output .imgpkg/images.yml
@@ -393,7 +393,7 @@ mkdir -p config/additions
 touch config/values.yaml
 ```
 
-In our [previous guide](solutions-secure-ingress), we created some additional resources to install our packages. These were created under the hood by the `tanzu CLI`. These are the [PackageInstall](https://carvel.dev/kapp-controller/docs/latest/packaging/#packageinstall) resources for [Contour](/docs/solutions-secure-ingress/#3-ingress-controller), [external-dns](/docs/solutions-secure-ingress/#external-dns) and [cert-manager](/docs/solutions-secure-ingress/#cert-manager) and the configuration needed for every package that we provided in a file as argument to the `tanzu package install` command. We will also create a PackageInstall and configuration file for the package we just created in the previous section `my-opinionated-config`. You will place these files in `config/additions` directory you just created:
+In our [previous guide](solutions-secure-ingress), we created some additional resources to install our packages. These were created under the hood by the `tanzu CLI`. These are the [PackageInstall](https://carvel.dev/kapp-controller/docs/latest/packaging/#packageinstall) resources for [Contour](solutions-secure-ingress/#3-ingress-controller), [external-dns](solutions-secure-ingress/#external-dns) and [cert-manager](solutions-secure-ingress/#cert-manager) and the configuration needed for every package that we provided in a file as argument to the `tanzu package install` command. We will also create a PackageInstall and configuration file for the package we just created in the previous section `my-opinionated-config`. You will place these files in `config/additions` directory you just created:
 
 `contour-packageinstall.yaml`
 
@@ -630,7 +630,7 @@ kbld --file config --imgpkg-lock-output .imgpkg/images.yml
 
 Again, this package does not contain any direct image references so the file will be empty. In this case, the images used by contour, cert-manager and external-dns are all defined in the `.imgpkg/images.yml` file of those packages. The opinionated-config package you created in the previous section has locked the imgpkg bundle image used in the `Package` resource.
 
-Next, you will create [the package bundle](/docs/designs/package-process/#6-bundle-configuration-and-deploy-to-registry). The bundle will be created and pushed into an OCI registry as a single operation. We use again `ttl.sh` as a convenience registry.
+Next, you will create [the package bundle](../designs/package-process/#6-bundle-configuration-and-deploy-to-registry). The bundle will be created and pushed into an OCI registry as a single operation. We use again `ttl.sh` as a convenience registry.
 
 ```shell
 imgpkg push --bundle ttl.sh/my-package-bundle:1d --file .
@@ -830,4 +830,4 @@ Error: Syncing directory '0': Syncing directory '.' with imgpkgBundle contents: 
 
 This guide should have provided you with some details on how you can package up multiple packages and configuration into an opinionated package so that users of the clusters only need to deal with one single package installation and configuration.
 
-There’s one last step left out of this guide which is to bundle your own packages into a [PackageRepository](https://carvel.dev/kapp-controller/docs/latest/packaging/#packagerepository) of your own. You can find more information on PackageRepositories on our [documentation](/docs/designs/package-repositories-and-versioning/).
+There’s one last step left out of this guide which is to bundle your own packages into a [PackageRepository](https://carvel.dev/kapp-controller/docs/latest/packaging/#packagerepository) of your own. You can find more information on PackageRepositories on our [documentation](../designs/package-repositories-and-versioning/).

--- a/docs/site/content/docs/edge/solutions-secure-ingress.md
+++ b/docs/site/content/docs/edge/solutions-secure-ingress.md
@@ -74,7 +74,7 @@ curl localhost:8080
 
 The output should look similar to:
 
-![CLI Architecture](../../img/tanzu-community-edition-ascciart.png)
+![CLI Architecture](../img/tanzu-community-edition-ascciart.png)
 
 This means that your application is up and running.
 
@@ -106,7 +106,7 @@ Where a Kubernetes cluster only hosts one web application that needs to be made 
 
 The third option is to install and configure an ingress controller. An ingress controller is a HTTP proxy service that can accept requests for many different hostnames and route traffic through to the appropriate application in the Kubernetes cluster.
 
-Tanzu Community Edition includes the open source [Contour](https://projectcontour.io/) ingress controller. Contour utilizes [Envoy Proxy](https://www.envoyproxy.io/) for routing. Standard Kubernetes Ingress resources for creating ingresses are supported, along with extended resources which provide additional features and flexibility above what the standard Ingress type provides. The readme for the Tanzu Community Edition Contour package is [here](https://tanzucommunityedition.io/docs/latest/package-readme-contour-1.19.1/).
+Tanzu Community Edition includes the open source [Contour](https://projectcontour.io/) ingress controller. Contour utilizes [Envoy Proxy](https://www.envoyproxy.io/) for routing. Standard Kubernetes Ingress resources for creating ingresses are supported, along with extended resources which provide additional features and flexibility above what the standard Ingress type provides. The readme for the Tanzu Community Edition Contour package is [here](https://tanzucommunityedition.io/docs/v0.10/package-readme-contour-1.19.1/).
 
 When installing the Contour ingress controller, by default it will use a Kubernetes Service of type LoadBalancer to expose the ingress controller router externally to the Kubernetes cluster. Since you are going to be using AWS for this guide, this is the type of service you would want.
 
@@ -157,7 +157,7 @@ Complete the following steps:
 
 1. Complete the following steps to install Contour:
 
-      1. You will need to provide some custom configuration specific to your environment. Note that although the options listed in the [Contour package readme](https://tanzucommunityedition.io/docs/latest/package-readme-contour-1.19.1/) are shown in a flat namespace, the data input values need to be supplied as a hierarchical YAML file definition.
+      1. You will need to provide some custom configuration specific to your environment. Note that although the options listed in the [Contour package readme](https://tanzucommunityedition.io/docs/v0.10/package-readme-contour-1.19.1/) are shown in a flat namespace, the data input values need to be supplied as a hierarchical YAML file definition.
 
           As you want to have an **external-dns** managing your DNS registrations, you will add an annotation to Contour for the [wildcard DNS](https://en.wikipedia.org/wiki/Wildcard_DNS_record) you want to use. You will configure external-dns later to manage this registration. In this example, we will use `*.example.com`.
 
@@ -542,7 +542,7 @@ You can now verify that your application works. Open a browser and type [**https
 
 Click the lock icon on the left of the address bar to verify that the certificate used is the wildcard certificate that was issued.
 
-![Secure Connection](../../img/secure-connection.png)
+![Secure Connection](../img/secure-connection.png)
 
 ## Summary
 

--- a/docs/site/content/docs/edge/vSphere-ldap-config.md
+++ b/docs/site/content/docs/edge/vSphere-ldap-config.md
@@ -67,13 +67,13 @@ This is the Root CA, which was retrieved via the Active Directory Certificate Se
 
 With all of these settings in place, the Identity Management Settings for LDAPS integration should look similar to the following:
 
-![LDAPS Identity Management Configuration](/docs/img/ldaps-im.png?raw=true)
+![LDAPS Identity Management Configuration](../img/ldaps-im.png?raw=true)
 
 ## Verify LDAP Configuration
 
 If everything has been configured correctly, and your LDAP service is working, then the `Verify LDAP Configuration` utility will run a check to ensure that it can correctly connect to your Active Directory/LDAPS service, do a BIND operation with the BIND user and credentials, and verify that it can search the user and group directories. If successful, it should report something simialr to the following. Note that an LDAP user has been added to the *Test User Name* field:
 
-![LDAPS Configuration Verification](/docs/img/ldap-verify.png?raw=true)
+![LDAPS Configuration Verification](../img/ldap-verify.png?raw=true)
 
 If there are issues, then determine which part of the verification is failing. If it is an X509 error during the Connect phase, check that the certificate is correct, and in base64 format. If it is a BIND issue, check the BIND DN and Password. If it is in the User Search or Group Search, check the Distinguished Names, Filters and Username/Name Attributues accordingly.
 
@@ -260,7 +260,7 @@ Switched to context "tanzu-cli-mgmt@mgmt".
 
 As soon as an attempt is made to query the cluster in the "non-admin" context, for example `kubectl get nodes`, the Dex portal launches in a browser window. Add the user credentials from the `ClusterRoleBinding` which was created in first step of this section, such as *chogan@rainpole.com*.
 
-![DEX LDAP Portal](/docs/img/dex-portal.png?raw=true)
+![DEX LDAP Portal](../img/dex-portal.png?raw=true)
 
 The `kubectl` command run previously to query the cluster should now complete once the authentication step with Dex has completed successfully.
 

--- a/docs/site/content/docs/edge/vsphere-monitoring-stack.md
+++ b/docs/site/content/docs/edge/vsphere-monitoring-stack.md
@@ -305,7 +305,7 @@ Handling connection for 9001
 
 Note that I have deliberately obfuscated the first two octets of the IP address allocated to Envoy above. Now if you point a browser to the localhost:9001, the following Envoy landing page should be displayed:
 
-![Envoy Listing](/docs/img/envoy-listings.png?raw=true)
+![Envoy Listing](../img/envoy-listings.png?raw=true)
 
 Everything is now in place to deploy Prometheus.
 
@@ -487,15 +487,15 @@ prometheus prometheus-httpproxy  prometheus.rainpole.com prometheus-tls valid  V
 
 To verify that Prometheus is working correctly, point to the Prometheus FQDN (e.g. http:// prometheus.rainpole.com). If everything has worked correctly, you should be able to see a Prometheus dashboard:
 
-![Envoy Dashboard Landing Page](/docs/img/envoy-db1.png?raw=true)
+![Envoy Dashboard Landing Page](../img/envoy-db1.png?raw=true)
 
 To do a very simple test, add a simple query, e.g. `prometheus_http_requests_total` and click Execute:
 
-![Envoy Simple Query](/docs/img/envoy-db2.png?raw=true)
+![Envoy Simple Query](../img/envoy-db2.png?raw=true)
 
 To check integration between Prometheus and Envoy, another query can be executed. When the Envoy landing page was displayed earlier, there was a section called `prometheus/stats`. These can now be queried as well, since these are the metrics that Envoy is sending to Prometheus. If we return to the Envoy landing page in the browser, and click on the prometheus/stats link and examine the metrics. one of these metrics, such as the `envoy_cluster_default_total_match`, and use it as a query in Prometheus (selecting Graph instead of Table this time):
 
-![Envoy Prometheus Metric Query](/docs/img/envoy-db3.png?raw=true)
+![Envoy Prometheus Metric Query](../img/envoy-db3.png?raw=true)
 
 If you see something similar to this, then it would appear that Prometheus is working successfully. Now let's complete the monitoring stack by provisioning Grafana, and connecting it to our Prometheus data source.
 
@@ -627,20 +627,20 @@ As mentioned, Grafana uses a Load Balancer service type by default, so it has be
 
 After adding your virtual host FQDN to your DNS, you can now connect to the Grafana dashboard using the FDQN. You connect directly to the Load Balancer IP address allocated to the Service. The login credentials are `admin/admin` initially, but you will need to change the password on first login. This is the landing page:
 
-![Grafana Landing Page](/docs/img/grafana-landing-page.png?raw=true)
+![Grafana Landing Page](../img/grafana-landing-page.png?raw=true)
 
 There is no need to add a datasource or create a dashboard - these have already been done for you.
 
 To examine the data source, click on the icon representing data sources on the left hand side (which looks like a cog). Here you can see the Prometheus data source that we placed in the data values manifest file when we deployed Grafana is already in place:
 
-![Grafana Data Source Prometheus](/docs/img/grafana-data-source.png?raw=true)
+![Grafana Data Source Prometheus](../img/grafana-data-source.png?raw=true)
 
 Now click on the dashboards icon on the left hand side (it looks like a square of 4 smaller squares), and select `Manage` from the drop-down list. This will show the existing dashboards. There are 2 existing dashboards that have been provided; one is Kubernetes monitoring and the other is TKG monitoring. These dashboards are based on the Kubernetes Grafana dashboards found on [GitHub](https://github.com/kubernetes-monitoring/kubernetes-mixin).
 
-![Grafana Dashboards Manager](/docs/img/grafana-manage-dashboards.png?raw=true)
+![Grafana Dashboards Manager](../img/grafana-manage-dashboards.png?raw=true)
 
 Finally, select the TKG dashboard which is being sent metrics via the Prometheus data source. This provides an overview of the TKG cluster:
 
-![TKG Dashboard](/docs/img/grafana-tkg-dashboard.png?raw=true)
+![TKG Dashboard](../img/grafana-tkg-dashboard.png?raw=true)
 
 The full monitoring stack of Contour/Envoy Ingress, with secure communication via Cert-Manager, alongside the Prometheus data scraper and Grafana visualization are now deployed through Tanzu Community Edition community packages. Happy monitoring/analyzing.

--- a/docs/site/data/docs/v0.10-toc.yml
+++ b/docs/site/data/docs/v0.10-toc.yml
@@ -103,7 +103,6 @@ toc:
             versions:
                 - 1.18.1
                 - 1.19.1
-                - 1.20.1
         - package:
             displayName: External Dns
             name: external-dns
@@ -144,7 +143,6 @@ toc:
             name: kpack
             versions:
                 - 0.5.0
-                - 0.5.1
         - package:
             displayName: Local Path Storage
             name: local-path-storage
@@ -167,7 +165,6 @@ toc:
             versions:
                 - 1.6.3
                 - 1.7.1
-                - 1.8.0
         - package:
             displayName: Whereabouts
             name: whereabouts


### PR DESCRIPTION
Signed-off-by: kcoriordan <koriordan@vmware.com>

## What this PR does / why we need it
- fixes broken links in v0.10.0 docs that occured because of change/move in doc structure to `docs/edge`
- removes some package readmes from toc that were causing broken links and that were appearing incorrectly in the v0.10.0 doc @seemiller 
https://tanzucommunityedition.io/docs/v0.10/package-readme-contour-1.20.1/ (HTTP_404)
https://tanzucommunityedition.io/docs/v0.10/package-readme-kpack-0.5.1/ (HTTP_404)
https://tanzucommunityedition.io/docs/v0.10/package-readme-velero-1.8.0/ (HTTP_404)

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
