### PR TITLE
Doubles operations able to be performed by stale-bot

### DIFF
--- a/.github/workflows/housekeeping-stale-bot.yaml
+++ b/.github/workflows/housekeeping-stale-bot.yaml
@@ -1,7 +1,7 @@
 name: Housekeeping - Close stale issues and PRs
 on:
   schedule:
-    - cron: '0 9 * * *'
+    - cron: '0 4 * * *'
 
 jobs:
   stale:
@@ -21,3 +21,6 @@ jobs:
           exempt-milestones: "upcoming"
           # Don't add stale label to PRs / issues with this label
           exempt-issue-labels: "never-stale"
+          # The number of operations to perform, default is 30
+          # but due to number of open issues and prs, the oldest open issues and prs are missed
+          operations-per-run: 60


### PR DESCRIPTION
## What this PR does / why we need it
Old issues and PRs are being missed by the stale bot since only ~200 items are being fetched and operated on. Since we have some ~400 issues and PRs opened at any one given time, this pathc doubles the number of operations the stale bot is able to perform.

#### _A note on rate limiting_: 
This action hits the GitHub API frequently and quickly. We may see rate limiting and should note any logs that indicate GitHub is rate limiting us. This PR also switches the action to run early in the morning when there aren't likely to be alot of things happeneing from _other_actions. So, given VMware's business subscription with GItHub and the time change, this PR should be safe.

[From their docs](https://github.com/actions/stale#operations-per-run):
> Based on your project, your GitHub business plan and the date of the cron job you set for this action, you can increase this limit to a higher number.

## Which issue(s) this PR fixes
N/a
