### PR TITLE
UI Plugin: Add page loading state for Management Clusters inventory

### DIFF
--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/PageLoading/PageLoading.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/PageLoading/PageLoading.tsx
@@ -1,0 +1,39 @@
+// React imports
+import React from 'react';
+
+// Library imports
+import { CdsProgressCircle } from '@cds/react/progress-circle';
+import { StatusTypes } from '@cds/core/internal';
+
+export const LoadingSpinnerStatus = {
+    DANGER: 'danger',
+    INFO: 'info',
+    SUCCESS: 'success',
+    WARNING: 'warning',
+};
+
+interface PageLoadingProps {
+    message?: string;
+    status?: string;
+}
+
+function PageLoading(props: PageLoadingProps) {
+    const { message, status } = props;
+
+    const statusType = status ? status : LoadingSpinnerStatus.INFO;
+
+    return (
+        <>
+            <div cds-layout="horizontal align:center">
+                <CdsProgressCircle status={statusType as StatusTypes} size="xl"></CdsProgressCircle>
+                {message && (
+                    <span cds-text="section" cds-layout="p-l:sm">
+                        {message}
+                    </span>
+                )}
+            </div>
+        </>
+    );
+}
+
+export default PageLoading;

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.tsx
@@ -18,7 +18,7 @@ import PageLoading, { LoadingSpinnerStatus } from '../../shared/components/PageL
 import PageNotification, { Notification, NotificationStatus } from '../../shared/components/PageNotification/PageNotification';
 
 function ManagementClusterInventory() {
-    const [showLoading, setShowLoading] = useState<boolean>(false);
+    const [showPageLoading, setShowPageLoading] = useState<boolean>(false);
     const [notification, setNotification] = useState<Notification | null>(null);
     const [managementClusters, setManagementClusters] = useState<ManagementCluster[]>([]);
     const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
@@ -39,7 +39,7 @@ function ManagementClusterInventory() {
     }, []);
 
     const retrieveManagementClusters = async () => {
-        setShowLoading(true);
+        setShowPageLoading(true);
         try {
             const data = await ManagementService.getMgmtClusters();
             setManagementClusters(data);
@@ -49,7 +49,7 @@ function ManagementClusterInventory() {
                 message: `Unable to retrieve Management Clusters: ${e}`,
             } as Notification);
         } finally {
-            setShowLoading(false);
+            setShowPageLoading(false);
         }
     };
 
@@ -196,7 +196,7 @@ function ManagementClusterInventory() {
     }
 
     function MainContent() {
-        if (showLoading) {
+        if (showPageLoading) {
             return <PageLoading message="Searching for existing management clusters"></PageLoading>;
         } else {
             return hasManagementClusters() ? ManagementClustersSection() : NoManagementClustersSection();

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/ManagementClusterInventory.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { CdsButton } from '@cds/react/button';
 import { CdsIcon } from '@cds/react/icon';
 import { CdsModal, CdsModalActions, CdsModalContent, CdsModalHeader } from '@cds/react/modal';
+import { CdsProgressCircle } from '@cds/react/progress-circle';
 
 // App imports
 import ManagementClusterCard from './ManagementClusterCard';
@@ -13,6 +14,7 @@ import { ManagementCluster } from '../../swagger-api/models/ManagementCluster';
 import { ManagementService } from '../../swagger-api';
 import { NavRoutes } from '../../shared/constants/NavRoutes.constants';
 import './ManagementClusterInventory.scss';
+import PageLoading, { LoadingSpinnerStatus } from '../../shared/components/PageLoading/PageLoading';
 import PageNotification, { Notification, NotificationStatus } from '../../shared/components/PageNotification/PageNotification';
 
 function ManagementClusterInventory() {
@@ -193,6 +195,14 @@ function ManagementClusterInventory() {
         );
     }
 
+    function MainContent() {
+        if (showLoading) {
+            return <PageLoading message="Searching for existing management clusters"></PageLoading>;
+        } else {
+            return hasManagementClusters() ? ManagementClustersSection() : NoManagementClustersSection();
+        }
+    }
+
     return (
         <>
             <div className="management-cluster-landing-container" cds-layout="vertical gap:md col@sm:12 grid">
@@ -202,7 +212,7 @@ function ManagementClusterInventory() {
                         Management Clusters
                     </div>
                     <PageNotification notification={notification} closeCallback={dismissAlert}></PageNotification>
-                    {hasManagementClusters() ? ManagementClustersSection() : NoManagementClustersSection()}
+                    {MainContent()}
                 </div>
                 <div cds-layout="col:4" className="mgmt-cluster-admins-img"></div>
                 {renderConfirmDeleteModal()}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/UnmanagedClusterInventory.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/UnmanagedClusterInventory.tsx
@@ -16,7 +16,7 @@ import UnmanagedClusterCard from './UnmanagedClusterCard/UnmanagedClusterCard';
 import './UnmanagedClusterInventory.scss';
 
 function UnmanagedClusterInventory() {
-    const [showLoading, setShowLoading] = useState<boolean>(false);
+    const [showPageLoading, setShowPageLoading] = useState<boolean>(false);
     const [notification, setNotification] = useState<Notification | null>(null);
     const [unmanagedClusters, setUnmanagedClusters] = useState<UnmanagedCluster[]>([]);
     const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
@@ -29,7 +29,7 @@ function UnmanagedClusterInventory() {
     }
 
     const retrieveUnmanagedClusters = async () => {
-        setShowLoading(true);
+        setShowPageLoading(true);
         try {
             const data = await UnmanagedService.getUnmanagedClusters();
             setUnmanagedClusters(data);
@@ -39,7 +39,7 @@ function UnmanagedClusterInventory() {
                 message: `Unable to retrieve Unmanaged Clusters: ${e}`,
             } as Notification);
         } finally {
-            setShowLoading(false);
+            setShowPageLoading(false);
         }
     };
 


### PR DESCRIPTION

## What this PR does / why we need it
Adds a shared PageLoading component that functions as a wrapper for the clarity loading spinner
Refactored Management Cluster Inventory list page to leverage PageLoading component to display
loading spinner while list of management clusters is being retrieved.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #5060

## Describe testing done for PR
Tested UI to confirm loading spinner appears when GET list of management clusters API call is pending

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
![Screen Shot 2022-07-18 at 1 31 32 PM](https://user-images.githubusercontent.com/13439013/179612796-574524b1-3ac0-4a52-bad6-59458f04b537.png)
