### PR TITLE
Unmanaged-cluster: Protect cli against extra arguments

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -26,6 +26,7 @@ var ConfigureCmd = &cobra.Command{
 	Short:   "Generate a config file to be used in cluster creation",
 	Long:    configureDesc,
 	RunE:    configure,
+	Args:    checkSingleClusterArg,
 }
 
 //nolint:dupl
@@ -49,14 +50,8 @@ func init() {
 }
 
 func configure(cmd *cobra.Command, args []string) error {
-	var clusterName string
-
-	// validate a cluster name was passed
-	if len(args) < 1 {
-		return fmt.Errorf("cluster name not specified")
-	} else if len(args) == 1 {
-		clusterName = args[0]
-	}
+	// args have already been checked by ConfigureCmd.Args()
+	clusterName := args[0]
 
 	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -72,7 +73,15 @@ var CreateCmd = &cobra.Command{
 	Short: "Create an unmanaged cluster",
 	Long:  createDesc,
 	Run:   create,
-	Args:  cobra.MaximumNArgs(1),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 1 {
+			return errors.New("only a single cluster name should be specified")
+		}
+		if len(args) == 0 && co.clusterConfigFile == "" && co.existingClusterKubeconfig == "" {
+			return errors.New("must specify a cluster name or configuration file")
+		}
+		return nil
+	},
 }
 
 var co = createUnmanagedOpts{}

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/delete.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -30,6 +29,7 @@ var DeleteCmd = &cobra.Command{
 	PostRunE: func(cmd *cobra.Command, args []string) (err error) {
 		return nil
 	},
+	Args: checkSingleClusterArg,
 }
 
 func init() {
@@ -37,14 +37,9 @@ func init() {
 }
 
 func destroy(cmd *cobra.Command, args []string) error {
-	var clusterName string
+	// args have already been checked by DeleteCmd.Args()
+	clusterName := args[0]
 
-	// validate a cluster name was passed
-	if len(args) < 1 {
-		return fmt.Errorf("must specify cluster name to delete")
-	} else if len(args) == 1 {
-		clusterName = args[0]
-	}
 	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	log.Eventf(logger.TestTubeEmoji, "Deleting cluster: %s\n", clusterName)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/list.go
@@ -40,6 +40,7 @@ var ListCmd = &cobra.Command{
 	PostRunE: func(cmd *cobra.Command, args []string) (err error) {
 		return nil
 	},
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/start.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/start.go
@@ -4,8 +4,6 @@
 package cmd // nolint:dupl
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/log"
@@ -27,6 +25,7 @@ var StartCmd = &cobra.Command{
 	PostRunE: func(cmd *cobra.Command, args []string) (err error) {
 		return nil
 	},
+	Args: checkSingleClusterArg,
 }
 
 func init() {
@@ -34,14 +33,9 @@ func init() {
 }
 
 func start(cmd *cobra.Command, args []string) error {
-	var clusterName string
+	// args have already been checked by StartCmd.Args()
+	clusterName := args[0]
 
-	// validate a cluster name was passed
-	if len(args) < 1 {
-		return fmt.Errorf("must specify cluster name to start")
-	} else if len(args) == 1 {
-		clusterName = args[0]
-	}
 	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	log.Eventf(logger.TestTubeEmoji, "Attempting to start cluster: %s\n", clusterName)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/stop.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/stop.go
@@ -4,8 +4,6 @@
 package cmd // nolint:dupl
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/log"
@@ -28,6 +26,7 @@ var StopCmd = &cobra.Command{
 	PostRunE: func(cmd *cobra.Command, args []string) (err error) {
 		return nil
 	},
+	Args: checkSingleClusterArg,
 }
 
 func init() {
@@ -35,14 +34,9 @@ func init() {
 }
 
 func stop(cmd *cobra.Command, args []string) error {
-	var clusterName string
+	// args have already been checked by StopCmd.Args()
+	clusterName := args[0]
 
-	// validate a cluster name was passed
-	if len(args) < 1 {
-		return fmt.Errorf("must specify cluster name to stop")
-	} else if len(args) == 1 {
-		clusterName = args[0]
-	}
 	log := logger.NewLogger(TtySetting(cmd.Flags()), LoggingVerbosity(cmd))
 
 	log.Eventf(logger.TestTubeEmoji, "Attempting to stop cluster: %s\n", clusterName)

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"runtime"
 	"strconv"
@@ -113,3 +114,14 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 var helpTemplate = `
 {{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+
+// checkSingleClusterArg validates that a single cluster name was passed
+func checkSingleClusterArg(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return errors.New("must specify a cluster name")
+	}
+	if len(args) > 1 {
+		return errors.New("only a single cluster name should be specified")
+	}
+	return nil
+}


### PR DESCRIPTION
## What this PR does / why we need it

Protects against unexpected behaviour of the unmanaged-cluster cli when too many arguments are specified.

## Which issue(s) this PR fixes

Fixes #4842

## Describe testing done for PR

I called unmanaged-cluster sub-command with zero, one and two arguments and verified arguments were properly checked.
For the `uc create` command, I also checked each combo with and without the `-f` and `-e` flags.
Below is a script that can be sourced that tests all combinations:
```
for cmd in config delete start stop;do
  echo \$ uc $cmd
  uc $cmd 2>&1 |head -3
  echo "============"
  echo \$ uc $cmd c1
  uc $cmd c1 2>&1 |head -3
  echo "============"
  echo \$ uc $cmd c1 c2
  uc $cmd c1 c2 2>&1 |head -3
  echo "============"
done

echo \$ uc list
uc list
echo "============"
echo \$ uc list extra_arg
uc list extra_arg 2>&1 |head -3
echo "============"

echo \$ uc create
uc create 2>&1 |head -3
echo "============"
echo \$ uc create c1 -p p
uc create c1 -p p
echo "============"
echo \$ uc create c1 c2
uc create c1 c2 2>&1 |head -3
echo "============"
echo \$ uc create -f test
uc create -f test
echo "============"
echo \$ uc create -e test
uc create -e test
echo "============"
echo \$ uc create c1 -f test
uc create c1 -f test
echo "============"
echo \$ uc create c1 -e test
uc create c1 -e test
echo "============"
echo \$ uc create c1 c2 -f test
uc create c1 c2 -f test 2>&1 |head -3
echo "============"
echo \$ uc create c1 c2 -e test
uc create c1 c2 -e test 2>&1 |head -3
echo "============"
```

## Special notes for your reviewer

Before `tanzu uc list extra` would work but now it won't.  This is technically not backwards-compatible.
