### PR TITLE
Update installation documentation for unmanaged-cluster

### DIFF
--- a/docs/site/content/docs/edge/assets/prereq-unmanaged-linux.md
+++ b/docs/site/content/docs/edge/assets/prereq-unmanaged-linux.md
@@ -4,5 +4,5 @@
 
 Tanzu Community Edition supports two cluster providers for unmanaged clusters: Kind and minikube
 
-- Kind is the default cluster provider and is included as default with the unmangaged cluster binary, you just need to install Docker.
+- Kind is the default cluster provider and is included as default with the unmanaged cluster binary, you just need to install Docker.
 - minikube is an alternative cluster provider, if you plan to use minikube as your cluster provider, you must first install minikube and a minikube supported container or virtual machine manager such as Docker.

--- a/docs/site/content/docs/edge/assets/prereq-unmanaged-mac.md
+++ b/docs/site/content/docs/edge/assets/prereq-unmanaged-mac.md
@@ -4,7 +4,7 @@
 
 Tanzu Community Edition supports two cluster providers for unmanaged clusters: Kind and minikube
 
-- Kind is the default cluster provider and is included as default with the unmangaged cluster binary, you just need to install Docker.
+- Kind is the default cluster provider and is included as default with the unmanaged cluster binary, you just need to install Docker.
 - minikube is an alternative cluster provider, if you plan to use minikube as your cluster provider, you must first install minikube and a minikube supported container or virtual machine manager such as Docker.
 
 Note: ARM64 support is experimental. Some packages might not install due to their ARM64 image not being available.

--- a/docs/site/content/docs/edge/assets/prereq-unmanaged-windows.md
+++ b/docs/site/content/docs/edge/assets/prereq-unmanaged-windows.md
@@ -4,7 +4,6 @@
 
 Tanzu Community Edition supports two cluster providers for unmanaged clusters: Kind and minikube
 
-- Kind is the default cluster provider and is included as default with the unmangaged cluster binary, you just need to install Docker.
+- Kind is the default cluster provider and is included as default with the unmanaged cluster binary, you just need to install Docker.
 - minikube is an alternative cluster provider, if you plan to use minikube as your cluster provider, you must first install minikube and a minikube supported container or virtual machine manager such as Docker.
 
-Note: ARM64 support is experimental. Some packages might not install due to their ARM64 image not being available.


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

1. Typos
2. ARM64 is not supported (nor experimental) for Windows
3. Match requirements table for Windows with the managed cluster req table

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran with `hugo server` and looked at http://localhost:1313/docs/edge/getting-started-unmanaged/

