### PR TITLE
GIT-4837: enable fluent-bit 1.9.4 as supported package

### DIFF
--- a/addons/packages/fluent-bit/1.9.4/README.md
+++ b/addons/packages/fluent-bit/1.9.4/README.md
@@ -1,0 +1,52 @@
+# Fluent Bit
+
+> Fluent Bit is an open source Log Processor and Forwarder which allows you to collect any data like metrics and logs from different sources, enrich them with filters and send them to multiple destinations.
+
+This package deploys Fluent Bit as a DaemonSet, with one Fluent Bit `pod` on each Kubernetes `node`, collecting and forwarding logs from each `pod` running on that `node`.
+The provided default configuration will print forwarded logs to `stdout` on the `fluent-bit`.
+The `stdout` output plugin is useful for testing, but typically not appropriate for production use.
+Instead, Fluent Bit supports configurations for a number of different output types, such as open-source software like `postgresql` or `loki`, cloud platform-provided services like `CloudWatch`, `S3`, or `Stackdriver`, or generic protocols like `http` and `syslog`.
+
+For more information on output types, see the [Output](https://docs.fluentbit.io/manual/pipeline/outputs) section of the Fluent Bit Documentation.
+
+## Supported Providers
+
+The following table shows the providers this package can work with.
+
+| AWS  |  Azure  | vSphere  | Docker |
+|:---:|:---:|:---:|:---:|
+| ✅  |  ✅  | ✅  | ✅ |
+
+## Configuration
+
+The following configuration values can be set to customize the Fluent Bit installation.
+
+### Global
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `namespace` | Optional | The namespace in which to deploy Fluent Bit. |
+
+### Fluent Bit Configuration
+
+Fluent-bit's primary configuration interface is its config file, which is documented on Fluent's [documentation](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file) page.
+
+In order to ensure that any supported inputs, outputs, filters, parsers, or other capabilities of the deployed version
+of Fluent Bit are available, the addon's configuration is intentionally a lightweight pass-through of the Fluent Bit config file format.
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+|`fluent_bit.config.service`|Optional|custom configuration for Fluent Bit service, as a multiline `yaml` string.|
+|`fluent_bit.config.outputs`|Optional|configuration for Fluent Bit outputs, as a multiline `yaml` string.|
+|`fluent_bit.config.inputs`|Optional|configuration for Fluent Bit inputs, as a multiline `yaml` string.|
+|`fluent_bit.config.filters`|Optional|configuration for Fluent Bit filters, as a multiline `yaml` string.|
+|`fluent_bit.config.parsers`|Optional|configuration for Fluent Bit parsers, as a multiline `yaml` string.|
+|`fluent_bit.config.streams`|Optional|content for Fluent Bit streams file, as a multiline `yaml` string.|
+|`fluent_bit.config.plugins`|Optional|content for a Fluent Bit plugins configuration file, as a multiline `yaml` string.|
+|`fluent_bit.daemonset.resources`|Optional|resource limits and/or requests for the `fluent-bit` container within the daemonset's pods  |
+|`fluent_bit.daemonset.podAnnotations`|Optional|metadata annotations for the daemonset pods|
+|`fluent_bit.daemonset.podLabels`|Optional|metadata labels for the daemonset pods|
+
+## Usage Example
+
+Once the package has been deployed, tail the logs from the Fluent Bit DaemonSet using `kubectl logs daemonset/fluent-bit -n fluent-bit`. You should see a large volume of logs from all pods.

--- a/addons/packages/fluent-bit/1.9.4/bundle/.imgpkg/bundle.yml
+++ b/addons/packages/fluent-bit/1.9.4/bundle/.imgpkg/bundle.yml
@@ -3,12 +3,8 @@ kind: Bundle
 metadata:
   name: fluent-bit
 authors:
-- name: Anil Kodali
-  email: akodali@vmware.com
-- name: John McBride
-  email: jmcbride@vmware.com
-- name: Luke Winikates
-  email: winikatesl@vmware.com
+- name: Harsha Narayana
+  email: harsha2k4@gmail.com
 websites:
 - url: https://fluentbit.io/
 - url: https://github.com/fluent/fluent-bit/

--- a/addons/packages/fluent-bit/1.9.4/bundle/.imgpkg/images.yml
+++ b/addons/packages/fluent-bit/1.9.4/bundle/.imgpkg/images.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- annotations:
+    kbld.carvel.dev/id: fluent/fluent-bit:1.9.4
+  image: index.docker.io/fluent/fluent-bit@sha256:128378e24347d2c3572ab4256f1f6e5e755304c92cb763e50f7a8065780efc89
+kind: ImagesLock

--- a/addons/packages/fluent-bit/1.9.4/bundle/config/overlays/overlay-configmap.yaml
+++ b/addons/packages/fluent-bit/1.9.4/bundle/config/overlays/overlay-configmap.yaml
@@ -1,0 +1,36 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind":"ConfigMap"}), expects=1
+---
+data:
+  #@yaml/text-templated-strings
+  #@overlay/replace
+  fluent-bit.conf: |
+    (@= data.values.fluent_bit.config.service @)
+
+      Parsers_File  parsers.conf
+      (@= "Plugins_File  plugins.conf" if data.values.fluent_bit.config.plugins else ""@)
+      (@= "Streams_File  streams.conf" if data.values.fluent_bit.config.streams else ""@)
+
+    @INCLUDE inputs.conf
+    @INCLUDE filters.conf
+    @INCLUDE outputs.conf
+  #@yaml/text-templated-strings
+  #@overlay/replace
+  outputs.conf: (@= data.values.fluent_bit.config.outputs @)
+  #@yaml/text-templated-strings
+  #@overlay/replace
+  inputs.conf: (@= data.values.fluent_bit.config.inputs @)
+  #@yaml/text-templated-strings
+  #@overlay/replace
+  filters.conf: (@= data.values.fluent_bit.config.filters @)
+  #@yaml/text-templated-strings
+  #@overlay/replace
+  parsers.conf: (@= data.values.fluent_bit.config.parsers @)
+  #@yaml/text-templated-strings
+  #@overlay/replace
+  streams.conf: (@= data.values.fluent_bit.config.streams @)
+  #@yaml/text-templated-strings
+  #@overlay/replace
+  plugins.conf: (@= data.values.fluent_bit.config.plugins @)

--- a/addons/packages/fluent-bit/1.9.4/bundle/config/overlays/overlay-daemonset.yaml
+++ b/addons/packages/fluent-bit/1.9.4/bundle/config/overlays/overlay-daemonset.yaml
@@ -1,0 +1,18 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet", "metadata": {"name": "fluent-bit"}}), expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+spec:
+  template:
+    #@overlay/merge
+    metadata:
+      labels: #@ data.values.fluent_bit.daemonset.podLabels
+      annotations: #@ data.values.fluent_bit.daemonset.podAnnotations
+    spec:
+      containers:
+       #@overlay/match by="name"
+        - name: fluent-bit
+          #@overlay/replace
+          resources: #@ data.values.fluent_bit.daemonset.resources

--- a/addons/packages/fluent-bit/1.9.4/bundle/config/overlays/overlay-namespace.yaml
+++ b/addons/packages/fluent-bit/1.9.4/bundle/config/overlays/overlay-namespace.yaml
@@ -1,0 +1,19 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind":"Namespace", "metadata": {"name": "fluent-bit"}})
+---
+metadata:
+  name: #@ data.values.namespace
+
+#@overlay/match by=overlay.subset({"metadata":{"namespace": "fluent-bit"}}), expects=3
+---
+metadata:
+  namespace: #@ data.values.namespace
+
+#@overlay/match by=overlay.subset({"kind":"ClusterRoleBinding"})
+---
+subjects:
+#@overlay/match by=overlay.subset({"namespace": "fluent-bit"})
+- kind: ServiceAccount
+  namespace: #@ data.values.namespace

--- a/addons/packages/fluent-bit/1.9.4/bundle/config/upstream/fluentbit/configmap.yaml
+++ b/addons/packages/fluent-bit/1.9.4/bundle/config/upstream/fluentbit/configmap.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: fluent-bit
+  labels:
+    k8s-app: fluent-bit
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+      Flush         1
+      Log_Level     info
+      Daemon        off
+      Parsers_File  parsers.conf
+      HTTP_Server   On
+      HTTP_Listen   0.0.0.0
+      HTTP_Port     2020
+
+    @INCLUDE inputs.conf
+    @INCLUDE filters.conf
+    @INCLUDE outputs.conf
+
+  inputs.conf: |
+    [INPUT]
+        Name tail
+        Path /var/log/containers/*.log
+        Parser docker
+        Tag kube.*
+        Mem_Buf_Limit 5MB
+        Skip_Long_Lines On
+
+    [INPUT]
+        Name systemd
+        Tag host.*
+        Systemd_Filter _SYSTEMD_UNIT=kubelet.service
+        Read_From_Tail On
+
+  filters.conf: |
+    [FILTER]
+      Name                kubernetes
+      Match               kube.*
+      Kube_URL            https://kubernetes.default.svc:443
+      Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+      Kube_Tag_Prefix     kube.var.log.containers.
+      Merge_Log           On
+      Merge_Log_Key       log_processed
+      K8S-Logging.Parser  On
+      K8S-Logging.Exclude Off
+
+    [FILTER]
+      Name                modify
+      Match               *
+      Rename message text
+
+  outputs.conf: |
+    
+  parsers.conf: |
+    [PARSER]
+      Name   json
+      Format json
+      Time_Key time
+      Time_Format %d/%b/%Y:%H:%M:%S %z
+  plugins.conf: ""
+  streams.conf: ""

--- a/addons/packages/fluent-bit/1.9.4/bundle/config/upstream/fluentbit/daemonset.yaml
+++ b/addons/packages/fluent-bit/1.9.4/bundle/config/upstream/fluentbit/daemonset.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: fluent-bit
+  labels:
+    app: fluent-bit
+spec:
+  updateStrategy:
+    type: "RollingUpdate"
+  template:
+    metadata:
+      labels:
+        app: fluent-bit
+      annotations:
+        fluentbit.io/exclude: "true"
+    spec:
+      containers:
+        - name: fluent-bit
+          image: fluent/fluent-bit:1.9.4
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - name: http
+              containerPort: 2020
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources: {}
+          securityContext: {}
+          volumeMounts:
+            - name: var-log
+              mountPath: /var/log
+            - name: var-lib-docker-containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: fluent-bit-config
+              mountPath: /fluent-bit/etc/
+            - name: systemd-log
+              mountPath: /run/log
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: var-log
+          hostPath:
+            path: /var/log
+        - name: var-lib-docker-containers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: systemd-log
+          hostPath:
+            path: /run/log
+        - name: fluent-bit-config
+          configMap:
+            name: fluent-bit-config
+      serviceAccountName: fluent-bit-sa
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - operator: "Exists"
+          effect: "NoExecute"
+        - operator: "Exists"
+          effect: "NoSchedule"
+  selector:
+    matchLabels:
+      app: fluent-bit

--- a/addons/packages/fluent-bit/1.9.4/bundle/config/upstream/fluentbit/namespace.yaml
+++ b/addons/packages/fluent-bit/1.9.4/bundle/config/upstream/fluentbit/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: fluent-bit
+  name: fluent-bit

--- a/addons/packages/fluent-bit/1.9.4/bundle/config/upstream/fluentbit/rbac.yml
+++ b/addons/packages/fluent-bit/1.9.4/bundle/config/upstream/fluentbit/rbac.yml
@@ -1,0 +1,35 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluent-bit-read
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluent-bit-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluent-bit-read
+subjects:
+  - kind: ServiceAccount
+    name: fluent-bit-sa
+    namespace: fluent-bit
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluent-bit-sa
+  namespace: fluent-bit

--- a/addons/packages/fluent-bit/1.9.4/bundle/config/values.yaml
+++ b/addons/packages/fluent-bit/1.9.4/bundle/config/values.yaml
@@ -1,0 +1,168 @@
+#@data/values
+#@overlay/match-child-defaults missing_ok=True
+---
+namespace: fluent-bit
+#! Required params for supported output plugins
+fluent_bit:
+  config:
+    service: |
+      [Service]
+        Flush         1
+        Log_Level     info
+        Daemon        off
+        Parsers_File  parsers.conf
+        HTTP_Server   On
+        HTTP_Listen   0.0.0.0
+        HTTP_Port     2020
+    outputs: |
+      [OUTPUT]
+        Name              stdout
+        Match             *
+    inputs: |
+      [INPUT]
+        Name tail
+        Path /var/log/containers/*.log
+        Parser docker
+        Tag kube.*
+        Mem_Buf_Limit 5MB
+        Skip_Long_Lines On
+
+      [INPUT]
+        Name systemd
+        Tag host.*
+        Systemd_Filter _SYSTEMD_UNIT=kubelet.service
+        Read_From_Tail On
+    filters: |
+      [FILTER]
+        Name                kubernetes
+        Match               kube.*
+        Kube_URL            https://kubernetes.default.svc:443
+        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+        Kube_Tag_Prefix     kube.var.log.containers.
+        Merge_Log           On
+        Merge_Log_Key       log_processed
+        K8S-Logging.Parser  On
+        K8S-Logging.Exclude On
+    parsers: |
+      [PARSER]
+        Name   apache
+        Format regex
+        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+      [PARSER]
+        Name   apache2
+        Format regex
+        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>.*)")?$
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+      [PARSER]
+        Name   apache_error
+        Format regex
+        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
+
+      [PARSER]
+        Name   nginx
+        Format regex
+        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+      [PARSER]
+        # https://rubular.com/r/IhIbCAIs7ImOkc
+        Name        k8s-nginx-ingress
+        Format      regex
+        Regex       ^(?<host>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" (?<request_length>[^ ]*) (?<request_time>[^ ]*) \[(?<proxy_upstream_name>[^ ]*)\] (\[(?<proxy_alternative_upstream_name>[^ ]*)\] )?(?<upstream_addr>[^ ]*) (?<upstream_response_length>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_status>[^ ]*) (?<reg_id>[^ ]*).*$
+        Time_Key    time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+      [PARSER]
+        Name   json
+        Format json
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+      [PARSER]
+        Name         docker
+        Format       json
+        Time_Key     time
+        Time_Format  %Y-%m-%dT%H:%M:%S.%L
+        Time_Keep    On
+
+      [PARSER]
+        Name        docker-daemon
+        Format      regex
+        Regex       time="(?<time>[^ ]*)" level=(?<level>[^ ]*) msg="(?<msg>[^ ].*)"
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+        Time_Keep   On
+
+      [PARSER]
+        Name        syslog-rfc5424
+        Format      regex
+        Regex       ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.+)$
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+        Time_Keep   On
+
+      [PARSER]
+        Name        syslog-rfc3164-local
+        Format      regex
+        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+        Time_Key    time
+        Time_Format %b %d %H:%M:%S
+        Time_Keep   On
+
+      [PARSER]
+        Name        syslog-rfc3164
+        Format      regex
+        Regex       /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
+        Time_Key    time
+        Time_Format %b %d %H:%M:%S
+        Time_Keep   On
+
+      [PARSER]
+        Name    mongodb
+        Format  regex
+        Regex   ^(?<time>[^ ]*)\s+(?<severity>\w)\s+(?<component>[^ ]+)\s+\[(?<context>[^\]]+)]\s+(?<message>.*?) *(?<ms>(\d+))?(:?ms)?$
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+        Time_Keep   On
+        Time_Key time
+
+      [PARSER]
+        # https://rubular.com/r/3fVxCrE5iFiZim
+        Name    envoy
+        Format  regex
+        Regex ^\[(?<start_time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)? (?<protocol>\S+)" (?<code>[^ ]*) (?<response_flags>[^ ]*) (?<bytes_received>[^ ]*) (?<bytes_sent>[^ ]*) (?<duration>[^ ]*) (?<x_envoy_upstream_service_time>[^ ]*) "(?<x_forwarded_for>[^ ]*)" "(?<user_agent>[^\"]*)" "(?<request_id>[^\"]*)" "(?<authority>[^ ]*)" "(?<upstream_host>[^ ]*)"
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+        Time_Keep   On
+        Time_Key start_time
+
+      [PARSER]
+        # http://rubular.com/r/tjUt3Awgg4
+        Name cri
+        Format regex
+        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+
+      [PARSER]
+        Name    kube-custom
+        Format  regex
+        Regex   (?<tag>[^.]+)?\.?(?<pod_name>[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace_name>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$
+    streams: ''
+    plugins: ''
+  #! optional configuration for the daemonset
+  daemonset:
+    resources: {}
+    #! limits:
+    #!   cpu: 100m
+    #!   memory: 128Mi
+    #! requests:
+    #!   cpu: 100m
+    #!   memory: 128Mi
+    podAnnotations: {}
+    podLabels: {}

--- a/addons/packages/fluent-bit/1.9.4/bundle/vendir.lock.yml
+++ b/addons/packages/fluent-bit/1.9.4/bundle/vendir.lock.yml
@@ -1,0 +1,7 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - manual: {}
+    path: fluentbit
+  path: config/upstream
+kind: LockConfig

--- a/addons/packages/fluent-bit/1.9.4/bundle/vendir.yml
+++ b/addons/packages/fluent-bit/1.9.4/bundle/vendir.yml
@@ -1,0 +1,8 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.12.0
+directories:
+- path: config/upstream
+  contents:
+  - path: fluentbit
+    manual: {}

--- a/addons/packages/fluent-bit/1.9.4/package.yaml
+++ b/addons/packages/fluent-bit/1.9.4/package.yaml
@@ -1,0 +1,90 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: fluent-bit.community.tanzu.vmware.com.1.9.4
+spec:
+  refName: fluent-bit.community.tanzu.vmware.com
+  version: 1.9.4
+  releasedAt: 2021-05-13T18:00:00Z
+  releaseNotes: "fluent-bit 1.9.4 https://github.com/fluent/fluent-bit/releases/tag/v1.9.4"
+  capacityRequirementsDescription: "Varies significantly based on cluster size. This should be tuned based on observed usage."
+  valuesSchema:
+    openAPIv3:
+      title: fluent-bit.community.tanzu.vmware.com.1.7.4 values schema
+      properties:
+        namespace:
+          type: string
+          description: The namespace in which to deploy fluent-bit.
+          default: fluent-bit
+        fluent_bit:
+          type: object
+          description: fluent-bit Kubernetes configuration.
+          properties:
+            daemonset:
+              type: object
+              description: fluent-bit deployment related configuration
+              properties:
+                resources:
+                  type: object
+                  description: fluent-bit containers resource requirements (See Kubernetes OpenAPI Specification io.k8s.api.core.v1.ResourceRequirements)
+                  additionalProperties: true
+                podAnnotations:
+                  type: object
+                  description: fluent-bit deployments pod annotations
+                  additionalProperties:
+                    type: string
+                podLabels:
+                  type: object
+                  description: fluent-bit deployments pod labels
+                  additionalProperties:
+                    type: string
+            config:
+              type: object
+              description: The fluent-bit configuration. See https://docs.fluentbit.io/manual/administration/configuring-fluent-bit for more information.
+              properties:
+                service:
+                  type: string
+                  description: Configuration for Fluent Bit service, as a multiline YAML. See https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section for more information.
+                  default: "default fluent-bit service config."
+                outputs:
+                  type: string
+                  description: Configuration for Fluent Bit outputs, as a multiline YAML. See https://docs.fluentbit.io/manual/pipeline/outputs for more information.
+                  default: "standard output"
+                inputs:
+                  type: string
+                  description: Configuration for Fluent Bit inputs, as a multiline YAML. See https://docs.fluentbit.io/manual/pipeline/inputs for more information.
+                  default: "tail"
+                filters:
+                  type: string
+                  description: Configuration for Fluent Bit filters, as a multiline YAML. See https://docs.fluentbit.io/manual/pipeline/filters/ for more information.
+                  default: "default kubernetes filter"
+                parsers:
+                  type: string
+                  description: Configuration for Fluent Bit parsers, as a multiline YAML. See https://docs.fluentbit.io/manual/pipeline/parsers/ for more information.
+                  default: "json parser"
+                streams:
+                  type: string
+                  description: Content for Fluent Bit streams file, as a multiline YAML
+                  default: null
+                plugins:
+                  type: string
+                  description: Content for Fluent Bit plugins configuration file, as a multiline YAML
+                  default: null
+  licenses:
+    - "Apache 2.0"
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            # this needs to be replaced with the actual image hash once pulled into the TCE repo
+            image: projects.registry.vmware.com/tce/fluent-bit@sha256:e8c0873ef8e1ea04f32b88afbab64fc4338d0c0536ef2f91b9dd54bee2c59ed7
+      template:
+        - ytt:
+            paths:
+              - config/
+        - kbld:
+            paths:
+              - "-"
+              - .imgpkg/images.yml
+      deploy:
+        - kapp: {}

--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -35,6 +35,7 @@ packages:
   - name: fluent-bit
     versions:
       - 1.7.5
+      - 1.9.4
   - name: fluxcd-helm-controller
     versions:
       - 0.17.2


### PR DESCRIPTION
## What this PR does / why we need it
Uptick `fluent-bit` to `1.9.4`

## Which issue(s) this PR fixes
Fixes: #4837 

## Describe testing done for PR
```bash
❯ tanzu package install fluent-bit --package-name fluent-bit.community.tanzu.vmware.com --version 1.9.4

 Installing package 'fluent-bit.community.tanzu.vmware.com'

 Getting package metadata for 'fluent-bit.community.tanzu.vmware.com'

 Creating service account 'fluent-bit-default-sa'

 Creating cluster admin role 'fluent-bit-default-cluster-role'

 Creating cluster role binding 'fluent-bit-default-cluster-rolebinding'

 Creating package resource

 Waiting for 'PackageInstall' reconciliation for 'fluent-bit'

 'PackageInstall' resource install status: Reconciling

 'PackageInstall' resource install status: ReconcileSucceeded

 'PackageInstall' resource successfully reconciled


 Added installed package 'fluent-bit'
```
```bash
❯ kubectl get pods -o wide -n fluent-bit
NAME               READY   STATUS    RESTARTS   AGE   IP              NODE                     NOMINATED NODE   READINESS GATES
fluent-bit-6j4gg   1/1     Running   0          26m   10.244.69.133   my-test-control-plane   <none>           <none>
```

## Special notes for your reviewer
I haven't been able to figure out how to get `fluent/fluent-bit:1.9.4` into the `projects.registry.vmware.com/tce/fluent-bit`. Any help would be really appreciated. 

