### PR TITLE
UI: Restore build output README to avoid lint failures

### DIFF
--- a/cli/cmd/plugin/ui/web/tanzu-ui/build/README.md
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/build/README.md
@@ -1,0 +1,5 @@
+# UI Plugin Web Build
+
+This directory will contain the built output of the React web site. This site
+gets built during compile and embedded in the go source, so this directory must
+exist prior to build for things like the linters to be happy.


### PR DESCRIPTION
This restores the README file from our web build output folder. This is
needed so the folder is present when the linter runs in CI. The lint job
does not do a full build first, so the generated files are not present.
Without something there the embed directive in the go source will fail
because there will be no files found.