### PR TITLE
Add nodeportlocal service type default akodeloymentconfig

### DIFF
--- a/addons/packages/ako-operator/1.6.0/bundle/config/overlays/overlay-akodeploymentconfig.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/overlays/overlay-akodeploymentconfig.yaml
@@ -40,22 +40,6 @@ spec:
         cniPlugin: #@ values.akoOperator.config.avi_cni_plugin
 #@ end
         disableStaticRouteSync: #@ values.akoOperator.config.avi_disable_static_route_sync
-        enableEVH: #@ values.akoOperator.config.avi_enable_evh
-        layer7Only: #@ values.akoOperator.config.avi_l7_only
-        servicesAPI: #@ values.akoOperator.config.avi_services_api
-
-#@ if values.akoOperator.config.avi_namespace_selector_label_key:
-#@overlay/match missing_ok=True
-        namespaceSelector:
-            labelKey: #@ values.akoOperator.config.avi_namespace_selector_label_key
-            labelValue: #@ values.akoOperator.config.avi_namespace_selector_label_value
-#@ end
-        l4Config:
-            advancedL4: #@ values.akoOperator.config.avi_advanced_l4
-#@ if values.akoOperator.config.avi_auto_fqdn:
-            #@overlay/match missing_ok=True
-            autoFQDN: #@ values.akoOperator.config.avi_auto_fqdn
-#@ end
         ingress:
             disableIngressClass: #@ values.akoOperator.config.avi_disable_ingress_class
             defaultIngressController: #@ values.akoOperator.config.avi_ingress_default_ingress_controller
@@ -71,15 +55,63 @@ spec:
             #@overlay/match missing_ok=True
             nodeNetworkList: #@ json.decode(values.akoOperator.config.avi_ingress_node_network_list)
 #@ end
-            noPGForSNI: #@ values.akoOperator.config.avi_no_pg_for_sni
+#@ if values.akoOperator.config.avi_nsxt_t1_lr:
+        #@overlay/append
         networksConfig:
-            enableRHI: #@ values.akoOperator.config.avi_enable_rhi
-#@ if values.akoOperator.config.avi_bgp_peer_labels:
+            nsxtT1LR: #@ values.akoOperator.config.avi_nsxt_t1_lr
+#@ end
+
+#@overlay/match by=overlay.subset({"kind": "AKODeploymentConfig", "metadata": {"name": "install-ako-for-all-npl"}})
+---
+#@overlay/replace
+apiVersion: networking.tkg.tanzu.vmware.com/v1alpha1
+kind: AKODeploymentConfig
+metadata:
+    name: install-ako-for-all-npl
+spec:
+    clusterSelector:
+        matchLabels:
+            nodeportlocal: "true"
+#@ if values.akoOperator.config.avi_controller_version != "":
+    #@overlay/match missing_ok=True
+    controllerVersion: #@ values.akoOperator.config.avi_controller_version
+#@ end
+    dataNetwork:
+        name: #@ values.akoOperator.config.avi_data_network
+        cidr: #@ values.akoOperator.config.avi_data_network_cidr
+    controlPlaneNetwork:
+        name: #@ values.akoOperator.config.avi_control_plane_network
+        cidr: #@ values.akoOperator.config.avi_control_plane_network_cidr
+    cloudName: #@ values.akoOperator.config.avi_cloud_name
+    serviceEngineGroup: #@ values.akoOperator.config.avi_service_engine_group
+    controller: #@ values.akoOperator.config.avi_controller
+    adminCredentialRef:
+        name: #@ values.akoOperator.config.avi_admin_credential_name
+        namespace: #@ values.akoOperator.namespace
+    certificateAuthorityRef:
+        name: #@ values.akoOperator.config.avi_ca_name
+        namespace: #@ values.akoOperator.namespace
+    extraConfigs:
+        cniPlugin: antrea
+        disableStaticRouteSync: #@ values.akoOperator.config.avi_disable_static_route_sync
+        ingress:
+            disableIngressClass: #@ values.akoOperator.config.avi_disable_ingress_class
+            defaultIngressController: #@ values.akoOperator.config.avi_ingress_default_ingress_controller
+#@ if values.akoOperator.config.avi_ingress_shard_vs_size != "":
             #@overlay/match missing_ok=True
-            bgpPeerLabels: #@ values.akoOperator.config.avi_bgp_peer_labels
+            shardVSSize: #@ values.akoOperator.config.avi_ingress_shard_vs_size
+#@ end
+#@ if values.akoOperator.config.avi_ingress_service_type != "":
+            #@overlay/match missing_ok=True
+            serviceType: #@ values.akoOperator.config.avi_ingress_service_type
+#@ end
+#@ if values.akoOperator.config.avi_ingress_node_network_list != '""':
+            #@overlay/match missing_ok=True
+            nodeNetworkList: #@ json.decode(values.akoOperator.config.avi_ingress_node_network_list)
 #@ end
 #@ if values.akoOperator.config.avi_nsxt_t1_lr:
-            #@overlay/match missing_ok=True
+        #@overlay/append
+        networksConfig:
             nsxtT1LR: #@ values.akoOperator.config.avi_nsxt_t1_lr
 #@ end
 
@@ -114,29 +146,8 @@ spec:
         name: #@ values.akoOperator.config.avi_ca_name
         namespace: #@ values.akoOperator.namespace
     extraConfigs:
-#@ if values.akoOperator.config.avi_cni_plugin:
-#@overlay/match missing_ok=True
-        cniPlugin: #@ values.akoOperator.config.avi_cni_plugin
-#@ end
+        cniPlugin: antrea
         disableStaticRouteSync: #@ values.akoOperator.config.avi_disable_static_route_sync
-        enableEVH: #@ values.akoOperator.config.avi_enable_evh
-        layer7Only: #@ values.akoOperator.config.avi_l7_only
-        servicesAPI: #@ values.akoOperator.config.avi_services_api
-
-#@ if values.akoOperator.config.avi_namespace_selector_label_key:
-#@overlay/match missing_ok=True
-        namespaceSelector:
-            labelKey: #@ values.akoOperator.config.avi_namespace_selector_label_key
-            labelValue: #@ values.akoOperator.config.avi_namespace_selector_label_value
-#@ end
-
-        l4Config:
-            advancedL4: #@ values.akoOperator.config.avi_advanced_l4
-#@ if values.akoOperator.config.avi_auto_fqdn:
-            #@overlay/match missing_ok=True
-            autoFQDN: #@ values.akoOperator.config.avi_auto_fqdn
-#@ end
-
         ingress:
             disableIngressClass: #@ values.akoOperator.config.avi_disable_ingress_class
             defaultIngressController: #@ values.akoOperator.config.avi_ingress_default_ingress_controller
@@ -152,14 +163,8 @@ spec:
             #@overlay/match missing_ok=True
             nodeNetworkList: #@ json.decode(values.akoOperator.config.avi_ingress_node_network_list)
 #@ end
-            noPGForSNI: #@ values.akoOperator.config.avi_no_pg_for_sni
-        networksConfig:
-            enableRHI: #@ values.akoOperator.config.avi_enable_rhi
-#@ if values.akoOperator.config.avi_bgp_peer_labels:
-            #@overlay/match missing_ok=True
-            bgpPeerLabels: #@ values.akoOperator.config.avi_bgp_peer_labels
-#@ end
 #@ if values.akoOperator.config.avi_nsxt_t1_lr:
-            #@overlay/match missing_ok=True
+        #@overlay/append
+        networksConfig:
             nsxtT1LR: #@ values.akoOperator.config.avi_nsxt_t1_lr
 #@ end

--- a/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/akodeploymentconfig.yaml
+++ b/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/akodeploymentconfig.yaml
@@ -21,18 +21,41 @@ spec:
         cidr: 10.1.0.0/20
     extraConfigs:
         disableStaticRouteSync: false
-        enableEVH: false
-        layer7Only: false
-        servicesAPI: false
-        l4Config:
-            advancedL4: false
-            autoFQDN: "disabled"
         ingress:
             disableIngressClass: true
             defaultIngressController: false
-            noPGForSNI: false
-        networksConfig:
-            enableRHI: false
+
+---
+apiVersion: networking.tkg.tanzu.vmware.com/v1alpha1
+kind: AKODeploymentConfig
+metadata:
+    name: install-ako-for-all-npl
+spec:
+    clusterSelector:
+        matchLabels:
+            nodeportlocal: "true"
+    cloudName: Default-Cloud
+    serviceEngineGroup: Default-Group
+    controller: 10.0.0.1
+    adminCredentialRef:
+        name: controller-credentials
+        namespace: default
+    certificateAuthorityRef:
+        name: controller-ca
+        namespace: default
+    dataNetwork:
+        name: VM Network
+        cidr: 10.0.0.0/20
+    controlPlaneNetwork:
+        name: VM Network 2
+        cidr: 10.1.0.0/20
+    extraConfigs:
+        cniPlugin: antrea
+        disableStaticRouteSync: false
+        ingress:
+            disableIngressClass: true
+            defaultIngressController: false
+            serviceType: NodePortLocal
 
 ---
 apiVersion: networking.tkg.tanzu.vmware.com/v1alpha1
@@ -59,16 +82,9 @@ spec:
         name: VM Network 2
         cidr: 10.1.0.0/20
     extraConfigs:
+        cniPlugin: antrea
         disableStaticRouteSync: false
-        enableEVH: false
-        layer7Only: false
-        servicesAPI: false
-        l4Config:
-            advancedL4: false
-            autoFQDN: "disabled"
         ingress:
             disableIngressClass: true
             defaultIngressController: false
-            noPGForSNI: false
-        networksConfig:
-            enableRHI: false
+            serviceType: NodePortLocal


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

- Add one more default akodeploymentconfig for NodePortLocal Service type
- Change management cluster's AKO default service type to NodeportLocal because management cluster's CNI must be antrea

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
