### PR TITLE
UI: Initialize clients on initial launch

### DIFF
--- a/cli/cmd/plugin/ui/server/handlers/app.go
+++ b/cli/cmd/plugin/ui/server/handlers/app.go
@@ -42,30 +42,39 @@ const sleepTimeForLogsPropogation = 2 * time.Second
 
 // App application structs consisting init options and clients
 type App struct {
-	Timeout     time.Duration
-	LogLevel    int32
-	aviClient   aviClient.Client
-	awsClient   awsclient.Client
-	azureClient azureclient.Client
-	ldapClient  ldapClient.Client
-	vcClient    vc.Client
-	// clientTKG         *tkgctl.TKGClient
-	// clientTkg         *client.TkgClient
+	Timeout           time.Duration
+	LogLevel          int32
+	aviClient         aviClient.Client
+	awsClient         awsclient.Client
+	azureClient       azureclient.Client
+	ldapClient        ldapClient.Client
+	vcClient          vc.Client
+	clientTKG         *tkgctl.TKGClient
+	clientTkg         *client.TkgClient
 	clusterConfigFile string
 }
 
-func (app *App) getTKGClient() (tkgctl.TKGClient, error) {
-	return system.NewTKGClient("", app.LogLevel)
+// Initialize performs initialization actions for our application.
+func (app *App) Initialize(api *operations.TanzuUIAPI) error {
+	clientTKG, err := system.NewTKGClient("", app.LogLevel)
+	if err != nil {
+		return err
+	}
+	app.clientTKG = &clientTKG
+
+	clientTkg, err := system.NewTkgClient()
+	if err != nil {
+		return err
+	}
+	app.clientTkg = clientTkg
+
+	app.configureHandlers(api)
+	return nil
 }
 
-// Yep, you read that right - there's a TKGClient and a TkgClient. o_O
-func (app *App) getTkgClient() (*client.TkgClient, error) {
-	return system.NewTkgClient()
-}
-
-// ConfigureHandlers configures API handlers func
+// configureHandlers configures API handlers func
 //nolint:funlen
-func (app *App) ConfigureHandlers(api *operations.TanzuUIAPI) {
+func (app *App) configureHandlers(api *operations.TanzuUIAPI) {
 	// Handlers for system settings, configuration, and general information
 	api.CriGetContainerRuntimeInfoHandler = cri.GetContainerRuntimeInfoHandlerFunc(app.GetContainerRuntimeInfo)
 	api.EditionGetTanzuEditionHandler = edition.GetTanzuEditionHandlerFunc(app.Edition)

--- a/cli/cmd/plugin/ui/server/handlers/docker.go
+++ b/cli/cmd/plugin/ui/server/handlers/docker.go
@@ -32,12 +32,7 @@ func (app *App) CheckIfDockerDaemonAvailable(params docker.CheckIfDockerDaemonAv
 
 // ApplyTKGConfigForDocker applies the TKG configuration for Docker.
 func (app *App) ApplyTKGConfigForDocker(params docker.ApplyTKGConfigForDockerParams) middleware.Responder {
-	tkgClient, err := app.getTkgClient()
-	if err != nil {
-		return docker.NewApplyTKGConfigForDockerInternalServerError().WithPayload(Err(err))
-	}
-
-	err = app.saveConfig(params.Params, tkgClient)
+	err := app.saveConfig(params.Params, app.clientTkg)
 	if err != nil {
 		return docker.NewApplyTKGConfigForDockerInternalServerError().WithPayload(Err(err))
 	}
@@ -47,12 +42,7 @@ func (app *App) ApplyTKGConfigForDocker(params docker.ApplyTKGConfigForDockerPar
 
 // CreateDockerManagementCluster creates a new management cluster using the CAPD provider.
 func (app *App) CreateDockerManagementCluster(params docker.CreateDockerManagementClusterParams) middleware.Responder {
-	tkgClient, err := app.getTkgClient()
-	if err != nil {
-		return docker.NewCreateDockerManagementClusterInternalServerError().WithPayload(Err(err))
-	}
-
-	err = app.saveConfig(params.Params, tkgClient)
+	err := app.saveConfig(params.Params, app.clientTkg)
 	if err != nil {
 		return docker.NewCreateDockerManagementClusterInternalServerError().WithPayload(Err(err))
 	}
@@ -67,12 +57,12 @@ func (app *App) CreateDockerManagementCluster(params docker.CreateDockerManageme
 		Edition:                "tce",
 	}
 
-	if err := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initOptions, false); err != nil {
+	if err := app.clientTkg.ConfigureAndValidateManagementClusterConfiguration(initOptions, false); err != nil {
 		return docker.NewCreateDockerManagementClusterInternalServerError().WithPayload(Err(err))
 	}
 
 	go app.StartSendingLogsToUI()
-	go createManagementCluster(tkgClient, initOptions)
+	go createManagementCluster(app.clientTkg, initOptions)
 
 	return docker.NewCreateDockerManagementClusterOK().WithPayload("started creating management cluster")
 }

--- a/cli/cmd/plugin/ui/server/handlers/mgmtcluster.go
+++ b/cli/cmd/plugin/ui/server/handlers/mgmtcluster.go
@@ -14,17 +14,12 @@ import (
 
 // DeleteMgmtCluster triggers the deletion of a management cluster.
 func (app *App) DeleteMgmtCluster(params management.DeleteMgmtClusterParams) middleware.Responder {
-	tkgClient, err := app.getTkgClient()
-	if err != nil {
-		return management.NewDeleteMgmtClusterBadRequest().WithPayload(Err(err))
-	}
-
 	deleteOptions := tfclient.DeleteRegionOptions{
 		ClusterName: params.ManagementClusterName,
 		Force:       true,
 	}
 
-	err = tkgClient.DeleteRegion(deleteOptions)
+	err := app.clientTkg.DeleteRegion(deleteOptions)
 	if err != nil {
 		return management.NewDeleteMgmtClusterInternalServerError().WithPayload(Err(err))
 	}
@@ -59,12 +54,8 @@ func (app *App) GetMgmtCluster(params management.GetMgmtClusterParams) middlewar
 
 func (app *App) getMgmtClusters(name string) ([]*models.ManagementCluster, error) {
 	apiClusters := []*models.ManagementCluster{}
-	tkgClient, err := app.getTkgClient()
-	if err != nil {
-		return apiClusters, err
-	}
 
-	clusters, err := tkgClient.GetRegionContexts(name)
+	clusters, err := app.clientTkg.GetRegionContexts(name)
 	if err != nil {
 		return apiClusters, err
 	}

--- a/cli/cmd/plugin/ui/server/serve.go
+++ b/cli/cmd/plugin/ui/server/serve.go
@@ -53,7 +53,12 @@ func Serve(bind, browser string, logLevel int32) error {
 	handlers.InitWebsocketUpgrader(server.Host)
 
 	app := handlers.App{LogLevel: logLevel}
-	app.ConfigureHandlers(api)
+	err = app.Initialize(api)
+	if err != nil {
+		server.Logf("Failed to initialize application, error: %s\n", err.Error())
+		os.Exit(1)
+	}
+
 	server.SetAPI(api)
 	server.SetHandler(globalMiddleware(api.Serve(apiMiddleware)))
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

There are two clients used for performing API operations, a TKGClient
and a TkgClient. We were initializing them at the point they were
needed.

Since almost all operations need to use one of the clients, and to allow
us to fail immediately if there is some sort of problem preventing the
creation of these clients, this initializes the clients right away as we
start, before we launch the UI, so we can make sure it is successful and
error out with a reasonable error message so the user doesn't go through
any wizards only to find out nothing works.

We also had an issue where the `~/.config/tanzu` directory was not being
initialized. We need that to exist along with the BOM and configuration
information that gets populated under it. Turns out this is triggered by
the creation of the TKGClient. It checks if the directory exists and
will perform the necessary steps to intialize everything.

Errors were seen when trying to create a management cluster on AWS. This
may be due to the missing content under the config directory.

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make build-cli-plugins` and verified it built.

Did `rm -fr ~/.config/tanzu`, then ran `go run .` from inside the UI plugin directory. Verified it launched and the `~/.config/tanzu` directory was reinitialized.