### PR TITLE
UI Plugin: Fix refresh 404

### DIFF
--- a/cli/cmd/plugin/ui/server/serve.go
+++ b/cli/cmd/plugin/ui/server/serve.go
@@ -134,7 +134,7 @@ func fileServerMiddleware(next http.Handler) http.Handler {
 			staticContent, _ := fs.Sub(fsys, "web/tanzu-ui/build")
 
 			fallBackFileSystem := newFallBackStaticFileSystem(staticContent)
-			if (strings.HasPrefix(r.URL.Path,"/ui/") && !strings.Contains(r.URL.Path,"/static")) {
+			if strings.HasPrefix(r.URL.Path, "/ui/") && !strings.Contains(r.URL.Path, "/static") {
 				http.FileServer(fallBackFileSystem).ServeHTTP(w, r)
 			} else {
 				w.Header().Set("Cache-Control", "no-store")
@@ -144,7 +144,7 @@ func fileServerMiddleware(next http.Handler) http.Handler {
 				if strings.HasSuffix(r.URL.Path, ".css") {
 					w.Header().Add("Content-Type", "text/css")
 				}
-				
+
 				http.StripPrefix("/ui", requestLogger(http.FileServer(http.FS(staticContent)), "UI")).ServeHTTP(w, r)
 			}
 		}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
When user are in pages other than '/ui' (e.g. '/ui/getting-started'), refreshing current page is gonna couse '404 not found'.
Modify handlers in 'server/serve.go' to fix this bug.
## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #5013 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
