### PR TITLE
Add rebase rule for metrics server to retain kapp app selector during…

### DIFF
--- a/addons/packages/metrics-server/0.6.1/bundle/config/kapp-config.yaml
+++ b/addons/packages/metrics-server/0.6.1/bundle/config/kapp-config.yaml
@@ -6,3 +6,8 @@ rebaseRules:
     resourceMatchers:
       - apiVersionKindMatcher: {apiVersion: apiregistration.k8s.io/v1beta1, kind: APIService}
       - apiVersionKindMatcher: {apiVersion: apiregistration.k8s.io/v1, kind: APIService}
+  - path: [ spec, selector, matchLabels, kapp.k14s.io/app ]
+    type: copy
+    sources: [ existing ]
+    resourceMatchers:
+      - apiVersionKindMatcher: { apiVersion: apps/v1, kind: Deployment }

--- a/addons/packages/metrics-server/0.6.1/package.yaml
+++ b/addons/packages/metrics-server/0.6.1/package.yaml
@@ -130,7 +130,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/metrics-server@sha256:c82ea7d5d51d63da0c256782348cdd5b7c143fad89137a00292a3646a158852b
+          image: projects.registry.vmware.com/tce/metrics-server@sha256:55f29f8ba79933204c49642b1c9b745e1d60af3221d16b7772f4ba1b7ad60725
       template:
       - ytt:
           paths:


### PR DESCRIPTION
Signed-off-by: Marjan Alavi <malavi@vmware.com>

## What this PR does / why we need it
Add rebase rule for metrics server to retain kapp app selector during update

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
Tested in a kind cluster while first deploying 1.5.0 metrics-server using kapp and then tried to upgrade to 1.6.0 by deploying 1.6.0 metrics server and verified the upgrade happened successfully after adding rebase rules to retain kapp specific selector 'kapp.k14s.io/app' per existing (pre-upgrade) cluster

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
