### PR TITLE
UI plugin, Unmanaged Cluster plugin: introduces tty-activate for output

### DIFF
--- a/cli/cmd/plugin/ui/server/handlers/unmanaged.go
+++ b/cli/cmd/plugin/ui/server/handlers/unmanaged.go
@@ -288,7 +288,7 @@ func copyAndLog(w io.Writer, r io.Reader) error {
 	}
 }
 
-func executeAndRedirect(args ...string) error {
+func executeAndRedirect(args ...string) {
 	cmdArgs := []string{"unmanaged-cluster"}
 	cmdArgs = append(cmdArgs, args...)
 
@@ -304,7 +304,7 @@ func executeAndRedirect(args ...string) error {
 	err := cmd.Start()
 	if err != nil {
 		fmt.Printf("cmd.Start() failed with '%s'\n", err)
-		return err
+		return
 	}
 
 	// cmd.Wait() should be called only after we finish reading from stdoutIn and stderrIn.
@@ -327,6 +327,4 @@ func executeAndRedirect(args ...string) error {
 	if errStdout != nil || errStderr != nil {
 		fmt.Printf("failed to capture stdout or stderr\n")
 	}
-
-	return err
 }

--- a/cli/cmd/plugin/ui/server/handlers/unmanaged.go
+++ b/cli/cmd/plugin/ui/server/handlers/unmanaged.go
@@ -108,6 +108,7 @@ func (app *App) CreateUnmanagedCluster(params unmanaged.CreateUnmanagedClusterPa
 	if createParams.Workernodecount > 0 {
 		args = append(args, "--worker-node-count", strconv.FormatInt(createParams.Workernodecount, 10))
 	}
+	args = append(args, "--tty-activate")
 
 	go executeAndRedirect(args...)
 
@@ -211,6 +212,19 @@ func sendTanzuCommand(tanzuArgs []string) {
 	doSendLog([]byte(formatTanzuCommandMessage(tanzuArgs)))
 }
 
+func customTrim(src string) string {
+	// We want to trim all spaces from the RIGHT side, and just "\r\n" from the left.
+	// For the right side, we COULD use TrimRight(), but
+	// that function requires us to specify the white characters,
+	// so instead we use TrimSpace to find the central non-whitespace string
+	// and then pull it out of the main string ALONG with any left side whitespace.
+	noSpaceMessage := strings.TrimSpace(src)
+	xStartNoSpaceMessage := strings.Index(src, noSpaceMessage)
+	rightTrimmedMessage := src[0 : xStartNoSpaceMessage+len(noSpaceMessage)]
+	// THEN we remove \r\n from the left
+	return strings.TrimLeft(rightTrimmedMessage, "\r\n")
+}
+
 // Our sendLog is a wrapper to the SendLog method.
 // The SendLog method is expecting a byte array of a valid JSON object, so our sendLog method
 // - splits the raw byte array into several messages along "\n" boundaries,
@@ -222,7 +236,7 @@ func sendLog(msg []byte) {
 	// remove messages that only contain white space
 	var messages []string
 	for x := range rawMessages {
-		trimmedMessage := strings.TrimSpace(rawMessages[x])
+		trimmedMessage := customTrim(rawMessages[x])
 		if len(trimmedMessage) > 0 {
 			messages = append(messages, trimmedMessage)
 		}

--- a/cli/cmd/plugin/ui/server/handlers/unmanaged.go
+++ b/cli/cmd/plugin/ui/server/handlers/unmanaged.go
@@ -251,7 +251,23 @@ func sendLog(msg []byte) {
 	for _, singleMessage := range messages {
 		fmt.Printf("%s: Sending LOG message: [%s]\n", time.Now(), singleMessage)
 		doSendLog([]byte(formatLogMessage(singleMessage)))
+		// NOTE: "RESULT: FAILURE" and "RESULT: SUCCESS" are magic strings output from the unmanaged-cluster plugin
+		if singleMessage == "RESULT: FAILURE" {
+			sendResultFailure()
+		} else if singleMessage == "RESULT: SUCCESS" {
+			sendResultSuccess()
+		}
 	}
+}
+
+func sendResultFailure() {
+	// NOTE: "failed" is a magic string recognized by the UI front end
+	doSendLog([]byte(formatResultMessage("failed")))
+}
+
+func sendResultSuccess() {
+	// NOTE: "successful" is a magic string recognized by the UI front end
+	doSendLog([]byte(formatResultMessage("successful")))
 }
 
 func doSendLog(msg []byte) {
@@ -262,6 +278,11 @@ func doSendLog(msg []byte) {
 func sleepAfterSendingWebSocketMessage() {
 	// A hack to avoid losing messages, which happens if we write another message too quickly to the websocket
 	time.Sleep(25 * time.Millisecond)
+}
+
+// NOTE: all the formatXXX methods are structuring JSON in a special way that is expected by the front end
+func formatResultMessage(result string) string {
+	return fmt.Sprintf("{\"type\":\"progress\", \"data\":{\"status\":%q,\"message\":\"RESULT: %s\"}}", result, result)
 }
 
 func formatLogMessage(logMessage string) string {

--- a/cli/cmd/plugin/ui/server/handlers/unmanaged.go
+++ b/cli/cmd/plugin/ui/server/handlers/unmanaged.go
@@ -251,9 +251,8 @@ func sleepAfterSendingWebSocketMessage() {
 }
 
 func formatLogMessage(logMessage string) string {
-	// Because we are sending the raw messages wrapped in JSON, we need to escape any double quotes
-	escapedMessage := strings.Replace(logMessage, "\"", "\\\"", -1)
-	return fmt.Sprintf("{\"type\":\"log\", \"data\":{\"logType\":\"output\",\"message\":\"%s\"}}", escapedMessage)
+	// Because we are sending the raw messages wrapped in JSON, we need to escape any double quotes, hence %q
+	return fmt.Sprintf("{\"type\":\"log\", \"data\":{\"logType\":\"output\",\"message\":%q}}", logMessage)
 }
 
 func formatPingMessage() string {
@@ -262,7 +261,7 @@ func formatPingMessage() string {
 
 func formatTanzuCommandMessage(args []string) string {
 	tanzuCmd := "tanzu " + strings.Join(args, " ")
-	return fmt.Sprintf("{\"type\":\"log\", \"data\":{\"logType\":\"tanzu command\",\"message\":\"%s\"}}", tanzuCmd)
+	return fmt.Sprintf("{\"type\":\"log\", \"data\":{\"logType\":\"tanzu command\",\"message\":%q}}", tanzuCmd)
 }
 
 // Adapted from copyAndCapture at https://blog.kowalczyk.info/article/wOYk/advanced-command-execution-in-go-with-osexec.html
@@ -270,7 +269,7 @@ func formatTanzuCommandMessage(args []string) string {
 func copyAndLog(w io.Writer, r io.Reader) error {
 	buf := make([]byte, 1024, 1024)
 	for {
-		n, err := r.Read(buf[:])
+		n, err := r.Read(buf)
 		if n > 0 {
 			d := buf[:n]
 			sendLog(d)

--- a/cli/cmd/plugin/ui/server/handlers/unmanaged.go
+++ b/cli/cmd/plugin/ui/server/handlers/unmanaged.go
@@ -294,7 +294,7 @@ func executeAndRedirect(args ...string) error {
 	cmdArgs = append(cmdArgs, args...)
 
 	fmt.Println("Tanzu CLI command: 'tanzu " + strings.Join(cmdArgs, " ") + "'")
-	sendTanzuCommand(args)
+	sendTanzuCommand(cmdArgs)
 	cmd := exec.Command("tanzu", cmdArgs...)
 
 	var errStdout, errStderr error

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/ConnectionNotification/ConnectionNotification.scss
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/ConnectionNotification/ConnectionNotification.scss
@@ -1,0 +1,3 @@
+.hide-me {
+  visibility: hidden;
+}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/ConnectionNotification/ConnectionNotification.scss
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/ConnectionNotification/ConnectionNotification.scss
@@ -1,3 +1,0 @@
-.hide-me {
-  visibility: hidden;
-}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/DeployProgress/DeployProgress.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/DeployProgress/DeployProgress.tsx
@@ -24,6 +24,7 @@ import { CdsIcon } from '@cds/react/icon';
 export const LogTypes = {
     LOG: 'log',
     PROGRESS: 'progress',
+    PING: 'ping',
 };
 
 export interface LogMessage {
@@ -63,6 +64,7 @@ function DeployProgress() {
     // Processes each message by type ('log' or 'status') and routes to appropriate handlers/state
     useEffect(() => {
         const lastMessage: MessageEvent | null = websocketSvc.lastMessage;
+        console.log(`WebSocket log message: ${lastMessage?.data}`);
         const logData = lastMessage ? JSON.parse(lastMessage.data) : null;
 
         if (logData && logData.type === LogTypes.LOG) {
@@ -70,6 +72,17 @@ function DeployProgress() {
             setLogMessageHistory((prev) => prev.concat([logLine]));
         } else if (logData && logData.type === LogTypes.PROGRESS) {
             handleDeploymentProgress(logData.data);
+        } else if (logData && logData.type === LogTypes.PING) {
+            // Add a '.' to the last line (if there is one)
+            setLogMessageHistory((prev) => {
+                const lastIndex = prev.length - 1;
+                if (lastIndex >= 0) {
+                    prev[lastIndex] = prev[lastIndex] + '.';
+                } else {
+                    prev.concat(['.']);
+                }
+                return prev;
+            });
         }
     }, [websocketSvc.lastMessage]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/configure.go
@@ -28,7 +28,6 @@ var ConfigureCmd = &cobra.Command{
 	RunE:    configure,
 }
 
-//nolint:dupl
 func init() {
 	ConfigureCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "Configuration file for unmanaged cluster creation")
 	ConfigureCmd.Flags().StringVar(&co.kubeconfigPath, "kubeconfig-path", "", "File path to where the kubeconfig will be persisted. Defaults to global user kubeconfig")

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -171,6 +171,8 @@ func create(cmd *cobra.Command, args []string) {
 	exitCode, err := tm.Deploy(clusterConfig)
 	if err != nil {
 		log.Error(err.Error())
+		log.Info("RESULT: FAILURE")
 		os.Exit(exitCode)
 	}
+	log.Info("RESULT: SUCCESS")
 }

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -91,6 +91,7 @@ func init() {
 	CreateCmd.Flags().StringVar(&co.servicecidr, "service-cidr", "", "The CIDR for Service IP allocation; default is 10.96.0.0/16")
 	CreateCmd.Flags().StringSliceVarP(&co.portMapping, "port-map", "p", []string{}, "Ports to map between container node and the host (format: '127.0.0.1:80:80/tcp', '80:80/tcp', '80:80', or just '80')")
 	CreateCmd.Flags().Bool("tty-disable", false, "Disable log stylization and emojis")
+	CreateCmd.Flags().Bool("tty-activate", false, "Force usage of log stylization and emojis")
 	CreateCmd.Flags().BoolVar(&co.skipPreflightChecks, "skip-preflight", false, "Skip the preflight checks; default is false")
 	CreateCmd.Flags().StringVar(&co.numContPlanes, "control-plane-node-count", "", "The number of control plane nodes to deploy; default is 1")
 	CreateCmd.Flags().StringVar(&co.numWorkers, "worker-node-count", "", "The number of worker nodes to deploy; default is 0")

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/create.go
@@ -77,7 +77,6 @@ var CreateCmd = &cobra.Command{
 
 var co = createUnmanagedOpts{}
 
-//nolint:dupl
 func init() {
 	CreateCmd.Flags().StringVarP(&co.clusterConfigFile, "config", "f", "", "A config file describing how to create the Tanzu environment")
 	CreateCmd.Flags().StringVar(&co.kubeconfigPath, "kubeconfig-path", "", "File path to where the kubeconfig will be persisted. Defaults to global user kubeconfig")

--- a/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
+++ b/cli/cmd/plugin/unmanaged-cluster/cmd/utils.go
@@ -46,6 +46,11 @@ func TtySetting(flags *pflag.FlagSet) bool {
 			result = !disableTTY
 		}
 	}
+	if flags.Changed("tty-activate") {
+		// User may explicitly ask for TTY-style output, when normal auto-detect would suppress it.
+		// For example, if stdout were re-directed.
+		result = true
+	}
 	return result
 }
 


### PR DESCRIPTION
Adds `tty-activate` as a command-line option for unmanaged cluster create, allowing the UI plugin to get stylized output from the unmanaged cluster plugin even while redirecting the output.