### PR TITLE
Ship pinniped v1a1 cascading controller in post-deploy image

### DIFF
--- a/addons/packages/pinniped/0.12.1/bundle/config/libs/constants.lib.yaml
+++ b/addons/packages/pinniped/0.12.1/bundle/config/libs/constants.lib.yaml
@@ -48,6 +48,14 @@
 #@   return post_deploy_job_name() + "-sa"
 #@ end
 
+#@ def post_deploy_controller_name():
+#@   return "pinniped-post-deploy-controller"
+#@ end
+
+#@ def post_deploy_controller_sa_name():
+#@   return post_deploy_controller_name() + "-sa"
+#@ end
+
 #@ def jwt_authenticator_name():
 #@   return "tkg-jwt-authenticator"
 #@ end

--- a/addons/packages/pinniped/0.12.1/bundle/config/overlay/post-deploy-overlay.yaml
+++ b/addons/packages/pinniped/0.12.1/bundle/config/overlay/post-deploy-overlay.yaml
@@ -25,7 +25,7 @@
 #@   return sha256.sum(yaml.encode(data.values))
 #@ end
 
-#@ commands = ["/tkg-pinniped-post-deploy"]
+#@ commands = ["/tkg-pinniped-post-deploy-job"]
 #@ if data.values.tkg_cluster_role == "management":
 #@   commands.append("--supervisor-namespace={}".format(pinniped_supervisor_namespace()))
 #@   commands.append("--concierge-namespace={}".format(pinniped_concierge_namespace()))

--- a/addons/packages/pinniped/0.12.1/bundle/config/upstream/03-post-deploy.yaml
+++ b/addons/packages/pinniped/0.12.1/bundle/config/upstream/03-post-deploy.yaml
@@ -1,6 +1,6 @@
 #@ load("/values.star", "render_on_mgmt_cluster", "render_on_workload_cluster")
 #@ load("@ytt:data", "data")
-#@ load("/libs/constants.lib.yaml", "post_deploy_job_name", "pinniped_supervisor_namespace", "post_deploy_job_sa_name")
+#@ load("/libs/constants.lib.yaml", "post_deploy_job_name", "pinniped_supervisor_namespace", "post_deploy_job_sa_name", "post_deploy_controller_name", "post_deploy_controller_sa_name")
 
 #@ if render_on_mgmt_cluster() or render_on_workload_cluster():
 ---
@@ -70,4 +70,81 @@ spec:
           image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
           imagePullPolicy: IfNotPresent
           command: []
+#@ end
+
+#@ if render_on_mgmt_cluster():
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: #@ post_deploy_controller_sa_name()
+  namespace: #@ pinniped_supervisor_namespace()
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: #@ post_deploy_controller_name()
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: #@ post_deploy_controller_name()
+subjects:
+  - kind: ServiceAccount
+    name: #@ post_deploy_controller_sa_name()
+    namespace: #@ pinniped_supervisor_namespace()
+roleRef:
+  kind: ClusterRole
+  name: #@ post_deploy_controller_name()
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: #@ post_deploy_controller_name()
+  namespace: #@ pinniped_supervisor_namespace()
+spec:
+  selector:
+    matchLabels:
+      app: #@ post_deploy_controller_name()
+  template:
+    metadata:
+      labels:
+        app: #@ post_deploy_controller_name()
+    #! TODO: check out the spec of other packages, such as addons-manager-v1 for resource limits, etc.
+    #! we probably want to flesh this out.
+    spec:
+      serviceAccountName: #@ post_deploy_controller_sa_name()
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: #@ post_deploy_controller_name()
+        command: ["/tkg-pinniped-post-deploy-controller"]
 #@ end

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-aws-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-aws-v1_3_0.yaml
@@ -2550,7 +2550,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2564,6 +2564,79 @@ spec:
         - --dex-configmap-name=dex
         - --is-dex-required=True
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-azure-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-azure-v1_3_0.yaml
@@ -2549,7 +2549,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2563,6 +2563,79 @@ spec:
         - --dex-configmap-name=dex
         - --is-dex-required=True
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-custom-cluster-issuer.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-custom-cluster-issuer.yaml
@@ -2569,7 +2569,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2583,6 +2583,79 @@ spec:
         - --dex-configmap-name=dex
         - --is-dex-required=True
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-updatestrategyoverlay-v1_5_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-updatestrategyoverlay-v1_5_0.yaml
@@ -2560,7 +2560,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2578,6 +2578,88 @@ spec:
         race: halfling
         class: ranger
         level: 5
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
+      nodeSelector:
+        race: halfling
+        class: ranger
+        level: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1111
+      maxSurge: 9999
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_3_1.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_3_1.yaml
@@ -2550,7 +2550,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2564,6 +2564,79 @@ spec:
         - --dex-configmap-name=dex
         - --is-dex-required=True
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_4_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_4_0.yaml
@@ -2569,7 +2569,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2583,6 +2583,79 @@ spec:
         - --dex-configmap-name=dex
         - --is-dex-required=True
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_5_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_5_0.yaml
@@ -2569,7 +2569,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2583,6 +2583,79 @@ spec:
         - --dex-configmap-name=dex
         - --is-dex-required=True
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-vsphere-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-vsphere-v1_3_0.yaml
@@ -2550,7 +2550,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2564,6 +2564,79 @@ spec:
         - --dex-configmap-name=dex
         - --is-dex-required=True
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-aws-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-aws-v1_3_0.yaml
@@ -2287,7 +2287,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2297,6 +2297,79 @@ spec:
         - --custom-tls-secret=
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-azure-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-azure-v1_3_0.yaml
@@ -2287,7 +2287,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2297,6 +2297,79 @@ spec:
         - --custom-tls-secret=
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-updatestrategyoverlay-v1_5_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-updatestrategyoverlay-v1_5_0.yaml
@@ -2303,7 +2303,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2317,6 +2317,88 @@ spec:
         race: wood elf
         class: paladin
         level: 6
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
+      nodeSelector:
+        race: wood elf
+        class: paladin
+        level: 6
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1111
+      maxSurge: 9999
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_3_1-custom-tls-cert.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_3_1-custom-tls-cert.yaml
@@ -2215,7 +2215,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2225,6 +2225,79 @@ spec:
         - --custom-tls-secret=custom-tls-certificate
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_3_1.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_3_1.yaml
@@ -2286,7 +2286,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2296,6 +2296,79 @@ spec:
         - --custom-tls-secret=
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_4_0-custom-tls-cert.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_4_0-custom-tls-cert.yaml
@@ -2215,7 +2215,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2225,6 +2225,79 @@ spec:
         - --custom-tls-secret=custom-tls-certificate
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_4_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_4_0.yaml
@@ -2286,7 +2286,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2296,6 +2296,79 @@ spec:
         - --custom-tls-secret=
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_5_0-custom-tls-cert.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_5_0-custom-tls-cert.yaml
@@ -2215,7 +2215,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2225,6 +2225,79 @@ spec:
         - --custom-tls-secret=custom-tls-certificate
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_5_0-external-dns.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_5_0-external-dns.yaml
@@ -2287,7 +2287,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2298,6 +2298,79 @@ spec:
         - --supervisor-svc-endpoint=https://my-cluster.dev
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_5_0-http-proxy.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_5_0-http-proxy.yaml
@@ -2294,7 +2294,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2304,6 +2304,79 @@ spec:
         - --custom-tls-secret=
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_5_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-v1_5_0.yaml
@@ -2286,7 +2286,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2296,6 +2296,79 @@ spec:
         - --custom-tls-secret=
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-vsphere-custom-concierge-audience-v1_5_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-vsphere-custom-concierge-audience-v1_5_0.yaml
@@ -2285,7 +2285,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2295,6 +2295,79 @@ spec:
         - --custom-tls-secret=
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-vsphere-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc-vsphere-v1_3_0.yaml
@@ -2288,7 +2288,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2298,6 +2298,79 @@ spec:
         - --custom-tls-secret=
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-oidc.yaml
@@ -2286,7 +2286,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --supervisor-namespace=pinniped-supervisor
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-name=pinniped-supervisor
@@ -2296,6 +2296,79 @@ spec:
         - --custom-tls-secret=
         - --is-dex-required=False
         - --concierge-is-cluster-scoped=true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pinniped-post-deploy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pinniped-post-deploy-controller
+subjects:
+- kind: ServiceAccount
+  name: pinniped-post-deploy-controller-sa
+  namespace: pinniped-supervisor
+roleRef:
+  kind: ClusterRole
+  name: pinniped-post-deploy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-post-deploy-controller
+  namespace: pinniped-supervisor
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-post-deploy-controller
+  template:
+    metadata:
+      labels:
+        app: pinniped-post-deploy-controller
+    spec:
+      serviceAccountName: pinniped-post-deploy-controller-sa
+      containers:
+      - image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
+        name: pinniped-post-deploy-controller
+        command:
+        - /tkg-pinniped-post-deploy-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/wlc-aws-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/wlc-aws-v1_3_0.yaml
@@ -1291,7 +1291,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --jwtauthenticator-name=tkg-jwt-authenticator
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-endpoint=https://<pinniped-supervisor-svc-host>:<port>

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/wlc-azure-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/wlc-azure-v1_3_0.yaml
@@ -1291,7 +1291,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --jwtauthenticator-name=tkg-jwt-authenticator
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-endpoint=https://<pinniped-supervisor-svc-host>:<port>

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/wlc-oidc-vsphere-custom-concierge-audience-v1_5_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/wlc-oidc-vsphere-custom-concierge-audience-v1_5_0.yaml
@@ -1291,7 +1291,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - "--jwtauthenticator-audience=tiny angry kittens TINY ANGRY KITTENS!!! \U0001F63E \U0001F638 \U0001F63E \U0001F638"
         - --jwtauthenticator-name=tkg-jwt-authenticator
         - --concierge-namespace=pinniped-concierge

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/wlc-v1_3_1.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/wlc-v1_3_1.yaml
@@ -1291,7 +1291,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --jwtauthenticator-name=tkg-jwt-authenticator
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-endpoint=https://<pinniped-supervisor-svc-host>:<port>

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/wlc-vsphere-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/wlc-vsphere-v1_3_0.yaml
@@ -1291,7 +1291,7 @@ spec:
         image: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
         imagePullPolicy: IfNotPresent
         command:
-        - /tkg-pinniped-post-deploy
+        - /tkg-pinniped-post-deploy-job
         - --jwtauthenticator-name=tkg-jwt-authenticator
         - --concierge-namespace=pinniped-concierge
         - --supervisor-svc-endpoint=https://<pinniped-supervisor-svc-host>:<port>


### PR DESCRIPTION
Signed-off-by: Andrew Keesler <akeesler@vmware.com>

## What this PR does / why we need it

* This PR adds the pinniped v1alpha1 cascading control loop to the pinniped package
* Specifically, this control loop automatically creates workload cluster pinniped addon secrets so that the user does not have to
* The workload cluster pinniped addon secrets contain the correct addressing information for the pinniped concierge on the workload cluster to talk to the pinniped supervisor on the management cluster

## Which issue(s) this PR fixes

None

## Describe testing done for PR

* Created a TKGm cluster with all of this in-development code, created an N-0, N-1, and N-2 cluster, validated that I could generate a kubeconfig and authenticate to all of them
I.e.,
```sh
$ for tkr in v1.21.11---vmware.1-tkg.2-zshippable v1.22.8---vmware.1-tkg.2-zshippable v1.23.5---vmware.1-tkg.1-zshippable; do tanzu cluster create "c-$(uuidgen)" -f tkg-mgmt-vc.yaml -n default -v 1000; done
$ for c in `tanzu cluster list -o json | jq .[].name -r`; do tanzu cluster kubeconfig get $c --export-file /tmp/${c}.yaml; done
$ for c in `tanzu cluster list -o json | jq .[].name -r`; do kubectl --kubeconfig /tmp/${c}.yaml get ns; done
```

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->

Hi Sarah