### PR TITLE
Enables ExternalDNS observability via pod labels

### DIFF
--- a/addons/packages/external-dns/0.11.0/README.md
+++ b/addons/packages/external-dns/0.11.0/README.md
@@ -270,6 +270,7 @@ You can set the following configuration values to customize your ExternalDNS ins
 | `deployment.securityContext` | Optional           | Security context of the ExternalDNS container   |
 | `deployment.volumeMounts`    | Optional           | Volume mounts of the ExternalDNS container      |
 | `deployment.volumes`         | Optional           | Volumes of the ExternalDNS pod                  |
+| `deployment.podLabels`       | Optional           | Lables for the ExternalDNS pod                  |
 | `serviceaccount.annotations` | Optional           | Annotations for the ExternalDNS service account |
 
 Follow [the ExternalDNS docs](https://github.com/kubernetes-sigs/external-dns#running-externaldns)
@@ -284,6 +285,20 @@ preconfigured with the correct RBAC permissions to watch for HTTPProxies, so you
 ### Multi-cloud configuration steps
 
 For this package there is no unique configuration for different clouds.
+
+## Expose Metrics
+
+ExternalDNS can be configured to expose metrics.  [What metrics can I get from ExternalDNS and what do they mean?](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/faq.md#what-metrics-can-i-get-from-externaldns-and-what-do-they-mean).  To configure with this package, include the following configuration in your data value file.
+
+```yaml
+deployment:
+  args:
+    - --metrics-address=:7979 #! ensures external dns exposes metrics
+  podLabels:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
+    prometheus.io/port: "7979"
+```
 
 ## What this package does
 

--- a/addons/packages/external-dns/0.11.0/bundle/config/overlays/overlay-00-deployment.yaml
+++ b/addons/packages/external-dns/0.11.0/bundle/config/overlays/overlay-00-deployment.yaml
@@ -32,6 +32,11 @@ spec:
 ---
 spec:
   template:
+    #@overlay/merge missing_ok=True
+    metadata:
+      #@overlay/merge missing_ok=True
+      #@ if/end data.values.deployment.podLabels != None: 
+      labels: #@ data.values.deployment.podLabels
     spec:
       containers:
         #@overlay/match by=overlay.subset({"name": "external-dns"})

--- a/addons/packages/external-dns/0.11.0/bundle/config/overlays/overlay-00-deployment.yaml
+++ b/addons/packages/external-dns/0.11.0/bundle/config/overlays/overlay-00-deployment.yaml
@@ -35,7 +35,7 @@ spec:
     #@overlay/merge missing_ok=True
     metadata:
       #@overlay/merge missing_ok=True
-      #@ if/end data.values.deployment.podLabels != None: 
+      #@ if/end data.values.deployment.podLabels != None:
       labels: #@ data.values.deployment.podLabels
     spec:
       containers:

--- a/addons/packages/external-dns/0.11.0/bundle/config/schema.yaml
+++ b/addons/packages/external-dns/0.11.0/bundle/config/schema.yaml
@@ -61,6 +61,9 @@ deployment:
   volumes:
     #@schema/type any=True
     - null
+  #@schema/desc "Labels to be added to all deployment pods"
+  #@schema/type any=True
+  podLabels: null
 #@schema/desc "Service account related configuration"
 serviceaccount:
   #@schema/desc "Annotations that can be set on the external-dns service account. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/"

--- a/addons/packages/external-dns/0.11.0/package.yaml
+++ b/addons/packages/external-dns/0.11.0/package.yaml
@@ -106,7 +106,7 @@ spec:
                 nullable: true
                 default: null
               default: null
-            podVolumes:
+            podLabels:
               nullable: true
               description: 'Labels to be added to all deployment pods'
               default: null

--- a/addons/packages/external-dns/0.11.0/package.yaml
+++ b/addons/packages/external-dns/0.11.0/package.yaml
@@ -106,6 +106,10 @@ spec:
                 nullable: true
                 default: null
               default: null
+            podVolumes:
+              nullable: true
+              description: 'Labels to be added to all deployment pods'
+              default: null
         serviceaccount:
           type: object
           additionalProperties: false

--- a/addons/packages/external-dns/0.11.0/test/unittest/externaldns_test.go
+++ b/addons/packages/external-dns/0.11.0/test/unittest/externaldns_test.go
@@ -498,6 +498,34 @@ var _ = Describe("External DNS Ytt Templates", func() {
 			})
 		})
 	})
+
+	Describe("Observability", func() {
+		var output string
+		Describe("when not provided", func() {
+			BeforeEach(func() {
+				var err error
+				output, err = renderWithDataValuesFixture("minimal-configuration.yaml")
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("does not add pod labels", func() {
+				deploymentDoc := findDeploymentDoc(output)
+				// Expect(deploymentDoc).NotTo(HaveYAMLPath("$.spec.template.metadata.annotations"))
+				Expect(deploymentDoc).NotTo(HaveYAMLPath("$.spec.template.metadata.labels.prometheus.io/scrape"))
+			})
+		})
+		Describe("when provided", func() {
+			It("renders a pod labels", func() {
+				var err error
+				output, err = renderWithDataValuesFixture("deployment-observability.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				deploymentDoc := findDeploymentDoc(output)
+				Expect(deploymentDoc).To(HaveYAMLPathWithValue(
+					".spec.template.metadata.labels['prometheus.io/scrape']",
+					"true",
+				))
+			})
+		})
+	})
 })
 
 func valueAtYAMLPath(doc, yamlPath string) string {

--- a/addons/packages/external-dns/0.11.0/test/unittest/fixtures/values/deployment-observability.yaml
+++ b/addons/packages/external-dns/0.11.0/test/unittest/fixtures/values/deployment-observability.yaml
@@ -1,0 +1,11 @@
+#@data/values
+---
+deployment:
+  args:
+    - --metrics-address=:7979
+    - --provider=rfc2136 #! Imaterial to observability test assertation, but requried to pass through testing other constraints
+    - --source=ingress #! Imaterial to observability test assertation, but requried to pass through testing other constraints
+  podLabels:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
+    prometheus.io/port: "7979"


### PR DESCRIPTION
## What this PR does / why we need it
Observability is key to day 2 operations. 

## Which issue(s) this PR fixes
Fixes: #5277

## Describe testing done for PR
Updated and executed unit tests for ExternalDNS 
