### PR TITLE
Add azs for vpc

### DIFF
--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/services/awsDeployment.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/services/awsDeployment.tsx
@@ -48,7 +48,7 @@ const useAwsDeployment = () => {
                 cidr: awsData[AWS_FIELDS.VPC_CIDR],
                 vpcID: '',
                 // TODO: single subregion name populated from region selection; but does not support multi-az/HA
-                azs: nodeType[awsData[AWS_FIELDS.NODE_PROFILE]]['vpc'],
+                azs: nodeType[awsData[AWS_FIELDS.NODE_PROFILE]]['azs'],
             },
             enableAuditLogging: awsData[AWS_FIELDS.ENABLE_AUDIT_LOGGING],
             networking: {

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/services/awsDeployment.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/shared/services/awsDeployment.tsx
@@ -26,7 +26,7 @@ const useAwsDeployment = () => {
     // TODO: more dynamic population of this payload
     const getAwsRequestPayload = () => {
         const awsData = awsState[STORE_SECTION_FORM];
-        const nodeType = awsState[STORE_SECTION_RESOURCES][AWS_FIELDS.NODE_TYPE];
+        const nodeType = awsState[STORE_SECTION_RESOURCES][AWS_FIELDS.NODE_TYPE][0];
         const awsClusterParams: AWSManagementClusterParams = {
             awsAccountParams: {
                 profileName: awsData[AWS_FIELDS.PROFILE],
@@ -41,21 +41,14 @@ const useAwsDeployment = () => {
             createCloudFormationStack: false,
             clusterName: awsData[AWS_FIELDS.CLUSTER_NAME],
             controlPlaneFlavor: awsData[AWS_FIELDS.CLUSTER_PLAN],
-            controlPlaneNodeType: nodeType[awsData[AWS_FIELDS.NODE_PROFILE]],
+            controlPlaneNodeType: nodeType[awsData[AWS_FIELDS.NODE_PROFILE]]['nodeType'],
             bastionHostEnabled: awsData[AWS_FIELDS.ENABLE_BASTION_HOST],
             machineHealthCheckEnabled: awsData[AWS_FIELDS.ENABLE_MACHINE_HEALTH_CHECK],
             vpc: {
                 cidr: awsData[AWS_FIELDS.VPC_CIDR],
                 vpcID: '',
                 // TODO: single subregion name populated from region selection; but does not support multi-az/HA
-                azs: [
-                    {
-                        name: awsData[AWS_FIELDS.REGION] + 'a',
-                        workerNodeType: nodeType[awsData[AWS_FIELDS.NODE_PROFILE]],
-                        publicSubnetID: '',
-                        privateSubnetID: '',
-                    },
-                ],
+                azs: nodeType[awsData[AWS_FIELDS.NODE_PROFILE]]['vpc'],
             },
             enableAuditLogging: awsData[AWS_FIELDS.ENABLE_AUDIT_LOGGING],
             networking: {

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/aws-orchestrator/AwsOrchestrator.service.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/aws-orchestrator/AwsOrchestrator.service.tsx
@@ -71,25 +71,25 @@ export class AwsOrchestrator {
             setErrorObject,
             fetcher: () => {
                 return new CancelablePromise(async (res, rej) => {
-                    const nodeProfileList: { [key: string]: { [key: string]: any } } = {
+                    const defaultNodeProfileValues: { [key: string]: { [key: string]: any } } = {
                         [AWS_NODE_PROFILE_NAMES.SINGLE_NODE]: {},
                         [AWS_NODE_PROFILE_NAMES.HIGH_AVAILABILITY]: {},
                         [AWS_NODE_PROFILE_NAMES.PRODUCTION_READY]: {},
                     };
-                    const keyList = Object.keys(nodeProfileList);
+                    const keyList = Object.keys(defaultNodeProfileValues);
                     for (const nodeProfile of keyList) {
-                        nodeProfileList[nodeProfile] = {
+                        defaultNodeProfileValues[nodeProfile] = {
                             nodeType: await AwsDefaults.setDefaultNodeType(nodeProfile).catch((e) => {
                                 rej(e);
                                 return '';
                             }),
-                            vpc: await AwsDefaults.setDefaultVpc(nodeProfile).catch((e) => {
+                            azs: await AwsDefaults.setDefaultAvailabilityZones(nodeProfile).catch((e) => {
                                 rej(e);
                                 return '';
                             }),
                         };
                     }
-                    res([nodeProfileList]);
+                    res([defaultNodeProfileValues]);
                 });
             },
         });

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/default-service/AwsDefaults.service.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/default-service/AwsDefaults.service.tsx
@@ -23,6 +23,7 @@ export class AwsDefaults {
     static setDefaultAvailabilityZones = async (nodeProfile: string) => {
         const result: { [key: string]: string }[] = [];
         const azList: AWSAvailabilityZone[] = await AwsService.getAwsAvailabilityZones();
+        // TODO: Create an error if the azList is empty
         switch (nodeProfile) {
             case AWS_NODE_PROFILE_NAMES.SINGLE_NODE:
                 {
@@ -34,6 +35,8 @@ export class AwsDefaults {
                         defaultAZ['publicSubnetID'] = '';
                         defaultAZ['privateSubnetID'] = '';
                         result.push(defaultAZ);
+                    } else {
+                        console.error(`This Availability Zone ${azList[0]} does not have name`);
                     }
                 }
                 break;
@@ -47,6 +50,8 @@ export class AwsDefaults {
                         defaultAZ['publicSubnetID'] = '';
                         defaultAZ['privateSubnetID'] = '';
                         result.push(defaultAZ);
+                    } else {
+                        console.error(`This Availability Zone ${az} does not have name`);
                     }
                 });
             }

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/default-service/AwsDefaults.service.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/default-service/AwsDefaults.service.tsx
@@ -20,7 +20,7 @@ export class AwsDefaults {
         return AwsDefaults.defaultNodeTypeStategy(nodeTypeList, nodeProfile);
     };
 
-    static setDefaultVpc = async (nodeProfile: string) => {
+    static setDefaultAvailabilityZones = async (nodeProfile: string) => {
         const result: { [key: string]: string }[] = [];
         const azList: AWSAvailabilityZone[] = await AwsService.getAwsAvailabilityZones();
         switch (nodeProfile) {
@@ -38,7 +38,7 @@ export class AwsDefaults {
                 }
                 break;
             default: {
-                [...azList].slice(0, 2).forEach(async (az: AWSAvailabilityZone) => {
+                [...azList].slice(0, 3).forEach(async (az: AWSAvailabilityZone) => {
                     const defaultAZ: { [key: string]: string } = {};
                     if (az['name'] !== undefined) {
                         defaultAZ['name'] = az['name'];

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/default-service/AwsDefaults.service.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/default-service/AwsDefaults.service.tsx
@@ -23,9 +23,6 @@ export class AwsDefaults {
     static setDefaultVpc = async (nodeProfile: string) => {
         const result: { [key: string]: string }[] = [];
         const azList: AWSAvailabilityZone[] = await AwsService.getAwsAvailabilityZones();
-        if (Object.keys(azList).length === 0) {
-            throw { field: 'AZs', info: 'Empty AZs' };
-        }
         switch (nodeProfile) {
             case AWS_NODE_PROFILE_NAMES.SINGLE_NODE:
                 {

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentials.test.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentials.test.tsx
@@ -55,6 +55,9 @@ describe('ManagementCredential component', () => {
         }),
         rest.get('api/provider/aws/nodetypes', (req, res, ctx) => {
             return res(ctx.status(200));
+        }),
+        rest.get('api/provider/aws/AvailabilityZones', (req, res, ctx) => {
+            return res(ctx.status(200));
         })
     );
 

--- a/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentials.tsx
+++ b/cli/cmd/plugin/ui/web/tanzu-ui/src/views/management-cluster/aws/aws-mc-common/management-credential-step/ManagementCredentials.tsx
@@ -217,7 +217,10 @@ function ManagementCredentials(props: Partial<StepProps>) {
                     {Object.keys(errorObject).map((errorField) => {
                         return (
                             <CdsControlMessage status="error" key={errorField}>
-                                {errorObject[errorField]}
+                                {errorField}
+                                &nbsp;
+                                {JSON.stringify(errorObject[errorField])}
+                                <br />
                             </CdsControlMessage>
                         );
                     })}


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Init default AZs(Availability Zones) for Node Profiles.
AZ(Availability Zones) contains the following fields:

> ```
> {
>         "name": "string",
>         "workerNodeType": "string",
>         "privateSubnetID": "string",
>         "publicSubnetID": "string"
> }
> ```

Currently, we do not care about 'privateSubnetID' & 'publicSubnetID'. The only info we are dealing with is 'name' & 'workerNodeType'.

We get  'name' & 'workerNodeType' by following API.

> **name:**  
> API: /api/provider/aws/AvailabilityZones
> Result: A list of az like following:
> ```
> [
>     {
>         "id": "us-west-a",
>         "name": "us-west-a"
>     },
>     {
>         "id": "us-west-b",
>         "name": "us-west-b"
>     },
>     {
>         "id": "us-west-c",
>         "name": "us-west-c"
>     }
> ]
> ```
> Default Strategy:
> `SINGLE_NODE` : Only has one az. Use the `name`  value of first element as default az `name` . (e.g. The first element is 
> ```
>  {
>         "id": "us-west-a",
>         "name": "us-west-a"
>     },
> ```
> The name value is "us-west-a", so for `SINGLE_NODE`, the default name value will be "us-west-a"
> `HIGH_AVAILABILITY` & `PRODUCTION_READY`: Those two node profile have three azs. The first three elements provide the name value for azs. (e.g. The names are "us-west-a" "us-west-b" "us-west-c"


> **workerNodeType**
> API: /api/provider/aws/nodetypes?=az
> Result: 
> ```
> [
>     "t3.small",
>     "t3.medium",
>     "t3.large",
>     "t3.xlarge",
>     "m5.large",
>     "m5.xlarge",
>     "m5a.2xlarge",
>     "m5a.4xlarge",
>     "c6gn.small",
>     "c6gn.medium",
>     "c6gn.large",
>     "r4.8xlarge",
>     "i3.xlarge",
>     "t3.small",
>     "t3.medium",
>     "t3.large",
>     "t3.xlarge",
>     "m5.large",
>     "m5.xlarge",
>     "m5a.2xlarge",
>     "m5a.4xlarge",
>     "r4.8xlarge",
>     "i3.xlarge",
>     "t4g.small",
>     "t4g.medium",
>     "t4g.large"
> ]
> ```
> Default Strategy: Compare the result with the default node type value. If the default value exists in the return list, set the default value as workerNodeType value. If not, set the middle value in the return list as the workerNodeType value.



## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Default node type:
![image](https://user-images.githubusercontent.com/106584724/186717354-0c2475fb-6bc0-4164-91e6-637d2c8ce6a5.png)

Choose `SINGLE_NODE`, the payload will be:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/106584724/186719780-ab286510-5c4d-4de4-b915-5cda60b1dbc8.png">


## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
