### PR TITLE
Update external-dns e2e test for custom overlays

### DIFF
--- a/addons/packages/external-dns/0.11.0/test/README.md
+++ b/addons/packages/external-dns/0.11.0/test/README.md
@@ -83,7 +83,7 @@ Set the `DOCKERHUB_PROXY` environment variable if you would like to override
 Run the tests from the e2e directory:
 
 ```bash
-$ cd addons/packages/external-dns/0.11.0/test/e2e
+$ cd addons/packages/external-dns/0.11.0/test
 $ make e2e-test
 ...
 External-dns Addon E2E Test

--- a/addons/packages/external-dns/0.11.0/test/e2e/fixtures/custom-data-values.yaml
+++ b/addons/packages/external-dns/0.11.0/test/e2e/fixtures/custom-data-values.yaml
@@ -1,0 +1,20 @@
+---
+namespace: PACKAGE_COMPONENTS_NAMESPACE
+
+deployment:
+  args:
+    - --source=service
+    - --source=ingress
+    - --txt-owner-id=k8s
+    - --domain-filter=k8s.example.org
+    - --namespace=EXTERNAL_DNS_SOURCES_NAMESPACE
+    - --provider=rfc2136
+    - --rfc2136-host=BIND_SERVER_ADDRESS
+    - --rfc2136-port=53
+    - --rfc2136-zone=k8s.example.org
+    - --rfc2136-tsig-secret=O0DhTJzZ0GjfuQmB9TBc1ELchv5oDMTlQs3NNOdMZJU=
+    - --rfc2136-tsig-secret-alg=hmac-sha256
+    - --rfc2136-tsig-keyname=externaldns-key
+    - --rfc2136-tsig-axfr
+
+custom_label_for_custom_overlay: "customized-label"

--- a/addons/packages/external-dns/0.11.0/test/e2e/fixtures/custom-overlay-and-schema-secret.yaml
+++ b/addons/packages/external-dns/0.11.0/test/e2e/fixtures/custom-overlay-and-schema-secret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-dns-overlay-secret
+  namespace: PACKAGE_INSTALL_NAMESPACE
+stringData:
+  add-new-data-value-to-schema.yml: |
+    #@data/values-schema
+    ---
+    #@overlay/match missing_ok=True
+    custom_label_for_custom_overlay: ""
+  add-deployment-label.yml: |
+    #@ load("@ytt:overlay", "overlay")
+    #@ load("@ytt:data", "data")
+    #@overlay/match by=overlay.subset({"kind":"Deployment", "metadata": {"name": "external-dns", "namespace": data.values.namespace}}),expects="1+"
+    ---
+    metadata:
+      #@overlay/match missing_ok=True
+      labels:
+        #@overlay/match missing_ok=True
+        custom-label: #@ data.values.custom_label_for_custom_overlay


### PR DESCRIPTION
Assert that the schema can be amended, allowing
additional overlays and data values.

## What this PR does / why we need it
This change enhances the external-dns e2e tests to ensure package install extensions work as expected.

https://carvel.dev/kapp-controller/docs/v0.36.1/package-install-extensions/

## Describe testing done for PR
Deployed unmanaged cluster and ran external-dns test. 
