### PR TITLE
GIT-4850: replace pkg/errors usage with native error packages

### DIFF
--- a/extensions/docker-desktop/apps/clustermgr/go.mod
+++ b/extensions/docker-desktop/apps/clustermgr/go.mod
@@ -5,11 +5,9 @@ go 1.17
 require (
 	github.com/docker/docker v20.10.16+incompatible
 	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/vmware-tanzu/community-edition/cli/cmd/plugin/unmanaged-cluster v0.0.0-20220607164142-9853e16163cb
 	gopkg.in/yaml.v3 v3.0.1
-	sigs.k8s.io/kind v0.14.0
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -62,6 +60,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
@@ -93,6 +92,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
+	sigs.k8s.io/kind v0.14.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
 

--- a/extensions/docker-desktop/apps/clustermgr/pkg/kubeconfig/internal/kubeconfig/encode.go
+++ b/extensions/docker-desktop/apps/clustermgr/pkg/kubeconfig/internal/kubeconfig/encode.go
@@ -5,9 +5,9 @@ package kubeconfig
 
 import (
 	"bytes"
+	"fmt"
 
 	yaml "gopkg.in/yaml.v3"
-	"sigs.k8s.io/kind/pkg/errors"
 	kubeyaml "sigs.k8s.io/yaml"
 )
 
@@ -17,7 +17,7 @@ func Encode(cfg *Config) ([]byte, error) {
 	// so we're not using that to marshal
 	encoded, err := yaml.Marshal(cfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to encode KUBECONFIG")
+		return nil, fmt.Errorf("failed to encode kubeconfig: %w", err)
 	}
 
 	// normalize with kubernetes's yaml library
@@ -25,7 +25,7 @@ func Encode(cfg *Config) ([]byte, error) {
 	// modifying kubeconfig files, which is nice to have
 	encoded, err = normYaml(encoded)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to normalize KUBECONFIG encoding")
+		return nil, fmt.Errorf("failed to normalize kubeconfig: %w", err)
 	}
 
 	return encoded, nil

--- a/extensions/docker-desktop/apps/clustermgr/pkg/kubeconfig/internal/kubeconfig/helpers.go
+++ b/extensions/docker-desktop/apps/clustermgr/pkg/kubeconfig/internal/kubeconfig/helpers.go
@@ -4,7 +4,7 @@
 package kubeconfig
 
 import (
-	"sigs.k8s.io/kind/pkg/errors"
+	"fmt"
 )
 
 // KINDClusterKey identifies kind clusters in kubeconfig files
@@ -16,13 +16,13 @@ func KINDClusterKey(clusterName string) string {
 // our expectations, namely on the number of entries
 func checkKubeadmExpectations(cfg *Config) error {
 	if len(cfg.Clusters) != 1 {
-		return errors.Errorf("kubeadm KUBECONFIG should have one cluster, but read %d", len(cfg.Clusters))
+		return fmt.Errorf("kubeadm KUBECONFIG should have one cluster, but read %d", len(cfg.Clusters))
 	}
 	if len(cfg.Users) != 1 {
-		return errors.Errorf("kubeadm KUBECONFIG should have one user, but read %d", len(cfg.Users))
+		return fmt.Errorf("kubeadm KUBECONFIG should have one user, but read %d", len(cfg.Users))
 	}
 	if len(cfg.Contexts) != 1 {
-		return errors.Errorf("kubeadm KUBECONFIG should have one context, but read %d", len(cfg.Contexts))
+		return fmt.Errorf("kubeadm KUBECONFIG should have one context, but read %d", len(cfg.Contexts))
 	}
 	return nil
 }

--- a/extensions/docker-desktop/apps/clustermgr/pkg/kubeconfig/internal/kubeconfig/merge.go
+++ b/extensions/docker-desktop/apps/clustermgr/pkg/kubeconfig/internal/kubeconfig/merge.go
@@ -4,9 +4,8 @@
 package kubeconfig
 
 import (
+	"fmt"
 	"os"
-
-	"sigs.k8s.io/kind/pkg/errors"
 )
 
 // WriteMerged writes a kind kubeconfig (see KINDFromRawKubeadm) into configPath
@@ -18,7 +17,7 @@ func WriteMerged(kindConfig *Config, explicitConfigPath string) error {
 
 	// lock config file the same as client-go
 	if err := lockFile(configPath); err != nil {
-		return errors.Wrap(err, "failed to lock config file")
+		return fmt.Errorf("failed to lock config file %s: %v", configPath, err)
 	}
 	defer func() {
 		_ = unlockFile(configPath)
@@ -27,7 +26,7 @@ func WriteMerged(kindConfig *Config, explicitConfigPath string) error {
 	// read in existing
 	existing, err := read(configPath)
 	if err != nil {
-		return errors.Wrap(err, "failed to get kubeconfig to merge")
+		return fmt.Errorf("failed to get kubeconfig from %s: %v", configPath, err)
 	}
 
 	// merge with kind kubeconfig

--- a/extensions/docker-desktop/apps/clustermgr/pkg/kubeconfig/internal/kubeconfig/read.go
+++ b/extensions/docker-desktop/apps/clustermgr/pkg/kubeconfig/internal/kubeconfig/read.go
@@ -4,11 +4,11 @@
 package kubeconfig
 
 import (
+	"fmt"
 	"io"
 	"os"
 
 	yaml "gopkg.in/yaml.v3"
-	"sigs.k8s.io/kind/pkg/errors"
 )
 
 // KINDFromRawKubeadm returns a kind kubeconfig derived from the raw kubeadm kubeconfig,
@@ -56,17 +56,17 @@ func read(configPath string) (*Config, error) {
 	if os.IsNotExist(err) {
 		return &Config{}, nil
 	} else if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, fmt.Errorf("failed to open %s: %v", configPath, err)
 	}
 
 	// otherwise read in and deserialize
 	cfg := &Config{}
 	rawExisting, err := io.ReadAll(f)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, fmt.Errorf("failed to read %s: %v", configPath, err)
 	}
 	if err := yaml.Unmarshal(rawExisting, cfg); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, fmt.Errorf("failed to unmarshal %s: %v", configPath, err)
 	}
 
 	return cfg, nil

--- a/extensions/docker-desktop/apps/clustermgr/pkg/kubeconfig/internal/kubeconfig/remove.go
+++ b/extensions/docker-desktop/apps/clustermgr/pkg/kubeconfig/internal/kubeconfig/remove.go
@@ -4,9 +4,8 @@
 package kubeconfig
 
 import (
+	"fmt"
 	"os"
-
-	"sigs.k8s.io/kind/pkg/errors"
 )
 
 // RemoveKIND removes the kind cluster kindClusterName from the KUBECONFIG
@@ -17,7 +16,7 @@ func RemoveKIND(kindClusterName, explicitPath string) error {
 		if err := func(configPath string) error {
 			// lock before modifying
 			if err := lockFile(configPath); err != nil {
-				return errors.Wrap(err, "failed to lock config file")
+				return fmt.Errorf("failed to lock %s: %v", configPath, err)
 			}
 			defer func(configPath string) {
 				_ = unlockFile(configPath)
@@ -26,7 +25,7 @@ func RemoveKIND(kindClusterName, explicitPath string) error {
 			// read in existing
 			existing, err := read(configPath)
 			if err != nil {
-				return errors.Wrap(err, "failed to read kubeconfig to remove KIND entry")
+				return fmt.Errorf("failed to get kubeconfig from %s to remove KIND entry: %v", configPath, err)
 			}
 
 			// remove the kind cluster from the config

--- a/extensions/docker-desktop/apps/clustermgr/pkg/kubeconfig/internal/kubeconfig/write.go
+++ b/extensions/docker-desktop/apps/clustermgr/pkg/kubeconfig/internal/kubeconfig/write.go
@@ -4,10 +4,9 @@
 package kubeconfig
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"sigs.k8s.io/kind/pkg/errors"
 )
 
 // write writes cfg to configPath
@@ -21,11 +20,11 @@ func write(cfg *Config, configPath string) error {
 	dir := filepath.Dir(configPath)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		if err = os.MkdirAll(dir, 0755); err != nil {
-			return errors.Wrap(err, "failed to create directory for KUBECONFIG")
+			return fmt.Errorf("failed to create directory %s for kubeconfig: %v", dir, err)
 		}
 	}
 	if err := os.WriteFile(configPath, encoded, 0600); err != nil {
-		return errors.Wrap(err, "failed to write KUBECONFIG")
+		return fmt.Errorf("failed to write kubeconfig to %s: %v", configPath, err)
 	}
 	return nil
 }

--- a/extensions/docker-desktop/apps/clustermgr/pkg/utils/lock.go
+++ b/extensions/docker-desktop/apps/clustermgr/pkg/utils/lock.go
@@ -4,12 +4,12 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/juju/fslock"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -41,7 +41,7 @@ func GetFileLockWithTimeOut(lockPath string, lockDuration time.Duration) (*fsloc
 	}
 
 	if err := lock.LockWithTimeout(lockDuration); err != nil {
-		return &fslock.Lock{}, errors.Wrap(err, "failed to acquire a lock with timeout")
+		return &fslock.Lock{}, fmt.Errorf("failed to acquire lock %s with timeout: %v", lockPath, err)
 	}
 	return lock, nil
 }


### PR DESCRIPTION
## What this PR does / why we need it
This Pull request addresses the need for removal deprecated `github.com/pkg/errors` and creation of a TCE specific error package that is common across the repository to standardize the error generation and formatting

## Which issue(s) this PR fixes
Fixes: #4850

## Describe testing done for PR
Unit Tests + Manual command workflow to bring up the clusters

## Special notes for your reviewer
NA