### PR TITLE
Skip sudo on install if running as root

### DIFF
--- a/hack/release/install.sh
+++ b/hack/release/install.sh
@@ -9,6 +9,11 @@ set -o pipefail
 set -o xtrace
 set +x
 
+SUDO="sudo"
+if [[ "$EUID" -eq 0 ]]; then
+    SUDO=""
+fi
+
 debug="false"
 if [[ $# -eq 1 ]] && [[ "$1" == "-d" ]]; then
     debug="true"
@@ -88,7 +93,7 @@ if [[ -n "${TANZU_BIN_PATH}" ]]; then
   if [[ -n "${TANZU_BIN_PATH}" ]]; then
     # best effort, so just ignore errors
     echo "Unable to delete Tanzu CLI. Retrying using sudo."
-    sudo rm -f "${TANZU_BIN_PATH}" > /dev/null
+    ${SUDO} rm -f "${TANZU_BIN_PATH}" > /dev/null
   fi
 fi
 
@@ -101,7 +106,7 @@ if [[ ":${PATH}:" == *":$HOME/bin:"* && -d "${HOME}/bin" ]]; then
   install "${MY_DIR}/tanzu" "${TANZU_BIN_PATH}"
 else
   echo Installing tanzu cli to "${TANZU_BIN_PATH}/tanzu"
-  sudo install "${MY_DIR}/tanzu" "${TANZU_BIN_PATH}" || handle_sudo_failure
+  ${SUDO} install "${MY_DIR}/tanzu" "${TANZU_BIN_PATH}" || handle_sudo_failure
 fi
 echo
 

--- a/hack/release/uninstall.sh
+++ b/hack/release/uninstall.sh
@@ -9,6 +9,11 @@ set -o pipefail
 set -o xtrace
 set +x
 
+SUDO="sudo"
+if [[ "$EUID" -eq 0 ]]; then
+    SUDO=""
+fi
+
 debug="false"
 if [[ $# -eq 1 ]] && [[ "$1" == "-d" ]]; then
     debug="true"
@@ -80,7 +85,7 @@ if [[ -n "${TANZU_BIN_PATH}" ]]; then
 
   # best effort, so just ignore errors
   if [[ "${TANZU_BIN_PATH}" == *"/usr/local"* ]]; then
-    sudo rm -f "${TANZU_BIN_PATH}" > /dev/null
+    ${SUDO} rm -f "${TANZU_BIN_PATH}" > /dev/null
   else
     rm -f "${TANZU_BIN_PATH}" > /dev/null
   fi


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

Our install script attempts to figure out the best place to install the
`tanzu` binary to. It will look in the user's home directory for a
`~/bin` path, and if that is not found it will try to install to the
common path of `/usr/local/bin`.

In the latter case, in normal cases this needs to be run using sudo to
have permissions to install to the system-wide path. But when running as
root, the use of sudo is a noop since there are no elevated permissions
needed.

On most systems, when running as root the `sudo` command is still
present somewhere in `$PATH`. But some systems do not have this
available. So despite the fact that the root user doesn't actually need
`sudo`, the command fails due to the command not being found.

To avoid this situation, this changes the install script to detect if we
are running as root, and if so, run the install to the system-wide path
without trying to invoke using sudo.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4957 