### PR TITLE
DDE: Clean up extension logging

### DIFF
--- a/extensions/docker-desktop/apps/clustermgr/main.go
+++ b/extensions/docker-desktop/apps/clustermgr/main.go
@@ -30,7 +30,10 @@ func init() {
 	}
 
 	// Only log the warning severity or above.
-	log.SetLevel(logrus.DebugLevel)
+	// For development purposes, change this to Debug level to get full
+	// tracing captured to the cluster.log file in the root of the extension
+	// container (docker exec ID tail -f cluster.log)
+	log.SetLevel(logrus.WarnLevel)
 }
 
 func main() {

--- a/extensions/docker-desktop/apps/clustermgr/pkg/checks/preflightchecks.go
+++ b/extensions/docker-desktop/apps/clustermgr/pkg/checks/preflightchecks.go
@@ -38,14 +38,14 @@ func testLocalPorts(ports []string) error {
 func testCPUandMemory() error {
 	info, err := docker.GetDockerInfo()
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	if info.NCPU < minCPUCount {
-		return fmt.Errorf("not have enough CPUs, currently set at %d", info.NCPU)
+		return fmt.Errorf("not enough CPUs configured, currently set to %d CPUs", info.NCPU)
 	}
 	if info.MemTotal < minMemBytes {
-		return fmt.Errorf("not have enough Memory, currently set at %d", info.MemTotal/1024/1024/1024)
+		return fmt.Errorf("not enough Memory configured, currently set to %d bytes, %d (%dGB) required", info.MemTotal, minMemBytes, minMemBytes/1024/1024/1024)
 	}
 	return nil
 }
@@ -63,7 +63,6 @@ func PreflightChecks() error {
 
 	err = testCPUandMemory()
 	if err != nil {
-		// TODO: Log
 		return err
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This adjusts the logging done by the Docker Desktop Extension.

- Raises default log level to WARNING to reduce noise
- Removes logs that do not add much value
- Changes log levels of some logs to only print at higher verbosity

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4699 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make build-install` to install the plugin. validated creating and deleting a cluster and that no extra logging was captured in the `cluster.log` file.

Then lowered the memory allocated to Docker Desktop to be less than our minimum requirement. Attempted to create a cluster and verified creation failed and a log message was captured to `cluster.log` for the failure:

```
time="2022-06-10T20:20:33Z" level=error msg="Preflight check error (not enough Memory configured, currently set to 2082136064 bytes, 2147483648 (2GB) required)"
```