### PR TITLE
GIT-4780: enhance image linter validation behavior

### DIFF
--- a/hack/check/imagelinter/pkg/imagewrapper/wrapper.go
+++ b/hack/check/imagelinter/pkg/imagewrapper/wrapper.go
@@ -34,7 +34,8 @@ func (w *Wrapper) PullImage() (string, error) {
 }
 
 func (w *Wrapper) CreateContainer() (string, error) {
-	result, err := w.CliRunner("docker", nil, []string{"run", "-d", "--name", w.Container, w.Image}...)
+	// Adding a dummy ls command at the tail end of this to account for image using `@sha256:id` format
+	result, err := w.CliRunner("docker", nil, []string{"create", "--name", w.Container, w.Image, "ls"}...)
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION
## What this PR does / why we need it
This PR changes the behavior of how the `imagelint` Make target validates the images for `alpine` base Images. The PR  makes the existing checks a bit more robust  by  changing a few things of how the validation is done.

Not all containers will have the `ENTRYPOINT` configured by default or will have an `ENTRYPOINT` that can just work when invoked with `docker run`.

One could suggest we can simple `docker run --entrypoint cmd` to customize this. However, there is no guarantee that it will work either. It very much depends on what the base image is. This can all lead to false negative/positive results. 

Instead, `docker` has a wonderful ability to just `create` a container and them copy the artifacts from it without every having to actually `run` it. This bypasses all the worry about `ENTRYPOINT` commands. We can simple create container and copy the required file to perform the validation. This also save a good amount of compute resources that would be taken up by the running containers if any.

## Which issue(s) this PR fixes
Fixes: #4780 

## Describe testing done for PR
```bash
❯ make imagelint                                                                                                                                                                                                                                                     80%  ▓▒░
User given Path /Users/harshnar/Work/Tesseract/Maglev/mks/k8s/community-edition
Total number of images to process: 1
Result 1 of 1 images
Status:   Fail
Image:    fluxcd/source-controller:v0.25.6
Message:  alpine image
-------------------------------  Fail  Summary  ---------------------------------------------
Total  Fail  : 0
-------------------------------  Pass  Summary  ---------------------------------------------
Total  Pass  : 0
-------------------------------  Pull Failed  Summary  ---------------------------------------------
Total  Pull Failed  : 0
-------------------------------  Not Identified  Summary  ---------------------------------------------
Total  Not Identified  : 0
-------------------------------  Summary  -----------------------------------------------
Total  Images                : 1
Total  Occurrences           : 0
Total  Pass                  : 0
Total  1  file(s) contain(s) this image
File Path: /Users/harshnar/Work/Tesseract/Maglev/mks/k8s/community-edition/addons/packages/fluxcd-source-controller/0.24.4/package.yaml
Image Position: 44 : 6

Total  Fail                  : 0
Total  Pull Failed           : 0
Total  Not Identified        : 0
[Note:All totals for Pass|Fail|Not Identified|Pull Failed are based on number of occurrences]
--------------------------------------------------------------------------------------------

exit status 1
make: *** [imagelint] Error 1
```

```bash
User given Path /Users/harshnar/Work/Tesseract/Maglev/mks/k8s/community-edition
Total number of images to process: 1
Result 1 of 1 images
Status:   Pass
Image:    projects.registry.vmware.com/tce/fluxcd-source-controller-bundle@sha256:4dc37bdc0a6188137905639cccd1938edb1ae882698b3d58a24615b44eb1fa3f
Message:  According to the image history, this is not an Alpine Image
Total  1  file(s) contain(s) this image
File Path: /Users/harshnar/Work/Tesseract/Maglev/mks/k8s/community-edition/addons/packages/fluxcd-source-controller/0.24.4/package.yaml
Image Position: 44 : 6

-------------------------------  Fail  Summary  ---------------------------------------------
Total  Fail  : 0
-------------------------------  Pass  Summary  ---------------------------------------------
Image:     projects.registry.vmware.com/tce/fluxcd-source-controller-bundle@sha256:4dc37bdc0a6188137905639cccd1938edb1ae882698b3d58a24615b44eb1fa3f
File Path: /Users/harshnar/Work/Tesseract/Maglev/mks/k8s/community-edition/addons/packages/fluxcd-source-controller/0.24.4/package.yaml
Image Position: 44 : 6

Total  Pass  : 1
-------------------------------  Pull Failed  Summary  ---------------------------------------------
Total  Pull Failed  : 0
-------------------------------  Not Identified  Summary  ---------------------------------------------
Total  Not Identified  : 0
-------------------------------  Summary  -----------------------------------------------
Total  Images                : 1
Total  Occurrences           : 1
Total  Pass                  : 1
Total  Fail                  : 0
Total  Pull Failed           : 0
Total  Not Identified        : 0
[Note:All totals for Pass|Fail|Not Identified|Pull Failed are based on number of occurrences]
--------------------------------------------------------------------------------------------
```

## Special notes for your reviewer
NA