### PR TITLE
Package Repository Update #4856

### DIFF
--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -32,6 +32,7 @@ packages:
     versions:
       - 0.8.0
       - 0.10.0
+      - 0.11.0
   - name: fluent-bit
     versions:
       - 1.7.5
@@ -45,6 +46,7 @@ packages:
     versions:
       - 0.21.2
       - 0.21.5
+      - 0.24.4+update.1
   - name: gatekeeper
     versions:
       - 3.2.3
@@ -65,17 +67,26 @@ packages:
       - 0.22.0
       - 0.26.0
       - 1.0.0
+      - 1.4.0
+      - 1.5.0
   - name: kpack
     versions:
       - 0.5.0
       - 0.5.1
       - 0.5.2
       - 0.5.3
+      - 0.6.0
   - name: kpack-dependencies
     versions:
       - 0.0.9
       - 0.0.22
       - 0.0.27
+      - 0.0.34
+      - 0.0.39
+      - 0.0.48
+  - name: kubeapps
+    versions:
+      - 8.1.7
   - name: local-path-storage
     versions:
       - 0.0.19


### PR DESCRIPTION
## What this PR does / why we need it

Adds packages:
external-dns 0.11.0
fluxcd-source-controller 0.24.4+update.1
knative-serving 1.4.0, 1.5.0
kpack 0.6.0
kpack-dependencies 0.0.34,0.0.39,0.0.48
kubeapps 8.1.7

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4856

## Describe testing done for PR

Successfully updated the package repository on an unmanaged cluster.
```
tanzu package repository update projects.registry.vmware.com-tce-main-0.12.0 -n tanzu-package-repo-global --url projects-stg.registry.vmware.com/tce/main@sha256:3cb6866d20c9c120a72ca53ae040a900c18149bc56b0cc2e4d7a6c7a9bc9d488
```

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
