### PR TITLE
Fix doc issue link and remove edit option

### DIFF
--- a/docs/site/themes/template/layouts/partials/docs-right-bar.html
+++ b/docs/site/themes/template/layouts/partials/docs-right-bar.html
@@ -1,15 +1,14 @@
 {{ if .Site.Params.docs_right_sidebar }}
 <div class="right-nav" id="right-nav">
     <div class="right-nav-content">
-        <ul class="buttons">
+	<ul class="buttons">
             {{ if (or .IsNode .IsPage) }}
-                {{ $issueBody := printf "[Docs] [%s](%s)" .Title .RelPermalink | htmlEscape }}
-                {{ $issueQuery := (querify "" $issueBody) }}
-                <li><a href="{{ $.Site.Params.github_base_url }}/issues/new?assignees=&labels=kind%2Fdocs%2C+triage%2Fneeds-triage&template=documentation.md&title{{ $issueQuery | safeURL }}" target="_blank">Report Issues</a></li>
-                {{ $editQuery := (querify "description" "Signed-off-by: NAME <EMAIL_ADDRESS>\n\n") }}
-                <li><a href="{{ $.Site.Params.github_base_url }}/edit/main/docs/site/content/{{ with .File }}{{ .Path }}{{ end }}?{{ $editQuery | safeURL }}" target="_blank"><img src="/img/github-blue.svg" /> Edit</a></li>
+                {{ $issueBody := printf "[Docs] (%s) - ADD_DESCRIPTION_HERE" .RelPermalink | htmlEscape }}
+                {{ $issueQuery := (querify "title" $issueBody) }}
+		<li><a href="{{ $.Site.Params.github_base_url }}/issues/new?assignees=&labels=kind%2Fdocs%2C+triage%2Fneeds-triage&template=documentation.md&{{ $issueQuery | safeURL }}" target="_blank">Report Issues</a></li>
+		<li><img src="/img/github-blue.svg" height=20 style="vertical-align:middle"/></li>
             {{ end }}
-        </ul>
+	</ul>
         {{ if ne .TableOfContents "<nav id=\"TableOfContents\"></nav>" }}
             <h4 class="strong">On this page:</h4>
             {{ .TableOfContents }}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

The docs pages have a "Report Issue" link in the right nav to quickly
get someone over to the docs template for filing any issues they see in
the documentation. This had been attempting to put a link in the title
based on the title of the page, but for most of our pages this ends up
being an empty value.

This updates the query to just put the relative link to the page
directly in the issue title, and puts a placeholder to try to nudge the
user to add an actual description to it.

While looking at this it was also noticed that we had an "Edit" link
there that would attempt to use the GitHub UI editor to be able to make
changes and submit a new PR. We had disabled this ability, so the link
would actualy bring the user to a GitHub 404 page.

Since the ability to file an issue is sufficient, to address the Edit
404 the link is just removed.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4672 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Made edits and ran `hugo` locally to verify rendered HTML looked correct and link works.