### PR TITLE
release external-dns package 0.11.0+2

### DIFF
--- a/addons/packages/external-dns/0.11.0/package.yaml
+++ b/addons/packages/external-dns/0.11.0/package.yaml
@@ -1,10 +1,10 @@
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: external-dns.community.tanzu.vmware.com.0.11.0+1
+  name: external-dns.community.tanzu.vmware.com.0.11.0+2
 spec:
   refName: external-dns.community.tanzu.vmware.com
-  version: 0.11.0+1
+  version: 0.11.0+2
   releasedAt: 2022-05-25T21:00:00Z
   releaseNotes: "external-dns 0.11.0 https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.11.0"
   valuesSchema:
@@ -184,7 +184,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/external-dns@sha256:880ba9aa1d28950b0ec3d25c37d93e43c286ae75014e31d923621be52e2be167
+            image: projects.registry.vmware.com/tce/external-dns@sha256:2081ab337c257414cc13d837da0b6d5701cce6dad741c58ca2acc808af91ad19
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This finalizes the package release for external-dns 0.11.0+2 which includes:
- aws configuration changes
  - add configuration fields for access id and secret key, creates
    secret and env var secretKeyRefs for these values
- azure configuration changes
  - add configuration field for azure data values, creates the json
    secret and volume mount for the azure.json
- default securityContext for external-dns
  - ensures running as non-root user. The Dockerfile already specifies
    it run as a non root user, this is a safeguard.
  - mounts the root filesystem as readonly
  - drops all capabilities
  - specifying package values will override the entire default security
    context for the deployment

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Releases the following PRs:
#5000 
#5052 
#4991 

Related: #4572

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
1. Deployed a standalone cluster
1. Applied the package.yaml
1. Ran e2e tests for external-dns

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
