### PR TITLE
Add dynamic shell completion for unmanaged-cluster

### DIFF
--- a/cli/cmd/plugin/unmanaged-cluster/completion/completion.go
+++ b/cli/cmd/plugin/unmanaged-cluster/completion/completion.go
@@ -1,0 +1,71 @@
+// Copyright 2022 VMware Tanzu Community Edition contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package completion
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/cluster"
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/cmd"
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/config"
+	logger "github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/log"
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/tanzu"
+)
+
+const clusterAnyStatus = ""
+
+func Setup(rootCmd *cobra.Command) {
+	// The below commands accept the names of existing clusters
+	cmd.DeleteCmd.ValidArgsFunction = completeExistingClusterName(clusterAnyStatus)
+	cmd.StartCmd.ValidArgsFunction = completeExistingClusterName(cluster.StatusStopped)
+	cmd.StopCmd.ValidArgsFunction = completeExistingClusterName(cluster.StatusRunning)
+
+	// The below commands should not provide any shell completion choices nor file names
+	cmd.ConfigureCmd.ValidArgsFunction = cobra.NoFileCompletions
+	cmd.CreateCmd.ValidArgsFunction = cobra.NoFileCompletions
+	cmd.ListCmd.ValidArgsFunction = cobra.NoFileCompletions
+}
+
+// completeExistingClusterName returns a completion function that lists all clusters that match
+// the specified clusterStatus.  If clusterStatus is clusterAnyStatus, all clusters will match.
+func completeExistingClusterName(clusterStatus string) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(c *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			// No more args accepted
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		log := logger.NewLogger(false, 0) // No need for logs
+		tClient := tanzu.New(log)
+
+		// Find clusters and their status
+		clusters, err := tClient.List()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		var clusterNames []string
+		for _, c := range clusters {
+			// retrieve status from provider
+			conf := &config.UnmanagedClusterConfig{
+				Provider: c.Provider,
+			}
+			clusterManager := cluster.NewClusterManager(conf)
+			kc, err := clusterManager.Get(c.Name)
+
+			if err != nil {
+				continue
+			}
+
+			// Only complete clusters of the right status, or if the status is unknown.
+			// A value of clusterAnyStatus indicates a request for all clusters.
+			if kc.Status == clusterStatus || kc.Status == cluster.StatusUnknown || clusterStatus == clusterAnyStatus {
+				clusterNames = append(clusterNames, fmt.Sprintf("%s\tstatus: %s - provider: %s", c.Name, kc.Status, c.Provider))
+			}
+		}
+		return clusterNames, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/cli/cmd/plugin/unmanaged-cluster/main.go
+++ b/cli/cmd/plugin/unmanaged-cluster/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin"
 	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/cmd"
+	"github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster/completion"
 )
 
 var description = `Deploy and manage single-node, static, Tanzu clusters.`
@@ -48,6 +49,7 @@ func main() {
 	)
 
 	cmd.SetupRootCommand(p.Cmd)
+	completion.Setup(p.Cmd)
 
 	if err := p.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
## What this PR does / why we need it

This adds dynamic shell completion of cluster names for the different commands of unmanaged-cluster.
It also disables file completion for the cases where file names are not accepted.

Dynamic completion for flag values is not handled yet.

## Which issue(s) this PR fixes

Related to https://github.com/vmware-tanzu/tanzu-framework/issues/701

## Describe testing done for PR

To test you should have unmanaged clusters available:
```
# Create a Running cluster
./unmanaged-cluster create c1

# Create a stopped cluster
./unmanaged-cluster create c2 && ./unmanaged-cluster stop c2

# Create a cluster that will have an Unknown status which will be named kind-c1
./unmanaged-cluster create c3 -e $HOME/.config/tanzu/tkg/unmanaged/c1/kube.conf
```

Setup completion for zsh:
```
autoload -Uz compinit;compinit # just in case completion was never setup

source <(./unmanaged-cluster completion zsh)
compdef _unmanaged-cluster unmanaged-cluster
```
or setup completion for bash:
```
# You need to have installed the bash-completion v2 package if you haven't already
source <(./unmanaged-cluster completion bash)
```
Now run some completion tests
```
# Completion of all cluster names
./unmanaged-cluster delete <tab>

# Completion of stopped or unknown clusters
./unmanaged-cluster start <tab>

# Completion of running or unknown clusters
./unmanaged-cluster stop <tab>

# No file completion or any other completion for the following
./unmanaged-cluster start c2 <tab>
./unmanaged-cluster stop c1 <tab>
./unmanaged-cluster delete c1 <tab>
./unmanaged-cluster list <tab>
./unmanaged-cluster config <tab>
./unmanaged-cluster create <tab>
```

## Special notes for your reviewer

**New package**
I've created a new package `completion` and completely isolated the completion code in it.  This is the approach that was requested for `kubectl`.  For `helm` however, I chose to keep the completion code in the same file as the rest of the command (e.g., in configure.go for the configure command).  The advantage of keeping the completion with the rest of the code is that I find it reduces the risk of forgetting to update it when something changes.  What do we want for TCE?

**Completion descriptions**
Cobra allows to add descriptions to each completion.  It aims to help the user make a decision more easily.
Choosing a good description often requires some experience with the product so I would particularly like your input. 

I chose to add the status and provider, but it may not be useful, or if it is, we could revisit the output format.  I currently _don't_ like the format I chose:
zsh: `cluster1  -- status: Running - provider: kind`
bash: `cluster1       (status: Running - provider: kind)`