### PR TITLE
Allows kube-system to be orphaned when deleting metrics-server

### DIFF
--- a/addons/packages/metrics-server/0.5.1/bundle/config/overlays/overlay-namespace.yaml
+++ b/addons/packages/metrics-server/0.5.1/bundle/config/overlays/overlay-namespace.yaml
@@ -15,6 +15,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: #@ metricsServerNamespace
+#@   if data.values.namespace == "kube-system":
+  annotations:
+    kapp.k14s.io/delete-strategy: orphan
+#@   end
 #@ end
 
 #@overlay/match by=overlay.subset({"kind": "ServiceAccount","metadata": {"name": "metrics-server"}}),expects="1+"


### PR DESCRIPTION
When the metrics-server is installed it might add the kube-system namespace
to its list of resources. Subsequently, when the metrics-server is deleted,
it will try to delete the kube-system namespace, but this is not allowed so
package deletion fails.

This patch makes it possible to delete the metrics-server package without
having to delete the kube-system namespace.



## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/vmware-tanzu/tanzu-framework/issues/1708

## Describe testing done for PR

Deployed kind cluster with following commands: 
#!/bin/bash  -ex
kind create cluster --name v0.34.0
kubectl cluster-info --context kind-v0.34.0
kubectl create namespace vmware-system-tkg
kubectl apply -f https://github.com/vmware-tanzu/carvel-kapp-controller/releases/download/v0.34.0/release.yml

Then proceeded to install current version of metrics-server pacakge (0.5.1)
with image: projects.registry.vmware.com/tce/metrics-server@sha256:4fa580c9b185d44f39847cd2347c8110b3a38d775e674ce77bc3b2569067f4c0
(this image has the problem). 

The proceeded to update the Package CR  to a version/image containing this fix
after succesful reconciliation, pacakgeinstall was deleted succesfully. PackageInstall cannot be deleted without this fix
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
