### PR TITLE
Add control plane node selector and toleration to kappcontroller

### DIFF
--- a/addons/packages/kapp-controller/0.41.2/bundle/config/overlays/update-deployment.yaml
+++ b/addons/packages/kapp-controller/0.41.2/bundle/config/overlays/update-deployment.yaml
@@ -2,6 +2,18 @@
 #@ load("/values.star", "values", "generateBashCmdForDNS")
 #@ load("@ytt:yaml", "yaml")
 
+#@ def is_toleration_specified(toleration):
+#@   return toleration in yaml.decode(yaml.encode(values.kappController.deployment.tolerations))
+#@ end
+
+#@ default_tolerations = []
+#@ is_master_specified = is_toleration_specified({"effect":"NoSchedule", "key":"node-role.kubernetes.io/master"})
+#@ is_control_specified = is_toleration_specified({"effect":"NoSchedule", "key":"node-role.kubernetes.io/control-plane"})
+
+#@ if is_master_specified and not is_control_specified:
+#@   default_tolerations += [{"effect":"NoSchedule", "key":"node-role.kubernetes.io/control-plane"}]
+#@ end
+
 #@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name": "kapp-controller"}})
 ---
 metadata:
@@ -64,7 +76,7 @@ spec:
       #@ if/end values.kappController.deployment.priorityClassName:
       priorityClassName: #@ values.kappController.deployment.priorityClassName
       #@ if hasattr(values.kappController.deployment, 'tolerations') and values.kappController.deployment.tolerations:
-      tolerations: #@ values.kappController.deployment.tolerations
+      tolerations: #@ default_tolerations + values.kappController.deployment.tolerations
       #@ end
       #@ if values.kappController.deployment.coreDNSIP:
       volumes:

--- a/addons/packages/kapp-controller/0.41.2/bundle/config/overlays/update-strategy-overlay.yaml
+++ b/addons/packages/kapp-controller/0.41.2/bundle/config/overlays/update-strategy-overlay.yaml
@@ -1,6 +1,17 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 
+#@ def matcher():
+kind: Deployment
+metadata:
+  name: kapp-controller
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+#@ end
+
 #! We are adding this overlay in the package to accomandate the need from vSphere supervisor cluster:
 #! `deployment.spec.strategy.type` is configured to `RollingUpdate`
 #! `deployment.spec.strategy.rollingUpdate.maxUnavailable` is set to `0`.
@@ -48,3 +59,15 @@ spec:
   updateStrategy:
     type: #@ data.values.daemonset.updateStrategy
   #@ end
+
+
+#@overlay/match by=overlay.subset(matcher()) , when=1
+---
+spec:
+  template:
+    spec:
+      nodeSelector:
+        #@overlay/remove
+        node-role.kubernetes.io/master:
+        #@overlay/match missing_ok=True
+        node-role.kubernetes.io/control-plane: ""


### PR DESCRIPTION
## What this PR does / why we need it
Add control plane node selector and toleration to kappcontroller using overlays
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
Test with the following ytt commnd for the following cases:
```
ytt --ignore-unknown-comments -f addons/packages/kapp-controller/0.41.2/bundle/config/ -f data-values.yaml > output.yaml
```

- case 1: 
   - values.yaml with master node selector & toleration :
   
     ```
      #@data/values
      #@overlay/match-child-defaults missing_ok=True
      ---
      nodeSelector:
        node-role.kubernetes.io/master: ""
        tkr: "v1.23.1"
      kappController:
        deployment:
          tolerations: [{"key": "CriticalAddonsOnly", "operator": "Exists"}, {"effect":"NoSchedule", "key":"node-role.kubernetes.io/master"}]
     ```

  - generated deployment yaml file:

      ```
     spec:
       template:
         spec:   
           tolerations:
           - effect: NoSchedule
              key: node-role.kubernetes.io/control-plane
           - key: CriticalAddonsOnly
              operator: Exists
           - effect: NoSchedule
              key: node-role.kubernetes.io/master
           nodeSelector:
             tkr: v1.23.1
             node-role.kubernetes.io/control-plane: ""
      ```

- case 2:
   - values.yaml with control-plane node selector & toleration :
   
     ```
     #@data/values
     #@overlay/match-child-defaults missing_ok=True
     ---
     nodeSelector:
       node-role.kubernetes.io/control-plane: ""
       tkr: "v1.23.1"
     kappController:
       deployment:
         tolerations: [{"key": "CriticalAddonsOnly", "operator": "Exists"}, {"effect":"NoSchedule", "key":"node-role.kubernetes.io/control-plane"}]
     ```

  - generated deployment yaml file:

     ```
    spec:
       template:
         spec:   
           tolerations:
           - key: CriticalAddonsOnly
              operator: Exists
            - effect: NoSchedule
               key: node-role.kubernetes.io/control-plane
           nodeSelector:
              node-role.kubernetes.io/control-plane: ""
              tkr: v1.23.1
    ```

- case 3:
   - values.yaml with master toleration:
    
    ```
     #@data/values
     #@overlay/match-child-defaults missing_ok=True
     ---
     nodeSelector:
       tkr: "v1.23.1"
     kappController:
       deployment:
         tolerations: [{"key": "CriticalAddonsOnly", "operator": "Exists"}, {"effect":"NoSchedule", "key":"node-role.kubernetes.io/master"}]
    ```

   - generated deployment yaml file:

   ```
     spec:
       template:
         spec:   
           tolerations:
             - effect: NoSchedule
                key: node-role.kubernetes.io/control-plane
            - key: CriticalAddonsOnly
               operator: Exists
            - effect: NoSchedule
               key: node-role.kubernetes.io/master
           nodeSelector:
             tkr: v1.23.1
     ```

 - case 4:
    - values.yaml with some other nodeSelector & toleration:

     ```
      #@data/values
      #@overlay/match-child-defaults missing_ok=True
      ---
        nodeSelector:
          tkr: "v1.23.1"
        kappController:
          deployment:
            tolerations: [{"key": "CriticalAddonsOnly", "operator": "Exists"}]
      ```

   - generated deployment yaml file:
   
     ```
     spec:
       template:
         spec:   
           tolerations:
           - key: CriticalAddonsOnly
             operator: Exists
           nodeSelector:
             tkr: v1.23.1
     ```

<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
