### PR TITLE
External-dns e2e test hardening

### DIFF
--- a/addons/packages/external-dns/0.11.0/test/e2e/externaldns_test.go
+++ b/addons/packages/external-dns/0.11.0/test/e2e/externaldns_test.go
@@ -182,12 +182,14 @@ var _ = Describe("External-dns Addon E2E Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer os.Remove(customValuesFilename)
 
-			_, err = utils.Tanzu(nil, "package", "installed", "update", packageInstallName,
-				"--namespace", packageInstallNamespace,
-				"--package-name", packageName,
-				"--version", utils.TanzuPackageAvailableVersionWithVersionSubString(packageName, version),
-				"--values-file", customValuesFilename)
-			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() error {
+				_, err = utils.Tanzu(nil, "package", "installed", "update", packageInstallName,
+					"--namespace", packageInstallNamespace,
+					"--package-name", packageName,
+					"--version", utils.TanzuPackageAvailableVersionWithVersionSubString(packageName, version),
+					"--values-file", customValuesFilename)
+				return err
+			}, "30s", "5s").Should(Succeed())
 
 			By("validating package install is ready")
 			utils.ValidatePackageInstallReady(packageInstallNamespace, packageInstallName)


### PR DESCRIPTION
## What this PR does / why we need it
The step that updates the installed package may fail due to a
simultaneous reconcilliation happening from previous steps.
Retrying should be safe.

## Describe testing done for PR

Created a uc cluster, installed metal lb, and ran the test.

