### PR TITLE
[E2E] Used tanzu lib to create and delete UC in UC e2e-test

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/test/e2e/utils/cli.go
+++ b/cli/cmd/plugin/unmanaged-cluster/test/e2e/utils/cli.go
@@ -10,6 +10,8 @@ import (
 	"log"
 	"os"
 	"os/exec"
+
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/tanzu"
 )
 
 func InstallTCE() error {
@@ -75,4 +77,13 @@ func cliRunner(name string, input io.Reader, args ...string) (string, error) {
 	}
 
 	return stdOut.String(), err
+}
+
+func ContainsUC(ucLists []tanzu.Cluster, e string) bool {
+	for _, uc := range ucLists {
+		if uc.Name == e {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Signed-off-by: Aman Sharma <amansh@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This PR is using the tanzu library in Unmanaged cluster plugin to create and delete UC in UC e2e-test. In this way the creation and deletion of cluster become independent of tanzu cli.
## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4110 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Ran `make unmanaged-cluster-e2e-test` from root.

