### PR TITLE
Add rebase rule for cert manager to remove caBundle for legacy clusters

### DIFF
--- a/addons/packages/metrics-server/0.6.1/bundle/config/kapp-config.yaml
+++ b/addons/packages/metrics-server/0.6.1/bundle/config/kapp-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+rebaseRules:
+  - path: [spec, caBundle]
+    type: remove
+    resourceMatchers:
+      - apiVersionKindMatcher: {apiVersion: apiregistration.k8s.io/v1beta1, kind: APIService}
+      - apiVersionKindMatcher: {apiVersion: apiregistration.k8s.io/v1, kind: APIService}

--- a/addons/packages/metrics-server/0.6.1/package.yaml
+++ b/addons/packages/metrics-server/0.6.1/package.yaml
@@ -130,7 +130,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/metrics-server@sha256:e4c3082180db55b540854b3370b7c3649c1955deb37f0e7fc8485e3a23a478aa
+          image: projects.registry.vmware.com/tce/metrics-server@sha256:c82ea7d5d51d63da0c256782348cdd5b7c143fad89137a00292a3646a158852b
       template:
       - ytt:
           paths:


### PR DESCRIPTION
Signed-off-by: Marjan Alavi <malavi@vmware.com>

## What this PR does / why we need it
Add rebase rule for cert manager to remove insecure flag for legacy clusters with cabundle

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
Tested in a kind cluster while simulating a legacy cluster having caBundle and then deployed the modified metrics server package bundle and noticed caBundle was removed
