### PR TITLE
UI Plugin: Add list of management cluster inventory

### DIFF
--- a/cli/cmd/plugin/ui/api/swagger.yaml
+++ b/cli/cmd/plugin/ui/api/swagger.yaml
@@ -2775,6 +2775,8 @@ definitions:
         type: string
       context:
         type: string
+      path:
+        type: string
       endpoint:
         type: string
       created:

--- a/cli/cmd/plugin/ui/web/tanzu-ui/node-server/src/routes/api/responses/management-clusters.json
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/node-server/src/routes/api/responses/management-clusters.json
@@ -1,6 +1,6 @@
 [
-  { "name": "aws-test-cluster-1", "provider": "aws", "created": "10/22/2021", "description": "This cluster should be deleted soon" },
-  { "name": "vsphere-other-cluster", "provider": "vsphere", "created": "4/13/2022", "description": "a very high-level cluster" },
-  { "name": "docker-foobar-cluster", "provider": "docker", "created": "2/14/2022", "description": "a local fun cluster" },
-  { "name": "azure-clown-cluster", "provider": "azure", "created": "3/15/2022", "description": "beware, Caesar, a backstabbing cluster" }
+  { "name": "aws-test-cluster-1", "context": "/some/context/here/1", "path": "/some/path/here/1", "provider": "aws", "created": "10/22/2021", "description": "This cluster should be deleted soon" },
+  { "name": "vsphere-other-cluster", "context": "/some/context/here/2", "path": "/some/path/here/2", "provider": "vsphere", "created": "4/13/2022", "description": "a very high-level cluster" },
+  { "name": "docker-foobar-cluster", "context": "/some/context/here/3", "path": "/some/path/here/3", "provider": "docker", "created": "2/14/2022", "description": "a local fun cluster" },
+  { "name": "azure-clown-cluster", "context": "/some/context/here/4", "path": "/some/path/here/4", "provider": "azure", "created": "3/15/2022", "description": "beware, Caesar, a backstabbing cluster" }
 ]

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/index.scss
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/index.scss
@@ -23,22 +23,13 @@ code {
     line-height: 24px;
 }
 
-// custom elements
-.code {
-    vertical-align: middle;
-    color: white;
-    background-color: #222222;
-    font-family: inline;
-    font-family: 'Fira Code', Menlo, Monaco, 'Courier New', monospace;
-    padding: 5px;
-    width: 100%;
-}
-
-.section-raised {
-    background-color: var(--cds-alias-object-container-background);
-    border: 1px solid var(--cds-alias-object-container-border-color);
-    border-radius: var(--cds-alias-object-border-radius-100, 0.25rem);
-    box-shadow: var(--cds-alias-object-shadow-100);
+// override and helper for clarity anchor link color and text decoration
+[cds-text~='link'],
+[cds-text~='link']:hover,
+[cds-text~='link']:visited:not([cds-text~='static']),
+[cds-text~='link'][cds-text~='visited'] {
+    color: var(--cds-global-typography-link-color) !important;
+    text-decoration: none !important;
 }
 
 // utility classes
@@ -83,6 +74,7 @@ code {
     text-decoration: none;
     font-size: small;
 }
+
 // icon custom colors
 .icon-blue {
     color: var(--cds-global-color-blue-400);
@@ -91,19 +83,7 @@ code {
 .icon-aqua {
     color: var(--cds-global-color-aqua-400);
 }
-
-.wizard-content-container {
-    width: 100%;
-    padding: 20px;
-}
-
-.select-sm-width {
-    min-width: 143px;
-}
-.select-md-width {
-    min-width: 200px;
-}
-
+// image and icon classes
 .mgmt-cluster-admins-img {
     display: inline-block;
     background-image: url('assets/admins-at-work.svg');
@@ -134,6 +114,43 @@ code {
     background-position: center 10px;
 }
 
+// custom elements
+.code {
+    vertical-align: middle;
+    color: white;
+    background-color: #222222;
+    font-family: inline;
+    font-family: 'Fira Code', Menlo, Monaco, 'Courier New', monospace;
+    padding: 5px;
+    width: 100%;
+}
+
+.section-raised {
+    background-color: var(--cds-alias-object-container-background);
+    border: 1px solid var(--cds-alias-object-container-border-color);
+    border-radius: var(--cds-alias-object-border-radius-100, 0.25rem);
+    box-shadow: var(--cds-alias-object-shadow-100);
+}
+
+.card-content-label {
+    color: var(--cds-global-color-blue-400);
+    font-weight: var(--cds-global-typography-font-weight-medium);
+}
+
+// wizard and form custom classes and overrides
+.wizard-content-container {
+    width: 100%;
+    padding: 20px;
+}
+
+.select-sm-width {
+    min-width: 143px;
+}
+.select-md-width {
+    min-width: 200px;
+}
+
+// workload cluster classes and overrides
 .accordion-normal {
     --cds-alias-object-interaction-background-selected: var(--cds-global-color-blue-700);
 }

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/index.scss
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/index.scss
@@ -13,10 +13,6 @@ main {
     height: 100vh;
 }
 
-code {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
-}
-
 // override clarity computed line height of 20px
 [cds-text*='body'],
 [cds-text*='subsection'] {
@@ -115,14 +111,15 @@ code {
 }
 
 // custom elements
-.code {
+.code-block {
     vertical-align: middle;
-    color: white;
     background-color: #222222;
-    font-family: inline;
-    font-family: 'Fira Code', Menlo, Monaco, 'Courier New', monospace;
     padding: 5px;
     width: 100%;
+
+    [cds-text~='code'] {
+        color: white;
+    }
 }
 
 .section-raised {

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/DeployProgress/DeployProgress.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/DeployProgress/DeployProgress.tsx
@@ -148,16 +148,16 @@ function DeployProgress() {
                         <div cds-text="caption semibold" cds-layout="col:12 p-b:sm">
                             Management Cluster configuration file
                         </div>
-                        <div className="code" cds-layout="col:12">
-                            {state.data.deployments['configPath']}
+                        <div className="code-block" cds-layout="col:12">
+                            <code cds-text="code">{state.data.deployments['configPath']}</code>
                         </div>
                     </div>
                     <div cds-layout="col:8">
                         <div cds-text="caption semibold" cds-layout="col:12 p-b:sm">
                             Create your workload cluster
                         </div>
-                        <div className="code" cds-layout="col:12">
-                            WC CLI Command here...
+                        <div className="code-block" cds-layout="col:12">
+                            <code cds-text="code">WC CLI Command here...</code>
                         </div>
                     </div>
                     <div cds-layout="col:12">

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterCard.test.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterCard.test.tsx
@@ -1,0 +1,46 @@
+// React imports
+import React from 'react';
+
+// Library imports
+import { render, screen, waitFor } from '@testing-library/react';
+
+// App imports
+import ManagementClusterCard from './ManagementClusterCard';
+
+describe('ManagementClusterCard component', () => {
+    const mockProps = {
+        name: 'test-mgmt-cluster',
+        path: '/some/path',
+        context: '/some/context',
+        confirmDeleteCallback: (arg?: string) => {
+            return;
+        },
+    };
+
+    test('should render', async () => {
+        const view = render(<ManagementClusterCard {...mockProps} />);
+        await waitFor(() => {
+            expect(view).toBeDefined();
+        });
+    });
+
+    test('should display the management cluster name', async () => {
+        render(<ManagementClusterCard {...mockProps} />);
+        expect(await screen.findByText('test-mgmt-cluster')).toBeInTheDocument();
+    });
+
+    test('should display the management cluster path', async () => {
+        render(<ManagementClusterCard {...mockProps} />);
+        expect(await screen.findByText('/some/path')).toBeInTheDocument();
+    });
+
+    test('should display the management cluster context', async () => {
+        render(<ManagementClusterCard {...mockProps} />);
+        expect(await screen.findByText('/some/context')).toBeInTheDocument();
+    });
+
+    test('should display a delete button', async () => {
+        render(<ManagementClusterCard {...mockProps} />);
+        expect(await screen.findByText('Delete')).toBeInTheDocument();
+    });
+});

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterCard.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterCard.tsx
@@ -1,0 +1,67 @@
+// React imports
+import React from 'react';
+
+// Library imports
+import { CdsButton } from '@cds/react/button';
+import { CdsDivider } from '@cds/react/divider';
+import { CdsIcon } from '@cds/react/icon';
+
+// App imports
+import { ManagementCluster } from '../../swagger-api';
+
+interface ManagementClusterProps extends ManagementCluster {
+    confirmDeleteCallback: (arg?: string) => void;
+}
+
+function ManagementClusterCard(props: ManagementClusterProps) {
+    const { name, path, context, confirmDeleteCallback } = props;
+
+    return (
+        <div className="section-raised" cds-layout="grid cols:12 wrap:none" data-testid="management-cluster-card">
+            <div cds-layout="vertical">
+                <div cds-layout="horizontal gap:md align:fill align:vertical-center p:md" cds-text="subsection">
+                    <div cds-layout="horizontal">
+                        <div cds-layout="horizontal gap:sm align:vertical-center p-y:sm">
+                            <CdsIcon cds-layout="m-r:sm" shape="cluster" size="lg" className="icon-blue"></CdsIcon>
+                            <div cds-text="section">{name}</div>
+                        </div>
+                        <CdsDivider orientation="vertical" cds-layout="align:right"></CdsDivider>
+                    </div>
+                    <div cds-layout="horizontal">
+                        <div cds-layout="vertical align:left m-r:xs">
+                            <label className="card-content-label">Path</label>
+                            <div cds-layout="horizontal">
+                                <div>{path}</div>
+                            </div>
+                        </div>
+                        <CdsDivider orientation="vertical" cds-layout="align:right"></CdsDivider>
+                    </div>
+                    <div cds-layout="horizontal">
+                        <div cds-layout="vertical m-r:xs">
+                            <label className="card-content-label">Context</label>
+                            <div cds-layout="horizontal">
+                                <div>{context}</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <CdsDivider></CdsDivider>
+                <div cds-layout="vertical gap:md align:vertical-center p:md">
+                    <div cds-layout="horizontal gap:xs align:vertical-center align:right p-r:lg">
+                        <CdsButton
+                            action="flat-inline"
+                            status="danger"
+                            onClick={() => {
+                                confirmDeleteCallback(name);
+                            }}
+                        >
+                            Delete
+                        </CdsButton>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default ManagementClusterCard;

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.scss
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.scss
@@ -1,0 +1,6 @@
+.mgmt-cluster-no-cluster-container {
+    background-image: url('../../assets/management-cluster-bg.svg');
+    background-repeat: no-repeat;
+    background-position: top right;
+    min-height: 174px;
+}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.test.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.test.tsx
@@ -81,6 +81,9 @@ describe('ManagementClusterInventory component', () => {
         const cancelBtn = await screen.findByText('Cancel');
         fireEvent.click(cancelBtn);
         expect(screen.queryByTestId('confirm-delete-cluster-modal')).not.toBeInTheDocument();
+
+        const managementClusterCards = await screen.findAllByTestId('management-cluster-card');
+        expect(managementClusterCards.length).toBe(4);
     });
 
     test('delete modal confirmation Delete button should delete management cluster', async () => {

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.test.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.test.tsx
@@ -1,0 +1,121 @@
+// React imports
+import React from 'react';
+
+// Library imports
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { rest } from 'msw';
+import { setupServer } from 'msw/lib/node';
+
+// App imports
+import ManagementClusterInventory from './ManagementClusterInventory';
+
+jest.mock('react-router-dom', () => ({
+    ...(jest.requireActual('react-router-dom') as any),
+    useNavigate: () => jest.fn(),
+}));
+
+describe('ManagementClusterInventory component', () => {
+    const server = setupServer(
+        rest.get('/api/management', (req, res, ctx) => {
+            return res(
+                ctx.status(200),
+                ctx.json([
+                    { name: 'aws-test-cluster-1', context: '/some/context/here/1', path: '/some/path/here/1', provider: 'aws' },
+                    { name: 'vsphere-other-cluster', context: '/some/context/here/2', path: '/some/path/here/2', provider: 'vsphere' },
+                    { name: 'docker-foobar-cluster', context: '/some/context/here/3', path: '/some/path/here/3', provider: 'docker' },
+                    { name: 'azure-clown-cluster', context: '/some/context/here/4', path: '/some/path/here/4', provider: 'azure' },
+                ])
+            );
+        })
+    );
+
+    beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
+
+    const clickFirstDeleteButton = async function () {
+        const deleteBtns = await screen.findAllByText('Delete');
+        const firstDeleteBtn = deleteBtns[0];
+        fireEvent.click(firstDeleteBtn);
+    };
+
+    test('should render', async () => {
+        const view = render(<ManagementClusterInventory />);
+        await waitFor(() => {
+            expect(view).toBeDefined();
+        });
+    });
+
+    test('should always display a button to create a management cluster', async () => {
+        render(<ManagementClusterInventory />);
+
+        expect(await screen.findByText('create a management cluster')).toBeInTheDocument();
+    });
+
+    test('should display four management cluster cards when management clusters are present', async () => {
+        render(<ManagementClusterInventory />);
+        const managementClusterCards = await screen.findAllByTestId('management-cluster-card');
+        expect(managementClusterCards.length).toBe(4);
+    });
+
+    test('should display title, path and context for a management cluster card', async () => {
+        render(<ManagementClusterInventory />);
+        expect(await screen.findByText('aws-test-cluster-1')).toBeInTheDocument();
+        expect(await screen.findByText('/some/context/here/1')).toBeInTheDocument();
+        expect(await screen.findByText('/some/path/here/1')).toBeInTheDocument();
+    });
+
+    test('delete button should open modal confirmation', async () => {
+        render(<ManagementClusterInventory />);
+
+        await clickFirstDeleteButton();
+
+        expect(await screen.findByTestId('confirm-delete-cluster-modal')).toBeInTheDocument();
+    });
+
+    test('delete modal confirmation cancel button should close modal window', async () => {
+        render(<ManagementClusterInventory />);
+
+        await clickFirstDeleteButton();
+
+        const cancelBtn = await screen.findByText('Cancel');
+        fireEvent.click(cancelBtn);
+        expect(screen.queryByTestId('confirm-delete-cluster-modal')).not.toBeInTheDocument();
+    });
+
+    test('delete modal confirmation Delete button should delete management cluster', async () => {
+        render(<ManagementClusterInventory />);
+
+        server.use(
+            rest.get('/api/management', (req, res, ctx) => {
+                return res(
+                    ctx.status(200),
+                    ctx.json([
+                        { name: 'vsphere-other-cluster', context: '/some/context/here/2', path: '/some/path/here/2', provider: 'vsphere' },
+                        { name: 'docker-foobar-cluster', context: '/some/context/here/3', path: '/some/path/here/3', provider: 'docker' },
+                        { name: 'azure-clown-cluster', context: '/some/context/here/4', path: '/some/path/here/4', provider: 'azure' },
+                    ])
+                );
+            })
+        );
+
+        await clickFirstDeleteButton();
+
+        const deleteBtn = await screen.findByTestId('delete-cluster-btn');
+        fireEvent.click(deleteBtn);
+
+        const managementClusterCards = await screen.findAllByTestId('management-cluster-card');
+        expect(managementClusterCards.length).toBe(3);
+    });
+
+    test('should display messaging when no management clusters are present', async () => {
+        render(<ManagementClusterInventory />);
+
+        server.use(
+            rest.get('/api/management', (req, res, ctx) => {
+                return res(ctx.status(200), ctx.json([]));
+            })
+        );
+        expect(await screen.findByTestId('no-clusters-messaging')).toBeInTheDocument();
+    });
+});

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.tsx
@@ -1,29 +1,188 @@
 // React imports
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 // Library imports
+import { CdsButton } from '@cds/react/button';
 import { CdsIcon } from '@cds/react/icon';
-import { ClarityIcons, cloudIcon } from '@cds/core/icon';
+import { CdsModal, CdsModalActions, CdsModalContent, CdsModalHeader } from '@cds/react/modal';
 
 // App imports
+import ManagementClusterCard from './ManagementClusterCard';
+import { ManagementCluster } from '../../swagger-api/models/ManagementCluster';
+import { ManagementService } from '../../swagger-api';
+import { NavRoutes } from '../../shared/constants/NavRoutes.constants';
+import './ManagementClusterInventory.scss';
 
-ClarityIcons.addIcons(cloudIcon);
+function ManagementClusterInventory() {
+    const [managementClusters, setManagementClusters] = useState<ManagementCluster[]>([]);
+    const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
+    const [clusterNameForDeletion, setClusterNameForDeletion] = useState<string>('');
 
-const ManagementClusterInventory: React.FC = () => {
+    const navigate = useNavigate();
+
+    const retrieveManagementClusters = function () {
+        ManagementService.getMgmtClusters().then((data) => setManagementClusters([]));
+    };
+
+    // Retrieve management clusters list on page load
+    useEffect(() => {
+        retrieveManagementClusters();
+    }, []);
+
+    // Helper function returns true if management clusters exist; otherwise returns false
+    const hasManagementClusters = function () {
+        return managementClusters.length ? true : false;
+    };
+
+    // Helper function to be passed to ManagementClusterCard components and leveraged for displaying confirm delete
+    // modal window when user clicks Delete button. Takes cluster name as parameter for displaying this name in the
+    // title and body of the modal window.
+    const showConfirmDeleteModal = function (clusterName?: string) {
+        if (!clusterName) {
+            console.warn(`toggleConfirmDeleteModal expected a cluster name string; instead got ${clusterName}`);
+            return;
+        }
+        setClusterNameForDeletion(clusterName);
+        setShowDeleteModal(!showDeleteModal);
+    };
+
+    // Handler function for confirmed delete action triggered in the modal window.
+    // Calls delete API with cluster name, then retrieves updated list of management clusters.
+    // TODO: test e2e as management cluster deletion may not be immediate, so we may have to use another mechanism
+    // for updating management cluster list periodically
+    const deleteManagementCluster = function (clusterName: string) {
+        setShowDeleteModal(!showDeleteModal);
+        ManagementService.deleteMgmtCluster(clusterName).then(
+            () => {
+                console.log(`management cluster ${clusterName} has been deleted`);
+                retrieveManagementClusters();
+            },
+            (err) => {
+                console.log(`management cluster delete api failed with error: ${err}`);
+            }
+        );
+        // TODO: show alert confirming deletion of mgmt cluster or failure - requires shared alert component
+    };
+
+    // Returns modal window HTML markup if showDeleteModal state variable is set to true.
+    const renderConfirmDeleteModal = function () {
+        if (!showDeleteModal) {
+            return;
+        }
+
+        return (
+            <>
+                <CdsModal
+                    aria-labelledby="default-modal-title"
+                    id="confirm-delete-modal"
+                    data-testid="confirm-delete-cluster-modal"
+                    onCloseChange={() => setShowDeleteModal(false)}
+                >
+                    <CdsModalHeader>
+                        <h3 cds-text="section" cds-first-focus="true" id="confirm-delete-modal-title">
+                            Delete cluster {clusterNameForDeletion}
+                        </h3>
+                    </CdsModalHeader>
+                    <CdsModalContent>
+                        <p cds-text="body">
+                            Deleting {clusterNameForDeletion} stops this Management Cluster and removes it from the provider you created it
+                            on.
+                        </p>
+                    </CdsModalContent>
+                    <CdsModalActions>
+                        <CdsButton action="outline" onClick={() => setShowDeleteModal(false)}>
+                            Cancel
+                        </CdsButton>
+                        <CdsButton
+                            status="danger"
+                            onClick={() => deleteManagementCluster(clusterNameForDeletion)}
+                            data-testid="delete-cluster-btn"
+                        >
+                            Delete
+                        </CdsButton>
+                    </CdsModalActions>
+                </CdsModal>
+            </>
+        );
+    };
+
+    // Returns view to be rendered when no management clusters are present.
+    const NoManagementClustersSection = function () {
+        return (
+            <>
+                <div
+                    cds-layout="grid horizontal cols:8 p:md"
+                    className="section-raised mgmt-cluster-no-cluster-container"
+                    data-testid="no-clusters-messaging"
+                >
+                    <div cds-layout="grid horizontal cols:12 gap:lg gap@md:lg">
+                        <div cds-text="title">Management Cluster not found</div>
+                        <div cds-text="body">
+                            Create a Management Cluster on your preferred cloud provider through a guided series of steps.
+                            <br />
+                            <br />
+                            This cluster will manage new workload clusters you create for your workloads.{' '}
+                            <a
+                                href="https://tanzucommunityedition.io/docs/v0.12/planning/#managed-cluster"
+                                target="_blank"
+                                rel="noreferrer"
+                                cds-text="link"
+                            >
+                                Learn more about Management Clusters Clusters
+                            </a>
+                            <br />
+                            <br />
+                            <CdsButton onClick={() => navigate(NavRoutes.MANAGEMENT_CLUSTER_SELECT_PROVIDER)}>
+                                <CdsIcon shape="cluster"></CdsIcon>create a management cluster
+                            </CdsButton>
+                        </div>
+                    </div>
+                </div>
+            </>
+        );
+    };
+
+    // Returns view to be rendered when management clusters are present.
+    const ManagementClustersSection = function () {
+        return (
+            <>
+                <div cds-text="subsection">The following clusters were discovered on this workstation.</div>
+                <div>
+                    <CdsButton onClick={() => navigate(NavRoutes.MANAGEMENT_CLUSTER_SELECT_PROVIDER)}>
+                        <CdsIcon shape="cluster"></CdsIcon>create a management cluster
+                    </CdsButton>
+                </div>
+                {managementClusters.map((cluster: ManagementCluster) => {
+                    return (
+                        <ManagementClusterCard
+                            key={cluster.name}
+                            name={cluster.name}
+                            path={cluster.path}
+                            context={cluster.context}
+                            confirmDeleteCallback={showConfirmDeleteModal}
+                        ></ManagementClusterCard>
+                    );
+                })}
+            </>
+        );
+    };
+
     return (
-        <div className="management-cluster-landing-container" cds-layout="vertical gap:md col@sm:12 grid">
-            <div cds-layout="vertical col:8 gap:lg">
-                <div cds-text="title">
-                    <CdsIcon cds-layout="m-r:sm" shape="cloud" size="xl" className="icon-blue"></CdsIcon>
-                    Management Cluster Inventory
+        <>
+            <div className="management-cluster-landing-container" cds-layout="vertical gap:md col@sm:12 grid">
+                <div cds-layout="vertical col:8 gap:lg">
+                    <div cds-text="title">
+                        <CdsIcon cds-layout="m-r:sm" shape="cluster" size="xl" className="icon-blue"></CdsIcon>
+                        Management Clusters
+                    </div>
+                    {hasManagementClusters() ? ManagementClustersSection() : NoManagementClustersSection()}
                 </div>
-                <div cds-text="subsection" cds-layout="p-y:md">
-                    Placeholder page for management cluster inventory
-                </div>
+                <div cds-layout="col:4" className="mgmt-cluster-admins-img"></div>
+                {renderConfirmDeleteModal()}
             </div>
-            <div cds-layout="col:4" className="mgmt-cluster-admins-img"></div>
-        </div>
+        </>
     );
-};
+}
 
 export default ManagementClusterInventory;

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.tsx
@@ -22,7 +22,14 @@ function ManagementClusterInventory() {
     const navigate = useNavigate();
 
     const retrieveManagementClusters = function () {
-        ManagementService.getMgmtClusters().then((data) => setManagementClusters([]));
+        ManagementService.getMgmtClusters().then(
+            (data) => {
+                setManagementClusters(data);
+            },
+            (err) => {
+                console.warn(`management clusters get api failed with error: ${err}`);
+            }
+        );
     };
 
     // Retrieve management clusters list on page load

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/vsphere/VsphereManagementCluster.scss
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/vsphere/VsphereManagementCluster.scss
@@ -1,3 +1,3 @@
 .thumbprint {
-  font-family: monospace;
+    font-family: monospace;
 }


### PR DESCRIPTION
## What this PR does / why we need it

Adds content to management cluster inventory page:

When no management clusters are present, displays messaging around creating management clusters

When management clusters are present, the page displays a list of management clusters in card format,
using the same card pattern that we are using for unmanaged clusters

Delete button for removing a management cluster launches a modal confirmation window

Includes unit tests for all new functionality


## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4676

## Describe testing done for PR
All linting passes, added unit tests for this page and management cluster card component, all unit tests passing

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
Screen shots attached:

![Screen Shot 2022-06-14 at 9 01 54 AM](https://user-images.githubusercontent.com/13439013/173624198-6900b556-b6f1-4271-a3b1-4e4fe3b3e542.png)
![Screen Shot 2022-06-14 at 9 02 17 AM](https://user-images.githubusercontent.com/13439013/173624204-bbdf12b9-2e0f-4e91-8f2d-b7709288894b.png)

![Screen Shot 2022-06-14 at 9 01 44 AM](https://user-images.githubusercontent.com/13439013/173624190-fdf86939-3e6d-420b-bd10-63b765a58c01.png)

