### PR TITLE
E2e test for conformance plugin

### DIFF
--- a/.github/workflows/e2e-conformance-plugin.yaml
+++ b/.github/workflows/e2e-conformance-plugin.yaml
@@ -1,26 +1,15 @@
----
-name: E2E Test - Unmanaged Cluster
+name: E2E Test - Conformance Plugin
 
 on:
-  repository_dispatch:
-    types: [daily-build]
-
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - cli/cmd/plugin/unmanaged-cluster
-
   workflow_dispatch:
   push:
     branches:
       - main
       - release-*
-
     paths:
-      - "cli/cmd/plugin/unmanaged-cluster/**"
-      - ".github/workflows/e2e-unmanaged-cluster.yaml"
-      - "Makefile"
-
+      - "cli/cmd/plugin/conformance/**"
+      - "!cli/cmd/plugin/conformance/**.md"
+      - ".github/workflows/e2e-conformance-plugin.yaml"
     tags-ignore:
       - "**"
 
@@ -42,39 +31,29 @@ jobs:
           echo "INSTANCE_NAME: ${INSTANCE_NAME}"
           echo ::set-output name=ec2-instance-id::${INSTANCE_NAME}
 
-  e2e-unmanaged-cluster-test:
-    name: E2E Unmanaged Cluster Test
+  e2e-test-conformance-plugin:
+    name: E2E Test - conformance plugin
     needs: setup-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.setup-runner.outputs.ec2-instance-id }} # run the job on the newly created runner
     steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "1.17"
         id: go
 
-      - name: Check out code
-        uses: actions/checkout@v1
-
-      - name: Run Unmanaged Cluster E2E Test
+      - name: Run E2E Test - Conformance Plugin
         run: |
-          make unmanaged-cluster-e2e-test
-
-      - name: Collect tanzu diagnostics data
-        uses: actions/upload-artifact@v2
-        if: ${{ always() }}
-        with:
-          name: diagnostics-data
-          path: |
-            bootstrap.*.diagnostics.tar.gz
-            management-cluster.*.diagnostics.tar.gz
-            workload-cluster.*.diagnostics.tar.gz
+          make conformance-e2e-test
 
   teardown-runner:
     name: Stop self-hosted EC2 runner
     needs:
       - setup-runner # required to get output from the setup-runner job
-      - e2e-unmanaged-cluster-test # required to wait when the main job is done
+      - e2e-test-conformance-plugin # required to wait when the main job is done
     runs-on: ubuntu-latest
     steps:
       - name: Stop EC2 runner

--- a/.github/workflows/e2e-diagnostics-plugin.yaml
+++ b/.github/workflows/e2e-diagnostics-plugin.yaml
@@ -7,7 +7,7 @@ on:
       - main
       - release-*
     paths:
-      - "cli/cmd/plugin/diagnostics/"
+      - "cli/cmd/plugin/diagnostics/**"
       - "!cli/cmd/plugin/diagnostics/**.md"
       - ".github/workflows/check-pr-diagnostics-plugin.yaml"
       - ".github/workflows/e2e-diagnostics-plugin.yaml"

--- a/Makefile
+++ b/Makefile
@@ -523,4 +523,7 @@ unmanaged-cluster-e2e-test:
 diagnostic-e2e-test:
 	cd cli/cmd/plugin/diagnostics && BUILD_VERSION=$(BUILD_VERSION) make e2e-test
 
+conformance-e2e-test:
+	cd cli/cmd/plugin/conformance && make e2e-test
+
 ##### E2E TESTS

--- a/cli/cmd/plugin/conformance/Makefile
+++ b/cli/cmd/plugin/conformance/Makefile
@@ -1,6 +1,8 @@
 # Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+ROOT_DIR := $(shell git rev-parse --show-toplevel)
+
 .DEFAULT_GOAL:=help
 
 help: ## Display this help message
@@ -20,10 +22,9 @@ endif
 test: ## Run unit testing suite
 	go test ./... -coverprofile=cover.out
 
+.PHONY: e2e-test
 e2e-test: ## Run e2e testing suite
-	echo "N/A: No e2e tests for hack/packages"
+	cd e2e-test && ROOT_DIR=$(ROOT_DIR) go test -tags=e2e -timeout 180m
 
 build: ## Build the executable
 	echo "N/A: Implement building"
-
-

--- a/cli/cmd/plugin/conformance/e2e-test/e2e_test.go
+++ b/cli/cmd/plugin/conformance/e2e-test/e2e_test.go
@@ -1,0 +1,119 @@
+//go:build e2e
+
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+var tceRepoPath string
+var clusterName string
+var conformanceDirPath string
+var unmanagedClusterDirPath string
+var conformanceResultFilename string
+
+func initializeVariable() {
+	// Variables used across functions
+	tceRepoPath = os.Getenv("ROOT_DIR")
+	conformanceDirPath = tceRepoPath + "/cli/cmd/plugin/conformance"
+	unmanagedClusterDirPath = tceRepoPath + "/cli/cmd/plugin/unmanaged-cluster"
+	rand, _ := rand.Int(rand.Reader, big.NewInt(1000))
+	clusterName = "uc" + rand.String() + "conformance-test"
+}
+
+func TestSetup(t *testing.T) {
+	initializeVariable()
+
+	err := os.Chdir(unmanagedClusterDirPath)
+	if err != nil {
+		t.Errorf("error while changing directory to unmanged-cluster: %v", err)
+	}
+	// Creating Unmanaged cluster
+	// Future task check the way cliRunner() is printing the log so that the space
+	// between the logs get removed and logs look nice
+	_, err = cliRunner("go", nil, "run", ".", "create", "--tty-disable", clusterName)
+	if err != nil {
+		t.Errorf("Error while Unmanaged Cluster creation: %v", err)
+	}
+}
+
+func TestConformance(t *testing.T) {
+	err := os.Chdir(conformanceDirPath)
+	if err != nil {
+		t.Errorf("error while changing directory to conformance: %v", err)
+	}
+
+	// Running Conformance Plugin
+	_, err = cliRunner("go", nil, "run", ".", "run", "--wait")
+	if err != nil {
+		t.Errorf("Error while running Conformance plugin: %v", err)
+	}
+
+	// Retrieving Conformance result file
+	conformanceResultFilename, err = cliRunner("go", nil, "run", ".", "retrieve")
+	if err != nil {
+		t.Errorf("Error while retrieving the conformance result filename: %v", err)
+	}
+	conformanceResultFilename = "/" + conformanceResultFilename[:len(conformanceResultFilename)-1]
+
+	// Extracting the result
+	conformanceResult, err := cliRunner("go", nil, "run", ".", "results", conformanceDirPath+conformanceResultFilename)
+	if err != nil {
+		t.Errorf("Error while fetching the result from tarball produced by conformance: %v", err)
+	}
+	fmt.Printf("%v", conformanceResult)
+}
+
+func TestCleanUp(t *testing.T) {
+	// Deleting Conformance result file
+	err := os.Remove(conformanceDirPath + conformanceResultFilename)
+	if err != nil {
+		t.Errorf("Error while deleting conformance result file: %v", err)
+	}
+
+	// Deleting Conformance
+	_, err = cliRunner("go", nil, "run", ".", "delete", "--wait")
+	if err != nil {
+		t.Errorf("Error while conformance deletion: %v", err)
+	}
+
+	// Deleting Unmanaged cluster
+	err = os.Chdir(unmanagedClusterDirPath)
+	if err != nil {
+		t.Errorf("error while changing directory to unmanged-cluster: %v", err)
+	}
+
+	_, err = cliRunner("go", nil, "run", ".", "delete", clusterName)
+	if err != nil {
+		t.Errorf("Error while Unmanaged Cluster deletion: %v", err)
+	}
+}
+
+func cliRunner(name string, input io.Reader, args ...string) (string, error) {
+	var stdOut bytes.Buffer
+	mwriter := io.MultiWriter(&stdOut, os.Stderr)
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = input
+	cmd.Stdout = mwriter
+	cmd.Stderr = mwriter
+	err := cmd.Run()
+	if err != nil {
+		rc := -1
+		if ee, ok := err.(*exec.ExitError); ok {
+			rc = ee.ExitCode()
+		}
+
+		return "", fmt.Errorf("%s\nexit status: %d", err.Error(), rc)
+	}
+	return stdOut.String(), nil
+}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR adds a E2E test for conformance Plugin.
- The flow of test is
	- Installing Unmanaged cluster.
	- Running conformance plugin.
	- Fetching the tar ball file which have the result of tarball.
	- Retrieve the result and print it.
	- Doing the cleanup of cluster, conformance and file.
- Small correction in path fields of Unmanaged and Diagnostic E2E test workflows.
## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #3694 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
- Run in Fork branch whose logs are https://github.com/aman556/community-edition/runs/6796153722?check_suite_focus=true
- Run `make conformance-e2e-test` in local.
