### PR TITLE
UI Plugin: sets default node server port to 8080

### DIFF
--- a/cli/cmd/plugin/ui/web/tanzu-ui/node-server/src/conf/appConfig.js
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/node-server/src/conf/appConfig.js
@@ -31,7 +31,7 @@ let __serverErrorState;
 
 // [internal]
 // @const {Number} Default app port.
-const DEFAULT_PORT = 8008;
+const DEFAULT_PORT = 8080;
 // @const {String} Default log level
 const DEFAULT_LOG_LEVEL = 'info';
 
@@ -75,7 +75,7 @@ let def = {
     },
 
     /**
-     * Web server port or named pipe. Defaults to port 8008.
+     * Web server port or named pipe. Defaults to port 8080.
      *
      * If a number is specified, it must be at least `minPort` (and will be adjusted as
      *  such if it isn't). If a string is specified, it's expected to be a named pipe.

--- a/cli/cmd/plugin/ui/web/tanzu-ui/package.json
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/package.json
@@ -53,7 +53,7 @@
             "last 1 safari version"
         ]
     },
-    "proxy": "http://localhost:8008",
+    "proxy": "http://localhost:8080",
     "devDependencies": {
         "@hookform/resolvers": "^2.8.8",
         "@testing-library/react": "^13.2.0",

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/constants/App.constants.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/constants/App.constants.tsx
@@ -4,7 +4,7 @@ export const AppEnvironment = {
 };
 
 export const WebsocketAddress = {
-    DEV_LOCATION: 'localhost:8008',
+    DEV_LOCATION: 'localhost:8080',
     DEFAULT_PROTOCOL: 'ws',
     SECURE_PROTOCOL: 'wss',
 };


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Changes default node server port to 8080 to avoid collision with Kickstart UI node server port

This enables us to run the Kickstart UI and Guided UI simultaneously on a local machine in dev mode

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Verified that UI and node server communication is working as expected when running in local dev mode

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
