### PR TITLE
Bump prometheus version to v2.36.2

### DIFF
--- a/addons/packages/prometheus/2.36.2/README.md
+++ b/addons/packages/prometheus/2.36.2/README.md
@@ -1,0 +1,148 @@
+# Prometheus
+
+A time series database for your metrics.
+
+## Supported Providers
+
+The following table shows the providers this package can work with.
+
+| AWS  |  Azure  | vSphere  | Docker |
+|:---:|:---:|:---:|:---:|
+| ✅  |  ✅  | ✅  | ✅ |
+
+## Components
+
+- A Prometheus server and corresponding alert manager
+
+## Configuration
+
+> Note: Ingress for Prometheus server is not available by default, and can be activated using the `ingress.enabled` configuration field.
+>
+> If you choose to activate the Contour-based Ingress, `Contour` must also be installed on the target cluster. Additionally, enabling the Ingress requires either `Cert Manager` or your own user-provided TLS certificate (`ingress.tlsCertificate.tls.crt` and `ingress.tlsCertificate.tls.key`) to configure TLS settings for the Ingress. For ad-hoc Prometheus UI access without an Ingress, use `kubectl port-forward`.
+
+The following configuration values can be set to customize the Prometheus/Alertmanager installation.
+
+| Parameter                                                  | Description                                                                                                          | Type      | Default                 |
+|:------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------|:-----------|:-------------------------|
+| namespace                                                  | Namespace where Prometheus will be deployed                                                                          | string    | prometheus              |
+| `prometheus.deployment.replicas`                             | Number of Prometheus replicas                                                                                        | integer   | 1                       |
+| `prometheus.deployment.updateStrategy`                  | Type of prometheus upgrade strategy. Supported Values: RollingUpdate, Recreate                                                       | string      | Recreate                   |
+| `prometheus.deployment.rollingUpdate.maxUnavailable`    | Number of maxUnavailable pods when prometheus is upgrading, It only work when updateStrategy is RollingUpdate                        | integer Or string     | null                       |
+| `prometheus.deployment.rollingUpdate.maxSurge`          | Number of maxSurge pods when prometheus is upgrading, It only work when updateStrategy is RollingUpdate                        | integer Or string     | null                       |
+| `prometheus.deployment.containers.args`                      | Prometheus container arguments                                                                                       | list      |                         |
+| `prometheus.deployment.containers.resources`                 | Prometheus container resource requests and limits                                                                    | map       | {}                      |
+| `prometheus.deployment.podAnnotations`                       | The Prometheus deployments pod annotations                                                                           | map       | {}                      |
+| `prometheus.deployment.podLabels`                            | The Prometheus deployments pod labels                                                                                | map       | {}                      |
+| `prometheus.deployment.configMapReload.containers.args`      | Configmap-reload container arguments.                                                                                | list      |                         |
+| `prometheus.deployment.configMapReload.containers.resources` | Configmap-reload container resource requests and limits                                                              | map       | {}                      |
+| `prometheus.service.type`                                    | Type of service to expose Prometheus. Supported Values: ClusterIP                                                    | string    | ClusterIP               |
+| `prometheus.service.port`                                    | Prometheus service port                                                                                              | integer   | 80                      |
+| `prometheus.service.targetPort`                              | Prometheus service target port                                                                                       | integer   | 9090                    |
+| `prometheus.service.labels`                                  | Prometheus service labels                                                                                            | map       | {}                      |
+| `prometheus.service.annotations`                             | Prometheus service annotations                                                                                       | map       | {}                      |
+| `prometheus.pvc.annotations`                                 | Storage class annotations                                                                                            | map       | {}                      |
+| `prometheus.pvc.storageClassName`                            | Storage class to use for persistent volume claim. By default this is null and default provisioner is used            | string    | null                    |
+| `prometheus.pvc.accessMode`                                  | Define access mode for persistent volume claim. Supported values: ReadWriteOnce, ReadOnlyMany, ReadWriteMany         | string    | ReadWriteOnce           |
+| `prometheus.pvc.storage`                                     | Define storage size for persistent volume claim                                                                      | string    | 150Gi                   |
+| `prometheus.config.prometheus_yml`                           | The [global Prometheus configuration](https://www.prometheus.io/docs/prometheus/latest/configuration/configuration/) | yaml file | prometheus.yaml         |
+| `prometheus.config.alerting_rules_yml`                       | The [Prometheus alerting rules](https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)      | yaml file | alerting_rules.yaml     |
+| `prometheus.config.recording_rules_yml`                      | The [prometheus recording rules](https://www.prometheus.io/docs/prometheus/latest/configuration/recording_rules/)    | yaml file | recording_rules.yaml    |
+| `prometheus.config.alerts_yml`                               | Additional Prometheus alerting rules can be configured here.                                                         | yaml file | alerts_yml.yaml         |
+| `prometheus.config.rules_yml`                                | Additional Prometheus recording rules can be configured here.                                                        | yaml file | rules_yml.yaml          |
+| `alertmanager.deployment.replicas`                           | Number of alertmanager replicas                                                                                      | integer   | 1                       |
+| `alertmanager.deployment.updateStrategy`                  | Type of prometheus upgrade strategy. Supported Values: RollingUpdate, Recreate                                                       | string      | Recreate                   |
+| `alertmanager.deployment.rollingUpdate.maxUnavailable`    | Number of maxUnavailable pods when alertmanager is upgrading, It only work when updateStrategy is RollingUpdate                        | integer Or string     | null                       |
+| `alertmanager.deployment.rollingUpdate.maxSurge`          | Number of maxSurge pods when alertmanager is upgrading, It only work when updateStrategy is RollingUpdate                        | integer Or string     | null                       |
+| `alertmanager.deployment.containers.resources`               | Alertmanager container resource requests and limits                                                                  | map       | {}                      |
+| `alertmanager.deployment.podAnnotations`                     | The Alertmanager deployments pod annotations                                                                         | map       | {}                      |
+| `alertmanager.deployment.podLabels`                          | The Alertmanager deployments pod labels                                                                              | map       | {}                      |
+| `alertmanager.service.type`                                  | Type of service to expose Alertmanager. Supported Values: ClusterIP                                                  | string    | ClusterIP               |
+| `alertmanager.service.port`                                  | Alertmanager service port                                                                                            | integer   | 80                      |
+| `alertmanager.service.targetPort`                            | Alertmanager service target port                                                                                     | integer   | 9093                    |
+| `alertmanager.service.labels`                               | Alertmanager service labels                                                                                          | map       | {}                      |
+| `alertmanager.service.annotations`                           | Alertmanager service annotations                                                                                     | map       | {}                      |
+| `alertmanager.pvc.annotations`                               | Storage class annotations                                                                                            | map       | {}                      |
+| `alertmanager.pvc.storageClassName`                          | Storage class to use for persistent volume claim. By default this is null and default provisioner is used.           | string    | null                    |
+| `alertmanager.pvc.accessMode`                                | Define access mode for persistent volume claim. Supported values: ReadWriteOnce, ReadOnlyMany, ReadWriteMany         | string    | ReadWriteOnce           |
+| `alertmanager.pvc.storage`                                   | Define storage size for persistent volume claim                                                                      | string    | 2Gi                     |
+| `alertmanager.config.alertmanager_yml`                       | The [global yaml configuration for alert manager](https://www.prometheus.io/docs/alerting/latest/configuration/).    | yaml file | alertmanager_yml        |
+| `kube_state_metrics.deployment.replicas`                     | Number of kube-state-metrics replicas                                                                                | integer   | 1                       |
+| `kube_state_metrics.deployment.containers.resources`         | kube-state-metrics container resource requests and limits                                                            | map       | {}                      |
+| `kube_state_metrics.deployment.podAnnotations`               | The kube-state-metrics deployments pod annotations                                                                   | map       | {}                      |
+| `kube_state_metrics.deployment.podLabels`                    | The kube-state-metrics deployments pod labels                                                                        | map       | {}                      |
+| `kube_state_metrics.service.type`                            | Type of service to expose kube-state-metrics. Supported Values: ClusterIP                                            | string    | ClusterIP               |
+| `kube_state_metrics.service.port`                            | kube-state-metrics service port                                                                                      | integer   | 80                      |
+| `kube_state_metrics.service.targetPort`                      | kube-state-metrics service target port                                                                               | integer   | 8080                    |
+| `kube_state_metrics.service.telemetryPort`                   | kube-state-metrics service telemetry port                                                                            | integer   | 81                      |
+| `kube_state_metrics.service.telemetryTargetPort`            | kube-state-metrics service target telemetry  port                                                                    | integer   | 8081                    |
+| `kube_state_metrics.service.labels`                          | kube-state-metrics service labels                                                                                    | map       | {}                      |
+| ``kube_state_metrics.service.annotations``                     | kube-state-metrics service annotations                                                                               | map       | {}                      |
+| `node_exporter.daemonset.replicas`                           | Number of node-exporter replicas                                                                                     | integer   | 1                       |
+| `node_exporter.daemonset.containers.resources`               | node-exporter container resource requests and limits                                                                 | map       | {}                      |
+| `node_exporter.daemonset.hostNetwork`                        |  Host networking requested for this pod                                                                              | boolean   | false                   |
+| `node_exporter.daemonset.podAnnotations`                     | The node-exporter deployments pod annotations                                                                        | map       | {}                      |
+| `node_exporter.daemonset.podLabels`                          | The node-exporter deployments pod labels                                                                             | map       | {}                      |
+| `node_exporter.service.type`                                 | Type of service to expose node-exporter. Supported Values: ClusterIP                                                 | string    | ClusterIP               |
+| `node_exporter.service.port`                                 | node-exporter service port                                                                                           | integer   | 9100                    |
+| `node_exporter.service.targetPort`                           | node-exporter service target port                                                                                    | integer   | 9100                    |
+| `node_exporter.service.labels`                               | node-exporter service labels                                                                                         | map       | {}                      |
+| `node_exporter.service.annotations`                          | node-exporter service annotations                                                                                    | map       | {}                      |
+| `pushgateway.deployment.replicas`                            | Number of pushgateway replicas                                                                                       | integer   | 1                       |
+| `pushgateway.deployment.containers.resources`                | pushgateway container resource requests and limits                                                                   | map       | {}                      |
+| `pushgateway.deployment.podAnnotations`                      | The pushgateway deployments pod annotations                                                                          | map       | {}                      |
+| `pushgateway.deployment.podLabels`                           | The pushgateway deployments pod labels                                                                               | map       | {}                      |
+| `pushgateway.service.type`                                  | Type of service to expose pushgateway. Supported Values: ClusterIP                                                   | string    | ClusterIP               |
+| `pushgateway.service.port`                                   | pushgateway service port                                                                                             | integer   | 9091                    |
+| `pushgateway.service.targetPort`                             | pushgateway service target port                                                                                      | integer   | 9091                    |
+| `pushgateway.service.labels`                                 | pushgateway service labels                                                                                           | map       | {}                      |
+| `pushgateway.service.annotations`                            | pushgateway service annotations                                                                                      | map       | {}                      |
+| `cadvisor.daemonset.replicas`                                | Number of cadvisor replicas                                                                                          | integer   | 1                       |
+| `cadvisor.daemonset.containers.resources`                    | cadvisor container resource requests and limits                                                                      | map       | {}                      |
+| `cadvisor.daemonset.podAnnotations`                          | The cadvisor deployments pod annotations                                                                             | map       | {}                      |
+| `cadvisor.daemonset.podLabels`                               | The cadvisor deployments pod labels                                                                                  | map       | {}                      |
+| `ingress.enabled`                                            | Activate/deactivate ingress for prometheus and alertmanager                                                               | boolean   | false                   |
+| `ingress.virtual_host_fqdn`                                  | Hostname for accessing prometheus and alertmanager                                                                   | string    | prometheus.system.tanzu |
+| `ingress.prometheus_prefix`                                  | Path prefix for prometheus                                                                                           | string    | /                       |
+| `ingress.alertmanager_prefix`                               | Path prefix for alertmanager                                                                                         | string    | /alertmanager/          |
+| `ingress.prometheusServicePort`                              | Prometheus service port to proxy traffic to                                                                          | integer   | 80                      |
+| `ingress.alertmanagerServicePort`                            | Alertmanager service port to proxy traffic to                                                                        | integer   | 80                      |
+| `ingress.tlsCertificate.tls.crt`                             | Optional cert for ingress if you want to use your own TLS cert. A self signed cert is generated by default           | string    | Generated cert          |
+| `ingress.tlsCertificate.tls.key`                             | Optional cert private key for ingress if you want to use your own TLS cert.                                          | string    | Generated cert key      |
+| `ingress.tlsCertificate.ca.crt`                              | Optional CA certificate                                                                                              | string    | CA certificate          |
+
+### Config files
+
+The various configuration files can be loaded from `/etc/config/`.
+For example, when loading `rule_files`:
+
+```text
+rule_files:
+- /etc/config/alerting_rules.yml
+- /etc/config/recording_rules.yml
+- /etc/config/alerts
+- /etc/config/rules
+```
+
+### Alert manager service
+
+The alert manager can be targeted by the deployed prometheus through it's service.
+For example:
+
+```text
+targets:
+- alertmanager.prometheus.svc:9093
+```
+
+`alertmanager` is the default service name and `prometheus` is the namespace of the alertmanager deployment.
+
+## Usage Example
+
+The default `prometheus.yml` configuration will deploy a prometheus server
+that will scrape metrics from pods that emit metrics
+on an endpoint and has the following annotations:
+
+```yaml
+prometheus.io/scrape: 'true'
+prometheus.io/path: '/metrics'
+prometheus.io/port: '8080'
+```

--- a/addons/packages/prometheus/2.36.2/bundle/.imgpkg/bundle.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/.imgpkg/bundle.yaml
@@ -1,0 +1,9 @@
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: Bundle
+metadata:
+  name: prometheus
+authors:
+- name: Ke Zhou
+  email: kez1@vmware.com
+websites:
+- url: vmware.com

--- a/addons/packages/prometheus/2.36.2/bundle/.imgpkg/images.yml
+++ b/addons/packages/prometheus/2.36.2/bundle/.imgpkg/images.yml
@@ -1,0 +1,53 @@
+---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- annotations:
+    kbld.carvel.dev/id: bitnami/kube-state-metrics:2.5.0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 2.5.0
+          url: bitnami/kube-state-metrics:2.5.0
+  image: index.docker.io/bitnami/kube-state-metrics@sha256:ec924a2e04520abbb49d6204f54d52d9c4ba50cb44bc0031ef0daba443174954
+- annotations:
+    kbld.carvel.dev/id: gcr.io/cadvisor/cadvisor:v0.44.0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v0.44.0
+          url: gcr.io/cadvisor/cadvisor:v0.44.0
+  image: gcr.io/cadvisor/cadvisor@sha256:ef1e224267584fc9cb8d189867f178598443c122d9068686f9c3898c735b711f
+- annotations:
+    kbld.carvel.dev/id: jimmidyson/configmap-reload:v0.7.1
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v0.7.1
+          url: jimmidyson/configmap-reload:v0.7.1
+  image: index.docker.io/jimmidyson/configmap-reload@sha256:9460ee0615c286576206fc5ed0d366dc1bab6707fdc5d647219d4bcdae983271
+- annotations:
+    kbld.carvel.dev/id: prom/alertmanager:v0.24.0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v0.24.0
+          url: prom/alertmanager:v0.24.0
+  image: index.docker.io/prom/alertmanager@sha256:088464f949de8065b9da7dfce7302a633d700e9d598e2bebc03310712f083b31
+- annotations:
+    kbld.carvel.dev/id: prom/prometheus:v2.36.2
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v2.36.2
+          url: prom/prometheus:v2.36.2
+  image: index.docker.io/prom/prometheus@sha256:df0cd5887887ec393c1934c36c1977b69ef3693611932c3ddeae8b7a412059b9
+- annotations:
+    kbld.carvel.dev/id: prom/pushgateway:v1.4.3
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v1.4.3
+          url: prom/pushgateway:v1.4.3
+  image: index.docker.io/prom/pushgateway@sha256:3496e0f859434b60e6e6eccbc1dddf33adad9a9eb19592dc4ed4a4bf167a844d
+- annotations:
+    kbld.carvel.dev/id: quay.io/prometheus/node-exporter:v1.3.1
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v1.3.1
+          url: quay.io/prometheus/node-exporter:v1.3.1
+  image: quay.io/prometheus/node-exporter@sha256:f2269e73124dd0f60a7d19a2ce1264d33d08a985aed0ee6b0b89d0be470592cd
+kind: ImagesLock

--- a/addons/packages/prometheus/2.36.2/bundle/config/certificates.lib.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/certificates.lib.yaml
@@ -1,0 +1,178 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:template", "template")
+#@ load("@ytt:yaml", "yaml")
+
+#@ def get_issuer():
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: "issuer"
+  namespace: "issuer-namespace"
+spec: {}
+#@ end
+
+#@ def self_signed_issuer():
+spec:
+  #@overlay/match missing_ok=True
+  selfSigned: {}
+#@ end
+
+#@ def ca_issuer():
+spec:
+  #@overlay/match missing_ok=True
+  ca:
+    secretName: "ca-key-pair"
+#@ end
+
+#@ def ca_secret(secret_name):
+spec:
+  ca:
+    secretName: #@ secret_name
+#@ end
+
+#@ def get_self_signed_issuer():
+#@   return overlay.apply(get_issuer(), self_signed_issuer())
+#@ end
+
+#@ def get_ca_issuer():
+#@   return overlay.apply(get_issuer(), ca_issuer())
+#@ end
+
+#@ def generate_self_signed_issuer(name, namespace):
+#@   return overlay.apply(get_self_signed_issuer(), metadata(name, namespace))
+#@ end
+
+#@ def generate_ca_issuer(name, namespace, secret_name):
+#@   return overlay.apply(get_ca_issuer(), metadata(name, namespace), ca_secret(secret_name))
+#@ end
+
+#@ def get_certificate():
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "certificate"
+  namespace: "certificate-namespace"
+spec:
+  secretName: "ca-key-pair"
+  duration: 8760h
+  renewBefore: 360h
+  organization: []
+  commonName: "certificate"
+  isCA: false
+  keySize: 2048
+  keyAlgorithm: rsa
+  keyEncoding: pkcs1
+  usages:
+    - server auth
+    - client auth
+  dnsNames: []
+  ipAddresses: []
+  issuerRef:
+    name: "ca-issuer"
+    kind: Issuer
+    group: cert-manager.io
+
+#@ end
+
+#@ def ca_certificate(isCA):
+spec:
+  isCA: #@ isCA
+#@ end
+
+#@ def ip_address(ips):
+spec:
+  #@overlay/replace
+  ipAddresses:
+  #@ for ip in ips:
+    - #@ ip
+  #@ end
+#@ end
+
+#@ def server_certificate():
+spec:
+  #@overlay/replace
+  usages:
+    - server auth
+#@ end
+
+#@ def client_certificate():
+spec:
+  #@overlay/replace
+  usages:
+    - client auth
+#@ end
+
+#@ def get_certificate_with_params(args):
+#@   return overlay.apply(get_certificate(), ca_certificate(args[0]), ip_address(args[1]))
+#@ end
+
+#@ def get_ca_certificate():
+#@   return overlay.apply(get_certificate(), ca_certificate(True))
+#@ end
+
+#@ def get_server_certificate():
+#@   return overlay.apply(get_certificate(), server_certificate())
+#@ end
+
+#@ def get_client_certificate():
+#@   return overlay.apply(get_certificate(), client_certificate())
+#@ end
+
+#@ def metadata(name, namespace):
+metadata:
+  name: #@ name
+  namespace: #@ namespace
+#@ end
+
+#@ def certificate_secret(secret_name):
+spec:
+  secretName: #@ secret_name
+#@ end
+
+#@ def certificate_details(duration, renew_before, organizations, common_name, dns_names):
+spec:
+  duration: #@ duration
+  renewBefore: #@ renew_before
+  #@overlay/replace
+  organization: #@ organizations
+  commonName: #@ common_name
+  #@overlay/replace
+  dnsNames: #@ dns_names
+#@ end
+
+#@ def certificate_issuer(issuer_name):
+spec:
+  issuerRef:
+    name: #@ issuer_name
+#@ end
+
+#@ def generate_dns_names(name, namespace):
+#@   full_name = name + "." + namespace
+#@   svc_name = full_name + ".svc"
+#@   svc_cluster_local_name = svc_name + ".cluster.local"
+#@   return [name, full_name, svc_name, svc_cluster_local_name]
+#@ end
+
+#@ def certificate_generate_args(certificate_func, name, namespace, duration, renew_before, secret_name, organizations, common_name, dns_names, issuer_name, args):
+#@  return overlay.apply(certificate_func(args), metadata(name, namespace), certificate_secret(secret_name), certificate_details(duration, renew_before, organizations, common_name, dns_names), certificate_issuer(issuer_name))
+#@ end
+
+#@ def certificate_generate(certificate_func, name, namespace, duration, renew_before, secret_name, organizations, common_name, dns_names, issuer_name):
+#@  return overlay.apply(certificate_func(), metadata(name, namespace), certificate_secret(secret_name), certificate_details(duration, renew_before, organizations, common_name, dns_names), certificate_issuer(issuer_name))
+#@ end
+
+#@ def generate_certificate(name, namespace, duration, renew_before, secret_name, organizations, common_name, dns_names, issuer_name):
+#@   return certificate_generate(get_certificate, name, namespace, duration, renew_before, secret_name, organizations, common_name, dns_names, issuer_name)
+#@ end
+
+#@ def generate_ca_certificate(name, namespace, duration, renew_before, secret_name, organizations, common_name, dns_names, issuer_name):
+#@   return certificate_generate(get_ca_certificate, name, namespace, duration, renew_before, secret_name, organizations, common_name, dns_names, issuer_name)
+#@ end
+
+#@ def generate_server_certificate(name, namespace, duration, renew_before, secret_name, organizations, common_name, dns_names, issuer_name):
+#@   return certificate_generate(get_server_certificate, name, namespace, duration, renew_before, secret_name, organizations, common_name, dns_names, issuer_name)
+#@ end
+
+#@ def generate_client_certificate(name, namespace, duration, renew_before, secret_name, organizations, common_name, dns_names, issuer_name):
+#@   return certificate_generate(get_client_certificate, name, namespace, duration, renew_before, secret_name, organizations, common_name, dns_names, issuer_name)
+#@ end

--- a/addons/packages/prometheus/2.36.2/bundle/config/globals.star
+++ b/addons/packages/prometheus/2.36.2/bundle/config/globals.star
@@ -1,0 +1,67 @@
+load("@ytt:data", "data")
+load("@ytt:assert", "assert")
+
+def get_image_location(repository, name, tag):
+  return '{0}/{1}:{2}'.format(repository, name, tag)
+end
+
+def validate_infrastructure_provider():
+  data.values.infrastructure_provider in ("aws", "vsphere", "azure") or assert.fail("infrastructure provider should be either aws or vsphere or azure")
+end
+
+def get_kapp_versioned_annotations(kapp):
+  annotations = {}
+  if kapp.config and kapp.config.versioned:
+    annotations["kapp.k14s.io/versioned"] = ""
+  end
+  return annotations
+end
+
+def get_kapp_disable_wait_annotations():
+  annotations = {}
+  annotations["kapp.k14s.io/disable-wait"] = ""
+  return annotations
+end
+
+def get_kapp_configmap_annotations(kapp):
+  return get_kapp_versioned_annotations(kapp)
+end
+
+def get_kapp_namespace_annotations(kapp):
+  annotations = {}
+  if kapp.config and kapp.config.orphanNamespace:
+    annotations["kapp.k14s.io/delete-strategy"] = "orphan"
+  end
+  return annotations
+end
+
+def get_kapp_secret_annotations(kapp):
+  return get_kapp_versioned_annotations(kapp)
+end
+
+# Get kapp annotations for volumeClaimTemplates
+# See https://github.com/k14s/kapp/issues/36
+def get_kapp_vct_annotations():
+  annotations = {}
+  annotations["kapp.k14s.io/owned-for-deletion"] = ""
+  return annotations
+end
+
+def get_kapp_annotations(kind):
+  annotations = {}
+  for deployer in data.values.app.deploy:
+    if deployer.kapp:
+      if kind == "ConfigMap":
+        return get_kapp_configmap_annotations(deployer.kapp)
+      elif kind == "Namespace":
+        return get_kapp_namespace_annotations(deployer.kapp)
+      elif kind == "Secret":
+        return get_kapp_versioned_annotations(deployer.kapp)
+      end
+    end
+  end
+  return annotations
+end
+
+#export
+globals = data.values

--- a/addons/packages/prometheus/2.36.2/bundle/config/helpers.star
+++ b/addons/packages/prometheus/2.36.2/bundle/config/helpers.star
@@ -1,0 +1,10 @@
+load("@ytt:data", "data")
+
+def generate_prometheus_tls():
+  for key in ["tls.crt", "tls.key"]:
+    if getattr(data.values.ingress.tlsCertificate, key):
+      return False
+    end
+  end
+  return True
+end

--- a/addons/packages/prometheus/2.36.2/bundle/config/kinds.lib.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/kinds.lib.yaml
@@ -1,0 +1,36 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:struct", "struct")
+
+#@ namespace = overlay.subset({"kind": "Namespace"})
+#@ serviceaccount = overlay.subset({"kind": "ServiceAccount"})
+#@ configmap = overlay.subset({"kind": "ConfigMap"})
+#@ role = overlay.subset({"kind": "Role"})
+#@ role_binding = overlay.subset({"kind": "RoleBinding"})
+#@ cluster_role = overlay.subset({"kind": "ClusterRole"})
+#@ cluster_role_binding = overlay.subset({"kind": "ClusterRoleBinding"})
+#@ service = overlay.subset({"kind": "Service"})
+#@ deployment = overlay.subset({"kind": "Deployment"})
+#@ job = overlay.subset({"kind": "Job"})
+#@ daemonset = overlay.subset({"kind": "DaemonSet"})
+#@ secret = overlay.subset({"kind": "Secret"})
+#@ persistent_volume_claim = overlay.subset({"kind": "PersistentVolumeClaim"})
+#@ stateful_set = overlay.subset({"kind": "StatefulSet"})
+#@ ingress = overlay.subset({"kind": "Ingress"})
+#@ httpproxy = overlay.subset({"kind": "HTTPProxy"})
+
+#@ kind_overlays = struct.make(namespace=namespace,
+#@                             serviceaccount=serviceaccount,
+#@                             configmap=configmap,
+#@                             role=role,
+#@                             role_binding=role_binding,
+#@                             cluster_role=cluster_role,
+#@                             cluster_role_binding=cluster_role_binding,
+#@                             service=service,
+#@                             deployment=deployment,
+#@                             job=job,
+#@                             daemonset=daemonset,
+#@                             secret=secret,
+#@                             persistent_volume_claim=persistent_volume_claim,
+#@                             stateful_set=stateful_set,
+#@                             ingress=ingress,
+#@                             httpproxy=httpproxy)

--- a/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-alertmanager.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-alertmanager.yaml
@@ -1,0 +1,70 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"Secret", "metadata":{"name":"alertmanager"}})
+---
+stringData:
+  #@overlay/match missing_ok=True
+  alertmanager.yml: #@ data.values.alertmanager.config.alertmanager_yml
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name":"alertmanager"}})
+#@overlay/match-child-defaults missing_ok=True
+---
+spec:
+  #@ if data.values.alertmanager.deployment.updateStrategy != None:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: #@ data.values.alertmanager.deployment.updateStrategy
+    #@overlay/match missing_ok=True
+    #@ if data.values.alertmanager.deployment.updateStrategy == "RollingUpdate":
+    rollingUpdate:
+      #@ if/end data.values.alertmanager.deployment.rollingUpdate.maxUnavailable != None:
+      maxUnavailable: #@ data.values.alertmanager.deployment.rollingUpdate.maxUnavailable
+      #@ if/end data.values.alertmanager.deployment.rollingUpdate.maxSurge != None:
+      maxSurge: #@ data.values.alertmanager.deployment.rollingUpdate.maxSurge
+    #@ end
+  #@ end
+  replicas: #@ data.values.alertmanager.deployment.replicas
+  template:
+    #@overlay/merge
+    metadata:
+      labels: #@ data.values.alertmanager.deployment.podLabels
+      annotations: #@ data.values.alertmanager.deployment.podAnnotations
+    spec:
+      containers:
+        #@overlay/match by="name"
+        - name: alertmanager
+          #@overlay/replace
+          resources: #@ data.values.alertmanager.deployment.containers.resources
+
+#@overlay/match by=overlay.subset({"kind": "PersistentVolumeClaim", "metadata": {"name": "alertmanager"}})
+#@overlay/match-child-defaults missing_ok=True
+---
+metadata:
+  #@ if/end data.values.alertmanager.pvc.annotations:
+  annotations: #@ data.values.alertmanager.pvc.annotations
+spec:
+  #@overlay/replace
+  accessModes:
+    - #@ data.values.alertmanager.pvc.accessMode
+    #@ if/end data.values.alertmanager.pvc.storageClassName:
+  storageClassName: #@ data.values.alertmanager.pvc.storageClassName
+  resources:
+    requests:
+      storage: #@ data.values.alertmanager.pvc.storage
+
+
+#@overlay/match by=overlay.subset({"kind":"Service", "metadata": {"name": "alertmanager"}}), expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+metadata:
+  #@overlay/merge
+  labels: #@ data.values.alertmanager.service.labels
+  annotations: #@ data.values.alertmanager.service.annotations
+spec:
+  type: #@ data.values.alertmanager.service.type
+  ports:
+    #@overlay/match by="name"
+    - name: http
+      port: #@ data.values.alertmanager.service.port
+      targetPort: #@ data.values.alertmanager.service.targetPort

--- a/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-ingress-secret.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-ingress-secret.yaml
@@ -1,0 +1,52 @@
+#@ load("@ytt:data", "data")
+#@ load("/globals.star", "globals")
+#@ load("/helpers.star", "generate_prometheus_tls")
+#@ load("@ytt:base64", "base64")
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:template", "template")
+#@ load("/certificates.lib.yaml", "generate_dns_names", "generate_self_signed_issuer", "generate_ca_issuer", "generate_ca_certificate", "generate_certificate")
+#@ if data.values.ingress.enabled:
+
+#@ prometheus_name = "prometheus"
+#@ prometheus_namespace = data.values.namespace
+#@ prometheus_organization = "Project Prometheus"
+#@ prometheus_self_signed_ca_issuer = prometheus_name + "-self-signed-ca-issuer"
+#@ prometheus_ca = prometheus_name + "-ca"
+#@ prometheus_ca_common_name = "Prometheus CA"
+#@ prometheus_ca_dns_name = prometheus_name + "ca"
+#@ prometheus_ca_key_pair = prometheus_name + "-ca-key-pair"
+#@ prometheus_ca_issuer = prometheus_name + "-ca-issuer"
+#@ prometheus_cert = prometheus_name + "-cert"
+#@ prometheus_cert_duration = "87600h"
+#@ prometheus_cert_renew_before = "360h"
+
+--- #@ generate_self_signed_issuer(prometheus_self_signed_ca_issuer, prometheus_namespace)
+--- #@ generate_ca_certificate(prometheus_ca, prometheus_namespace, prometheus_cert_duration, prometheus_cert_renew_before, prometheus_ca_key_pair, [prometheus_organization], prometheus_ca_common_name, [prometheus_ca_dns_name], prometheus_self_signed_ca_issuer)
+--- #@ generate_ca_issuer(prometheus_ca_issuer, prometheus_namespace, prometheus_ca_key_pair)
+
+#@ prometheus_tls_cert = "prometheus-tls-cert"
+#@ prometheus_tls_secret = "prometheus-tls"
+#@ prometheus_tls_common_name = "prometheus"
+#@ if generate_prometheus_tls():
+--- #@ generate_certificate(prometheus_tls_cert, prometheus_namespace, prometheus_cert_duration, prometheus_cert_renew_before, prometheus_tls_secret, [prometheus_organization], prometheus_tls_common_name, [data.values.ingress.virtual_host_fqdn, "notary." + data.values.ingress.virtual_host_fqdn], prometheus_ca_issuer)
+#@ end
+
+#@ if not generate_prometheus_tls():
+#@ ca_crt = getattr(data.values.ingress.tlsCertificate, "ca.crt")
+#@ tls_crt = getattr(data.values.ingress.tlsCertificate, "tls.crt")
+#@ tls_key = getattr(data.values.ingress.tlsCertificate, "tls.key")
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ prometheus_tls_secret
+  namespace: #@ prometheus_namespace
+type: kubernetes.io/tls
+data:
+  #@ if/end ca_crt:
+  ca.crt: #@ base64.encode(ca_crt)
+  tls.crt: #@ base64.encode(tls_crt)
+  tls.key: #@ base64.encode(tls_key)
+#@ end
+
+#@ end

--- a/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-kube-state-metrics.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-kube-state-metrics.yaml
@@ -1,0 +1,38 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name":"prometheus-kube-state-metrics"}})
+#@overlay/match-child-defaults missing_ok=True
+---
+spec:
+  replicas: #@ data.values.kube_state_metrics.deployment.replicas
+  template:
+    #@overlay/merge
+    metadata:
+      labels: #@ data.values.kube_state_metrics.deployment.podLabels
+      annotations: #@ data.values.kube_state_metrics.deployment.podAnnotations
+    spec:
+      containers:
+        #@overlay/match by="name"
+        - name: prometheus-kube-state-metrics
+          #@overlay/replace
+          resources: #@ data.values.kube_state_metrics.deployment.containers.resources
+
+#@overlay/match by=overlay.subset({"kind":"Service", "metadata": {"name": "prometheus-kube-state-metrics"}}), expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+metadata:
+  #@overlay/merge
+  labels: #@ data.values.kube_state_metrics.service.labels
+  annotations: #@ data.values.kube_state_metrics.service.annotations
+spec:
+  type: #@ data.values.kube_state_metrics.service.type
+  ports:
+    #@overlay/match by="name"
+    - name: http
+      port: #@ data.values.kube_state_metrics.service.port
+      targetPort: #@ data.values.kube_state_metrics.service.targetPort
+    #@overlay/match by="name"
+    - name: telemetry
+      port: #@ data.values.kube_state_metrics.service.telemetryPort
+      targetPort: #@ data.values.kube_state_metrics.service.telemetryTargetPort

--- a/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-namespace.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-namespace.yaml
@@ -1,0 +1,19 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind":"Namespace", "metadata": {"name": "default"}})
+---
+metadata:
+  name: #@ data.values.namespace
+
+#@overlay/match by=overlay.subset({"metadata":{"namespace": "default"}}), expects=20
+---
+metadata:
+  namespace: #@ data.values.namespace
+
+#@overlay/match by=overlay.subset({"kind":"ClusterRoleBinding"}), expects=5
+---
+subjects:
+#@overlay/match by=overlay.subset({"namespace": "default"})
+- kind: ServiceAccount
+  namespace: #@ data.values.namespace

--- a/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-node-exporter.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-node-exporter.yaml
@@ -1,0 +1,36 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "prometheus-node-exporter"}})
+#@overlay/match-child-defaults missing_ok=True
+---
+spec:
+  updateStrategy:
+    type: #@ data.values.node_exporter.daemonset.updatestrategy
+  template:
+    #@overlay/merge
+    metadata:
+      labels: #@ data.values.node_exporter.daemonset.podLabels
+      annotations: #@ data.values.node_exporter.daemonset.podAnnotations
+    spec:
+      containers:
+        #@overlay/match by="name"
+        - name: prometheus-node-exporter
+          #@overlay/replace
+          resources: #@ data.values.node_exporter.daemonset.containers.resources
+      hostNetwork: #@ data.values.node_exporter.daemonset.hostNetwork
+
+#@overlay/match by=overlay.subset({"kind":"Service", "metadata": {"name": "prometheus-node-exporter"}}), expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+metadata:
+  #@overlay/merge
+  labels: #@ data.values.node_exporter.service.labels
+  annotations: #@ data.values.node_exporter.service.annotations
+spec:
+  type: #@ data.values.node_exporter.service.type
+  ports:
+    #@overlay/match by="name"
+    - name: metrics
+      port: #@ data.values.node_exporter.service.port
+      targetPort: #@ data.values.node_exporter.service.targetPort

--- a/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-prometheus-httpproxy.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-prometheus-httpproxy.yaml
@@ -1,0 +1,36 @@
+#@ load("@ytt:data", "data")
+
+#@ if data.values.ingress.enabled:
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: prometheus-httpproxy
+  namespace: #@ data.values.namespace
+  labels:
+    app: prometheus
+spec:
+  virtualhost:
+    fqdn: #@ data.values.ingress.virtual_host_fqdn
+    tls:
+      secretName: prometheus-tls
+  routes:
+    - conditions:
+      - prefix: #@ data.values.ingress.prometheus_prefix
+      pathRewritePolicy:
+        replacePrefix:
+          - prefix: #@ data.values.ingress.prometheus_prefix
+            replacement: /
+      services:
+        - name: prometheus-server
+          port: #@ data.values.ingress.prometheusServicePort
+    - conditions:
+      - prefix: #@ data.values.ingress.alertmanager_prefix
+      pathRewritePolicy:
+        replacePrefix:
+          - prefix: #@ data.values.ingress.alertmanager_prefix
+            replacement: /
+      services:
+        - name: alertmanager
+          port: #@ data.values.ingress.alertmanagerServicePort
+#@ end

--- a/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-prometheus.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-prometheus.yaml
@@ -1,0 +1,96 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"ConfigMap", "metadata":{"name":"prometheus-server"}})
+---
+data:
+  #@overlay/match missing_ok=True
+  prometheus.yml: #@ data.values.prometheus.config.prometheus_yml
+
+  #@overlay/match missing_ok=True
+  alerting_rules.yml: #@ data.values.prometheus.config.alerting_rules_yml
+
+  #@overlay/match missing_ok=True
+  recording_rules.yml: #@ data.values.prometheus.config.recording_rules_yml
+
+  #@overlay/match missing_ok=True
+  alerts: #@ data.values.prometheus.config.alerts_yml
+
+  #@overlay/match missing_ok=True
+  rules: #@ data.values.prometheus.config.rules_yml
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name":"prometheus-server"}})
+#@overlay/match-child-defaults missing_ok=True
+---
+spec:
+  #@ if data.values.prometheus.deployment.updateStrategy != None:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: #@ data.values.prometheus.deployment.updateStrategy
+    #@overlay/match missing_ok=True
+    #@ if data.values.prometheus.deployment.updateStrategy == "RollingUpdate":
+    rollingUpdate:
+      #@ if/end data.values.prometheus.deployment.rollingUpdate.maxUnavailable != None:
+      maxUnavailable: #@ data.values.prometheus.deployment.rollingUpdate.maxUnavailable
+      #@ if/end data.values.prometheus.deployment.rollingUpdate.maxSurge != None:
+      maxSurge: #@ data.values.prometheus.deployment.rollingUpdate.maxSurge
+    #@ end
+  #@ end
+  replicas: #@ data.values.prometheus.deployment.replicas
+  template:
+    #@overlay/merge
+    metadata:
+      labels: #@ data.values.prometheus.deployment.podLabels
+      annotations: #@ data.values.prometheus.deployment.podAnnotations
+    spec:
+      containers:
+        #@overlay/match by="name"
+        - name: prometheus-server
+          #@overlay/replace
+          args:
+            #@ for arg in data.values.prometheus.deployment.containers.args:
+            - #@ arg
+            #@ end
+          #@overlay/replace
+          resources: #@ data.values.prometheus.deployment.containers.resources
+        #@overlay/match by="name"
+        - name: prometheus-server-configmap-reload
+          #@overlay/replace
+          resources: #@ data.values.prometheus.deployment.configmapReload.containers.resources
+          #@overlay/replace
+          args:
+            #@ for arg in data.values.prometheus.deployment.configmapReload.containers.args:
+            - #@ arg
+              #@ end
+
+#@overlay/match by=overlay.subset({"kind": "PersistentVolumeClaim", "metadata": {"name": "prometheus-server"}})
+#@overlay/match-child-defaults missing_ok=True
+---
+metadata:
+  #@ if/end data.values.prometheus.pvc.annotations:
+  annotations: #@ data.values.prometheus.pvc.annotations
+spec:
+  #@overlay/replace
+  accessModes:
+    - #@ data.values.prometheus.pvc.accessMode
+  #@ if/end data.values.prometheus.pvc.storageClassName:
+  storageClassName: #@ data.values.prometheus.pvc.storageClassName
+  resources:
+    requests:
+      storage: #@ data.values.prometheus.pvc.storage
+
+
+#@overlay/match by=overlay.subset({"kind":"Service", "metadata": {"name": "prometheus-server"}}), expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+metadata:
+  #@overlay/merge
+  labels: #@ data.values.prometheus.service.labels
+  annotations: #@ data.values.prometheus.service.annotations
+spec:
+  type: #@ data.values.prometheus.service.type
+  ports:
+    #@overlay/match by="name"
+    - name: http
+      port: #@ data.values.prometheus.service.port
+      targetPort: #@ data.values.prometheus.service.targetPort

--- a/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-pushgateway.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/overlays/overlay-pushgateway.yaml
@@ -1,0 +1,35 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name":"prometheus-pushgateway"}})
+#@overlay/match-child-defaults missing_ok=True
+---
+spec:
+  replicas: #@ data.values.pushgateway.deployment.replicas
+  template:
+    #@overlay/merge
+    metadata:
+      labels: #@ data.values.pushgateway.deployment.podLabels
+      annotations: #@ data.values.pushgateway.deployment.podAnnotations
+    spec:
+      containers:
+        #@overlay/match by="name"
+        - name: prometheus-pushgateway
+          #@overlay/replace
+          resources: #@ data.values.pushgateway.deployment.containers.resources
+
+
+#@overlay/match by=overlay.subset({"kind":"Service", "metadata": {"name": "prometheus-pushgateway"}}), expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+metadata:
+  #@overlay/merge
+  labels: #@ data.values.pushgateway.service.labels
+  annotations: #@ data.values.pushgateway.service.annotations
+spec:
+  type: #@ data.values.pushgateway.service.type
+  ports:
+    #@overlay/match by="name"
+    - name: http
+      port: #@ data.values.pushgateway.service.port
+      targetPort: #@ data.values.pushgateway.service.targetPort

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/clusterrole.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/clusterrole.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: "alertmanager"
+    app: prometheus
+  name: alertmanager
+rules:
+  - apiGroups:
+    - policy
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/clusterrolebinding.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: "alertmanager"
+    app: prometheus
+  name: alertmanager
+subjects:
+  - kind: ServiceAccount
+    name: alertmanager-sa
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alertmanager

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/deployment.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/deployment.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: "alertmanager"
+    app: prometheus
+  name: alertmanager
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      component: "alertmanager"
+      app: prometheus
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        component: "alertmanager"
+        app: prometheus
+    spec:
+      serviceAccountName: alertmanager-sa
+      containers:
+        - name: alertmanager
+          image: "prom/alertmanager:v0.24.0"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --config.file=/etc/config/alertmanager.yml
+            - --storage.path=/data
+          ports:
+            - containerPort: 9093
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9093
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          resources:
+            {}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+            - name: storage-volume
+              mountPath: "/data"
+              subPath: ""
+
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      volumes:
+        - name: config-volume
+          secret:
+            secretName: alertmanager
+        - name: storage-volume
+          persistentVolumeClaim:
+            claimName: alertmanager

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/pvc.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    component: "alertmanager"
+    app: prometheus
+  name: alertmanager
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "2Gi"

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/secret.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/secret.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    component: "alertmanager"
+    app: prometheus
+  name: alertmanager
+  namespace: default
+stringData:
+  alertmanager.yml: |
+    {}

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/service.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: "alertmanager"
+    app: prometheus
+  name: alertmanager
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 9093
+  selector:
+    component: "alertmanager"
+    app: prometheus
+  sessionAffinity: None
+  type: "ClusterIP"

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/serviceaccount.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/alertmanager/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alertmanager-sa
+  namespace: default

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/kube-state-metrics/clusterrole.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/kube-state-metrics/clusterrole.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: "kube-state-metrics"
+    app: prometheus
+  name: prometheus-kube-state-metrics
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - pods
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - endpoints
+      - secrets
+      - configmaps
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - ingresses
+      - replicasets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - statefulsets
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+    - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/kube-state-metrics/clusterrolebinding.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/kube-state-metrics/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: "kube-state-metrics"
+    app: prometheus
+  name: prometheus-kube-state-metrics
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-kube-state-metrics
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-kube-state-metrics

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/kube-state-metrics/deployment.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/kube-state-metrics/deployment.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: "kube-state-metrics"
+    app: prometheus
+  name: prometheus-kube-state-metrics
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      component: "kube-state-metrics"
+      app: prometheus
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: "kube-state-metrics"
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus-kube-state-metrics
+      containers:
+        - name: prometheus-kube-state-metrics
+          image: "bitnami/kube-state-metrics:2.5.0"
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: telemetry
+              containerPort: 8081
+          resources:
+            {}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/kube-state-metrics/service.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/kube-state-metrics/service.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+  labels:
+    component: "kube-state-metrics"
+    app: prometheus
+  name: prometheus-kube-state-metrics
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: telemetry
+      port: 81
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    component: "kube-state-metrics"
+    app: prometheus
+  type: "ClusterIP"

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/kube-state-metrics/serviceaccount.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/kube-state-metrics/serviceaccount.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: "kube-state-metrics"
+    app: prometheus
+  name: prometheus-kube-state-metrics
+  namespace: default

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/node-exporter/clusterolebinding.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/node-exporter/clusterolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-node-exporter
+  labels:
+    component: node-exporter
+    app: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-node-exporter-sa
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-node-exporter

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/node-exporter/clusterrole.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/node-exporter/clusterrole.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: node-exporter
+    app: prometheus
+  name: prometheus-node-exporter
+rules:
+- apiGroups: ['']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - node-exporter

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/node-exporter/daemonset.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/node-exporter/daemonset.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    component: node-exporter
+    app: prometheus
+  name: prometheus-node-exporter
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      component: node-exporter
+      app: prometheus
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        component: node-exporter
+        app: prometheus
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "9100"
+    spec:
+      serviceAccountName: prometheus-node-exporter-sa
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      containers:
+        - name: prometheus-node-exporter
+          image: "quay.io/prometheus/node-exporter:v1.3.1"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --web.listen-address=$(HOST_IP):9100
+          env:
+          - name: HOST_IP
+            value: 0.0.0.0
+          ports:
+            - name: metrics
+              containerPort: 9100
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9100
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9100
+          resources:
+            {}
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly:  true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
+              readOnly: true
+      hostNetwork: false
+      hostPID: true
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: root
+          hostPath:
+            path: /

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/node-exporter/psp.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/node-exporter/psp.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: prometheus-node-exporter
+  namespace: default
+  labels:
+    component: node-exporter
+    app: prometheus
+spec:
+  privileged: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+    - 'hostPath'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: true
+  hostPorts:
+    - min: 0
+      max: 65535
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      #! Forbid adding the root group.
+      - min: 0
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      #! Forbid adding the root group.
+      - min: 0
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/node-exporter/service.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/node-exporter/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-node-exporter
+  namespace: default
+  labels:
+    component: node-exporter
+    app: prometheus
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9100
+      targetPort: 9100
+      protocol: TCP
+      name: metrics
+  selector:
+    component: node-exporter
+    app: prometheus

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/node-exporter/serviceaccount.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/node-exporter/serviceaccount.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-node-exporter-sa
+  namespace: default
+  labels:
+    component: node-exporter
+    app: prometheus

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/clusterrole.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/clusterrole.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+  name: prometheus-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - ingresses
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses/status
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/clusterrolebinding.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+  name: prometheus-server
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-server-sa
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-server

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/configmap.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/configmap.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+  name: prometheus-server
+  namespace: default
+data:
+  prometheus.yml: |
+    {}
+  alerting_rules.yml: |
+    {}
+  recording_rules.yml: |
+    {}
+  alerts: |
+    {}
+  rules: |
+    {}

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/deployment.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/deployment.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+  name: prometheus-server
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      component: "server"
+      app: prometheus
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        component: "server"
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus-server-sa
+      containers:
+        - name: prometheus-server-configmap-reload
+          image: "jimmidyson/configmap-reload:v0.7.1"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --volume-dir=/etc/config
+            - --webhook-url=http://127.0.0.1:9090/-/reload
+          resources:
+            {}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+              readOnly: true
+        - name: prometheus-server
+          image: prom/prometheus:v2.36.2
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --storage.tsdb.retention.time=15d
+            - --config.file=/etc/config/prometheus.yml
+            - --storage.tsdb.path=/data
+            - --web.console.libraries=/etc/prometheus/console_libraries
+            - --web.console.templates=/etc/prometheus/consoles
+            - --web.enable-lifecycle
+          ports:
+            - containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 4
+            failureThreshold: 3
+            successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+            successThreshold: 1
+          resources:
+            {}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+            - name: storage-volume
+              mountPath: /data
+              subPath: ""
+      hostNetwork: false
+      dnsPolicy: ClusterFirst
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      terminationGracePeriodSeconds: 300
+      volumes:
+        - name: config-volume
+          configMap:
+            name: prometheus-server
+        - name: storage-volume
+          persistentVolumeClaim:
+            claimName: prometheus-server

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/namespace.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+  name: default

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/pvc.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/pvc.yaml
@@ -1,0 +1,16 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+  name: prometheus-server
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "8Gi"

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/service.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/service.yaml
@@ -1,0 +1,21 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+  name: prometheus-server
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    component: "server"
+    app: prometheus
+  sessionAffinity: None
+  type: "ClusterIP"

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/serviceaccount.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/prometheus/serviceaccount.yaml
@@ -1,0 +1,7 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-server-sa
+  namespace: default

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/pushgateway/clusterrole.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/pushgateway/clusterrole.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: "pushgateway"
+    app: prometheus
+  name: prometheus-pushgateway
+rules:
+  - apiGroups:
+    - policy
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/pushgateway/clusterrolebinding.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/pushgateway/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: "pushgateway"
+    app: prometheus
+  name: prometheus-pushgateway
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-pushgateway
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-pushgateway

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/pushgateway/deployment.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/pushgateway/deployment.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: "pushgateway"
+    app: prometheus
+  name: prometheus-pushgateway
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      component: "pushgateway"
+      app: prometheus
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: "pushgateway"
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus-pushgateway
+      containers:
+        - name: prometheus-pushgateway
+          image: "prom/pushgateway:v1.4.3"
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 9091
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9091
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9091
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+          resources:
+            {}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/pushgateway/service.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/pushgateway/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/probe: pushgateway
+  labels:
+    component: "pushgateway"
+    app: prometheus
+  name: prometheus-pushgateway
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 9091
+      protocol: TCP
+      targetPort: 9091
+  selector:
+    component: "pushgateway"
+    app: prometheus
+  type: "ClusterIP"

--- a/addons/packages/prometheus/2.36.2/bundle/config/upstream/pushgateway/serviceaccount.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/upstream/pushgateway/serviceaccount.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: "pushgateway"
+    app: prometheus
+  name: prometheus-pushgateway
+  namespace: default

--- a/addons/packages/prometheus/2.36.2/bundle/config/values.yaml
+++ b/addons/packages/prometheus/2.36.2/bundle/config/values.yaml
@@ -1,0 +1,773 @@
+#@data/values
+---
+
+#! The namespace in which to deploy prometheus.
+namespace: prometheus
+
+prometheus:
+  deployment:
+    #! Number of prometheus servers
+    replicas: 1
+    #! Type of prometheus upgrade strategy
+    updateStrategy: Recreate
+    rollingUpdate:
+      maxUnavailable: null
+      maxSurge: null
+    #! Replaces the prometheus-server container args with the ones provided below (i.e. Does not append).
+    containers:
+      args:
+        - --storage.tsdb.retention.time=42d
+        - --config.file=/etc/config/prometheus.yml
+        - --storage.tsdb.path=/data
+        - --web.console.libraries=/etc/prometheus/console_libraries
+        - --web.console.templates=/etc/prometheus/consoles
+        - --web.enable-lifecycle
+      resources: {}
+    podAnnotations: {}
+    podLabels: {}
+    configmapReload:
+      containers:
+        args:
+          - --volume-dir=/etc/config
+          - --webhook-url=http://127.0.0.1:9090/-/reload
+        resources: {}
+  #! Prometheus service configuration
+  service:
+    type: "ClusterIP"
+    port: 80
+    targetPort: 9090
+    labels: {}
+    annotations: {}
+  pvc:
+    annotations: {}
+    storageClassName: null
+    accessMode: ReadWriteOnce
+    storage: "150Gi"
+  #! The prometheus configuration
+  config:
+    prometheus_yml: |
+      global:
+        evaluation_interval: 1m
+        scrape_interval: 1m
+        scrape_timeout: 10s
+      rule_files:
+      - /etc/config/alerting_rules.yml
+      - /etc/config/recording_rules.yml
+      - /etc/config/alerts
+      - /etc/config/rules
+      scrape_configs:
+      - job_name: 'prometheus'
+        scrape_interval: 5s
+        static_configs:
+        - targets: ['localhost:9090']
+      - job_name: 'kube-state-metrics'
+        static_configs:
+        - targets: ['prometheus-kube-state-metrics.prometheus.svc.cluster.local:8080']
+
+      - job_name: 'node-exporter'
+        static_configs:
+        - targets: ['prometheus-node-exporter.prometheus.svc.cluster.local:9100']
+
+      - job_name: 'kubernetes-pods'
+        kubernetes_sd_configs:
+        - role: pod
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name
+      - job_name: kubernetes-nodes-cadvisor
+        kubernetes_sd_configs:
+        - role: node
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - replacement: kubernetes.default.svc:443
+          target_label: __address__
+        - regex: (.+)
+          replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+          source_labels:
+          - __meta_kubernetes_node_name
+          target_label: __metrics_path__
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      - job_name: kubernetes-apiservers
+        kubernetes_sd_configs:
+        - role: endpoints
+        relabel_configs:
+        - action: keep
+          regex: default;kubernetes;https
+          source_labels:
+          - __meta_kubernetes_namespace
+          - __meta_kubernetes_service_name
+          - __meta_kubernetes_endpoint_port_name
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      alerting:
+        alertmanagers:
+        - scheme: http
+          static_configs:
+          - targets:
+            - alertmanager.prometheus.svc:80
+        - kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+          - source_labels: [__meta_kubernetes_namespace]
+            regex: default
+            action: keep
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            regex: prometheus
+            action: keep
+          - source_labels: [__meta_kubernetes_pod_label_component]
+            regex: alertmanager
+            action: keep
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_probe]
+            regex: .*
+            action: keep
+          - source_labels: [__meta_kubernetes_pod_container_port_number]
+            regex:
+            action: drop
+    alerting_rules_yml: |
+      {}
+    recording_rules_yml: |
+      groups:
+        - name: kube-apiserver.rules
+          interval: 3m
+          rules:
+          - expr: |2
+              (
+                (
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"LIST|GET"}[1d]))
+                  -
+                  (
+                    (
+                      sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[1d]))
+                      or
+                      vector(0)
+                    )
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="namespace",le="0.5"}[1d]))
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="cluster",le="5"}[1d]))
+                  )
+                )
+                +
+                # errors
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET",code=~"5.."}[1d]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET"}[1d]))
+            labels:
+              verb: read
+            record: apiserver_request:burnrate1d
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"LIST|GET"}[1h]))
+                  -
+                  (
+                    (
+                      sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[1h]))
+                      or
+                      vector(0)
+                    )
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="namespace",le="0.5"}[1h]))
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="cluster",le="5"}[1h]))
+                  )
+                )
+                +
+                # errors
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET",code=~"5.."}[1h]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET"}[1h]))
+            labels:
+              verb: read
+            record: apiserver_request:burnrate1h
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"LIST|GET"}[2h]))
+                  -
+                  (
+                    (
+                      sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[2h]))
+                      or
+                      vector(0)
+                    )
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="namespace",le="0.5"}[2h]))
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="cluster",le="5"}[2h]))
+                  )
+                )
+                +
+                # errors
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET",code=~"5.."}[2h]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET"}[2h]))
+            labels:
+              verb: read
+            record: apiserver_request:burnrate2h
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"LIST|GET"}[30m]))
+                  -
+                  (
+                    (
+                      sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[30m]))
+                      or
+                      vector(0)
+                    )
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="namespace",le="0.5"}[30m]))
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="cluster",le="5"}[30m]))
+                  )
+                )
+                +
+                # errors
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET",code=~"5.."}[30m]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET"}[30m]))
+            labels:
+              verb: read
+            record: apiserver_request:burnrate30m
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"LIST|GET"}[3d]))
+                  -
+                  (
+                    (
+                      sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[3d]))
+                      or
+                      vector(0)
+                    )
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="namespace",le="0.5"}[3d]))
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="cluster",le="5"}[3d]))
+                  )
+                )
+                +
+                # errors
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET",code=~"5.."}[3d]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET"}[3d]))
+            labels:
+              verb: read
+            record: apiserver_request:burnrate3d
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"LIST|GET"}[5m]))
+                  -
+                  (
+                    (
+                      sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[5m]))
+                      or
+                      vector(0)
+                    )
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="namespace",le="0.5"}[5m]))
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="cluster",le="5"}[5m]))
+                  )
+                )
+                +
+                # errors
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET",code=~"5.."}[5m]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET"}[5m]))
+            labels:
+              verb: read
+            record: apiserver_request:burnrate5m
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"LIST|GET"}[6h]))
+                  -
+                  (
+                    (
+                      sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[6h]))
+                      or
+                      vector(0)
+                    )
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="namespace",le="0.5"}[6h]))
+                    +
+                    sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="cluster",le="5"}[6h]))
+                  )
+                )
+                +
+                # errors
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET",code=~"5.."}[6h]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET"}[6h]))
+            labels:
+              verb: read
+            record: apiserver_request:burnrate6h
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
+                  -
+                  sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",le="1"}[1d]))
+                )
+                +
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1d]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
+            labels:
+              verb: write
+            record: apiserver_request:burnrate1d
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
+                  -
+                  sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",le="1"}[1h]))
+                )
+                +
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
+            labels:
+              verb: write
+            record: apiserver_request:burnrate1h
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
+                  -
+                  sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",le="1"}[2h]))
+                )
+                +
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[2h]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
+            labels:
+              verb: write
+            record: apiserver_request:burnrate2h
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
+                  -
+                  sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",le="1"}[30m]))
+                )
+                +
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[30m]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
+            labels:
+              verb: write
+            record: apiserver_request:burnrate30m
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
+                  -
+                  sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",le="1"}[3d]))
+                )
+                +
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[3d]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
+            labels:
+              verb: write
+            record: apiserver_request:burnrate3d
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+                  -
+                  sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",le="1"}[5m]))
+                )
+                +
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[5m]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+            labels:
+              verb: write
+            record: apiserver_request:burnrate5m
+          - expr: |2
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
+                  -
+                  sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",le="1"}[6h]))
+                )
+                +
+                sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[6h]))
+              )
+              /
+              sum(rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
+            labels:
+              verb: write
+            record: apiserver_request:burnrate6h
+          - expr: |
+              sum by (code,resource) (rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"LIST|GET"}[5m]))
+            labels:
+              verb: read
+            record: code_resource:apiserver_request_total:rate5m
+          - expr: |
+              sum by (code,resource) (rate(apiserver_request_total{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+            labels:
+              verb: write
+            record: code_resource:apiserver_request_total:rate5m
+          - expr: |
+              histogram_quantile(0.99, sum by (le, resource) (rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET"}[5m]))) > 0
+            labels:
+              quantile: "0.99"
+              verb: read
+            record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+          - expr: |
+              histogram_quantile(0.99, sum by (le, resource) (rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"POST|PUT|PATCH|DELETE"}[5m]))) > 0
+            labels:
+              quantile: "0.99"
+              verb: write
+            record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+          - expr: |2
+              sum(rate(apiserver_request_duration_seconds_sum{subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod)
+              /
+              sum(rate(apiserver_request_duration_seconds_count{subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod)
+            record: cluster:apiserver_request_duration_seconds:mean5m
+          - expr: |
+              histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
+            labels:
+              quantile: "0.99"
+            record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+          - expr: |
+              histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
+            labels:
+              quantile: "0.9"
+            record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+          - expr: |
+              histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
+            labels:
+              quantile: "0.5"
+            record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+        - interval: 3m
+          name: kube-apiserver-availability.rules
+          rules:
+          - expr: |2
+              1 - (
+                (
+                  # write too slow
+                  sum(increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[30d]))
+                  -
+                  sum(increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[30d]))
+                ) +
+                (
+                  # read too slow
+                  sum(increase(apiserver_request_duration_seconds_count{verb=~"LIST|GET"}[30d]))
+                  -
+                  (
+                    (
+                      sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope=~"resource|",le="0.1"}[30d]))
+                      or
+                      vector(0)
+                    )
+                    +
+                    sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="namespace",le="0.5"}[30d]))
+                    +
+                    sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="cluster",le="5"}[30d]))
+                  )
+                ) +
+                # errors
+                sum(code:apiserver_request_total:increase30d{code=~"5.."} or vector(0))
+              )
+              /
+              sum(code:apiserver_request_total:increase30d)
+            labels:
+              verb: all
+            record: apiserver_request:availability30d
+          - expr: |2
+              1 - (
+                sum(increase(apiserver_request_duration_seconds_count{job="kubernetes-apiservers",verb=~"LIST|GET"}[30d]))
+                -
+                (
+                  # too slow
+                  (
+                    sum(increase(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[30d]))
+                    or
+                    vector(0)
+                  )
+                  +
+                  sum(increase(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="namespace",le="0.5"}[30d]))
+                  +
+                  sum(increase(apiserver_request_duration_seconds_bucket{job="kubernetes-apiservers",verb=~"LIST|GET",scope="cluster",le="5"}[30d]))
+                )
+                +
+                # errors
+                sum(code:apiserver_request_total:increase30d{verb="read",code=~"5.."} or vector(0))
+              )
+              /
+              sum(code:apiserver_request_total:increase30d{verb="read"})
+            labels:
+              verb: read
+            record: apiserver_request:availability30d
+          - expr: |2
+              1 - (
+                (
+                  # too slow
+                  sum(increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[30d]))
+                  -
+                  sum(increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[30d]))
+                )
+                +
+                # errors
+                sum(code:apiserver_request_total:increase30d{verb="write",code=~"5.."} or vector(0))
+              )
+              /
+              sum(code:apiserver_request_total:increase30d{verb="write"})
+            labels:
+              verb: write
+            record: apiserver_request:availability30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="LIST",code=~"2.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="GET",code=~"2.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="POST",code=~"2.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="PUT",code=~"2.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="PATCH",code=~"2.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="DELETE",code=~"2.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="LIST",code=~"3.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="GET",code=~"3.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="POST",code=~"3.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="PUT",code=~"3.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="PATCH",code=~"3.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="DELETE",code=~"3.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="LIST",code=~"4.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="GET",code=~"4.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="POST",code=~"4.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="PUT",code=~"4.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="PATCH",code=~"4.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="DELETE",code=~"4.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="LIST",code=~"5.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="GET",code=~"5.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="POST",code=~"5.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="PUT",code=~"5.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="PATCH",code=~"5.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code, verb) (increase(apiserver_request_total{job="kubernetes-apiservers",verb="DELETE",code=~"5.."}[30d]))
+            record: code_verb:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code) (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
+            labels:
+              verb: read
+            record: code:apiserver_request_total:increase30d
+          - expr: |
+              sum by (code) (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+            labels:
+              verb: write
+            record: code:apiserver_request_total:increase30d
+    alerts_yml: |
+      {}
+    rules_yml: |
+      {}
+
+
+ingress:
+  enabled: false
+  virtual_host_fqdn: "prometheus.system.tanzu"
+  prometheus_prefix: "/"
+  alertmanager_prefix: "/alertmanager/"
+  prometheusServicePort: 80
+  alertmanagerServicePort: 80
+  #! [Optional] The certificate for the ingress if you want to use your own TLS certificate.
+  #! We will issue the certificate by cert-manager when it's empty.
+  tlsCertificate:
+    #! [Required] the certificate
+    tls.crt:
+    #! [Required] the private key
+    tls.key:
+    #! [Optional] the CA certificate
+    ca.crt:
+
+alertmanager:
+  deployment:
+    #! The number of alert manager servers
+    replicas: 1
+    #! Type of prometheus upgrade strategy
+    updateStrategy: Recreate
+    rollingUpdate:
+      maxUnavailable: null
+      maxSurge: null
+    containers:
+      resources: {}
+    podAnnotations: {}
+    podLabels: {}
+
+  #! AlertManager service configuration
+  service:
+    type: "ClusterIP"
+    port: 80
+    targetPort: 9093
+    labels: {}
+    annotations: {}
+  pvc:
+    annotations: {}
+    storageClassName: null
+    accessMode: ReadWriteOnce
+    storage: "2Gi"
+
+  #! The alertmanager configuration. Note that alertmanager config is a kubernetes secret.
+  config:
+    alertmanager_yml: |
+      global: {}
+      receivers:
+      - name: default-receiver
+      templates:
+      - '/etc/alertmanager/templates/*.tmpl'
+      route:
+        group_interval: 5m
+        group_wait: 10s
+        receiver: default-receiver
+        repeat_interval: 3h
+
+kube_state_metrics:
+  deployment:
+    replicas: 1
+    containers:
+      resources: {}
+    podAnnotations: {}
+    podLabels: {}
+  #! kube-state-metrics service configuration
+  service:
+    type: "ClusterIP"
+    port: 80
+    targetPort: 8080
+    telemetryPort: 81
+    telemetryTargetPort: 8081
+    labels: {}
+    annotations: {}
+
+node_exporter:
+  daemonset:
+    hostNetwork: false
+    updatestrategy: RollingUpdate
+    containers:
+      resources: {}
+    podAnnotations: {}
+    podLabels: {}
+
+  #! node-exporter service configuration
+  service:
+    type: "ClusterIP"
+    port: 9100
+    targetPort: 9100
+    labels: {}
+    annotations: {}
+
+
+pushgateway:
+  deployment:
+    replicas: 1
+    containers:
+      resources: {}
+    podAnnotations: {}
+    podLabels: {}
+
+  #! pushgateway service configuration
+  service:
+    type: "ClusterIP"
+    port: 9091
+    targetPort: 9091
+    labels: {}
+    annotations: {}

--- a/addons/packages/prometheus/2.36.2/bundle/kbld-config.yml
+++ b/addons/packages/prometheus/2.36.2/bundle/kbld-config.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+
+minimumRequiredVersion: 0.15.0
+
+overrides:
+- image: gcr.io/cadvisor/cadvisor:v0.39.1
+  newImage: projects.registry.vmware.com/tkg/prometheus/cadvisor:v0.39.1_vmware.1

--- a/addons/packages/prometheus/2.36.2/bundle/vendir.lock.yml
+++ b/addons/packages/prometheus/2.36.2/bundle/vendir.lock.yml
@@ -1,0 +1,15 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - manual: {}
+    path: alertmanager
+  - manual: {}
+    path: prometheus
+  - manual: {}
+    path: node-exporter
+  - manual: {}
+    path: pushgateway
+  - manual: {}
+    path: kube-state-metrics
+  path: config/upstream
+kind: LockConfig

--- a/addons/packages/prometheus/2.36.2/bundle/vendir.yml
+++ b/addons/packages/prometheus/2.36.2/bundle/vendir.yml
@@ -1,0 +1,16 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.12.0
+directories:
+- path: config/upstream
+  contents:
+  - path: alertmanager
+    manual: {}
+  - path: prometheus
+    manual: {}
+  - path: node-exporter
+    manual: {}
+  - path: pushgateway
+    manual: {}
+  - path: kube-state-metrics
+    manual: {}

--- a/addons/packages/prometheus/2.36.2/package.yaml
+++ b/addons/packages/prometheus/2.36.2/package.yaml
@@ -1,0 +1,501 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: prometheus.community.tanzu.vmware.com.2.36.2-2
+spec:
+  refName: prometheus.community.tanzu.vmware.com
+  version: 2.36.2-2
+  releasedAt: 2022-06-23T18:00:00Z
+  releaseNotes: "prometheus 2.36.2-2 https://github.com/prometheus/prometheus/releases/tag/v2.36.2"
+  capacityRequirementsDescription: "Varies significantly based on cluster size. A starting point is 16GB RAM and 4 CPU, but this should be tuned based on observed usage."
+  valuesSchema:
+    openAPIv3:
+      title: prometheus.community.tanzu.vmware.com.2.36.2 values schema
+      properties:
+        namespace:
+          type: string
+          description: The namespace in which to deploy Prometheus.
+          default: prometheus
+        prometheus:
+          type: object
+          description: Prometheus Kubernetes configuration.
+          properties:
+            deployment:
+              type: object
+              description: Prometheus Deployment related configuration
+              properties:
+                replicas:
+                  type: integer
+                  description: Number of prometheus replicas.
+                  default: 1
+                updateStrategy:
+                  type: string
+                  description: The type of Prometheus upgrage strategy (RollingUpdate/Recreate)
+                  default: Recreate
+                rollingUpdate:
+                  type: object
+                  description: Prometheus rollingupdate configuration when strategy is RollingUpdate, It is only work when updateStrategy has been setted RollingUpdate.
+                  properties:
+                    maxUnavailable:
+                      type: string
+                      description:  Specifies the maximum number of Pods that can be unavailable during the update process.
+                      default: 25%
+                    maxSurge:
+                      type: string
+                      description:  Specifies the maximum number of Pods that can be created over the desired number of Pods.
+                      default: 25%
+                containers:
+                  type: object
+                  description: Prometheus server container configuration.
+                  properties:
+                    args:
+                      type: array
+                      description: List of arguments passed via command-line to prometheus server. For more guidance on configuration options consult the Prometheus docs at https://prometheus.io/
+                      default: "prometheus storage retention time = 42d"
+                      items:
+                        type: string
+                    resources:
+                      type: object
+                      description: Prometheus containers resource requirements (See Kubernetes OpenAPI Specification io.k8s.api.core.v1.ResourceRequirements)
+                      additionalProperties: true
+                podAnnotations:
+                  type: object
+                  description: Prometheus deployments pod annotations
+                  additionalProperties:
+                    type: string
+                podLabels:
+                  type: object
+                  description: Prometheus deployments pod labels
+                  additionalProperties:
+                    type: string
+                configmapReload:
+                  type: object
+                  description: configmap-reload related configuration.
+                  properties:
+                    containers:
+                      type: object
+                      description: configmap-reload container configuration.
+                      properties:
+                        args:
+                          type: array
+                          description: List of arguments passed via command-line to configmap reload container. For more guidance on configuration options consult the configmap-reload docs at https://github.com/jimmidyson/configmap-reload#usage
+                          default: "webhook-url=http://127.0.0.1:9090/-/reload"
+                          items:
+                            type: string
+                        resources:
+                          type: object
+                          description: configmap-reload containers resource requirements (io.k8s.api.core.v1.ResourceRequirements)
+                          additionalProperties: true
+            service:
+              type: object
+              description: Prometheus service configuration.
+              properties:
+                type:
+                  type: string
+                  description: The type of Kubernetes service to provision for Prometheus.
+                  default: ClusterIP
+                port:
+                  type: integer
+                  description: The ports that are exposed by Prometheus service.
+                  default: 80
+                targetPort:
+                  type: integer
+                  description: Target Port to access on the Prometheus pods.
+                  default: 9090
+                annotations:
+                  type: object
+                  description: Prometheus service annotations
+                  additionalProperties:
+                    type: string
+                labels:
+                  type: object
+                  description: Prometheus service pod labels
+                  additionalProperties:
+                    type: string
+            pvc:
+              type: object
+              description: Prometheus's PVC configuration
+              properties:
+                annotations:
+                  type: object
+                  description: Prometheus's persistent volume claim annotations
+                  additionalProperties:
+                    type: string
+                storageClassName:
+                  type: string
+                  description: The name of the StorageClass to use for persistent volume claim. By default this is null and default provisioner is used
+                  default: null
+                accessMode:
+                  type: string
+                  description: The name of the AccessModes to use for persistent volume claim. By default this is null and default provisioner is used
+                  default: ReadWriteOnce
+                storage:
+                  type: string
+                  description: The storage size for Prometheus server persistent volume claim.
+                  default: "150Gi"
+            config:
+              type: object
+              description: Prometheus configuration.
+              properties:
+                prometheus_yml:
+                  type: object
+                  description: The contents of the Prometheus config file. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/ for more information.
+                  default: "See default values file"
+                alerting_rules_yml:
+                  type: object
+                  description: The YAML contents of the Prometheus alerting rules file.
+                  default: "See default values file"
+                alerts_yml:
+                  type: object
+                  description: Additional prometheus alerts can be configured in this YAML file.
+                  default: null
+                recording_rules_yml:
+                  type: object
+                  description: The YAML contents of the Prometheus recording rules file.
+                  default: "See default values file"
+                rules_yml:
+                  type: object
+                  description: Additional prometheus rules can be configured in this YAML file.
+                  default: null
+        alertmanager:
+          type: object
+          description: Alertmanager Kubernetes configuration.
+          properties:
+            deployment:
+              type: object
+              description: Alertmanager Deployment related configuration
+              properties:
+                replicas:
+                  type: integer
+                  description: Number of alertmanager replicas.
+                  default: 1
+                updateStrategy:
+                  type: string
+                  description: The type of alertmanager upgrage strategy (RollingUpdate/Recreate)
+                  default: Recreate
+                rollingUpdate:
+                  type: object
+                  description: alertmanager rollingupdate configuration when strategy is RollingUpdate, It is only work when updateStrategy has been setted RollingUpdate.
+                  properties:
+                    maxUnavailable:
+                      type: string
+                      description:  Specifies the maximum number of Pods that can be unavailable during the update process.
+                      default: 25%
+                    maxSurge:
+                      type: string
+                      description:  Specifies the maximum number of Pods that can be created over the desired number of Pods.
+                      default: 25%
+                containers:
+                  type: object
+                  description: Alertmanager server container configuration.
+                  properties:
+                    resources:
+                      type: object
+                      description: Alertmanager containers resource requirements (See Kubernetes OpenAPI Specification io.k8s.api.core.v1.ResourceRequirements)
+                      additionalProperties: true
+                podAnnotations:
+                  type: object
+                  description: Alertmanager deployments pod annotations
+                  additionalProperties:
+                    type: string
+                podLabels:
+                  type: object
+                  description: Alertmanager deployments pod labels
+                  additionalProperties:
+                    type: string
+            service:
+              type: object
+              description: Alertmanager service configuration.
+              properties:
+                type:
+                  type: string
+                  description: The type of Kubernetes service to provision for Alertmanager.
+                  default: ClusterIP
+                port:
+                  type: integer
+                  description: The ports that are exposed by Alertmanager service.
+                  default: 80
+                targetPort:
+                  type: integer
+                  description: Target Port to access on the Alertmanager pods.
+                  default: 9093
+                annotations:
+                  type: object
+                  description: Alertmanager service annotations
+                  additionalProperties:
+                    type: string
+                labels:
+                  type: object
+                  description: Alertmanager service pod labels
+                  additionalProperties:
+                    type: string
+            pvc:
+              type: object
+              description: Alertmanager's PVC configuration
+              properties:
+                annotations:
+                  type: object
+                  description: Alertmanager's persistent volume claim annotations
+                  additionalProperties:
+                    type: string
+                storageClassName:
+                  type: string
+                  description: The name of the StorageClass to use for persistent volume claim. By default this is null and default provisioner is used
+                  default: null
+                accessMode:
+                  type: string
+                  description: The name of the AccessModes to use for persistent volume claim. By default this is null and default provisioner is used
+                  default: ReadWriteOnce
+                storage:
+                  type: string
+                  description: The storage size for Alertmanager server persistent volume claim.
+                  default: "2Gi"
+            config:
+              type: object
+              description: Alertmanager configuration.
+              properties:
+                alertmanager_yml:
+                  type: object
+                  description: The contents of the Alertmanager config file. See https://prometheus.io/docs/alerting/latest/configuration/ for more information.
+                  default: "See default values file"
+        kube_state_metrics:
+          type: object
+          description: kube-state-metrics Kubernetes configuration.
+          properties:
+            deployment:
+              type: object
+              description: kube-state-metrics deployment related configuration
+              properties:
+                replicas:
+                  type: integer
+                  description: Number of kube-state-metrics replicas.
+                  default: 1
+                containers:
+                  type: object
+                  description: kube-state-metrics container configuration.
+                  properties:
+                    resources:
+                      type: object
+                      description: kube-state-metrics containers resource requirements (See Kubernetes OpenAPI Specification io.k8s.api.core.v1.ResourceRequirements)
+                      additionalProperties: true
+                podAnnotations:
+                  type: object
+                  description: kube-state-metrics deployments pod annotations
+                  additionalProperties:
+                    type: string
+                podLabels:
+                  type: object
+                  description: kube-state-metrics deployments pod labels
+                  additionalProperties:
+                    type: string
+            service:
+              type: object
+              description: kube-state-metrics service configuration.
+              properties:
+                type:
+                  type: string
+                  description: The type of Kubernetes service to provision for kube-state-metrics.
+                  default: ClusterIP
+                port:
+                  type: integer
+                  description: The ports that are exposed by kube-state-metrics service.
+                  default: 80
+                targetPort:
+                  type: integer
+                  description: Target Port to access on the kube-state-metrics pods.
+                  default: 8080
+                telemetryPort:
+                  type: integer
+                  description: The ports that are exposed by kube-state-metrics service.
+                  default: 81
+                telemetryTargetPort:
+                  type: integer
+                  description: Target Port to access on the kube-state-metrics pods.
+                  default: 8081
+                annotations:
+                  type: object
+                  description: kube-state-metrics service annotations
+                  additionalProperties:
+                    type: string
+                labels:
+                  type: object
+                  description: kube-state-metrics service pod labels
+                  additionalProperties:
+                    type: string
+        node_exporter:
+          type: object
+          description: node-exporter Kubernetes configuration.
+          properties:
+            daemonset:
+              type: object
+              description: node-exporter deployment related configuration
+              properties:
+                hostNetwork:
+                  type: boolean
+                  description: The Host networking requested for this pod
+                  default: false
+                updatestrategy:
+                  type: string
+                  description: The type of DaemonSet update.
+                  default: RollingUpdate
+                containers:
+                  type: object
+                  description: node-exporter container configuration.
+                  properties:
+                    resources:
+                      type: object
+                      description: node-exporter containers resource requirements (See Kubernetes OpenAPI Specification io.k8s.api.core.v1.ResourceRequirements)
+                      additionalProperties: true
+                podAnnotations:
+                  type: object
+                  description: node-exporter deployments pod annotations
+                  additionalProperties:
+                    type: string
+                podLabels:
+                  type: object
+                  description: node-exporter deployments pod labels
+                  additionalProperties:
+                    type: string
+            service:
+              type: object
+              description: node-exporter service configuration.
+              properties:
+                type:
+                  type: string
+                  description: The type of Kubernetes service to provision for node-exporter.
+                  default: ClusterIP
+                port:
+                  type: integer
+                  description: The ports that are exposed by node-exporter service.
+                  default: 9100
+                targetPort:
+                  type: integer
+                  description: Target Port to access on the node-exporter pods.
+                  default: 9100
+                annotations:
+                  type: object
+                  description: node-exporter service annotations
+                  additionalProperties:
+                    type: string
+                labels:
+                  type: object
+                  description: node-exporter service pod labels
+                  additionalProperties:
+                    type: string
+        pushgateway:
+          type: object
+          description: pushgateway Kubernetes configuration.
+          properties:
+            deployment:
+              type: object
+              description: pushgateway deployment related configuration
+              properties:
+                replicas:
+                  type: integer
+                  description: Number of pushgateway replicas.
+                  default: 1
+                containers:
+                  type: object
+                  description: pushgateway container configuration.
+                  properties:
+                    resources:
+                      type: object
+                      description: pushgateway containers resource requirements (See Kubernetes OpenAPI Specification io.k8s.api.core.v1.ResourceRequirements)
+                      additionalProperties: true
+                podAnnotations:
+                  type: object
+                  description: pushgateway deployments pod annotations
+                  additionalProperties:
+                    type: string
+                podLabels:
+                  type: object
+                  description: pushgateway deployments pod labels
+                  additionalProperties:
+                    type: string
+            service:
+              type: object
+              description: pushgateway service configuration.
+              properties:
+                type:
+                  type: string
+                  description: The type of Kubernetes service to provision for pushgateway.
+                  default: ClusterIP
+                port:
+                  type: integer
+                  description: The ports that are exposed by pushgateway service.
+                  default: 9091
+                targetPort:
+                  type: integer
+                  description: Target Port to access on the pushgateway pods.
+                  default: 9091
+                annotations:
+                  type: object
+                  description: pushgateway service annotations
+                  additionalProperties:
+                    type: string
+                labels:
+                  type: object
+                  description: pushgateway service pod labels
+                  additionalProperties:
+                    type: string
+        ingress:
+          type: object
+          description: Prometheus and Alertmanager Ingress configuration.
+          properties:
+            enabled:
+              type: boolean
+              description: Whether to enable Prometheus and Alertmanager Ingress. Note that this requires contour.
+              default: false
+            virtual_host_fqdn:
+              type: string
+              description: Hostname for accessing prometheus and alertmanager.
+              default: "prometheus.system.tanzu"
+            prometheus_prefix:
+              type: string
+              description: Path prefix for Prometheus.
+              default: "/"
+            alertmanager_prefix:
+              type: string
+              description: Path prefix for Alertmanager.
+              default: "/alertmanager/"
+            prometheusServicePort:
+              type: integer
+              description: Prometheus service port to proxy traffic to.
+              default: 80
+            alertmanagerServicePort:
+              type: integer
+              description: Alertmanager service port to proxy traffic to.
+              default: 80
+            tlsCertificate:
+              type: object
+              description: Prometheus Ingress TLS certificate configuration. If skipped, a cert-manager cert will be issued and the cert-manager package must be installed on your cluster.
+              properties:
+                tls.crt:
+                  type: string
+                  description: Optional cert for ingress if you want to use your own TLS cert. A self signed cert is generated by default. Note that tls.crt is a key and not nested.
+                  default: null
+                tls.key:
+                  type: string
+                  description: Optional cert private key for ingress if you want to use your own TLS cert. Note that tls.key is a key and not nested.
+                  default: null
+                ca.crt:
+                  type: string
+                  description: Optional CA certificate. Note that ca.crt is a key and not nested.
+                  default: null
+  licenses:
+    - "Apache 2.0"
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects.registry.vmware.com/tce/prometheus@sha256:af674cf2fc7921ddea9979c0df8f9fdf238679c9e5dcba4cfb2dc9a42f4d873d
+      template:
+        - ytt:
+            paths:
+              - config/
+        - kbld:
+            paths:
+              - "-"
+              - .imgpkg/images.yml
+      deploy:
+        - kapp: {}

--- a/addons/packages/prometheus/metadata.yaml
+++ b/addons/packages/prometheus/metadata.yaml
@@ -9,9 +9,7 @@ spec:
   shortDescription: "A time series database for your metrics"
   providerName: VMware
   maintainers:
-    - name: Anil Kodali
-    - name: John McBride
-    - name: Luke Winikates
+    - name: Ke Zhou
   categories:
     - "monitoring"
     - "observability"

--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -88,6 +88,7 @@ packages:
   - name: prometheus
     versions:
       - 2.27.0
+      - 2.36.2
   - name: velero
     versions:
       - 1.6.3


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Bump prometheus and other related components to a new version.
## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Bump prometheus to v2.36.2.
Bump prometheus-node-exporter to v1.3.1.
Bump prometheus-alertmanager to v0.24.0.
Bump prometheus-pushgateway to v1.4.2.
Bump prometheus-configmap-reload to v0.7.1.
Bump kube-state-metrics to v.2.5.0.

In addition, cadvisor is going to be dropped in the new version, because it is not used by Prometheus, what works is the cadvisor in kubelet. And it is also not in helm charts of [prometheus community](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus/templates)

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
