### PR TITLE
Fix notify failed unmanaged cluster

### DIFF
--- a/cli/cmd/plugin/ui/server/handlers/unmanaged.go
+++ b/cli/cmd/plugin/ui/server/handlers/unmanaged.go
@@ -163,7 +163,7 @@ func (app *App) getUnmanagedCluster(clusterName string) (*models.UnmanagedCluste
 
 // getUnmanagedClusters gets a list of all unmanaged clusters.
 func (app *App) getUnmanagedClusters() ([]*models.UnmanagedCluster, error) {
-	jsonOutput, err := parseCommandOutput(runCommand("list", "-o", "json"))    
+	jsonOutput, err := parseCommandOutput(runCommand("list", "-o", "json"))
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/UnmanagedClusterInventory.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/UnmanagedClusterInventory.tsx
@@ -33,6 +33,14 @@ function UnmanagedClusterInventory() {
         setShowPageLoading(true);
         try {
             const data = await UnmanagedService.getUnmanagedClusters();
+            data.filter((cluster) => {
+                if (cluster.status === 'Unknown') {
+                    setNotification({
+                        status: NotificationStatus.DANGER,
+                        message: `Unmanaged Clusters ${cluster.name} is failed: Please Delete it first`,
+                    } as Notification);
+                }
+            });
             setUnmanagedClusters(data);
         } catch (e) {
             setNotification({

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/UnmanagedClusterInventory.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/UnmanagedClusterInventory.tsx
@@ -37,7 +37,7 @@ function UnmanagedClusterInventory() {
                 if (cluster.status === 'Unknown') {
                     setNotification({
                         status: NotificationStatus.DANGER,
-                        message: `Unmanaged Clusters ${cluster.name} is failed: Please Delete it first`,
+                        message: `Unmanaged Clusters ${cluster.name} is failed: Please delete this cluster before attempting to create a new unmanaged cluster.`,
                     } as Notification);
                 }
             });

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/unmanaged-cluster-common/UnmanagedClusterCard/UnmanagedClusterCard.scss
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/unmanaged-cluster-common/UnmanagedClusterCard/UnmanagedClusterCard.scss
@@ -1,3 +1,7 @@
 label {
     color: var(--cds-global-color-gray-700);
 }
+
+.unknown {
+    border-color: hsl(9, 100%, 44%);
+}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/unmanaged-cluster-common/UnmanagedClusterCard/UnmanagedClusterCard.scss
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/unmanaged-cluster-common/UnmanagedClusterCard/UnmanagedClusterCard.scss
@@ -2,6 +2,6 @@ label {
     color: var(--cds-global-color-gray-700);
 }
 
-.unknown {
+.status-unknown {
     border-color: hsl(9, 100%, 44%);
 }

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/unmanaged-cluster-common/UnmanagedClusterCard/UnmanagedClusterCard.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/unmanaged-cluster-common/UnmanagedClusterCard/UnmanagedClusterCard.tsx
@@ -28,7 +28,7 @@ function UnmanagedClusterCard(props: UnmanagedClusterProps) {
     const { name, provider, status, confirmDeleteCallback } = props;
 
     return (
-        <div className="section-raised" cds-layout="grid cols:12 wrap:none" data-testid="unmanaged-cluster-card">
+        <div className={'section-raised ' + status?.toLowerCase()} cds-layout="grid cols:12 wrap:none" data-testid="unmanaged-cluster-card">
             <div cds-layout="vertical">
                 <div cds-layout="vertical" cds-text="subsection">
                     <div cds-layout="horizontal">

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/unmanaged-cluster-common/UnmanagedClusterCard/UnmanagedClusterCard.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/unmanaged-cluster/unmanaged-cluster-common/UnmanagedClusterCard/UnmanagedClusterCard.tsx
@@ -28,7 +28,11 @@ function UnmanagedClusterCard(props: UnmanagedClusterProps) {
     const { name, provider, status, confirmDeleteCallback } = props;
 
     return (
-        <div className={'section-raised ' + status?.toLowerCase()} cds-layout="grid cols:12 wrap:none" data-testid="unmanaged-cluster-card">
+        <div
+            className={'section-raised ' + 'status-' + status?.toLowerCase()}
+            cds-layout="grid cols:12 wrap:none"
+            data-testid="unmanaged-cluster-card"
+        >
             <div cds-layout="vertical">
                 <div cds-layout="vertical" cds-text="subsection">
                     <div cds-layout="horizontal">


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Previously, there is a ApiError when retrieving unmanaged clusters if a failed one exists like below:
image.
<img width="1532" alt="image" src="https://user-images.githubusercontent.com/106584724/181674322-2557ed8f-2a81-4134-8c7e-3c4c08a130de.png">

This PR tries to fix. The retrieve API will show all unmanaged clusters both succeed and failed.
The result will be like:
**With failed cluster**
<img width="964" alt="image" src="https://user-images.githubusercontent.com/106584724/181682986-4a80ef22-c3a5-4552-be85-cdae13cc6295.png">

**Delete failed cluster**

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/106584724/181683087-b2f293ec-c96b-4066-8c26-5d4ccba3b551.png">



## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #5093 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
