### PR TITLE
UI Plugin: Cluster inventory refinements

### DIFF
--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/index.scss
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/index.scss
@@ -98,6 +98,7 @@ main {
 .mgmt-cluster-admins-img {
     display: inline-block;
     background-image: url('assets/admins-at-work.svg');
+    background-size: contain;
     background-repeat: no-repeat;
     width: 100%;
     height: 100%;

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/HeaderBar/HeaderBar.scss
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/HeaderBar/HeaderBar.scss
@@ -5,6 +5,7 @@
     // uses clarity global var
     background-color: var(--cds-global-color-blue-700);
     color: #fff;
+    min-height: 3rem;
 
     .branding {
         cursor: pointer;

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/SideNavigation/SideNavigation.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/SideNavigation/SideNavigation.tsx
@@ -64,7 +64,7 @@ function SideNavigation(this: any) {
             <CdsDivider cds-layout="p-y:sm"></CdsDivider>
             <CdsNavigationItem active={isActiveNavItem(NavRoutes.MANAGEMENT_CLUSTER_INVENTORY)}>
                 <Link cds-layout={navigationItemLinkLayout} to={NavRoutes.MANAGEMENT_CLUSTER_INVENTORY}>
-                    <CdsIcon shape="cluster" size="sm"></CdsIcon>
+                    <CdsIcon shape="blocks-group" size="sm"></CdsIcon>
                     Management Clusters
                 </Link>
             </CdsNavigationItem>
@@ -79,7 +79,7 @@ function SideNavigation(this: any) {
             {unmanagedClusterSupport && (
                 <CdsNavigationItem active={isActiveNavItem(NavRoutes.UNMANAGED_CLUSTER_INVENTORY)}>
                     <Link cds-layout={navigationItemLinkLayout} to={NavRoutes.UNMANAGED_CLUSTER_INVENTORY}>
-                        <CdsIcon shape="node" size="sm"></CdsIcon>
+                        <CdsIcon shape="computer" size="sm"></CdsIcon>
                         Unmanaged Clusters
                     </Link>
                 </CdsNavigationItem>

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterCard.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterCard.tsx
@@ -19,35 +19,37 @@ function ManagementClusterCard(props: ManagementClusterProps) {
     return (
         <div className="section-raised" cds-layout="grid cols:12 wrap:none" data-testid="management-cluster-card">
             <div cds-layout="vertical">
-                <div cds-layout="horizontal gap:md align:fill align:vertical-center p:md" cds-text="subsection">
+                <div cds-layout="vertical" cds-text="subsection">
                     <div cds-layout="horizontal">
-                        <div cds-layout="horizontal gap:sm align:vertical-center p-y:sm">
-                            <CdsIcon cds-layout="m-r:sm" shape="cluster" size="lg" className="icon-blue"></CdsIcon>
+                        <div cds-layout="horizontal gap:sm align:vertical-center p:sm">
+                            <CdsIcon shape="blocks-group" size="md" className="icon-blue"></CdsIcon>
                             <div cds-text="section">{name}</div>
                         </div>
-                        <CdsDivider orientation="vertical" cds-layout="align:right"></CdsDivider>
                     </div>
-                    <div cds-layout="horizontal">
-                        <div cds-layout="vertical align:left m-r:xs">
-                            <label className="card-content-label">Path</label>
+                    <CdsDivider></CdsDivider>
+                    <div cds-layout="horizontal gap:md p:sm">
+                        <div cds-layout="vertical">
+                            <label cds-text="p4" cds-layout="m-b:sm">
+                                Path
+                            </label>
                             <div cds-layout="horizontal">
-                                <div>{path}</div>
+                                <div cds-text="body">{path}</div>
                             </div>
                         </div>
-                        <CdsDivider orientation="vertical" cds-layout="align:right"></CdsDivider>
-                    </div>
-                    <div cds-layout="horizontal">
+                        <CdsDivider orientation="vertical"></CdsDivider>
                         <div cds-layout="vertical m-r:xs">
-                            <label className="card-content-label">Context</label>
+                            <label cds-text="p4" cds-layout="m-b:sm">
+                                Context
+                            </label>
                             <div cds-layout="horizontal">
-                                <div>{context}</div>
+                                <div cds-text="body">{context}</div>
                             </div>
                         </div>
                     </div>
                 </div>
                 <CdsDivider></CdsDivider>
-                <div cds-layout="vertical gap:md align:vertical-center p:md">
-                    <div cds-layout="horizontal gap:xs align:vertical-center align:right p-r:lg">
+                <div cds-layout="vertical gap:md p:md">
+                    <div cds-layout="horizontal gap:xs p-r:lg">
                         <CdsButton
                             action="flat-inline"
                             status="danger"

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.scss
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.scss
@@ -1,5 +1,6 @@
 .mgmt-cluster-no-cluster-container {
     background-image: url('../../assets/management-cluster-bg.svg');
+    background-size: 40%;
     background-repeat: no-repeat;
     background-position: top right;
     min-height: 174px;

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.tsx
@@ -119,29 +119,30 @@ function ManagementClusterInventory() {
         return (
             <>
                 <div
-                    cds-layout="grid horizontal cols:8 p:md"
+                    cds-layout="grid horizontal cols:8 p:lg"
                     className="section-raised mgmt-cluster-no-cluster-container"
                     data-testid="no-clusters-messaging"
                 >
                     <div cds-layout="grid horizontal cols:12 gap:lg gap@md:lg">
-                        <div cds-text="title">Management Cluster not found</div>
+                        <div cds-text="section">Management Cluster not found</div>
                         <div cds-text="body">
-                            Create a Management Cluster on your preferred cloud provider through a guided series of steps.
-                            <br />
-                            <br />
-                            This cluster will manage new workload clusters you create for your workloads.{' '}
-                            <a
-                                href="https://tanzucommunityedition.io/docs/v0.12/planning/#managed-cluster"
-                                target="_blank"
-                                rel="noreferrer"
-                                cds-text="link"
-                            >
-                                Learn more about Management Clusters Clusters
-                            </a>
-                            <br />
-                            <br />
+                            <p cds-layout="m-t:none">
+                                Create a Management Cluster on your preferred cloud provider through a guided series of steps.
+                            </p>
+                            <p>
+                                This cluster will manage new workload clusters you create for your workloads.{' '}
+                                <a
+                                    href="https://tanzucommunityedition.io/docs/v0.12/planning/#managed-cluster"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    cds-text="link"
+                                >
+                                    Learn more about Management Clusters
+                                </a>
+                                .
+                            </p>
                             <CdsButton onClick={() => navigate(NavRoutes.MANAGEMENT_CLUSTER_SELECT_PROVIDER)}>
-                                <CdsIcon shape="cluster"></CdsIcon>create a management cluster
+                                <CdsIcon shape="blocks-group"></CdsIcon>create a management cluster
                             </CdsButton>
                         </div>
                     </div>
@@ -154,10 +155,10 @@ function ManagementClusterInventory() {
     const ManagementClustersSection = function () {
         return (
             <>
-                <div cds-text="subsection">The following clusters were discovered on this workstation.</div>
+                <div cds-text="body">The following clusters were discovered on this workstation.</div>
                 <div>
                     <CdsButton onClick={() => navigate(NavRoutes.MANAGEMENT_CLUSTER_SELECT_PROVIDER)}>
-                        <CdsIcon shape="cluster"></CdsIcon>create a management cluster
+                        <CdsIcon shape="blocks-group"></CdsIcon>create a management cluster
                     </CdsButton>
                 </div>
                 {managementClusters.map((cluster: ManagementCluster) => {
@@ -179,8 +180,8 @@ function ManagementClusterInventory() {
         <>
             <div className="management-cluster-landing-container" cds-layout="vertical gap:md col@sm:12 grid">
                 <div cds-layout="vertical col:8 gap:lg">
-                    <div cds-text="title">
-                        <CdsIcon cds-layout="m-r:sm" shape="cluster" size="xl" className="icon-blue"></CdsIcon>
+                    <div cds-text="title" cds-layout="horizontal align:vertical-center">
+                        <CdsIcon cds-layout="m-r:sm" shape="blocks-group" size="lg"></CdsIcon>
                         Management Clusters
                     </div>
                     {hasManagementClusters() ? ManagementClustersSection() : NoManagementClustersSection()}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/UnmanagedClusterCard/UnmanagedClusterCard.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/UnmanagedClusterCard/UnmanagedClusterCard.tsx
@@ -24,46 +24,48 @@ function UnmanagedClusterCard(props: UnmanagedCluster) {
     return (
         <div className="section-raised" cds-layout="grid cols:12 wrap:none">
             <div cds-layout="vertical">
-                <div cds-layout="horizontal gap:md align:fill align:vertical-center p:md" cds-text="subsection">
+                <div cds-layout="vertical" cds-text="subsection">
                     <div cds-layout="horizontal">
-                        <div cds-layout="horizontal gap:sm align:vertical-center p-y:sm">
-                            <CdsIcon cds-layout="m-r:sm" shape="cluster" size="lg" className="icon-blue"></CdsIcon>
+                        <div cds-layout="horizontal gap:sm align:vertical-center p:sm">
+                            <CdsIcon shape="block" size="md" className="icon-blue"></CdsIcon>
                             <div cds-text="section">{name}</div>
                         </div>
-                        <CdsDivider orientation="vertical" cds-layout="align:right"></CdsDivider>
                     </div>
-                    <div cds-layout="horizontal">
-                        <div cds-layout="vertical align:left m-r:xs">
-                            <label>Provider</label>
+                    <CdsDivider></CdsDivider>
+                    <div cds-layout="horizontal gap:md p:sm">
+                        <div cds-layout="vertical m-r:xs">
+                            <label cds-text="p4" cds-layout="m-b:sm">
+                                Provider
+                            </label>
                             <div cds-layout="horizontal">
-                                <div>{provider}</div>
+                                <div cds-text="body">{provider}</div>
                             </div>
                         </div>
-                        <CdsDivider orientation="vertical" cds-layout="align:right"></CdsDivider>
-                    </div>
-                    <div cds-layout="horizontal">
+                        <CdsDivider orientation="vertical"></CdsDivider>
                         <div cds-layout="vertical m-r:xs">
-                            <label>Status</label>
-                            <div cds-layout="horizontal">
+                            <label cds-text="p4" cds-layout="m-b:sm">
+                                Status
+                            </label>
+                            <div cds-layout="horizontal align:vertical-center">
                                 {status?.toUpperCase() === UnmanagedClusterStatus.RUNNING ? (
-                                    <CdsIcon cds-layout="m-r:sm" shape="connect" size="md" status="success"></CdsIcon>
+                                    <CdsIcon cds-layout="m-r:xs" shape="check" size="sm" status="success"></CdsIcon>
                                 ) : status?.toUpperCase() === UnmanagedClusterStatus.STOPPED ? (
-                                    <CdsIcon cds-layout="m-r:sm" shape="disconnect" size="md" status="danger"></CdsIcon>
+                                    <CdsIcon cds-layout="m-r:xs" shape="exclamation-circle" solid size="sm" status="danger"></CdsIcon>
                                 ) : (
-                                    <CdsIcon cds-layout="m-r:sm" shape="unknown-status" size="md" status="warning"></CdsIcon>
+                                    <CdsIcon cds-layout="m-r:xs" shape="unknown-status" size="sm"></CdsIcon>
                                 )}
-                                <div>{status}</div>
+                                <div cds-text="body">{status}</div>
                             </div>
                         </div>
                     </div>
                 </div>
                 <CdsDivider></CdsDivider>
-                <div cds-layout="vertical gap:md align:vertical-center p:md">
-                    <div cds-layout="horizontal gap:xs align:vertical-center align:left">
-                        <CdsButton action="flat" size="sm" cds-layout="m-x:md">
+                <div cds-layout="vertical gap:md p:md">
+                    <div cds-layout="horizontal gap:lg">
+                        <CdsButton action="flat-inline" size="md">
                             Access This Cluster
                         </CdsButton>
-                        <CdsButton action="flat" size="sm" cds-layout="m-x:md" status="danger">
+                        <CdsButton action="flat-inline" size="md" status="danger">
                             Delete
                         </CdsButton>
                     </div>

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/UnmanagedClusterInventory.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/UnmanagedClusterInventory.tsx
@@ -27,11 +27,11 @@ function UnmanagedClusterInventory() {
         <div className="management-cluster-landing-container" cds-layout="grid vertical col:12 gap:lg align:fill">
             <div cds-layout="grid horizontal col:12">
                 <div cds-layout="vertical gap:md gap@md:lg col@sm:8 col:8">
-                    <div cds-text="title">
-                        <CdsIcon cds-layout="m-r:sm" shape="computer" size="xl" className="icon-blue"></CdsIcon>
-                        Unmanaged Cluster
+                    <div cds-text="title" cds-layout="horizontal align:vertical-center">
+                        <CdsIcon cds-layout="m-r:sm" shape="computer" size="lg"></CdsIcon>
+                        Unmanaged Clusters
                     </div>
-                    <div cds-text="subsection">
+                    <div cds-text="body">
                         Create a single node, local workstation cluster suitable for a development/test environment. It requires minimal
                         local resources and is fast to deploy. It provides support for running multiple clusters. The default Tanzu
                         Community Edition package repository is automatically installed when you deploy an unmanaged cluster.
@@ -42,8 +42,8 @@ function UnmanagedClusterInventory() {
                             status="primary"
                             onClick={() => navigate(NavRoutes.UNMANAGED_CLUSTER_WIZARD)}
                         >
-                            <CdsIcon shape="cluster"></CdsIcon>
-                            Create Unmanaged Cluster
+                            <CdsIcon shape="block"></CdsIcon>
+                            Create an Unmanaged Cluster
                         </CdsButton>
                     </div>
                     <div cds-layout="vertical gap:lg col:6">
@@ -57,18 +57,7 @@ function UnmanagedClusterInventory() {
                         })}
                     </div>
                 </div>
-                <div cds-layout="col@sm:4 col:4 container:fill">
-                    <div cds-layout="vertical">
-                        <CdsButton
-                            action="flat"
-                            onClick={() => {
-                                window.open('http://tanzucommunityedition.io', '_blank');
-                            }}
-                        >
-                            Learn more about Tanzu&apos;s architecture
-                        </CdsButton>
-                    </div>
-                </div>
+                <div cds-layout="col@sm:4 col:4 container:fill"></div>
             </div>
         </div>
     );


### PR DESCRIPTION
Signed-off-by: Garry Ing <ging@vmware.com>

## What this PR does / why we need it
Refinements to the cluster inventory views:
- Set `min-height` for header element
- Updated icons to match side navigation to inventory view icons
- Layout refinements to Management Clusters empty-state component

![localhost_3000_ui_management-clusters](https://user-images.githubusercontent.com/227587/174674525-322f41bb-6bf0-42a3-a0f9-fcc2a98f4599.png)
![localhost_3000_ui_unmanaged-clusters (1)](https://user-images.githubusercontent.com/227587/174674529-c031787a-c368-4cf8-a45b-4e9834b35581.png)
![localhost_3000_ui_unmanaged-clusters](https://user-images.githubusercontent.com/227587/174674534-2ca118c6-8bed-48e4-8b0c-21a71f980120.png)

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: n/a

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
