### PR TITLE
correct setting of coreDNSIP in kapp-controller package

### DIFF
--- a/addons/packages/kapp-controller/0.38.1/bundle/config/overlays/update-deployment.yaml
+++ b/addons/packages/kapp-controller/0.38.1/bundle/config/overlays/update-deployment.yaml
@@ -29,11 +29,14 @@ spec:
           #@overlay/match by="name"
           - name: KAPPCTRL_API_PORT
             value: #@ str(values.kappController.deployment.apiPort)
-        #@ if values.kappController.deployment.coreDNSIP:
+
+      #@overlay/match by=overlay.subset({"name":"kapp-controller-sidecarexec"})
+      -
+        #@ if/end values.kappController.deployment.coreDNSIP:
         volumeMounts:
           - mountPath: /etc
             name: etc
-        #@ end
+
       #@ if values.kappController.deployment.coreDNSIP:
       #! Using init container bypasses the restriction of not having root access in main container
       #! It modifies /etc/resolv.conf which is shared to main container
@@ -45,7 +48,7 @@ spec:
         - /bin/sh
         #! Beware, update this image with each version bump!!!!!!!
         #! This image needs to be the same as the image used in basefile
-        image: ghcr.io/vmware-tanzu/carvel-kapp-controller@sha256:e8547348b57d10da98051d330386cfd961959ac82def18832eefce87da1ca661
+        image: ghcr.io/vmware-tanzu/carvel-kapp-controller@sha256:a6cd018f365ab138ebc9f7d414513ec26418ce35b1ce3e8efe644ee1ab513f3a
         name: init-kapp-controller
         securityContext:
           allowPrivilegeEscalation: false

--- a/addons/packages/kapp-controller/0.38.1/bundle/config/values.star
+++ b/addons/packages/kapp-controller/0.38.1/bundle/config/values.star
@@ -14,5 +14,5 @@ def generateBashCmdForDNS(coreDNSIP):
     # In this way, Kapp Controller will have cluster IP access,
     # and still able to resolve enternal urls when core DNS is unavailable
 
-    return "cp /etc/resolv.conf /etc/resolv.conf.bak; sed '1 i nameserver " + coreDNSIP + "' /etc/resolv.conf.bak > /etc/resolv.conf; rm /etc/resolv.conf.bak; cp -R /etc/* /kapp-etc; chmod g+w /kapp-etc/pki/tls/certs/ca-bundle.crt"
+    return "cp /etc/resolv.conf /etc/resolv.conf.bak; sed '1 i nameserver " + coreDNSIP + "' /etc/resolv.conf.bak > /etc/resolv.conf; rm /etc/resolv.conf.bak; cp -R /etc/* /kapp-etc; chmod g+w /kapp-etc/pki/tls/certs/"
 end


### PR DESCRIPTION
## What this PR does / why we need it

in v0.38.1 kapp-controller package:
- overlays were not correctly updated to account for kapp-controller now having 2 containers
- image was not updated to the correct digest

tested manually via `ytt -f bundle/config | kapp deploy -a kc -f- -c`

also includes a change (chmod) that makes cert reloading compatible with how kapp-controller does cert reload.

(im assuming PackageCR needs to be updated as well. not sure if we already released this version of PackageCR into the wild.)

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
