### PR TITLE
Clear previous credentials

### DIFF
--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/Input/TextInputWithError.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/components/Input/TextInputWithError.tsx
@@ -15,7 +15,7 @@ interface Props {
     handleInputChange: (field: any, value: string) => void;
     maskText?: boolean;
 }
-function TextInputWithError(props: Props) {
+function TextInputWithError(props: Partial<Props>) {
     const { className, defaultValue, label, name, handleInputChange, placeholder, maskText } = props;
     const {
         register,
@@ -25,9 +25,9 @@ function TextInputWithError(props: Props) {
         <CdsInput layout="vertical" control-width="shrink">
             <label>{label}</label>
             <input
-                {...register(name, {
+                {...register(name as string, {
                     onChange: (e: ChangeEvent<HTMLInputElement>) => {
-                        handleInputChange(name, e.target.value);
+                        if (handleInputChange) handleInputChange(name, e.target.value);
                     },
                 })}
                 name={name}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialOneTime.test.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialOneTime.test.tsx
@@ -34,6 +34,7 @@ const useFormMock = {
                 ...obj,
             };
         },
+        reset: jest.fn(),
     }),
 };
 const methods = useFormMock.useForm();

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialOneTime.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialOneTime.tsx
@@ -24,14 +24,29 @@ function ManagementCredentialOneTime(props: Props) {
     const { selectCallback } = props;
     const { awsState, awsDispatch } = useContext(AwsStore);
     const {
+        reset,
         register,
         formState: { errors },
     } = useFormContext();
 
     const [regions, setRegions] = useState<string[]>([]);
     const [regionLoading, setRegionLoading] = useState(false);
+    const clearCredentialProfile = () => {
+        awsDispatch({
+            type: INPUT_CHANGE,
+            field: AWS_FIELDS.PROFILE,
+            payload: '',
+        } as FormAction);
+        awsDispatch({
+            type: INPUT_CHANGE,
+            field: AWS_FIELDS.REGION,
+            payload: '',
+        } as FormAction);
+    };
 
     useEffect(() => {
+        // reset();
+        clearCredentialProfile();
         // fetch regions
         const fetchRegions = async () => {
             try {
@@ -45,6 +60,7 @@ function ManagementCredentialOneTime(props: Props) {
             }
         };
         fetchRegions();
+        reset();
     }, []);
 
     const onInputValueChange = (field: string, value: string) => {
@@ -108,6 +124,13 @@ function ManagementCredentialOneTime(props: Props) {
                         </SpinnerSelect>
                     </div>
                 </div>
+                {/* <button
+                    onClick={() => {
+                        reset();
+                    }}
+                >
+                    reset
+                </button> */}
             </CdsFormGroup>
         </div>
     );

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialOneTime.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialOneTime.tsx
@@ -31,22 +31,10 @@ function ManagementCredentialOneTime(props: Props) {
 
     const [regions, setRegions] = useState<string[]>([]);
     const [regionLoading, setRegionLoading] = useState(false);
-    const clearCredentialProfile = () => {
-        awsDispatch({
-            type: INPUT_CHANGE,
-            field: AWS_FIELDS.PROFILE,
-            payload: '',
-        } as FormAction);
-        awsDispatch({
-            type: INPUT_CHANGE,
-            field: AWS_FIELDS.REGION,
-            payload: '',
-        } as FormAction);
-    };
 
     useEffect(() => {
         reset();
-        // clearCredentialProfile();
+        onInputValueChange(AWS_FIELDS.REGION, '');
         // fetch regions
         const fetchRegions = async () => {
             try {
@@ -70,13 +58,6 @@ function ManagementCredentialOneTime(props: Props) {
         } as FormAction);
     };
 
-    const onRegionChange = (field: string, value: string) => {
-        awsDispatch({
-            type: INPUT_CHANGE,
-            field,
-            payload: value,
-        } as FormAction);
-    };
     return (
         <div className="credential-one-time-container">
             <p cds-layout="m-y:lg">
@@ -91,21 +72,18 @@ function ManagementCredentialOneTime(props: Props) {
                             defaultValue={awsState[STORE_SECTION_FORM][AWS_FIELDS.SECRET_ACCESS_KEY]}
                             label="Secret access key"
                             name={AWS_FIELDS.SECRET_ACCESS_KEY}
-                            handleInputChange={onInputValueChange}
                             maskText
                         />
                         <TextInputWithError
                             defaultValue={awsState[STORE_SECTION_FORM][AWS_FIELDS.ACCESS_KEY_ID]}
                             label="Access key ID"
                             name={AWS_FIELDS.ACCESS_KEY_ID}
-                            handleInputChange={onInputValueChange}
                             maskText
                         />
                         <TextInputWithError
                             defaultValue={awsState[STORE_SECTION_FORM][AWS_FIELDS.SESSION_TOKEN]}
                             label="Session token"
                             name={AWS_FIELDS.SESSION_TOKEN}
-                            handleInputChange={onInputValueChange}
                             maskText
                         />
                     </div>
@@ -114,7 +92,7 @@ function ManagementCredentialOneTime(props: Props) {
                             label="AWS region"
                             className="select-sm-width"
                             handleSelect={(e: ChangeEvent<HTMLSelectElement>) => {
-                                onRegionChange(AWS_FIELDS.REGION, e.target.value);
+                                onInputValueChange(AWS_FIELDS.REGION, e.target.value);
                                 selectCallback();
                             }}
                             name={AWS_FIELDS.REGION}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialOneTime.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialOneTime.tsx
@@ -46,7 +46,7 @@ function ManagementCredentialOneTime(props: Props) {
 
     useEffect(() => {
         reset();
-        clearCredentialProfile();
+        // clearCredentialProfile();
         // fetch regions
         const fetchRegions = async () => {
             try {
@@ -63,6 +63,14 @@ function ManagementCredentialOneTime(props: Props) {
     }, []);
 
     const onInputValueChange = (field: string, value: string) => {
+        awsDispatch({
+            type: INPUT_CHANGE,
+            field,
+            payload: value,
+        } as FormAction);
+    };
+
+    const onRegionChange = (field: string, value: string) => {
         awsDispatch({
             type: INPUT_CHANGE,
             field,
@@ -106,7 +114,7 @@ function ManagementCredentialOneTime(props: Props) {
                             label="AWS region"
                             className="select-sm-width"
                             handleSelect={(e: ChangeEvent<HTMLSelectElement>) => {
-                                onInputValueChange(AWS_FIELDS.REGION, e.target.value);
+                                onRegionChange(AWS_FIELDS.REGION, e.target.value);
                                 selectCallback();
                             }}
                             name={AWS_FIELDS.REGION}
@@ -123,13 +131,6 @@ function ManagementCredentialOneTime(props: Props) {
                         </SpinnerSelect>
                     </div>
                 </div>
-                {/* <button
-                    onClick={() => {
-                        reset();
-                    }}
-                >
-                    reset
-                </button> */}
             </CdsFormGroup>
         </div>
     );

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialOneTime.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialOneTime.tsx
@@ -45,7 +45,7 @@ function ManagementCredentialOneTime(props: Props) {
     };
 
     useEffect(() => {
-        // reset();
+        reset();
         clearCredentialProfile();
         // fetch regions
         const fetchRegions = async () => {
@@ -60,7 +60,6 @@ function ManagementCredentialOneTime(props: Props) {
             }
         };
         fetchRegions();
-        reset();
     }, []);
 
     const onInputValueChange = (field: string, value: string) => {

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.test.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.test.tsx
@@ -35,6 +35,7 @@ const useFormMock = {
                 ...obj,
             };
         },
+        reset: jest.fn(),
     }),
 };
 const methods = useFormMock.useForm();

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.tsx
@@ -55,7 +55,7 @@ function ManagementCredentialProfile(props: Props) {
     };
 
     useEffect(() => {
-        // reset();
+        reset();
         clearOneTimeCredentials();
         // fetch regions
         const fetchRegions = async () => {
@@ -70,7 +70,6 @@ function ManagementCredentialProfile(props: Props) {
             }
         };
         fetchRegions();
-        reset();
     }, []);
     useEffect(() => {
         // fetch profiles

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.tsx
@@ -22,6 +22,7 @@ function ManagementCredentialProfile(props: Props) {
     const { selectCallback } = props;
     const { awsDispatch } = useContext(AwsStore);
     const {
+        reset,
         register,
         formState: { errors },
     } = useFormContext();
@@ -30,8 +31,32 @@ function ManagementCredentialProfile(props: Props) {
     const [profilesLoading, setProfilesLoading] = useState(false);
     const [regions, setRegions] = useState<string[]>([]);
     const [regionLoading, setRegionLoading] = useState(false);
+    const clearOneTimeCredentials = () => {
+        awsDispatch({
+            type: INPUT_CHANGE,
+            field: AWS_FIELDS.SECRET_ACCESS_KEY,
+            payload: '',
+        } as FormAction);
+        awsDispatch({
+            type: INPUT_CHANGE,
+            field: AWS_FIELDS.ACCESS_KEY_ID,
+            payload: '',
+        } as FormAction);
+        awsDispatch({
+            type: INPUT_CHANGE,
+            field: AWS_FIELDS.SESSION_TOKEN,
+            payload: '',
+        } as FormAction);
+        awsDispatch({
+            type: INPUT_CHANGE,
+            field: AWS_FIELDS.REGION,
+            payload: '',
+        } as FormAction);
+    };
 
     useEffect(() => {
+        // reset();
+        clearOneTimeCredentials();
         // fetch regions
         const fetchRegions = async () => {
             try {
@@ -45,6 +70,7 @@ function ManagementCredentialProfile(props: Props) {
             }
         };
         fetchRegions();
+        reset();
     }, []);
     useEffect(() => {
         // fetch profiles

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.tsx
@@ -56,7 +56,7 @@ function ManagementCredentialProfile(props: Props) {
 
     useEffect(() => {
         reset();
-        clearOneTimeCredentials();
+        // clearOneTimeCredentials();
         // fetch regions
         const fetchRegions = async () => {
             try {

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.tsx
@@ -31,32 +31,10 @@ function ManagementCredentialProfile(props: Props) {
     const [profilesLoading, setProfilesLoading] = useState(false);
     const [regions, setRegions] = useState<string[]>([]);
     const [regionLoading, setRegionLoading] = useState(false);
-    const clearOneTimeCredentials = () => {
-        awsDispatch({
-            type: INPUT_CHANGE,
-            field: AWS_FIELDS.SECRET_ACCESS_KEY,
-            payload: '',
-        } as FormAction);
-        awsDispatch({
-            type: INPUT_CHANGE,
-            field: AWS_FIELDS.ACCESS_KEY_ID,
-            payload: '',
-        } as FormAction);
-        awsDispatch({
-            type: INPUT_CHANGE,
-            field: AWS_FIELDS.SESSION_TOKEN,
-            payload: '',
-        } as FormAction);
-        awsDispatch({
-            type: INPUT_CHANGE,
-            field: AWS_FIELDS.REGION,
-            payload: '',
-        } as FormAction);
-    };
 
     useEffect(() => {
         reset();
-        // clearOneTimeCredentials();
+        onSelectChange(AWS_FIELDS.REGION, '');
         // fetch regions
         const fetchRegions = async () => {
             try {
@@ -127,7 +105,7 @@ function ManagementCredentialProfile(props: Props) {
                         label="AWS credential profile"
                         className="select-sm-width"
                         handleSelect={(e: ChangeEvent<HTMLSelectElement>) => {
-                            onSelectChange(AWS_FIELDS.PROFILE, e.target.value);
+                            // onSelectChange(AWS_FIELDS.PROFILE, e.target.value);
                             selectCallback();
                         }}
                         name={AWS_FIELDS.PROFILE}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentialProfile.tsx
@@ -105,7 +105,6 @@ function ManagementCredentialProfile(props: Props) {
                         label="AWS credential profile"
                         className="select-sm-width"
                         handleSelect={(e: ChangeEvent<HTMLSelectElement>) => {
-                            // onSelectChange(AWS_FIELDS.PROFILE, e.target.value);
                             selectCallback();
                         }}
                         name={AWS_FIELDS.PROFILE}

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentials.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentials.tsx
@@ -54,7 +54,7 @@ function ManagementCredentials(props: Partial<StepProps>) {
             [AWS_FIELDS.ACCESS_KEY_ID]: '',
             [AWS_FIELDS.SESSION_TOKEN]: '',
             [AWS_FIELDS.PROFILE]: '',
-            [AWS_FIELDS.REGION]: '',
+            // [AWS_FIELDS.REGION]: '',
             [AWS_FIELDS.EC2_KEY_PAIR]: '',
         },
     });
@@ -103,6 +103,8 @@ function ManagementCredentials(props: Partial<StepProps>) {
     };
 
     const onSubmit: SubmitHandler<FormInputs> = (data) => {
+        console.log('ggggggg');
+        console.log(getValues(AWS_FIELDS.SECRET_ACCESS_KEY));
         if (connectionStatus === CONNECTION_STATUS.CONNECTED && Object.keys(errors).length === 0) {
             if (goToStep && currentStep && submitForm) {
                 goToStep(currentStep + 1);
@@ -180,6 +182,7 @@ function ManagementCredentials(props: Partial<StepProps>) {
 
     useEffect(() => {
         if (awsState[STORE_SECTION_FORM].REGION) {
+            console.log('llllllll');
             AwsOrchestrator.initOsImages({ awsState, awsDispatch, errorObject, setErrorObject });
         }
     }, [awsState[STORE_SECTION_FORM][AWS_FIELDS.REGION]]);

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentials.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentials.tsx
@@ -54,7 +54,7 @@ function ManagementCredentials(props: Partial<StepProps>) {
             [AWS_FIELDS.ACCESS_KEY_ID]: '',
             [AWS_FIELDS.SESSION_TOKEN]: '',
             [AWS_FIELDS.PROFILE]: '',
-            // [AWS_FIELDS.REGION]: '',
+            [AWS_FIELDS.REGION]: '',
             [AWS_FIELDS.EC2_KEY_PAIR]: '',
         },
     });
@@ -103,8 +103,16 @@ function ManagementCredentials(props: Partial<StepProps>) {
     };
 
     const onSubmit: SubmitHandler<FormInputs> = (data) => {
-        console.log('ggggggg');
-        console.log(getValues(AWS_FIELDS.SECRET_ACCESS_KEY));
+        const valueList = getValues();
+        for (const i in valueList) {
+            console.log(i);
+            awsDispatch({
+                type: INPUT_CHANGE,
+                field: i,
+                payload: valueList[i],
+            } as FormAction);
+        }
+
         if (connectionStatus === CONNECTION_STATUS.CONNECTED && Object.keys(errors).length === 0) {
             if (goToStep && currentStep && submitForm) {
                 goToStep(currentStep + 1);
@@ -181,8 +189,7 @@ function ManagementCredentials(props: Partial<StepProps>) {
     };
 
     useEffect(() => {
-        if (awsState[STORE_SECTION_FORM].REGION) {
-            console.log('llllllll');
+        if (awsState[STORE_SECTION_FORM][AWS_FIELDS.REGION]) {
             AwsOrchestrator.initOsImages({ awsState, awsDispatch, errorObject, setErrorObject });
         }
     }, [awsState[STORE_SECTION_FORM][AWS_FIELDS.REGION]]);

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentials.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentials.tsx
@@ -105,7 +105,6 @@ function ManagementCredentials(props: Partial<StepProps>) {
     const onSubmit: SubmitHandler<FormInputs> = (data) => {
         const valueList = getValues();
         for (const i in valueList) {
-            console.log(i);
             awsDispatch({
                 type: INPUT_CHANGE,
                 field: i,

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentials.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentials.tsx
@@ -49,6 +49,14 @@ function ManagementCredentials(props: Partial<StepProps>) {
     const methods = useForm<FormInputs>({
         resolver: yupResolver(managementCredentialFormSchema),
         mode: 'all',
+        defaultValues: {
+            [AWS_FIELDS.SECRET_ACCESS_KEY]: '',
+            [AWS_FIELDS.ACCESS_KEY_ID]: '',
+            [AWS_FIELDS.SESSION_TOKEN]: '',
+            [AWS_FIELDS.PROFILE]: '',
+            [AWS_FIELDS.REGION]: '',
+            [AWS_FIELDS.EC2_KEY_PAIR]: '',
+        },
     });
     const {
         register,


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
**Bug Description**
**1.**
Assume user chooses to use _One-time credential_ and input some value already as following:

![image](https://user-images.githubusercontent.com/106584724/184811419-0ced1ec6-5ff8-4716-8c56-31242c26255b.png)

**2.**
Then user switch to _AWS credential profile_ , and input some value.

![image](https://user-images.githubusercontent.com/106584724/184811661-16900662-9ecf-44a7-af9f-ce6ceba0c9c8.png)

**But the previous input info from _One-time credential_ will still exist.**

This PR fix this issue.
1.Add reset to clean the previous input info
2.Remove the `awsDispatch` while change input. As substituion, call `awsDispatch` when click _**Next**_ button.
3.Resolved minor issue from previous PR which is changing all field names to AWS_FIELDS element.
## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
