### PR TITLE
UI Plugin: modify css difference between Safari and Chrome

### DIFF
--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/FormInputComponents/ClusterName/ClusterName.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/FormInputComponents/ClusterName/ClusterName.tsx
@@ -56,7 +56,7 @@ export function ClusterName(props: ClusterNameProps) {
         <div className="cluster-name-container" cds-layout="m:lg">
             <CdsFormGroup layout="vertical-inline">
                 <div cds-layout="horizontal gap:lg align:vertical-center p-b:sm">
-                    <CdsInput layout="compact">
+                    <CdsInput layout="vertical">
                         <label cds-layout="p-b:xs">Cluster name</label>
                         <input type="text" {...register(field)} onChange={onClusterNameChange} placeholder={placeholderClusterName} />
                         {fieldError && <CdsControlMessage status="error">{fieldError.message}</CdsControlMessage>}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialOneTime.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialOneTime.tsx
@@ -69,7 +69,7 @@ function ManagementCredentialOneTime(props: Props) {
             <CdsFormGroup layout="vertical-inline" control-width="shrink">
                 <div cds-layout="horizontal gap:lg align:vertical-top">
                     <div cds-layout="vertical gap:lg align:vertical-center">
-                        <CdsInput>
+                        <CdsInput layout="vertical">
                             <label>Secret access key</label>
                             <input
                                 {...register('SECRET_ACCESS_KEY')}
@@ -82,7 +82,7 @@ function ManagementCredentialOneTime(props: Props) {
                                 <CdsControlMessage status="error">{errors['SECRET_ACCESS_KEY'].message}</CdsControlMessage>
                             )}
                         </CdsInput>
-                        <CdsInput>
+                        <CdsInput layout="vertical">
                             <label>Access key ID</label>
                             <input
                                 {...register('ACCESS_KEY_ID')}
@@ -95,7 +95,7 @@ function ManagementCredentialOneTime(props: Props) {
                                 <CdsControlMessage status="error">{errors['ACCESS_KEY_ID'].message}</CdsControlMessage>
                             )}
                         </CdsInput>
-                        <CdsInput>
+                        <CdsInput layout="vertical">
                             <label>Session token</label>
                             <input
                                 {...register('SESSION_TOKEN')}
@@ -110,7 +110,7 @@ function ManagementCredentialOneTime(props: Props) {
                         </CdsInput>
                     </div>
                     <div cds-layout="vertical gap:lg align:vertical-top">
-                        <CdsSelect layout="compact">
+                        <CdsSelect layout="vertical">
                             <label>AWS Region </label>
                             <select
                                 className="select-sm-width"

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.tsx
@@ -77,7 +77,7 @@ function ManagementCredentialProfile(props: Props) {
             </p>
             <CdsFormGroup layout="vertical-inline" control-width="shrink">
                 <div cds-layout="horizontal gap:lg align:vertical-center">
-                    <CdsSelect layout="compact">
+                    <CdsSelect layout="vertical">
                         <label>AWS credential profile</label>
                         <select
                             className="select-sm-width"
@@ -94,7 +94,7 @@ function ManagementCredentialProfile(props: Props) {
                         </select>
                     </CdsSelect>
 
-                    <CdsSelect layout="compact">
+                    <CdsSelect layout="vertical">
                         <label>AWS region </label>
                         <select
                             className="select-sm-width"

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/azure/azure-mc-common/management-credential-step/ManagementCredentials.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/azure/azure-mc-common/management-credential-step/ManagementCredentials.tsx
@@ -149,7 +149,7 @@ function ManagementCredentials(props: Partial<StepProps>) {
                             </option>
                         ))}
                     </SpinnerSelect>
-                    <CdsTextarea status={errors[AZURE_FIELDS.SSH_PUBLIC_KEY] ? 'error' : 'neutral'}>
+                    <CdsTextarea layout="vertical" status={errors[AZURE_FIELDS.SSH_PUBLIC_KEY] ? 'error' : 'neutral'}>
                         <label>SSH public key</label>
                         <textarea
                             {...register(AZURE_FIELDS.SSH_PUBLIC_KEY)}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/azure/azure-mc-common/management-credential-step/ManagementCredentialsLogin.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/azure/azure-mc-common/management-credential-step/ManagementCredentialsLogin.tsx
@@ -59,7 +59,7 @@ export default function ManagementCredentialsLogin(props: Props) {
         <>
             <div cds-layout="horizontal gap:lg">
                 <div cds-layout="horizontal gap:lg">
-                    <CdsInput>
+                    <CdsInput layout="vertical">
                         <label>Tenant ID</label>
                         <input
                             {...register(AZURE_FIELDS.TENANT_ID)}
@@ -73,7 +73,7 @@ export default function ManagementCredentialsLogin(props: Props) {
                             <CdsControlMessage status="error">{errors[AZURE_FIELDS.TENANT_ID]?.message}</CdsControlMessage>
                         )}
                     </CdsInput>
-                    <CdsInput>
+                    <CdsInput layout="vertical">
                         <label>Client ID</label>
                         <input
                             {...register(AZURE_FIELDS.CLIENT_ID)}
@@ -91,7 +91,7 @@ export default function ManagementCredentialsLogin(props: Props) {
             </div>
             <div cds-layout="horizontal gap:lg">
                 <div cds-layout="horizontal gap:md">
-                    <CdsInput>
+                    <CdsInput layout="vertical" className="test">
                         <label>Client Secret</label>
                         <input
                             {...register(AZURE_FIELDS.CLIENT_SECRET)}
@@ -104,7 +104,7 @@ export default function ManagementCredentialsLogin(props: Props) {
                             <CdsControlMessage status="error">{errors[AZURE_FIELDS.CLIENT_SECRET]?.message}</CdsControlMessage>
                         )}
                     </CdsInput>
-                    <CdsInput>
+                    <CdsInput layout="vertical" className="test">
                         <label>Subscription ID</label>
                         <input
                             {...register(AZURE_FIELDS.SUBSCRIPTION_ID)}
@@ -117,7 +117,7 @@ export default function ManagementCredentialsLogin(props: Props) {
                             <CdsControlMessage status="error">{errors[AZURE_FIELDS.SUBSCRIPTION_ID]?.message}</CdsControlMessage>
                         )}
                     </CdsInput>
-                    <CdsSelect layout="compact">
+                    <CdsSelect layout="vertical">
                         <label>Azure environment</label>
                         <select
                             className="select-sm-width"

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/vsphere/vsphere-mc-common/VsphereCredentialsStep.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/vsphere/vsphere-mc-common/VsphereCredentialsStep.tsx
@@ -367,7 +367,7 @@ export function VsphereCredentialsStep(props: Partial<StepProps>) {
     function CredentialsField(label: string, fieldName: VSPHERE_CREDENTIALS_STEP_FIELDS, placeholder: string, isPassword = false) {
         const err = errors[fieldName];
         return (
-            <CdsInput layout="compact">
+            <CdsInput layout="vertical">
                 <label cds-layout="p-b:xs">{label}</label>
                 <input
                     {...register(fieldName)}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/vsphere/vsphere-mc-common/VsphereLoadBalancerStep.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/vsphere/vsphere-mc-common/VsphereLoadBalancerStep.tsx
@@ -99,7 +99,7 @@ function EndpointProviderSection(
                     <CdsControlMessage status="neutral">&nbsp;</CdsControlMessage>
                 </CdsSelect>
 
-                <CdsInput layout="compact">
+                <CdsInput layout="vertical">
                     <label cds-layout="p-b:xs">Control Plane Endpoint ({IP_FAMILIES_DISPLAY[ipFamily]})</label>
                     <input {...register(VSPHERE_FIELDS.CLUSTER_ENDPOINT)} onChange={handleEndpointChange} defaultValue={endpoint} />
                     {err && <CdsControlMessage status="error">{err.message}</CdsControlMessage>}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
For some input without setting `layout=vertical` , those input fields will be rendered differently between Safari and Chrome.
In Safari, those input fields will be `horizontal ` like below
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/106584724/181850890-4427f1a2-ae78-4220-a93a-e89b0f0b602d.png">

![image](https://user-images.githubusercontent.com/106584724/181851204-669c4fca-7b6a-4d90-b4c8-c0f82f6d82d0.png)


Fixed those difference

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #4771 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
