### PR TITLE
Add exernal-dns 0.11.0+1 to package repo

### DIFF
--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -32,6 +32,7 @@ packages:
     versions:
       - 0.8.0
       - 0.10.0
+      - 0.11.0
   - name: fluent-bit
     versions:
       - 1.7.5


### PR DESCRIPTION
## What this PR does / why we need it

Adds external-dns package v0.11.0+1 version to the main repo so that it's available to community edition users.

## Which issue(s) this PR fixes
NA

## Describe testing done for PR

- Setup a local repository
- Ran the `hack/packages make run` command.
- Pulled the new bundle from the local repo using imgpkg.
- Applied the packages.yaml from the pulled bundle to a local UC.
- Noted the 0.11.0+1 version was present.
- $$$

## Special notes for your reviewer
You're awesome and stay cool!