### PR TITLE
UI: Test reinit config when creating clients

### DIFF
--- a/cli/cmd/plugin/ui/pkg/system/client.go
+++ b/cli/cmd/plugin/ui/pkg/system/client.go
@@ -64,6 +64,19 @@ func NewTkgClient() (*client.TkgClient, error) {
 		return nil, err
 	}
 
+	tkgConfigFile, err := allClients.TKGConfigPathsClient.GetTKGConfigPath()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get TKG config file path")
+	}
+
+	// Set default BOM name to the config variables to use during template generation
+	_ = allClients.ConfigClient.TKGConfigReaderWriter().Init(tkgConfigFile)
+	defaultBoMFileName, err := allClients.TKGBomClient.GetDefaultBoMFileName()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get default BOM file name")
+	}
+	allClients.ConfigClient.TKGConfigReaderWriter().Set(constants.ConfigVariableDefaultBomFile, defaultBoMFileName)
+
 	tkgClient, err := client.New(client.Options{
 		ClusterCtlClient:         allClients.ClusterCtlClient,
 		ReaderWriterConfigClient: allClients.ConfigClient,


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This is a test to see if reinitializing the config client settings after
loading the config directory is the cause of failures when deploying
management clusters.