### PR TITLE
support dualstack e2e testing for external-dns

### DIFF
--- a/addons/packages/external-dns/0.10.0/test/e2e/fixtures/kuard-deployment.yaml
+++ b/addons/packages/external-dns/0.10.0/test/e2e/fixtures/kuard-deployment.yaml
@@ -28,6 +28,7 @@ metadata:
   labels:
     app: kuard
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - port: 80
     protocol: TCP

--- a/addons/packages/external-dns/0.11.0/test/e2e/fixtures/kuard-deployment.yaml
+++ b/addons/packages/external-dns/0.11.0/test/e2e/fixtures/kuard-deployment.yaml
@@ -28,6 +28,7 @@ metadata:
   labels:
     app: kuard
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - port: 80
     protocol: TCP

--- a/addons/packages/external-dns/0.8.0/test/e2e/fixtures/kuard-deployment.yaml
+++ b/addons/packages/external-dns/0.8.0/test/e2e/fixtures/kuard-deployment.yaml
@@ -28,6 +28,7 @@ metadata:
   labels:
     app: kuard
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - port: 80
     protocol: TCP


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
ipv6-primary tests were failing due to connectivy issues over ipv4
addressed for services. Preferring dualstack will ensure that both ipv4
and ipv6 rules are created when dualstack is available, but still
falling back to single stack behavior otherwise.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Ran tests against a dualstack cluster with this service change and saw it pass.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
