### PR TITLE
[external-dns] Add default securityContext in deploy

### DIFF
--- a/addons/packages/external-dns/0.11.0/bundle/config/overlays/overlay-00-deployment.yaml
+++ b/addons/packages/external-dns/0.11.0/bundle/config/overlays/overlay-00-deployment.yaml
@@ -39,8 +39,15 @@ spec:
           args: #@ data.values.deployment.args
           #@ if/end data.values.deployment.env:
           env: #@ data.values.deployment.env
-          #@ if/end data.values.deployment.securityContext:
+          #@ if data.values.deployment.securityContext:
           securityContext: #@ data.values.deployment.securityContext
+          #@ else:
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          #@ end
           #@ if/end data.values.deployment.volumeMounts:
           volumeMounts: #@ data.values.deployment.volumeMounts
       #@ if/end data.values.deployment.volumes:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

This PR sets a default limited privileged security context for external-dns package similar to what is shown here: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/security-context.md. We did not set the `runAsUser` field to 65534 as shown in the doc because we use the bitnami image which already sets a `USER` directive in the Dockerfile to `1001`, so it will already be a non-root user by default.

If a custom security context is provided to the external-dns package via data values it will override the entire security context for the deployment.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: n/a

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make e2e-test`
Also validated the settings of the limited security context on a running cluster. This included checking capabilities, user running external-dns process, and the read-only setting on the root filesystem.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
