### PR TITLE
GIT-4729: enable io.Writer based logger

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/log/log_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/log/log_test.go
@@ -1,0 +1,41 @@
+package log
+
+import (
+	"bufio"
+	"bytes"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNewLoggerWithWriter(t *testing.T) {
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+	logger := NewLoggerWithWriter(false, 5, writer)
+	logger.Info("Generating Message in Info")
+	logger.Info("Generating Message in Info again")
+	writer.Flush()
+	lineCount := len(strings.Split(strings.Trim(b.String(), "\n"), "\n"))
+	if lineCount != 2 {
+		t.Errorf("Expected 2 lines to be captured into buffer but found %d", lineCount)
+	}
+}
+
+func TestNewLogger(t *testing.T) {
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+	logger := NewLogger(false, 5)
+	logger.Writer(writer)
+	logger.Info("Generating Message in Info")
+	logger.Info("Generating Message in Info again")
+	logger.Writer(os.Stdout)
+	logger.Info("This should not be in the buffer")
+	logger.Writer(ioutil.Discard)
+	logger.Info("This should be discarded")
+	writer.Flush()
+	lineCount := len(strings.Split(strings.Trim(b.String(), "\n"), "\n"))
+	if lineCount != 2 {
+		t.Errorf("Expected 2 lines to be captured into buffer but found %d", lineCount)
+	}
+}

--- a/cli/cmd/plugin/unmanaged-cluster/log/log_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/log/log_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package log
 
 import (
@@ -33,9 +36,11 @@ func TestNewLogger(t *testing.T) {
 	logger.Info("This should not be in the buffer")
 	logger.Writer(ioutil.Discard)
 	logger.Info("This should be discarded")
+	logger.Writer(writer)
+	logger.Info("This should be captured in buffer writer")
 	writer.Flush()
 	lineCount := len(strings.Split(strings.Trim(b.String(), "\n"), "\n"))
-	if lineCount != 2 {
+	if lineCount != 3 {
 		t.Errorf("Expected 2 lines to be captured into buffer but found %d", lineCount)
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it
Currently the `CMDLogger` hardcodes the `output` to `os.Stdout`. Which means the consumers can't customize the logging behavior by either capturing it into a buffer or by discarding the logs by pointing that to `ioutil.Discard`. 


This PR enables that behaviour in two ways. 

1. Provides a new Logger instance creator that accepts an `io.Writer` to configure the `output` accordingly
2. A `Writer(w io.Writer)` method of the `Logger` interface that can be used to programatically switch the `output` of the logger at different stages of the workflow

## Which issue(s) this PR fixes
Fixes: #4729 

## Describe testing done for PR
UTs have been included for the new feature in question

## Special notes for your reviewer
Introducing the `defaultWriter` attribute under the `CMDLogger` to be able to handle the `AddLogFile` to make sure the `io.MultiWriter` will always honor the custom `io.Writer` configured and not mutate if the `AddLogFile` is invoked multiple times from different point in workflow. (This is something I am not entirely sure about from a thread safety perspective. I think we need to lock the call to `AddLogFile` with a mutex may be ?)