### PR TITLE
UI: Centralize init of default CAPI providers

### DIFF
--- a/cli/cmd/plugin/ui/pkg/system/client.go
+++ b/cli/cmd/plugin/ui/pkg/system/client.go
@@ -82,7 +82,7 @@ func NewTkgClient() (*client.TkgClient, error) {
 		ReaderWriterConfigClient: allClients.ConfigClient,
 		RegionManager:            allClients.RegionManager,
 		TKGConfigDir:             configDir,
-		Timeout:                  constants.DefaultOperationTimeout,
+		Timeout:                  constants.DefaultLongRunningOperationTimeout,
 		FeaturesClient:           allClients.FeaturesClient,
 		TKGConfigProvidersClient: allClients.TKGConfigProvidersClient,
 		TKGBomClient:             allClients.TKGBomClient,

--- a/cli/cmd/plugin/ui/server/handlers/aws.go
+++ b/cli/cmd/plugin/ui/server/handlers/aws.go
@@ -51,13 +51,12 @@ func (app *App) ApplyTKGConfigForAWS(params aws.ApplyTKGConfigForAWSParams) midd
 		return aws.NewApplyTKGConfigForAWSInternalServerError().WithPayload(Err(err))
 	}
 
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	awsConfig, err := tkgconfigproviders.New(system.GetConfigDir(), configReaderWriter).NewAWSConfig(convertedParams, encodedCreds)
+	awsConfig, err := tkgconfigproviders.New(system.GetConfigDir(), app.clientTkg.TKGConfigReaderWriter()).NewAWSConfig(convertedParams, encodedCreds)
 	if err != nil {
 		return aws.NewApplyTKGConfigForAWSInternalServerError().WithPayload(Err(err))
 	}
 
-	err = tkgconfigupdater.SaveConfig(app.getFilePathForSavingConfig(), configReaderWriter, awsConfig)
+	err = tkgconfigupdater.SaveConfig(app.getFilePathForSavingConfig(), app.clientTkg.TKGConfigReaderWriter(), awsConfig)
 	if err != nil {
 		return aws.NewApplyTKGConfigForAWSInternalServerError().WithPayload(Err(err))
 	}
@@ -81,30 +80,21 @@ func (app *App) CreateAWSManagementCluster(params aws.CreateAWSManagementCluster
 		return aws.NewCreateAWSManagementClusterInternalServerError().WithPayload(Err(err))
 	}
 
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	awsConfig, err := tkgconfigproviders.New(system.GetConfigDir(), configReaderWriter).NewAWSConfig(convertedParams, encodedCreds)
+	awsConfig, err := tkgconfigproviders.New(system.GetConfigDir(), app.clientTkg.TKGConfigReaderWriter()).NewAWSConfig(convertedParams, encodedCreds)
 	if err != nil {
 		return aws.NewCreateAWSManagementClusterInternalServerError().WithPayload(Err(err))
 	}
 
-	err = tkgconfigupdater.SaveConfig(app.getFilePathForSavingConfig(), configReaderWriter, awsConfig)
-	if err != nil {
-		return aws.NewCreateAWSManagementClusterInternalServerError().WithPayload(Err(err))
-	}
-
-	// TODO: Need to validate this is needed. If so, look at doing this in a better, more centralized
-	// way so all providers can be initialized with it.
-	bomClient := tkgconfigbom.New(system.GetConfigDir(), configReaderWriter)
-	coreProvider, bootstrapProvider, controlPlaneProvider, err := bomClient.GetDefaultClusterAPIProviders()
+	err = tkgconfigupdater.SaveConfig(app.getFilePathForSavingConfig(), app.clientTkg.TKGConfigReaderWriter(), awsConfig)
 	if err != nil {
 		return aws.NewCreateAWSManagementClusterInternalServerError().WithPayload(Err(err))
 	}
 
 	initOptions := &tfclient.InitRegionOptions{
 		InfrastructureProvider: "aws",
-		CoreProvider:           coreProvider,
-		BootstrapProvider:      bootstrapProvider,
-		ControlPlaneProvider:   controlPlaneProvider,
+		CoreProvider:           app.providerDefaults.CoreProvider,
+		BootstrapProvider:      app.providerDefaults.BootstrapProvider,
+		ControlPlaneProvider:   app.providerDefaults.ControlPlaneProvider,
 		ClusterName:            convertedParams.ClusterName,
 		Plan:                   convertedParams.ControlPlaneFlavor,
 		CeipOptIn:              *convertedParams.CeipOptIn,
@@ -150,8 +140,7 @@ func (app *App) ExportAWSConfig(params aws.ExportTKGConfigForAWSParams) middlewa
 	}
 
 	// create the provider object with the configuration data
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	config, err := tkgconfigproviders.New(system.GetConfigDir(), configReaderWriter).NewAWSConfig(convertedParams, encodedCreds)
+	config, err := tkgconfigproviders.New(system.GetConfigDir(), app.clientTkg.TKGConfigReaderWriter()).NewAWSConfig(convertedParams, encodedCreds)
 	if err != nil {
 		return aws.NewExportTKGConfigForAWSInternalServerError().WithPayload(Err(err))
 	}
@@ -241,8 +230,7 @@ func (app *App) GetAWSNodeTypes(params aws.GetAWSNodeTypesParams) middleware.Res
 
 // GetAWSOSImages gets available OS images.
 func (app *App) GetAWSOSImages(params aws.GetAWSOSImagesParams) middleware.Responder {
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	bomConfig, err := tkgconfigbom.New(system.GetConfigDir(), configReaderWriter).GetDefaultTkrBOMConfiguration()
+	bomConfig, err := tkgconfigbom.New(system.GetConfigDir(), app.clientTkg.TKGConfigReaderWriter()).GetDefaultTkrBOMConfiguration()
 	if err != nil {
 		return aws.NewGetAWSOSImagesInternalServerError().WithPayload(Err(err))
 	}

--- a/cli/cmd/plugin/ui/server/handlers/azure.go
+++ b/cli/cmd/plugin/ui/server/handlers/azure.go
@@ -35,13 +35,12 @@ func (app *App) ApplyTKGConfigForAzure(params azure.ApplyTKGConfigForAzureParams
 	}
 
 	filePathForSavingConfig := app.getFilePathForSavingConfig()
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	config, err := tkgconfigproviders.New(system.GetConfigDir(), configReaderWriter).NewAzureConfig(convertedParams)
+	config, err := tkgconfigproviders.New(system.GetConfigDir(), app.clientTkg.TKGConfigReaderWriter()).NewAzureConfig(convertedParams)
 	if err != nil {
 		return azure.NewApplyTKGConfigForAzureInternalServerError().WithPayload(Err(err))
 	}
 
-	err = tkgconfigupdater.SaveConfig(filePathForSavingConfig, configReaderWriter, config)
+	err = tkgconfigupdater.SaveConfig(filePathForSavingConfig, app.clientTkg.TKGConfigReaderWriter(), config)
 	if err != nil {
 		return azure.NewApplyTKGConfigForAzureInternalServerError().WithPayload(Err(err))
 	}
@@ -61,13 +60,12 @@ func (app *App) CreateAzureManagementCluster(params azure.CreateAzureManagementC
 	}
 
 	filePathForSavingConfig := app.getFilePathForSavingConfig()
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	azureConfig, err := tkgconfigproviders.New(system.GetConfigDir(), configReaderWriter).NewAzureConfig(convertedParams)
+	azureConfig, err := tkgconfigproviders.New(system.GetConfigDir(), app.clientTkg.TKGConfigReaderWriter()).NewAzureConfig(convertedParams)
 	if err != nil {
 		return azure.NewCreateAzureManagementClusterInternalServerError().WithPayload(Err(err))
 	}
 
-	err = tkgconfigupdater.SaveConfig(filePathForSavingConfig, configReaderWriter, azureConfig)
+	err = tkgconfigupdater.SaveConfig(filePathForSavingConfig, app.clientTkg.TKGConfigReaderWriter(), azureConfig)
 	if err != nil {
 		return azure.NewCreateAzureManagementClusterInternalServerError().WithPayload(Err(err))
 	}
@@ -76,32 +74,32 @@ func (app *App) CreateAzureManagementCluster(params azure.CreateAzureManagementC
 	if params.Params.ResourceGroup == "" {
 		return azure.NewCreateAzureManagementClusterInternalServerError().WithPayload(Err(errors.New("azure resource group name cannot be empty")))
 	}
-	configReaderWriter.Set(constants.ConfigVariableAzureResourceGroup, params.Params.ResourceGroup)
+	app.clientTkg.TKGConfigReaderWriter().Set(constants.ConfigVariableAzureResourceGroup, params.Params.ResourceGroup)
 
 	if params.Params.VnetResourceGroup == "" {
 		return azure.NewCreateAzureManagementClusterInternalServerError().WithPayload(Err(errors.New("azure vnet resource group name cannot be empty")))
 	}
-	configReaderWriter.Set(constants.ConfigVariableAzureVnetResourceGroup, params.Params.VnetResourceGroup)
+	app.clientTkg.TKGConfigReaderWriter().Set(constants.ConfigVariableAzureVnetResourceGroup, params.Params.VnetResourceGroup)
 
 	if params.Params.VnetName == "" {
 		return azure.NewCreateAzureManagementClusterInternalServerError().WithPayload(Err(errors.New("azure vnet name cannot be empty")))
 	}
-	configReaderWriter.Set(constants.ConfigVariableAzureVnetName, params.Params.VnetName)
+	app.clientTkg.TKGConfigReaderWriter().Set(constants.ConfigVariableAzureVnetName, params.Params.VnetName)
 
 	if params.Params.ControlPlaneSubnet == "" {
 		return azure.NewCreateAzureManagementClusterInternalServerError().WithPayload(Err(errors.New("azure controlplane subnet name cannot be empty")))
 	}
-	configReaderWriter.Set(constants.ConfigVariableAzureControlPlaneSubnet, params.Params.ControlPlaneSubnet)
+	app.clientTkg.TKGConfigReaderWriter().Set(constants.ConfigVariableAzureControlPlaneSubnet, params.Params.ControlPlaneSubnet)
 
 	if params.Params.WorkerNodeSubnet == "" {
 		return azure.NewCreateAzureManagementClusterInternalServerError().WithPayload(Err(errors.New("azure node subnet name cannot be empty")))
 	}
-	configReaderWriter.Set(constants.ConfigVariableAzureWorkerSubnet, params.Params.WorkerNodeSubnet)
+	app.clientTkg.TKGConfigReaderWriter().Set(constants.ConfigVariableAzureWorkerSubnet, params.Params.WorkerNodeSubnet)
 
 	if params.Params.VnetCidr != "" { // create new vnet
-		configReaderWriter.Set(constants.ConfigVariableAzureVnetCidr, params.Params.VnetCidr)
-		configReaderWriter.Set(constants.ConfigVariableAzureControlPlaneSubnetCidr, params.Params.ControlPlaneSubnetCidr)
-		configReaderWriter.Set(constants.ConfigVariableAzureWorkerNodeSubnetCidr, params.Params.WorkerNodeSubnetCidr)
+		app.clientTkg.TKGConfigReaderWriter().Set(constants.ConfigVariableAzureVnetCidr, params.Params.VnetCidr)
+		app.clientTkg.TKGConfigReaderWriter().Set(constants.ConfigVariableAzureControlPlaneSubnetCidr, params.Params.ControlPlaneSubnetCidr)
+		app.clientTkg.TKGConfigReaderWriter().Set(constants.ConfigVariableAzureWorkerNodeSubnetCidr, params.Params.WorkerNodeSubnetCidr)
 	}
 
 	initOptions := &tfclient.InitRegionOptions{
@@ -160,8 +158,7 @@ func (app *App) ExportAzureConfig(params azure.ExportTKGConfigForAzureParams) mi
 		return azure.NewExportTKGConfigForAzureInternalServerError().WithPayload(Err(err))
 	}
 
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	config, err := tkgconfigproviders.New(system.GetConfigDir(), configReaderWriter).NewAzureConfig(convertedParams)
+	config, err := tkgconfigproviders.New(system.GetConfigDir(), app.clientTkg.TKGConfigReaderWriter()).NewAzureConfig(convertedParams)
 	if err != nil {
 		return azure.NewExportTKGConfigForAzureInternalServerError().WithPayload(Err(err))
 	}
@@ -202,8 +199,7 @@ func (app *App) GetAzureInstanceTypes(params azure.GetAzureInstanceTypesParams) 
 
 // GetAzureOSImages gets OS information for Azure.
 func (app *App) GetAzureOSImages(params azure.GetAzureOSImagesParams) middleware.Responder {
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	bomConfig, err := tkgconfigbom.New(system.GetConfigDir(), configReaderWriter).GetDefaultTkrBOMConfiguration()
+	bomConfig, err := tkgconfigbom.New(system.GetConfigDir(), app.clientTkg.TKGConfigReaderWriter()).GetDefaultTkrBOMConfiguration()
 	if err != nil {
 		return azure.NewGetAzureOSImagesInternalServerError().WithPayload(Err(err))
 	}

--- a/cli/cmd/plugin/ui/server/handlers/docker.go
+++ b/cli/cmd/plugin/ui/server/handlers/docker.go
@@ -32,7 +32,7 @@ func (app *App) CheckIfDockerDaemonAvailable(params docker.CheckIfDockerDaemonAv
 
 // ApplyTKGConfigForDocker applies the TKG configuration for Docker.
 func (app *App) ApplyTKGConfigForDocker(params docker.ApplyTKGConfigForDockerParams) middleware.Responder {
-	err := app.saveConfig(params.Params, app.clientTkg)
+	err := app.saveConfig(params.Params)
 	if err != nil {
 		return docker.NewApplyTKGConfigForDockerInternalServerError().WithPayload(Err(err))
 	}
@@ -42,7 +42,7 @@ func (app *App) ApplyTKGConfigForDocker(params docker.ApplyTKGConfigForDockerPar
 
 // CreateDockerManagementCluster creates a new management cluster using the CAPD provider.
 func (app *App) CreateDockerManagementCluster(params docker.CreateDockerManagementClusterParams) middleware.Responder {
-	err := app.saveConfig(params.Params, app.clientTkg)
+	err := app.saveConfig(params.Params)
 	if err != nil {
 		return docker.NewCreateDockerManagementClusterInternalServerError().WithPayload(Err(err))
 	}
@@ -86,14 +86,13 @@ func (app *App) ExportDockerConfig(params docker.ExportTKGConfigForDockerParams)
 }
 
 // saveConfig parses and saves a cluster configuration.
-func (app *App) saveConfig(params *models.DockerManagementClusterParams, tkgClient *client.TkgClient) error {
+func (app *App) saveConfig(params *models.DockerManagementClusterParams) error {
 	config, err := paramsToDockerConfig(params)
 	if err != nil {
 		return err
 	}
 
-	configReaderWriter := tkgClient.TKGConfigReaderWriter()
-	err = tkgconfigupdater.SaveConfig(app.getFilePathForSavingConfig(), configReaderWriter, config)
+	err = tkgconfigupdater.SaveConfig(app.getFilePathForSavingConfig(), app.clientTkg.TKGConfigReaderWriter(), config)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/plugin/ui/server/handlers/vsphere.go
+++ b/cli/cmd/plugin/ui/server/handlers/vsphere.go
@@ -33,13 +33,12 @@ func (app *App) ApplyTKGConfigForVsphere(params vsphere.ApplyTKGConfigForVsphere
 	}
 
 	filePathForSavingConfig := app.getFilePathForSavingConfig()
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	config, err := tkgconfigproviders.New(system.GetConfigDir(), configReaderWriter).NewVSphereConfig(convertedParams)
+	config, err := tkgconfigproviders.New(system.GetConfigDir(), app.clientTkg.TKGConfigReaderWriter()).NewVSphereConfig(convertedParams)
 	if err != nil {
 		return vsphere.NewApplyTKGConfigForVsphereInternalServerError().WithPayload(Err(err))
 	}
 
-	err = tkgconfigupdater.SaveConfig(filePathForSavingConfig, configReaderWriter, config)
+	err = tkgconfigupdater.SaveConfig(filePathForSavingConfig, app.clientTkg.TKGConfigReaderWriter(), config)
 	if err != nil {
 		return vsphere.NewApplyTKGConfigForVsphereInternalServerError().WithPayload(Err(err))
 	}
@@ -54,13 +53,12 @@ func (app *App) CreateVSphereManagementCluster(params vsphere.CreateVSphereManag
 		return vsphere.NewCreateVSphereManagementClusterInternalServerError().WithPayload(Err(err))
 	}
 
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	config, err := tkgconfigproviders.New(system.GetConfigDir(), configReaderWriter).NewVSphereConfig(convertedParams)
+	config, err := tkgconfigproviders.New(system.GetConfigDir(), app.clientTkg.TKGConfigReaderWriter()).NewVSphereConfig(convertedParams)
 	if err != nil {
 		return vsphere.NewCreateVSphereManagementClusterInternalServerError().WithPayload(Err(err))
 	}
 
-	err = tkgconfigupdater.SaveConfig(app.getFilePathForSavingConfig(), configReaderWriter, config)
+	err = tkgconfigupdater.SaveConfig(app.getFilePathForSavingConfig(), app.clientTkg.TKGConfigReaderWriter(), config)
 	if err != nil {
 		return vsphere.NewCreateVSphereManagementClusterInternalServerError().WithPayload(Err(err))
 	}
@@ -95,8 +93,7 @@ func (app *App) ExportVSphereConfig(params vsphere.ExportTKGConfigForVspherePara
 		return vsphere.NewExportTKGConfigForVsphereInternalServerError().WithPayload(Err(err))
 	}
 
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	config, err := tkgconfigproviders.New(system.GetConfigDir(), configReaderWriter).NewVSphereConfig(convertedParams)
+	config, err := tkgconfigproviders.New(system.GetConfigDir(), app.clientTkg.TKGConfigReaderWriter()).NewVSphereConfig(convertedParams)
 	if err != nil {
 		return vsphere.NewExportTKGConfigForVsphereInternalServerError().WithPayload(Err(err))
 	}
@@ -190,8 +187,7 @@ func (app *App) GetVsphereOSImages(params vsphere.GetVSphereOSImagesParams) midd
 		return vsphere.NewGetVSphereOSImagesInternalServerError().WithPayload(Err(err))
 	}
 
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	defaultTKRBom, err := tkgconfigbom.New(system.GetConfigDir(), configReaderWriter).GetDefaultTkrBOMConfiguration()
+	defaultTKRBom, err := tkgconfigbom.New(system.GetConfigDir(), app.clientTkg.TKGConfigReaderWriter()).GetDefaultTkrBOMConfiguration()
 	if err != nil {
 		return vsphere.NewGetVSphereOSImagesInternalServerError().WithPayload(Err(errors.Wrap(err, "unable to get the default TanzuKubernetesRelease")))
 	}
@@ -263,8 +259,7 @@ func (app *App) SetVSphereEndpoint(params vsphere.SetVSphereEndpointParams) midd
 	vcURL.Path = "/sdk"
 
 	vsphereInsecure := false
-	configReaderWriter := app.clientTkg.TKGConfigReaderWriter()
-	vsphereInsecureString, err := configReaderWriter.Get(constants.ConfigVariableVsphereInsecure)
+	vsphereInsecureString, err := app.clientTkg.TKGConfigReaderWriter().Get(constants.ConfigVariableVsphereInsecure)
 	if err == nil {
 		vsphereInsecure = (vsphereInsecureString == trueStr)
 	}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

In addition to the infrastructure provider, there are a set of other
providers that need to be specified when creating a cluster. This was
proven out by making changes specifically for the AWS provider, but the
same thing needs to happen for all other infrastructure.

To support this, this moves the discovery of those defaults from the BOM
file into the app-wide initialization so all infra provider workflows
have easy access to these values.

Also increases our default timeout to allow for long running operations.
The default was previously set very low. This changes it to 30 minutes
so operations like management cluster operation can complete.