### PR TITLE
Add rebase rules for cert-manager v1.7.2

### DIFF
--- a/addons/packages/cert-manager/1.7.2/bundle/config/kapp-config.yaml
+++ b/addons/packages/cert-manager/1.7.2/bundle/config/kapp-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+rebaseRules:
+  - path: [spec, conversion]
+    type: remove
+    resourceMatchers:
+      - apiVersionKindMatcher: {apiVersion: apiextensions.k8s.io/v1, kind: CustomResourceDefinition}

--- a/addons/packages/cert-manager/1.7.2/package.yaml
+++ b/addons/packages/cert-manager/1.7.2/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/certmanager/cert-manager@sha256:4ddd056a0711b9067b2f4e64d209dc26af869883e1459001a08c7e1bc6cff163
+            image: projects.registry.vmware.com/tce/cert-manager@sha256:6835074a07c582684d140258bde2254ae1943872bdc061c7d4e087cfbfbd4f5b
       template:
         - ytt:
             paths:


### PR DESCRIPTION
Signed-off-by: Leo Li [lhaoran@vmware.com](mailto:lhaoran@vmware.com)

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
- Add rebase rules for cert manager `v1.7.2` to overcome the bug below observed in upgrade from previous version to `v1.7.2`

Bug symptom description:
- When upgrade installed cert-manager package from `v1.5.3` to `v1.7.2` using `tanzu` CLI or `kapp deploy`, the upgrade would fail due to
```
kapp: Error: Applying update customresourcedefinition/certificaterequests.cert-manager.io (apiextensions.k8s.io/v1) cluster:
Updating resource customresourcedefinition/certificaterequests.cert-manager.io (apiextensions.k8s.io/v1) cluster:
API server says:
CustomResourceDefinition.apiextensions.k8s.io "certificaterequests.cert-manager.io" is invalid:

spec.conversion.strategy: Required value
spec.conversion.webhookClientConfig: Forbidden: should not be set when strategy is not set to Webhook
(reason: Invalid). Reconcile failed: Error (see .status.usefulErrorMessage for details)
Error: exit status 1
```

Root cause:
- Starting from cert-manager `v1.7.0`, `spec.conversion` field is deprecated. However, this field is managed by both `cainjector` and `kapp` by `managedFields` in previous version. So removing this field is not allowed by kube-apiserver during upgrade.
- There is a public issue about it (https://github.com/cert-manager/cert-manager/issues/4831), but in our case we can't go with the workaround since `kapp` also manages it. So we need to go with the `kapp` way by adding rebase rules.

*Note: we might also need to apply the same change to cert-manager with version >= `v1.7.0`

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
- Tested in a TKG cluster while first deploying cert-manager `v1.5.3` using tanzu package, and then tried to upgrade to `v1.7.2` and verified the upgrade happened successfully after adding rebase rules to remove the `spec.conversion` path.
```
$ tanzu package installed list -A

  NAME                               PACKAGE-NAME                                        PACKAGE-VERSION             STATUS                                                                NAMESPACE
  cert-manager                       cert-manager.tanzu.vmware.com                       1.7.2+vmware.1-tkg.1-rc.2   Reconcile succeeded                                                   my-packages
```
## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
