### PR TITLE
Set default cipher suites for kapp-controller 0.41.2

### DIFF
--- a/addons/packages/kapp-controller/0.41.2/bundle/config/overlays/update-deployment.yaml
+++ b/addons/packages/kapp-controller/0.41.2/bundle/config/overlays/update-deployment.yaml
@@ -17,6 +17,8 @@ spec:
       - args:
         #@overlay/match by=overlay.subset("-packaging-global-namespace=kapp-controller-packaging-global")
         - #@ "-packaging-global-namespace={}".format(values.kappController.globalNamespace)
+        #@overlay/match by=overlay.subset("-tls-cipher-suites=")
+        - #@ "-tls-cipher-suites={}".format(values.kappController.deployment.tlsCipherSuites)
         #@overlay/append
         - #@ "-concurrency={}".format(values.kappController.deployment.concurrency)
         #@overlay/append

--- a/addons/packages/kapp-controller/0.41.2/bundle/config/values.yaml
+++ b/addons/packages/kapp-controller/0.41.2/bundle/config/values.yaml
@@ -23,6 +23,7 @@ kappController:
     tolerations: []
     apiPort: 10350
     metricsBindAddress: ":8080"
+    tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
   config:
     caCerts: ""
     httpProxy: ""

--- a/addons/packages/kapp-controller/0.41.2/package.yaml
+++ b/addons/packages/kapp-controller/0.41.2/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:75d09b5b7c0e2996aec16f7725628b7e37ff978af5db60a6ee289cce322eb453
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:d32526854ff0c053b1025329dec1d6ff1f327f4e0beaab0cde28bbb80f4aa025
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
- Set default cipher suites for `kapp-controller` 0.41.2

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #5383 

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
- Verified that the `kapp-controller` yaml is generated correctly
```
spec:
  containers:
  - args:
    - -packaging-global-namespace=tanzu-package-repo-global
    - -enable-api-priority-and-fairness=True
    - -tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
    - -concurrency=4
    - -metrics-bind-address=:8080
```
- Verified on cluster that `kapp-controller` can be deployed successfully, and handshakes with other cipher algorithms cannot be completed.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
