### PR TITLE
Replacing alpine image by distroless base image from fluxcd-helm-controller v0.21.0

### DIFF
--- a/addons/packages/fluxcd-helm-controller/0.21.0/package.yaml
+++ b/addons/packages/fluxcd-helm-controller/0.21.0/package.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/fluxcd-helm-controller-bundle@sha256:681a765ee996c21b33f0911aa9e26f402ee0ab64b9610b7670f92dcc5d108a9a
+            image: projects.registry.vmware.com/tce/fluxcd-helm-controller-bundle@sha256:0c1aab710919cc2f886855235c63fbf50c32fc428c4d14bdb3404ac6217e4f1b
       template:
         - ytt:
             paths:

--- a/addons/packages/fluxcd-helm-controller/vendir.lock.yml
+++ b/addons/packages/fluxcd-helm-controller/vendir.lock.yml
@@ -7,7 +7,7 @@ directories:
   path: 0.17.2
 - contents:
   - githubRelease:
-      url: https://api.github.com/repos/vmware-tanzu/package-for-helm-controller/releases/67810077
+      url: https://api.github.com/repos/vmware-tanzu/package-for-helm-controller/releases/71784442
     path: .
   path: 0.21.0
 kind: LockConfig

--- a/addons/packages/fluxcd-helm-controller/vendir.yml
+++ b/addons/packages/fluxcd-helm-controller/vendir.yml
@@ -17,7 +17,7 @@ directories:
       - path: .
         githubRelease:
           slug: vmware-tanzu/package-for-helm-controller
-          tag: v0.21.0
+          tag: v0.21.0+update.1
           disableAutoChecksumValidation: true
           assetNames:
             - "package.yaml"


### PR DESCRIPTION

## What this PR does / why we need it

Replacing alpine image by distroless base image from fluxcd-helm-controller v0.21.0

## Which issue(s) this PR fixes
Fixes: #[OLYMP-30817](https://jira.eng.vmware.com/browse/OLYMP-30817)

## Describe testing done for PR
Manual
