### PR TITLE
Contour: Envoy service overlay allows nodeport configuration w/ LoadBalancer Service

### DIFF
--- a/addons/packages/contour/1.22.0/README.md
+++ b/addons/packages/contour/1.22.0/README.md
@@ -67,8 +67,8 @@ You can configure the following in the data values file:
 | `envoy.service.externalTrafficPolicy` | `Cluster` for vsphere; `Local` for others | The external traffic policy for the Envoy service. Valid values are `Local` and `Cluster`.  If `envoy.service.type` is `ClusterIP`, this field is ignored. |
 | `envoy.service.loadBalancerIP` | (none) | The desired load balancer IP for the Envoy service. If `envoy.service.type` is not `LoadBalancer`, this field is ignored. |
 | `envoy.service.annotations` | (none) | Annotations to set on the Envoy service. |
-| `envoy.service.nodePorts.http` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
-| `envoy.service.nodePorts.https` | (none) | If `envoy.service.type` == `NodePort`, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
+| `envoy.service.nodePorts.http` | (none) | If `envoy.service.type` == `NodePort` or `LoadBalancer`, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
+| `envoy.service.nodePorts.https` | (none) | If `envoy.service.type` == `NodePort` or `LoadBalancer`, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes. |
 | `envoy.service.aws.loadBalancerType` | (none) | If `infrastructureProvider` == `aws`, the type of AWS load balancer to provision. Valid values are `classic` and `nlb`. If `infrastructureProvider` is not `aws`, this field is ignored. |
 | `envoy.hostPorts.enable` | `false` | Whether to enable host ports for the Envoy pods. If false, `envoy.hostPorts.http` and `envoy.hostPorts.https` are ignored. |
 | `envoy.hostPorts.http` | `80` | If `envoy.hostPorts.enable` == true, the host port number to expose Envoy's HTTP listener on. |

--- a/addons/packages/contour/1.22.0/bundle/config/overlays/update-envoy-service.yaml
+++ b/addons/packages/contour/1.22.0/bundle/config/overlays/update-envoy-service.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   type: #@ get_envoy_service_type()
 
-  #@ if get_envoy_service_type() == "NodePort":
+  #@ if get_envoy_service_type() == "NodePort" or get_envoy_service_type() == "LoadBalancer":
   ports:
   #@overlay/match by=overlay.subset({"name":"http"})
   -

--- a/addons/packages/contour/1.22.0/bundle/config/schema.yaml
+++ b/addons/packages/contour/1.22.0/bundle/config/schema.yaml
@@ -40,12 +40,12 @@ envoy:
     #@schema/type any=True
     annotations: null
 
-    #@schema/desc "NodePort settings for the Envoy service. If type is not 'NodePort', these settings are ignored."
+    #@schema/desc "NodePort settings for the Envoy service. If type is not 'NodePort' or 'LoadBalancer', these settings are ignored."
     nodePorts:
-      #@schema/desc "If type == NodePort, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes."
+      #@schema/desc "The node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes."
       http: 0
 
-      #@schema/desc "If type == NodePort, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes."
+      #@schema/desc "The node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes."
       https: 0
 
     #@schema/desc "AWS-specific settings for the Envoy service. If infrastructure provider is not 'aws', these settings are ignored."

--- a/addons/packages/contour/1.22.0/package.yaml
+++ b/addons/packages/contour/1.22.0/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/contour@sha256:b682046e9da9008b2efd729c65265ee960ee7b34a95cf3d079ad5d2efb0ba10c
+          image: projects.registry.vmware.com/tce/contour@sha256:4b01d102e78cdd7c99d2dae3a4e8108e09b87bbbef75cef9265394d75972fc1e
       template:
       - ytt:
           paths:

--- a/addons/packages/contour/1.22.0/package.yaml
+++ b/addons/packages/contour/1.22.0/package.yaml
@@ -89,15 +89,15 @@ spec:
                 nodePorts:
                   type: object
                   additionalProperties: false
-                  description: NodePort settings for the Envoy service. If type is not 'NodePort', these settings are ignored.
+                  description: NodePort settings for the Envoy service. If type is not 'NodePort' or 'LoadBalancer', these settings are ignored.
                   properties:
                     http:
                       type: integer
-                      description: If type == NodePort, the node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes.
+                      description: The node port number to expose Envoy's HTTP listener on. If not specified, a node port will be auto-assigned by Kubernetes.
                       default: 0
                     https:
                       type: integer
-                      description: If type == NodePort, the node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes.
+                      description: The node port number to expose Envoy's HTTPS listener on. If not specified, a node port will be auto-assigned by Kubernetes.
                       default: 0
                 aws:
                   type: object

--- a/addons/packages/contour/1.22.0/test/unittest/contour_test.go
+++ b/addons/packages/contour/1.22.0/test/unittest/contour_test.go
@@ -209,6 +209,9 @@ var _ = Describe("Contour Ytt Templates", func() {
 
 			service := unmarshalService(docs[0])
 			Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
+			// NodePorts are unset.
+			Expect(service.Spec.Ports[0].NodePort).To(Equal(int32(0)))
+			Expect(service.Spec.Ports[1].NodePort).To(Equal(int32(0)))
 		})
 
 		It("defaults the Envoy service external traffic policy to Local", func() {
@@ -606,6 +609,25 @@ var _ = Describe("Contour Ytt Templates", func() {
 			Expect(docs).To(HaveLen(1), "Envoy service not found")
 
 			service := unmarshalService(docs[0])
+			Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			Expect(service.Spec.Ports[0].NodePort).To(Equal(int32(30080)))
+			Expect(service.Spec.Ports[1].NodePort).To(Equal(int32(30443)))
+		})
+	})
+
+	Context("Envoy service type LoadBalancer with node ports set", func() {
+		BeforeEach(func() {
+			values = envoyServiceNodePortsWithLoadBalancerService
+		})
+
+		It("sets the Envoy service node ports", func() {
+			Expect(err).NotTo(HaveOccurred())
+
+			docs := findDocsContainingLines(output, "kind: Service", "name: envoy")
+			Expect(docs).To(HaveLen(1), "Envoy service not found")
+
+			service := unmarshalService(docs[0])
+			Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 			Expect(service.Spec.Ports[0].NodePort).To(Equal(int32(30080)))
 			Expect(service.Spec.Ports[1].NodePort).To(Equal(int32(30443)))
 		})

--- a/addons/packages/contour/1.22.0/test/unittest/fixtures_test.go
+++ b/addons/packages/contour/1.22.0/test/unittest/fixtures_test.go
@@ -304,6 +304,18 @@ envoy:
       https: 30443
 `
 
+// envoyServiceNodePorts has envoy.service.type set to LoadBalancer and envoy.service.nodePorts set.
+const envoyServiceNodePortsWithLoadBalancerService = `
+#@data/values
+---
+envoy:
+  service:
+    type: LoadBalancer
+    nodePorts:
+      http: 30080
+      https: 30443
+`
+
 // envoyHostPorts has envoy.hostPorts set.
 const envoyHostPorts = `
 #@data/values


### PR DESCRIPTION
## What this PR does / why we need it
Allow NodePort configuration of the Envoy Service when using LoadBalancer type as well as NodePort type

## Which issue(s) this PR fixes
N/A

## Describe testing done for PR
- unit testing
- applied generated YAML to cluster w/ configuratio exercised

## Special notes for your reviewer
N/A
