### PR TITLE
UI: Set provider names for all infra types

### DIFF
--- a/cli/cmd/plugin/ui/server/handlers/azure.go
+++ b/cli/cmd/plugin/ui/server/handlers/azure.go
@@ -104,6 +104,9 @@ func (app *App) CreateAzureManagementCluster(params azure.CreateAzureManagementC
 
 	initOptions := &tfclient.InitRegionOptions{
 		InfrastructureProvider: "azure",
+		CoreProvider:           app.providerDefaults.CoreProvider,
+		BootstrapProvider:      app.providerDefaults.BootstrapProvider,
+		ControlPlaneProvider:   app.providerDefaults.ControlPlaneProvider,
 		ClusterName:            convertedParams.ClusterName,
 		Plan:                   convertedParams.ControlPlaneFlavor,
 		CeipOptIn:              *convertedParams.CeipOptIn,

--- a/cli/cmd/plugin/ui/server/handlers/docker.go
+++ b/cli/cmd/plugin/ui/server/handlers/docker.go
@@ -49,6 +49,9 @@ func (app *App) CreateDockerManagementCluster(params docker.CreateDockerManageme
 
 	initOptions := &client.InitRegionOptions{
 		InfrastructureProvider: "docker",
+		CoreProvider:           app.providerDefaults.CoreProvider,
+		BootstrapProvider:      app.providerDefaults.BootstrapProvider,
+		ControlPlaneProvider:   app.providerDefaults.ControlPlaneProvider,
 		ClusterName:            params.Params.ClusterName,
 		Plan:                   "dev",
 		Annotations:            params.Params.Annotations,

--- a/cli/cmd/plugin/ui/server/handlers/vsphere.go
+++ b/cli/cmd/plugin/ui/server/handlers/vsphere.go
@@ -65,6 +65,9 @@ func (app *App) CreateVSphereManagementCluster(params vsphere.CreateVSphereManag
 
 	initOptions := &tfclient.InitRegionOptions{
 		InfrastructureProvider:      "vsphere",
+		CoreProvider:                app.providerDefaults.CoreProvider,
+		BootstrapProvider:           app.providerDefaults.BootstrapProvider,
+		ControlPlaneProvider:        app.providerDefaults.ControlPlaneProvider,
 		ClusterName:                 convertedParams.ClusterName,
 		Plan:                        convertedParams.ControlPlaneFlavor,
 		CeipOptIn:                   *convertedParams.CeipOptIn,


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This adds setting the core CAPI provider names for all of the providers.
We had originally only done this for AWS as we worked through the logic,
but it is needed for the rest of them too.

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Built the ui artifacts and run the UI:

```
make ui-build-docker
go run .
```

Followed the management cluster steps to create a Docker management cluster. Kicked off creation and verified cluster was created successfully.

```
...
Waiting for additional components to be up and running...
Waiting for packages to be up and running...
You can now access the management cluster docker1 by running 'kubectl config use-context docker1-admin@docker1'

Management cluster created!


You can now create your first workload cluster by running the following:

  tanzu cluster create [name] -f [file]
```