### PR TITLE
External-dns support for azure secret configuration

### DIFF
--- a/addons/packages/external-dns/0.11.0/bundle/config/overlays/overlay-azure-secret.yaml
+++ b/addons/packages/external-dns/0.11.0/bundle/config/overlays/overlay-azure-secret.yaml
@@ -1,0 +1,58 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+#@ load("@ytt:json", "json")
+#@ load("@ytt:struct", "struct")
+#@ load("@ytt:assert", "assert")
+
+#@ if data.values.azure:
+#@ if data.values.azure.resourceGroup == "":
+#@   assert.fail("`data.values.azure.resourceGroup` must be specified")
+#@ end
+#@ if data.values.azure.tenantId == "":
+#@   assert.fail("`data.values.azure.tenantId` must be specified")
+#@ end
+#@ if data.values.azure.subscriptionId == "":
+#@   assert.fail("`data.values.azure.subscriptionId` must be specified")
+#@ end
+#@ if data.values.azure.useManagedIdentityExtension in [None, False] and data.values.azure.aadClientSecret in [None, ""]:
+#@   assert.fail("`data.values.azure.aadClientSecret` must be specified if not using managed identity extension")
+#@ end
+#@ if data.values.azure.useManagedIdentityExtension in [None, False] and data.values.azure.aadClientId in [None, ""]:
+#@   assert.fail("`data.values.azure.aadClientId` must be specified if not using managed identity extension")
+#@ end
+#@
+#@ json_data = {}
+#@ azure_config = data.values.azure
+#@ for key in azure_config:
+#@   if azure_config[key] != None:
+#@     json_data[key] = azure_config[key]
+#@   end
+#@ end
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-config-file
+  namespace: #@ data.values.namespace
+type: Opaque
+stringData:
+  azure.json: #@ json.encode(json_data)
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name":"external-dns"}})
+#@overlay/match-child-defaults missing_ok=True
+---
+spec:
+  template:
+    spec:
+      volumes:
+        - name: azure-config-file
+          secret:
+            secretName: azure-config-file
+      containers:
+        #@overlay/match by=overlay.subset({"name": "external-dns"})
+        - volumeMounts:
+          - name: azure-config-file
+            mountPath: /etc/kubernetes
+            readOnly: true
+#@ end

--- a/addons/packages/external-dns/0.11.0/bundle/config/schema.yaml
+++ b/addons/packages/external-dns/0.11.0/bundle/config/schema.yaml
@@ -75,3 +75,28 @@ aws:
     accessKey: ""
     #@schema/desc "AWS secret key. When provided along with the aws.accessKey, a Secret will be created and referenced in the external-dns Deployment."
     secretKey: ""
+
+#@schema/desc "Azure configuration. Package will create azure.json Secret, Volume, and VolumeMount with supplied values."
+#@schema/nullable
+azure:
+  #@schema/desc "AAD Client ID"
+  #@schema/nullable
+  aadClientId: ""
+  #@schema/desc "AAD Client Secret"
+  #@schema/nullable
+  aadClientSecret: ""
+  #@schema/desc "Cloud"
+  #@schema/nullable
+  cloud: ""
+  #@schema/desc "Resource Group"
+  resourceGroup: ""
+  #@schema/desc "Subscription ID"
+  subscriptionId: ""
+  #@schema/desc "Tenant ID"
+  tenantId: ""
+  #@schema/desc "Use manaaged identity extension"
+  #@schema/nullable
+  useManagedIdentityExtension: false
+  #@schema/desc "User Assigned Identity ID"
+  #@schema/nullable
+  userAssignedIdentityID: ""

--- a/addons/packages/external-dns/0.11.0/package.yaml
+++ b/addons/packages/external-dns/0.11.0/package.yaml
@@ -134,6 +134,49 @@ spec:
                   type: string
                   description: AWS secret key. When provided along with the aws.accessKey, a Secret will be created and referenced in the external-dns Deployment.
                   default: ""
+        azure:
+          type: object
+          additionalProperties: false
+          nullable: true
+          description: Azure configuration. Package will create azure.json Secret, Volume, and VolumeMount with supplied values.
+          properties:
+            aadClientId:
+              type: string
+              nullable: true
+              description: AAD Client ID
+              default: null
+            aadClientSecret:
+              type: string
+              nullable: true
+              description: AAD Client Secret
+              default: null
+            cloud:
+              type: string
+              nullable: true
+              description: Cloud
+              default: null
+            resourceGroup:
+              type: string
+              description: Resource Group
+              default: ""
+            subscriptionId:
+              type: string
+              description: Subscription ID
+              default: ""
+            tenantId:
+              type: string
+              description: Tenant ID
+              default: ""
+            useManagedIdentityExtension:
+              type: boolean
+              nullable: true
+              description: Use manaaged identity extension
+              default: null
+            userAssignedIdentityID:
+              type: string
+              nullable: true
+              description: User Assigned Identity ID
+              default: null
   capacityRequirementsDescription: "No specific capacity requirements."
   licenses:
     - "Apache 2.0"

--- a/addons/packages/external-dns/0.11.0/test/go.mod
+++ b/addons/packages/external-dns/0.11.0/test/go.mod
@@ -5,8 +5,10 @@ go 1.17
 require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
+	github.com/vmware-labs/yaml-jsonpath v0.3.2
 	github.com/vmware-tanzu/community-edition/addons/packages/test/matchers v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/community-edition/addons/packages/test/pkg v0.0.0-00010101000000-000000000000
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
 require (
@@ -14,14 +16,12 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
-	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e // indirect
 )
 

--- a/addons/packages/external-dns/0.11.0/test/unittest/externaldns_test.go
+++ b/addons/packages/external-dns/0.11.0/test/unittest/externaldns_test.go
@@ -11,12 +11,14 @@ import (
 	. "github.com/vmware-tanzu/community-edition/addons/packages/test/matchers"
 	"github.com/vmware-tanzu/community-edition/addons/packages/test/pkg/ytt"
 
+	"github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
+	"gopkg.in/yaml.v3"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("External DNS Ytt Templates", func() {
-
 	Context("Providing a minimal configuration", func() {
 		var output string
 
@@ -27,20 +29,41 @@ var _ = Describe("External DNS Ytt Templates", func() {
 		})
 
 		It("renders upstream yaml documents", func() {
-			Expect(FindDocsMatchingYAMLPath(output, map[string]string{".kind": "ClusterRole", ".metadata.name": "external-dns"})).To(HaveLen(1))
-			Expect(FindDocsMatchingYAMLPath(output, map[string]string{".kind": "ClusterRoleBinding", ".metadata.name": "external-dns-viewer"})).To(HaveLen(1))
-			Expect(FindDocsMatchingYAMLPath(output, map[string]string{".kind": "ServiceAccount", ".metadata.name": "external-dns"})).To(HaveLen(1))
+			Expect(FindDocsMatchingYAMLPath(output, map[string]string{
+				".kind":          "ClusterRole",
+				".metadata.name": "external-dns",
+			})).To(HaveLen(1))
+			Expect(FindDocsMatchingYAMLPath(output, map[string]string{
+				".kind":          "ClusterRoleBinding",
+				".metadata.name": "external-dns-viewer",
+			})).To(HaveLen(1))
+			Expect(FindDocsMatchingYAMLPath(output, map[string]string{
+				".kind":          "ServiceAccount",
+				".metadata.name": "external-dns",
+			})).To(HaveLen(1))
 		})
 
 		It("renders the default namespace", func() {
-			Expect(FindDocsMatchingYAMLPath(output, map[string]string{".kind": "Namespace", ".metadata.name": "external-dns"})).To(HaveLen(1))
+			Expect(FindDocsMatchingYAMLPath(output, map[string]string{
+				".kind":          "Namespace",
+				".metadata.name": "external-dns",
+			})).To(HaveLen(1))
 		})
 
 		It("renders the deployment.args", func() {
 			deploymentDoc := findDeploymentDoc(output)
-			Expect(deploymentDoc).To(HaveYAMLPathWithValue(".spec.template.spec.containers[0].args[0]", "--source=ingress"))
-			Expect(deploymentDoc).To(HaveYAMLPathWithValue(".spec.template.spec.containers[0].args[1]", "--source=contour-httpproxy"))
-			Expect(deploymentDoc).To(HaveYAMLPathWithValue(".spec.template.spec.containers[0].args[2]", "--provider=rfc2136"))
+			Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+				".spec.template.spec.containers[0].args[0]",
+				"--source=ingress",
+			))
+			Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+				".spec.template.spec.containers[0].args[1]",
+				"--source=contour-httpproxy",
+			))
+			Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+				".spec.template.spec.containers[0].args[2]",
+				"--provider=rfc2136",
+			))
 		})
 
 		It("does not configure optional keys", func() {
@@ -68,8 +91,14 @@ var _ = Describe("External DNS Ytt Templates", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			deploymentDoc := findDeploymentDoc(output)
-			Expect(deploymentDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.containers[0].env[0].name", "FOO"))
-			Expect(deploymentDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.containers[0].env[0].value", "bar"))
+			Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+				"$.spec.template.spec.containers[0].env[0].name",
+				"FOO",
+			))
+			Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+				"$.spec.template.spec.containers[0].env[0].value",
+				"bar",
+			))
 		})
 	})
 
@@ -77,11 +106,19 @@ var _ = Describe("External DNS Ytt Templates", func() {
 		It("renders a deployment with a custom security context", func() {
 			output, err := renderWithDataValuesFixture("deployment-security-context.yaml")
 			Expect(err).NotTo(HaveOccurred())
-
 			deploymentDoc := findDeploymentDoc(output)
-			Expect(deploymentDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.containers[0].securityContext.runAsUser", "1000"))
-			Expect(deploymentDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.containers[0].securityContext.runAsGroup", "2000"))
-			Expect(deploymentDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation", "false"))
+			Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+				"$.spec.template.spec.containers[0].securityContext.runAsUser",
+				"1000",
+			))
+			Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+				"$.spec.template.spec.containers[0].securityContext.runAsGroup",
+				"2000",
+			))
+			Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+				"$.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation",
+				"false",
+			))
 		})
 	})
 
@@ -91,10 +128,22 @@ var _ = Describe("External DNS Ytt Templates", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			deploymentDoc := findDeploymentDoc(output)
-			Expect(deploymentDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.volumes[0].name", "additional-volume"))
-			Expect(deploymentDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.volumes[0].emptyDir", ""))
-			Expect(deploymentDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.containers[0].volumeMounts[0].name", "additional-volume"))
-			Expect(deploymentDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.containers[0].volumeMounts[0].mountPath", "/path/in/container"))
+			Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+				"$.spec.template.spec.volumes[0].name",
+				"additional-volume",
+			))
+			Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+				"$.spec.template.spec.volumes[0].emptyDir",
+				"",
+			))
+			Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+				"$.spec.template.spec.containers[0].volumeMounts[0].name",
+				"additional-volume",
+			))
+			Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+				"$.spec.template.spec.containers[0].volumeMounts[0].mountPath",
+				"/path/in/container",
+			))
 		})
 	})
 
@@ -128,6 +177,7 @@ var _ = Describe("External DNS Ytt Templates", func() {
 			})
 		})
 	})
+
 	Describe("aws secrets", func() {
 		Describe("when not supplied", func() {
 			var output string
@@ -229,7 +279,222 @@ var _ = Describe("External DNS Ytt Templates", func() {
 			})
 		})
 	})
+
+	Describe("Azure credentials", func() {
+		var output string
+		Describe("when not provided", func() {
+			BeforeEach(func() {
+				var err error
+				output, err = renderWithDataValuesFixture("minimal-configuration.yaml")
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("does not add a Secret", func() {
+				secretDocs, err := FindDocsMatchingYAMLPath(
+					output,
+					map[string]string{".kind": "Secret"},
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(secretDocs).To(BeEmpty())
+			})
+			It("does not add Volumes, VolumeMounts", func() {
+				deploymentDoc := findDeploymentDoc(output)
+				Expect(deploymentDoc).NotTo(HaveYAMLPath("$.spec.template.spec.volumes"))
+				Expect(deploymentDoc).NotTo(HaveYAMLPath("$.spec.template.spec.containers[0].volumeMounts"))
+			})
+		})
+		Describe("when provided", func() {
+			It("renders a Secret and updates the Deployment to ref the volume", func() {
+				var err error
+				output, err = renderWithDataValuesFixture("azure-configuration.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				deploymentDoc := findDeploymentDoc(output)
+				Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+					"$.spec.template.spec.volumes[?(@.name=='azure-config-file')].secret.secretName",
+					"azure-config-file",
+				))
+				Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+					"$.spec.template.spec.containers[0].volumeMounts[?(@.name=='azure-config-file')].mountPath",
+					"/etc/kubernetes",
+				))
+				Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+					"$.spec.template.spec.containers[0].volumeMounts[?(@.name=='azure-config-file')].readOnly",
+					"true",
+				))
+
+				secretDocs, err := FindDocsMatchingYAMLPath(
+					output,
+					map[string]string{".kind": "Secret"},
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(secretDocs).To(HaveLen(1))
+				secretName := valueAtYAMLPath(deploymentDoc, "$.spec.template.spec.volumes[?(@.name=='azure-config-file')].secret.secretName")
+				Expect(secretDocs[0]).To(HaveYAMLPathWithValue("$.metadata.name", secretName))
+				Expect(secretDocs[0]).To(HaveYAMLPathWithValue("$.metadata.namespace", "external-dns-azure"))
+				Expect(valueAtYAMLPath(secretDocs[0], "$.stringData['azure.json']")).To(MatchJSON(`{
+				  "cloud": "azure-cloud",
+				  "tenantId": "azure-tenant-id",
+				  "subscriptionId": "azure-subscription-id",
+				  "resourceGroup": "azure-resource-group",
+				  "aadClientId": "azure-aad-client-id",
+				  "aadClientSecret": "azure-aad-client-secret",
+				  "useManagedIdentityExtension": false,
+				  "userAssignedIdentityID": "azure-user-assigned-identity-id"
+				}`))
+			})
+
+			When("only the required fields are provided", func() {
+				It("renders a Secret that omits the optional fields", func() {
+					var err error
+					output, err = renderWithDataValuesFixture("azure-minimal-configuration.yaml")
+					Expect(err).NotTo(HaveOccurred())
+					secretDocs, err := FindDocsMatchingYAMLPath(
+						output,
+						map[string]string{".kind": "Secret"},
+					)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(secretDocs).To(HaveLen(1))
+					Expect(secretDocs[0]).To(HaveYAMLPathWithValue(
+						"$.metadata.name",
+						"azure-config-file",
+					))
+					Expect(valueAtYAMLPath(secretDocs[0], "$.stringData['azure.json']")).To(MatchJSON(`{
+					  "resourceGroup": "azure-resource-group",
+					  "subscriptionId": "azure-subscription-id",
+					  "tenantId": "azure-tenant-id",
+					  "aadClientId": "azure-aad-client-id",
+					  "aadClientSecret": "azure-aad-client-secret"
+					}`))
+				})
+			})
+			When("useManagedIdentityExtension is true", func() {
+				It("does not require aadClientId and aadClientSecret", func() {
+					values := []string{
+						`#@data/values`,
+						`---`,
+						`deployment:`,
+						`  args:`,
+						`    - --source=ingress`,
+						`    - --provider=azure`,
+						`azure:`,
+						`  subscriptionId: "azure-subscription-id"`,
+						`  resourceGroup: "azure-resource-group"`,
+						`  tenantId: "azure-tenant-id"`,
+						`  useManagedIdentityExtension: true`,
+					}
+					valuesYaml := strings.Join(values, "\n")
+					_, err := renderWithDataValuesInline(valuesYaml)
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+			When("useManagedIdentityExtension is false or not specified", func() {
+				It("requires aadClientId", func() {
+					values := []string{
+						`#@data/values`,
+						`---`,
+						`deployment:`,
+						`  args:`,
+						`    - --source=ingress`,
+						`    - --provider=azure`,
+						`azure:`,
+						`  subscriptionId: "azure-subscription-id"`,
+						`  resourceGroup: "azure-resource-group"`,
+						`  tenantId: "azure-tenant-id"`,
+						`  aadClientSecret: "azure-aad-client-secret"`,
+					}
+					valuesYaml := strings.Join(values, "\n")
+					_, err := renderWithDataValuesInline(valuesYaml)
+					Expect(err).To(MatchError(ContainSubstring(
+						"aadClientId` must be specified if not using managed identity extension",
+					)))
+				})
+				It("requires aadClientSecret", func() {
+					values := []string{
+						`#@data/values`,
+						`---`,
+						`deployment:`,
+						`  args:`,
+						`    - --source=ingress`,
+						`    - --provider=azure`,
+						`azure:`,
+						`  subscriptionId: "azure-subscription-id"`,
+						`  resourceGroup: "azure-resource-group"`,
+						`  tenantId: "azure-tenant-id"`,
+						`  aadClientId: "azure-aad-client-id"`,
+					}
+					valuesYaml := strings.Join(values, "\n")
+					_, err := renderWithDataValuesInline(valuesYaml)
+					Expect(err).To(MatchError(ContainSubstring(
+						"aadClientSecret` must be specified if not using managed identity extension",
+					)))
+				})
+			})
+			When("the required fields are missing", func() {
+				It("returns an error when resourceGroup is not provided", func() {
+					values := []string{
+						`#@data/values`,
+						`---`,
+						`deployment:`,
+						`  args:`,
+						`    - --source=ingress`,
+						`    - --provider=azure`,
+						`azure:`,
+						`  subscriptionId: "azure-subscription-id"`,
+						`  tenantId: "azure-tenant-id"`,
+					}
+					valuesYaml := strings.Join(values, "\n")
+					_, err := renderWithDataValuesInline(valuesYaml)
+					Expect(err).To(MatchError(ContainSubstring("resourceGroup` must be specified")))
+				})
+				It("returns an error when tenantId is not provided", func() {
+					values := []string{
+						`#@data/values`,
+						`---`,
+						`deployment:`,
+						`  args:`,
+						`    - --source=ingress`,
+						`    - --provider=azure`,
+						`azure:`,
+						`  resourceGroup: "azure-resource-group"`,
+						`  subscriptionId: "azure-subscription-id"`,
+					}
+					valuesYaml := strings.Join(values, "\n")
+					_, err := renderWithDataValuesInline(valuesYaml)
+					Expect(err).To(MatchError(ContainSubstring("tenantId` must be specified")))
+				})
+				It("returns an error when subscriptionID is not provided", func() {
+					values := []string{
+						`#@data/values`,
+						`---`,
+						`deployment:`,
+						`  args:`,
+						`    - --source=ingress`,
+						`    - --provider=azure`,
+						`azure:`,
+						`  resourceGroup: "azure-resource-group"`,
+						`  tenantId: "azure-tenant-id"`,
+					}
+					valuesYaml := strings.Join(values, "\n")
+					_, err := renderWithDataValuesInline(valuesYaml)
+					Expect(err).To(MatchError(ContainSubstring("subscriptionId` must be specified")))
+				})
+			})
+		})
+	})
 })
+
+func valueAtYAMLPath(doc, yamlPath string) string {
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(doc), &node)
+	Expect(err).NotTo(HaveOccurred())
+
+	path, err := yamlpath.NewPath(yamlPath)
+	Expect(err).NotTo(HaveOccurred())
+
+	q, err := path.Find(&node)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(q).To(HaveLen(1))
+	return q[0].Value
+}
 
 func renderWithDataValuesFixture(filename string) (string, error) {
 	workingDir, err := os.Getwd()

--- a/addons/packages/external-dns/0.11.0/test/unittest/fixtures/values/azure-configuration.yaml
+++ b/addons/packages/external-dns/0.11.0/test/unittest/fixtures/values/azure-configuration.yaml
@@ -1,0 +1,22 @@
+#@data/values
+---
+namespace: "external-dns-azure"
+
+deployment:
+  args:
+    - --source=ingress
+    - --source=contour-httpproxy
+    - --provider=rfc2136
+  env:
+    - name: "other-key"
+      value: "other-value"
+
+azure:
+  cloud: "azure-cloud"
+  tenantId: "azure-tenant-id"
+  subscriptionId: "azure-subscription-id"
+  resourceGroup: "azure-resource-group"
+  aadClientId: "azure-aad-client-id"
+  aadClientSecret: "azure-aad-client-secret"
+  useManagedIdentityExtension: false #! Either this is true or aadClientId and aadClientSecret are required. Left in for test coverage.
+  userAssignedIdentityID: "azure-user-assigned-identity-id" #! Unused because useManagedIdentityExtension is false.

--- a/addons/packages/external-dns/0.11.0/test/unittest/fixtures/values/azure-minimal-configuration.yaml
+++ b/addons/packages/external-dns/0.11.0/test/unittest/fixtures/values/azure-minimal-configuration.yaml
@@ -1,0 +1,12 @@
+#@data/values
+---
+deployment:
+  args:
+    - --source=ingress
+    - --provider=azure
+azure:
+  resourceGroup: "azure-resource-group"
+  subscriptionId: "azure-subscription-id"
+  tenantId: "azure-tenant-id"
+  aadClientId: "azure-aad-client-id"
+  aadClientSecret: "azure-aad-client-secret"


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds the ability to supply `data.values.azure.*` variables.
When supplied, the package will create a Secret, as well as configure the Deployment with a Volume and VolumeMount.

## Which issue(s) this PR fixes
#4572

## Describe testing done for PR
- PR adds unit tests
- built the package, configured azure properties, and deployed it to Azure where it was seen external-dns updated a test zone
