### PR TITLE
UI Plugin: fixes websocket connection issue

### DIFF
--- a/cli/cmd/plugin/ui/server/serve.go
+++ b/cli/cmd/plugin/ui/server/serve.go
@@ -81,9 +81,7 @@ func Serve(bind, browser string, logLevel int32) error {
 // apiMiddleware routes the API request handling
 func apiMiddleware(handler http.Handler) http.Handler {
 	return requestLogger(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/ws") {
-			handlers.HandleWebsocketRequest(w, r)
-		} else if strings.HasPrefix(r.URL.Path, "/api") {
+		if strings.HasPrefix(r.URL.Path, "/api") {
 			handler.ServeHTTP(w, r)
 		} else {
 			http.Redirect(w, r, "/ui", http.StatusMovedPermanently)
@@ -100,7 +98,9 @@ func globalMiddleware(handler http.Handler) http.Handler {
 
 func fileServerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasPrefix(r.URL.Path, "/ui") {
+        if strings.HasPrefix(r.URL.Path, "/ws") {
+    		handlers.HandleWebsocketRequest(w, r)
+        } else if !strings.HasPrefix(r.URL.Path, "/ui") {
 			if r.URL.Path == "/" {
 				http.Redirect(w, r, "/ui", http.StatusMovedPermanently)
 			} else {

--- a/cli/cmd/plugin/ui/server/serve.go
+++ b/cli/cmd/plugin/ui/server/serve.go
@@ -98,8 +98,8 @@ func globalMiddleware(handler http.Handler) http.Handler {
 
 func fileServerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        if strings.HasPrefix(r.URL.Path, "/ws") {
-    		handlers.HandleWebsocketRequest(w, r)
+	    if strings.HasPrefix(r.URL.Path, "/ws") {
+            handlers.HandleWebsocketRequest(w, r)
         } else if !strings.HasPrefix(r.URL.Path, "/ui") {
 			if r.URL.Path == "/" {
 				http.Redirect(w, r, "/ui", http.StatusMovedPermanently)

--- a/cli/cmd/plugin/ui/server/serve.go
+++ b/cli/cmd/plugin/ui/server/serve.go
@@ -98,9 +98,9 @@ func globalMiddleware(handler http.Handler) http.Handler {
 
 func fileServerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	    if strings.HasPrefix(r.URL.Path, "/ws") {
-            handlers.HandleWebsocketRequest(w, r)
-        } else if !strings.HasPrefix(r.URL.Path, "/ui") {
+		if strings.HasPrefix(r.URL.Path, "/ws") {
+			handlers.HandleWebsocketRequest(w, r)
+		} else if !strings.HasPrefix(r.URL.Path, "/ui") {
 			if r.URL.Path == "/" {
 				http.Redirect(w, r, "/ui", http.StatusMovedPermanently)
 			} else {


### PR DESCRIPTION
## What this PR does / why we need it
Moved code that parses http requests for '/ws' prefix to fileServerMiddleware instead of
the apiMiddleware handler. Websocket connection now establishes successfully and streams
logs

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4680 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Confirmed that UI plugin still runs as expected and that logs are streamed through websocket connection

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
<img width="1874" alt="Screen Shot 2022-06-14 at 4 10 34 PM" src="https://user-images.githubusercontent.com/13439013/173704534-fb74945d-b143-4a91-9e3a-a2976f64a396.png">
