### PR TITLE
Add external-dns version 0.12.2 to main repo

### DIFF
--- a/addons/repos/main.yaml
+++ b/addons/repos/main.yaml
@@ -33,6 +33,7 @@ packages:
       - 0.8.0
       - 0.10.0
       - 0.11.0
+      - 0.12.2
   - name: fluent-bit
     versions:
       - 1.7.5


### PR DESCRIPTION
## What this PR does / why we need it
Adds the new version of external-dns to the main repo