### PR TITLE
uninstall docs: edit to include missing escape command

### DIFF
--- a/docs/site/content/docs/edge/cli-uninstall.md
+++ b/docs/site/content/docs/edge/cli-uninstall.md
@@ -22,7 +22,7 @@ Complete the following steps to uninstall the Tanzu CLI and any associated confi
    ~/Library/Application\ Support/tce/uninstall.sh
    ```
 
-   The `~/Library/ApplicationSupport/tce` folder is deleted.
+   The `~/Library/Application Support/tce` folder is deleted.
 
 ## Windows
 

--- a/docs/site/content/docs/edge/cli-uninstall.md
+++ b/docs/site/content/docs/edge/cli-uninstall.md
@@ -8,31 +8,31 @@ Complete the following steps to uninstall the Tanzu CLI and any associated confi
 
 1. Run the following command to uninstall the Tanzu CLI:
 
-    ```sh
-    ~/.local/share/tce/uninstall.sh
-    ```
+   ```sh
+   ~/.local/share/tce/uninstall.sh
+   ```
 
-    The `~/.local/share/tce` folder is deleted.
+   The `~/.local/share/tce` folder is deleted.
 
 ## MacOS
 
 1. Run the following command to uninstall the Tanzu CLI:
 
-    ```sh
-    ~/Library/Application Support/tce/uninstall.sh
-    ```
+   ```sh
+   ~/Library/Application\ Support/tce/uninstall.sh
+   ```
 
-    The `~/Library/Application Support/tce` folder is deleted.
+   The `~/Library/ApplicationSupport/tce` folder is deleted.
 
 ## Windows
 
 1. Open a Command Prompt as an administrator and run the following command to uninstall the Tanzu CLI:
 
-    ```sh
-    run uninstall.bat
-    ```
+   ```sh
+   run uninstall.bat
+   ```
 
-    The `%LocalAppData%\tce` folder is deleted.
+   The `%LocalAppData%\tce` folder is deleted.
 
 For information about how to delete a management and workload cluster, see:
 


### PR DESCRIPTION
## What this PR does / why we need it
This PR edits the docs to include a backslash symbol needed in the uninstall command. This is needed for clarity and accuracy of the command to run to uninstall.


## Which issue(s) this PR fixes

Fixes #4737 

## Describe testing done for PR
Ran command without escape symbol. It did not work. Ran command again with escape symbol, which worked.

## Special notes for your reviewer
Regarding TCE Makefile, target skipped/not applicable. 