### PR TITLE
Add rebase rule for metrics server to remove insecure flag for legacy clusters with cabundle

### DIFF
--- a/addons/packages/metrics-server/0.6.1/bundle/config/kapp-config.yaml
+++ b/addons/packages/metrics-server/0.6.1/bundle/config/kapp-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+rebaseRules:
+  - ytt:
+      overlayContractV1:
+        overlay.yml: |
+          #@ load("@ytt:data", "data")
+          #@ load("@ytt:overlay", "overlay")
+
+          #@ if/end hasattr(data.values.existing.spec, "caBundle"):
+          #@overlay/match by=overlay.all
+          ---
+          spec:
+            #@overlay/remove
+            insecureSkipTLSVerify:
+    resourceMatchers:
+      - apiVersionKindMatcher: {apiVersion: apiregistration.k8s.io/v1beta1, kind: APIService}
+      - apiVersionKindMatcher: {apiVersion: apiregistration.k8s.io/v1, kind: APIService}

--- a/addons/packages/metrics-server/0.6.1/package.yaml
+++ b/addons/packages/metrics-server/0.6.1/package.yaml
@@ -130,7 +130,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/metrics-server@sha256:e4c3082180db55b540854b3370b7c3649c1955deb37f0e7fc8485e3a23a478aa
+          image: projects.registry.vmware.com/tce/metrics-server@sha256:59403562a7a0b3f3f4a642f2bab6135f9153d461a78170860c24818f12c850b3
       template:
       - ytt:
           paths:


### PR DESCRIPTION
## What this PR does / why we need it
Add rebase rule for metrics server to remove insecure flag for legacy clusters with cabundle

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
