### PR TITLE
Support for Choco Updates for non-GA Releases

### DIFF
--- a/hack/choco/tanzu-community-edition-release.nuspec
+++ b/hack/choco/tanzu-community-edition-release.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>tanzu-community-edition</id>
+    <version>0.12.1</version>
+    <owners>VMware</owners>
+    <title>Tanzu Community Edition</title>
+    <authors>VMware Tanzu</authors>
+    <projectUrl>https://github.com/vmware-tanzu/community-edition</projectUrl>
+    <packageSourceUrl>https://github.com/vmware-tanzu/community-edition/blob/main/hack/choco</packageSourceUrl>
+    <!-- TODO:
+    <iconUrl></iconUrl>
+    -->
+    <licenseUrl>https://github.com/vmware-tanzu/community-edition/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/vmware-tanzu/community-edition</projectSourceUrl>
+    <docsUrl>https://github.com/vmware-tanzu/community-edition/blob/main/README.md</docsUrl>
+    <mailingListUrl>https://groups.google.com/g/tanzu-community-edition</mailingListUrl>
+    <bugTrackerUrl>https://github.com/vmware-tanzu/community-edition/issues</bugTrackerUrl>
+    <tags>tanzu community kubernetes</tags>
+    <summary>Create Tanzu clusters and deploy packages</summary>
+    <description>Tanzu Community Edition provides an easy-to-use distribution of Kubernetes.</description>
+    <releaseNotes>Release notes are available at https://github.com/vmware-tanzu/community-edition/releases</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/hack/choco/tanzu-community-edition-unstable.nuspec
+++ b/hack/choco/tanzu-community-edition-unstable.nuspec
@@ -2,10 +2,10 @@
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <id>tanzu-community-edition</id>
+    <id>tanzu-community-edition-unstable</id>
     <version>0.12.1</version>
     <owners>VMware</owners>
-    <title>Tanzu Community Edition</title>
+    <title>Tanzu Community Edition (Unstable)</title>
     <authors>VMware Tanzu</authors>
     <projectUrl>https://github.com/vmware-tanzu/community-edition</projectUrl>
     <packageSourceUrl>https://github.com/vmware-tanzu/community-edition/blob/main/hack/choco</packageSourceUrl>
@@ -19,8 +19,8 @@
     <mailingListUrl>https://groups.google.com/g/tanzu-community-edition</mailingListUrl>
     <bugTrackerUrl>https://github.com/vmware-tanzu/community-edition/issues</bugTrackerUrl>
     <tags>tanzu community kubernetes</tags>
-    <summary>Create Tanzu clusters and deploy packages</summary>
-<description>Tanzu Community Edition provides an easy-to-use distribution of Kubernetes.</description>
+    <summary>(Unstable Builds) Create Tanzu clusters and deploy packages</summary>
+    <description>(Unstable Builds) These builds are forward looking but unstable builds of Tanzu Community Edition.</description>
     <releaseNotes>Release notes are available at https://github.com/vmware-tanzu/community-edition/releases</releaseNotes>
   </metadata>
   <files>

--- a/hack/choco/test/choco-upgrade-test.ps1
+++ b/hack/choco/test/choco-upgrade-test.ps1
@@ -7,6 +7,12 @@ if ((Test-Path env:BUILD_VERSION) -eq $False) {
   throw "BUILD_VERSION environment variable is not set"
 }
 
+if ($env:BUILD_VERSION -notlike '*-*') {
+  Copy-Item tanzu-community-edition-release.nuspec -Destination .\tanzu-community-edition.nuspec
+} else {
+  Copy-Item tanzu-community-edition-unstable.nuspec -Destination .\tanzu-community-edition.nuspec
+}
+
 $parentDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $TCE_REPO = "https://github.com/vmware-tanzu/community-edition" 
 $TCE_REPO_RELEASES_URL = "https://github.com/vmware-tanzu/community-edition/releases"

--- a/hack/choco/update-choco-package.ps1
+++ b/hack/choco/update-choco-package.ps1
@@ -13,14 +13,16 @@ if ((Test-Path env:CHOCO_API_KEY) -eq $False) {
   throw "CHOCO_API_KEY environment variable is not set"
 }
 
-if ($env:BUILD_VERSION -like '*-*') {
-      Write-Host 'Do not commit any RC, Beta, Alpha type release'
-      Exit 0
+# copy the modified nuspec file from a previous stage and stage it to push
+if ($env:BUILD_VERSION -notlike '*-*') {
+  Copy-Item tanzu-community-edition-release.nuspec -Destination .\tanzu-community-edition.nuspec
+} else {
+  Copy-Item tanzu-community-edition-unstable.nuspec -Destination .\tanzu-community-edition.nuspec
 }
 
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
 # push choco
 choco apikey -k $env:CHOCO_API_KEY -s https://push.chocolatey.org/
-choco pack
+choco pack .\tanzu-community-edition.nuspec
 choco push --source https://push.chocolatey.org/ --api-key $env:CHOCO_API_KEY

--- a/hack/homebrew/update-homebrew-package.sh
+++ b/hack/homebrew/update-homebrew-package.sh
@@ -83,7 +83,7 @@ pushd "./homebrew-tanzu" || exit 1
     git checkout "${WHICH_BRANCH}"
     git pull origin "${WHICH_BRANCH}"
 
-    # unstable (non-GA) homebrew file
+    # GA release or unstable (non-GA) homebrew file??
     HOMEBREW_FILE="tanzu-community-edition.rb"
     if [[ "${BUILD_VERSION}" == *"-"* ]]; then
         HOMEBREW_FILE="tanzu-community-edition-unstable.rb"


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR should enable us to publish RC type releases to an "Unstable" choco package that I just initially created here:
https://community.chocolatey.org/packages/tanzu-community-edition-unstable/0.12.1

The purpose for having this `unstable` choco package is to publish RCs release so that we know the GA releases will publish without any problems (think of this as a pre-test). To minimize the number of code changes, we copy either the `release` or `unstable` into the default location based on the tag of the release.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
NA
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
