### PR TITLE
Add 0.10.3 of secretgen-controller

### DIFF
--- a/addons/packages/secretgen-controller/0.10.3/README.md
+++ b/addons/packages/secretgen-controller/0.10.3/README.md
@@ -1,0 +1,31 @@
+# Secretgen Controller Package
+
+Secretgen-controller provides CRDs to specify what secrets need to be on cluster (generated or not).
+
+Features:
+
+* supports generating certificates, passwords, RSA keys and SSH keys
+* supports exporting and importing secrets across namespaces
+
+## Components
+
+* secretgen-controller
+
+## Configuration
+
+The following configuration values can be set to customize the secretgen-controller installation.
+
+### Secret Gen Controller Configuration
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `namespace` | Optional | The namespace in which to deploy secretgen-controller. |
+| `create_namespace` | Optional | A boolean that indicates whether to create the namespace specified. Default value is `true`. |
+| `deployment.updateStrategy` | Optional | Update strategy of deployments, either 'RollingUpdate' or empty (use default strategy). |
+| `deployment.rollingUpdate.maxUnavailable` | Optional | The maxUnavailable of rollingUpdate. Applied only if RollingUpdate is used as updateStrategy. |
+| `deployment.rollingUpdate.maxSurge` | Optional | The maxSurge of rollingUpdate. Applied only if RollingUpdate is used as updateStrategy. |
+| `deployment.nodeSelector` | Optional | NodeSelector configuration applied to all the deployments. |
+
+## Usage Example
+
+To learn more about how to use secretgen-controller refer to [secretgen-controller website](https://github.com/vmware-tanzu/carvel-secretgen-controller)

--- a/addons/packages/secretgen-controller/0.10.3/package.yml
+++ b/addons/packages/secretgen-controller/0.10.3/package.yml
@@ -1,0 +1,63 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: secretgen-controller.carvel.dev.0.10.3
+spec:
+  refName: secretgen-controller.carvel.dev
+  version: 0.10.3
+  releaseNotes: https://github.com/vmware-tanzu/carvel-secretgen-controller/releases/tag/v0.10.3
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      properties:
+        namespace:
+          type: string
+          description: The namespace in which to deploy secretgen-controller
+          default: secretgen-controller
+        create_namespace:
+          type: boolean
+          description: Whether to create namespace specified for secretgen-controller
+          default: true
+        deployment:
+          type: object
+          additionalProperties: false
+          description: Configuration for secretgen-controller deployment
+          properties:
+            updateStrategy:
+              type: string
+              description: Update strategy of deployments, empty uses default strategy
+              default: ""
+            rollingUpdate:
+              type: object
+              additionalProperties: false
+              properties:
+                maxUnavailable:
+                  type: integer
+                  description: The maxUnavailable of rollingUpdate. Applied only if RollingUpdate is used as updateStrategy
+                  default: 1
+                maxSurge:
+                  type: integer
+                  description: The maxSurge of rollingUpdate. Applied only if RollingUpdate is used as updateStrategy
+                  default: 0
+            nodeSelector:
+              nullable: true
+              description: NodeSelector configuration applied to all the deployments
+              default: null
+  licenses:
+  - Apache 2.0
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: ghcr.io/vmware-tanzu/carvel-secretgen-controller-package-bundle@sha256:f9e6b9f888f2ffd454fdb5afad4f119f0b7c8deccf465fc9ca3fa3a5c882ad73
+      template:
+      - ytt:
+          paths:
+          - config
+      - kbld:
+          paths:
+          - .imgpkg/images.yml
+          - '-'
+      deploy:
+      - kapp: {}

--- a/addons/packages/secretgen-controller/vendir.lock.yml
+++ b/addons/packages/secretgen-controller/vendir.lock.yml
@@ -1,0 +1,8 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/carvel-secretgen-controller/releases/71524101
+    path: .
+  path: 0.10.3
+kind: LockConfig

--- a/addons/packages/secretgen-controller/vendir.yml
+++ b/addons/packages/secretgen-controller/vendir.yml
@@ -1,0 +1,13 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.12.0
+directories:
+  - path: 0.10.3
+    contents:
+      - path: .
+        githubRelease:
+          slug: vmware-tanzu/carvel-secretgen-controller
+          tag: v0.10.3
+          assetNames: ["package.yml"]
+          checksums:
+            package.yml: 0fdcfbaff66b5bbfea0cef9b261c60552417ee008c5cb852e7604e5ea9215605

--- a/addons/packages/secretgen-controller/vendir.yml
+++ b/addons/packages/secretgen-controller/vendir.yml
@@ -9,5 +9,3 @@ directories:
           slug: vmware-tanzu/carvel-secretgen-controller
           tag: v0.10.3
           assetNames: ["package.yml"]
-          checksums:
-            package.yml: 0fdcfbaff66b5bbfea0cef9b261c60552417ee008c5cb852e7604e5ea9215605


### PR DESCRIPTION
- This simplfies the process of ingesting secretgen as a package
- TCE just needs the published artifacts from SGC github now

Signed-off-by: Neil Hickey <nhickey@vmware.com>

## What this PR does / why we need it
This PR simplifies the process for secretgen controller PackageCR management from 0.10.3 onwards.

It is also a signal that the PackageCR management will be done by the carvel team in the OSS repo 

https://github.com/vmware-tanzu/carvel-secretgen-controller/tree/develop/config

## Describe testing done for PR
The release process for SGC runs our e2e tests against the PackageCR installed via a PackageInstallCR

## Special notes for your reviewer
The values schema is different now - this could have implications on any downstream consumers of TCE

For the values schema... checkout https://github.com/vmware-tanzu/carvel-secretgen-controller/blob/develop/config/package-bundle/config/values-schema.yml
