### PR TITLE
Add avi-version-config configMap with kapp versioned annotation so ako will be recreated at its updates.

### DIFF
--- a/addons/packages/load-balancer-and-ingress-service/1.7.2/bundle/.imgpkg/images.yml
+++ b/addons/packages/load-balancer-and-ingress-service/1.7.2/bundle/.imgpkg/images.yml
@@ -2,6 +2,6 @@
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
-    kbld.carvel.dev/id: projects-stg.registry.vmware.com/tkg/ako:v1.7.2_vmware.1
-  image: projects-stg.registry.vmware.com/tkg/ako@sha256:483c22fb9b2f032ffbb08551dd502bc6bb72ef94076a76af5ced6edf4fe3316e
+    kbld.carvel.dev/id: projects-stg.registry.vmware.com/tkg/ako:v1.7.2_vmware.2
+  image: projects-stg.registry.vmware.com/tkg/ako@sha256:913e895b2ef12facecb456737517854ee12ed1dc1fb7a245bf448d7453c2076f
 kind: ImagesLock

--- a/addons/packages/load-balancer-and-ingress-service/1.7.2/bundle/config/overlays/overlay-configmap.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.7.2/bundle/config/overlays/overlay-configmap.yaml
@@ -15,10 +15,6 @@ data:
   primaryInstance: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.primary_instance)
 #@ end
   controllerIP: #@ "{}".format(values.loadBalancerAndIngressService.config.controller_settings.controller_ip)
-#@ if values.loadBalancerAndIngressService.config.controller_settings.controller_version:
-  #@overlay/match missing_ok=True
-  controllerVersion: #@ "{}".format(values.loadBalancerAndIngressService.config.controller_settings.controller_version)
-#@ end
 #@ if values.loadBalancerAndIngressService.config.ako_settings.cni_plugin:
   #@overlay/match missing_ok=True
   cniPlugin: #@ "{}".format(values.loadBalancerAndIngressService.config.ako_settings.cni_plugin)
@@ -119,3 +115,22 @@ data:
   #@overlay/match missing_ok=True
   enableMCI: #@ values.loadBalancerAndIngressService.config.l7_settings.enable_MCI
 #@ end
+
+#@ def avi_version_config():
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: avi-version-config
+  namespace: #@ values.loadBalancerAndIngressService.namespace
+  #@overlay/match missing_ok=True
+  annotations:
+    kapp.k14s.io/versioned: ""
+    kapp.k14s.io/num-versions: "5"
+data:
+#@ if values.loadBalancerAndIngressService.config.controller_settings.controller_version:
+  #@overlay/match missing_ok=True
+  controllerVersion: #@ "{}".format(values.loadBalancerAndIngressService.config.controller_settings.controller_version)
+#@ end
+#@ end
+
+--- #@ avi_version_config()

--- a/addons/packages/load-balancer-and-ingress-service/1.7.2/bundle/config/overlays/overlay-statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.7.2/bundle/config/overlays/overlay-statefulset.yaml
@@ -62,7 +62,7 @@ spec:
             - name: CTRL_VERSION
               valueFrom:
                 configMapKeyRef:
-                  name: avi-k8s-config
+                  name: avi-version-config
                   key: controllerVersion
 #@ end
 #@ if values.loadBalancerAndIngressService.config.ako_settings.cni_plugin:

--- a/addons/packages/load-balancer-and-ingress-service/1.7.2/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.7.2/bundle/config/upstream/loadbalancerandingressservice/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: ako
           securityContext: {}
-          image: projects-stg.registry.vmware.com/tkg/ako:v1.7.2_vmware.1
+          image: projects-stg.registry.vmware.com/tkg/ako:v1.7.2_vmware.2
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:

--- a/addons/packages/load-balancer-and-ingress-service/1.7.2/package.yaml
+++ b/addons/packages/load-balancer-and-ingress-service/1.7.2/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/load-balancer-and-ingress-service@sha256:b5507ebc7106b20835e19226d6715ed0b6bde14d0e94314177e14f95ca15b510
+            image: projects.registry.vmware.com/tce/load-balancer-and-ingress-service@sha256:c8cfc75bdbbe16ef85428c49f2a98145a311ad05e158632584dd371471ade39b
       template:
         - ytt:
             paths:


### PR DESCRIPTION
…will be recreated at its updates.

Make sure the ako pod will be reloaded whenever there is an update on the `avi-k8s-config` configmap.


## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
