### PR TITLE
Add control plane node selector and toleration to kappcontroller

### DIFF
--- a/addons/packages/kapp-controller/0.41.2/bundle/config/overlays/update-deployment.yaml
+++ b/addons/packages/kapp-controller/0.41.2/bundle/config/overlays/update-deployment.yaml
@@ -2,6 +2,18 @@
 #@ load("/values.star", "values", "generateBashCmdForDNS")
 #@ load("@ytt:yaml", "yaml")
 
+#@ def is_toleration_specified(toleration):
+#@   return toleration in yaml.decode(yaml.encode(values.kappController.deployment.tolerations))
+#@ end
+
+#@ default_tolerations = []
+#@ is_master_specified = is_toleration_specified({"effect":"NoSchedule", "key":"node-role.kubernetes.io/master"})
+#@ is_control_specified = is_toleration_specified({"effect":"NoSchedule", "key":"node-role.kubernetes.io/control-plane"})
+
+#@ if is_master_specified and not is_control_specified:
+#@   default_tolerations += [{"effect":"NoSchedule", "key":"node-role.kubernetes.io/control-plane"}]
+#@ end
+
 #@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name": "kapp-controller"}})
 ---
 metadata:
@@ -64,7 +76,7 @@ spec:
       #@ if/end values.kappController.deployment.priorityClassName:
       priorityClassName: #@ values.kappController.deployment.priorityClassName
       #@ if hasattr(values.kappController.deployment, 'tolerations') and values.kappController.deployment.tolerations:
-      tolerations: #@ values.kappController.deployment.tolerations
+      tolerations: #@ default_tolerations + values.kappController.deployment.tolerations
       #@ end
       #@ if values.kappController.deployment.coreDNSIP:
       volumes:

--- a/addons/packages/kapp-controller/0.41.2/bundle/config/overlays/update-strategy-overlay.yaml
+++ b/addons/packages/kapp-controller/0.41.2/bundle/config/overlays/update-strategy-overlay.yaml
@@ -1,6 +1,17 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 
+#@ def matcher():
+kind: Deployment
+metadata:
+  name: kapp-controller
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+#@ end
+
 #! We are adding this overlay in the package to accomandate the need from vSphere supervisor cluster:
 #! `deployment.spec.strategy.type` is configured to `RollingUpdate`
 #! `deployment.spec.strategy.rollingUpdate.maxUnavailable` is set to `0`.
@@ -48,3 +59,14 @@ spec:
   updateStrategy:
     type: #@ data.values.daemonset.updateStrategy
   #@ end
+
+#@overlay/match by=overlay.subset(matcher()) , when=1
+---
+spec:
+  template:
+    spec:
+      nodeSelector:
+        #@overlay/remove
+        node-role.kubernetes.io/master:
+        #@overlay/match missing_ok=True
+        node-role.kubernetes.io/control-plane: ""

--- a/addons/packages/kapp-controller/0.41.2/package.yaml
+++ b/addons/packages/kapp-controller/0.41.2/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/kapp-controller@sha256:3bc7da1d0881125d0a2c3c9d0e1a70d5fa223bf9e2a539c2b812702812c07f7f
+            image: projects.registry.vmware.com/tce/kapp-controller@sha256:c0c407116db8d8aee11ba6f0cc99eec62b65e20398c486657b5ca6a03e8c8fbd
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
- The master label `node-role.kubernetes.io/master` is deprecated in k8s 1.24, see [here](https://kubernetes.io/blog/2022/04/07/upcoming-changes-in-kubernetes-1-24/). Instead `node-role.kubernetes.io/control-plane` will be used in new clusters. So we need to add overlays to change the labels based on need.
- This change adds overlays to kapp-controller to adjust the master labels based on different scenarios.
- Same change as https://github.com/vmware-tanzu/community-edition/pull/5421, just modify the image package url to the registry.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

Test with the following ytt commnd for the following cases:
```
ytt --ignore-unknown-comments -f addons/packages/kapp-controller/0.41.2/bundle/config/ -f data-values.yaml > output.yaml
```
- case 1:
   - values.yaml with master node selector & toleration :
```
 #@data/values
 #@overlay/match-child-defaults missing_ok=True
 ---
 nodeSelector:
   node-role.kubernetes.io/master: ""
   tkr: "v1.23.1"
 kappController:
   deployment:
     tolerations: [{"key": "CriticalAddonsOnly", "operator": "Exists"}, {"effect":"NoSchedule", "key":"node-role.kubernetes.io/master"}]
```
- 
   - generated deployment yaml file:
```
spec:
 template:
   spec:   
     tolerations:
     - effect: NoSchedule
        key: node-role.kubernetes.io/control-plane
     - key: CriticalAddonsOnly
        operator: Exists
     - effect: NoSchedule
        key: node-role.kubernetes.io/master
     nodeSelector:
       tkr: v1.23.1
       node-role.kubernetes.io/control-plane: ""
```

- case 2:
   - values.yaml with control-plane node selector & toleration :
```
#@data/values
#@overlay/match-child-defaults missing_ok=True
---
nodeSelector:
  node-role.kubernetes.io/control-plane: ""
  tkr: "v1.23.1"
kappController:
  deployment:
    tolerations: [{"key": "CriticalAddonsOnly", "operator": "Exists"}, {"effect":"NoSchedule", "key":"node-role.kubernetes.io/control-plane"}]
```
- 
   - generated deployment yaml file:
```
spec:
  template:
    spec:   
      tolerations:
      - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
          key: node-role.kubernetes.io/control-plane
      nodeSelector:
         node-role.kubernetes.io/control-plane: ""
         tkr: v1.23.1
```

- case 3:
   - values.yaml with master toleration:
```
 #@data/values
 #@overlay/match-child-defaults missing_ok=True
 ---
 nodeSelector:
   tkr: "v1.23.1"
 kappController:
   deployment:
     tolerations: [{"key": "CriticalAddonsOnly", "operator": "Exists"}, {"effect":"NoSchedule", "key":"node-role.kubernetes.io/master"}]
```
- 
   - generated deployment yaml file:
```
  spec:
    template:
      spec:   
        tolerations:
          - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
         - key: CriticalAddonsOnly
            operator: Exists
         - effect: NoSchedule
            key: node-role.kubernetes.io/master
        nodeSelector:
          tkr: v1.23.1
```

- case 4:
   - values.yaml with some other nodeSelector & toleration:
```
 #@data/values
 #@overlay/match-child-defaults missing_ok=True
 ---
   nodeSelector:
     tkr: "v1.23.1"
   kappController:
     deployment:
       tolerations: [{"key": "CriticalAddonsOnly", "operator": "Exists"}]
```
-
   - generated deployment yaml file:
```
spec:
  template:
    spec:   
      tolerations:
      - key: CriticalAddonsOnly
        operator: Exists
      nodeSelector:
        tkr: v1.23.1
```

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
