### PR TITLE
Remove ioutil usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,13 @@ lint: tools verify-modules
 			$(MAKE) lint || exit 1; \
 			cd $$working_dir; \
 		fi; \
-	done
+	done; \
+	CHECK=$$(grep -r --include="*.go" ioutil ./); \
+	if [ -n "$${CHECK}" ]; then \
+		echo "ioutil is deprecated, use io or os replacements"; \
+		echo "$${CHECK}"; \
+		exit 1; \
+	fi
 
 mdlint:
 	# mdlint rules with common errors and possible fixes can be found here:

--- a/addons/packages/antrea/1.5.2/test/antrea_test.go
+++ b/addons/packages/antrea/1.5.2/test/antrea_test.go
@@ -5,22 +5,19 @@ package antrea_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
-	appsv1 "k8s.io/api/apps/v1"
-
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	goyaml "gopkg.in/yaml.v3"
-
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/repo"
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/ytt"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 const portRange = "60000-61000"
@@ -386,7 +383,7 @@ func loadAntreaConfig(configFile string) (*AntreaConfig, error) {
 		config  = AntreaConfig{}
 	)
 
-	if content, err = ioutil.ReadFile(configFile); err != nil {
+	if content, err = os.ReadFile(configFile); err != nil {
 		return nil, err
 	}
 	if err := goyaml.Unmarshal(content, &config); err != nil {

--- a/cli/cmd/plugin/unmanaged-cluster/log/log_test.go
+++ b/cli/cmd/plugin/unmanaged-cluster/log/log_test.go
@@ -6,7 +6,7 @@ package log
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -34,7 +34,7 @@ func TestNewLogger(t *testing.T) {
 	logger.Info("Generating Message in Info again")
 	logger.Writer(os.Stdout)
 	logger.Info("This should not be in the buffer")
-	logger.Writer(ioutil.Discard)
+	logger.Writer(io.Discard)
 	logger.Info("This should be discarded")
 	logger.Writer(writer)
 	logger.Info("This should be captured in buffer writer")


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

A few instances of using the deprecated ioutil module have snuck in.
This updates those to use their proper io or os replacements.

Also added a simple check to the lint job so we catch and prevent these
from happening again.

https://go.dev/doc/go1.16#ioutil

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran updated `make lint` target without changing source files and verified it failed from detecting `ioutil` usage.
Updated source files and ran `make lint` again to verify it was happy.