### PR TITLE
UI: Trigger lint on build output readme

### DIFF
--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -12,6 +12,7 @@ on:
       - "**/go.mod"
       - "hack/check-lint.sh"
       - ".golangci.yaml"
+      - "cli/cmd/plugin/ui/web/tanzu-ui/build/README.md"
 
 jobs:
   checklint:


### PR DESCRIPTION
The README.md file in our web build output is needed to make sure the
expected folder structure is present, otherwise the linting will fail
due to the go embed directive not being able to find any files.

We've had a couple instances where this has happened. It was not noticed
in the PRs that removed the file, partly because the lint job would only
run if go source files were modified - which they were not in these
cases. So it was only later when there were go updates that the failure
would be noticed.

This adds the README path explicitly to the patterns that will trigger
the linter job so that it will run if someone modifies or removes that
file again.