### PR TITLE
Upgrade CSI driver to 2.6.2

### DIFF
--- a/addons/packages/vsphere-csi/2.6.2/README.md
+++ b/addons/packages/vsphere-csi/2.6.2/README.md
@@ -1,0 +1,42 @@
+# vSphere CSI
+
+> This package provides cloud storage interface using vsphere-csi.
+
+For more information, see the [GitHub page](https://github.com/kubernetes-sigs/vsphere-csi-driver) of vSphere CSI.
+
+## Configuration
+
+The following configuration values can be set to customize the vsphere CSI installation.
+
+### Global
+
+None
+
+### vSphere CSI Configuration
+
+| Value | Required/Optional | Description |
+|-------|-------------------|-------------|
+| `vsphereCSI.namespace` | Required | The namespace of the Kubernetes cluster in cluster ID. Default value is `null`. |
+| `vsphereCSI.clusterName` | Required | The name of the Kubernetes cluster in cluster ID. Default value is `null`. |
+| `vsphereCSI.server` | Required | The IP address or FQDN of the vCenter endpoint. Default value is `null`. |
+| `vsphereCSI.datacenter` | Required | The Datacenter in which VMs are located. Default value is `null`. |
+| `vsphereCSI.publicNetwork` | Required | The public network to be used. Default value is `null`. |
+| `vsphereCSI.username` | Required | vCenter username in clear text. Default value is `null`. |
+| `vsphereCSI.password` | Required | vCenter password in clear text. Default value is `null`. |
+| `vsphereCSI.tlsThumbprint` | Optional | The cryptographic thumbprint of the vSphere endpoint's certificate. Default value is `""`. |
+| `vsphereCSI.region` | Optional | The region used by multi-AZ feature. Default value is `null`. |
+| `vsphereCSI.zone` | Optional | The zone used by multi-AZ feature. Default value is `null`. |
+| `vsphereCSI.useTopologyCategories` | Optional | Use topology-categories label in vSphere config. Default value is `false`. |
+| `vsphereCSI.provisionTimeout` | Optional | The timeout period for csi-provisioner container. Default value is `300s`. |
+| `vsphereCSI.attachTimeout` | Optional | The timeout period for csi-attacher container. Default value is `300s`. |
+| `vsphereCSI.resizerTimeout` | Optional | The timeout period for csi-resizer container. Default: `300s` |
+| `vsphereCSI.vSphereVersion` | Optional | The vSphere version used. Default: `false`. |
+| `vsphereCSI.http_proxy` | Optional | The HTTP_PROXY env var passed to csi-attacher container. Default value is `null`. |
+| `vsphereCSI.https_proxy` | Optional | The HTTPS_PROXY env var passed to csi-attacher container. Default value is `null`. |
+| `vsphereCSI.no_proxy` | Optional | The NO_PROXY env var passed to csi-attacher container. Default value is `null`. |
+| `vsphereCSI.deployment_replicas` | Optional | The number of replicas of vsphere-csi-controller deployment. Default: `3`. |
+| `vsphereCSI.windows_support` | Optional | Enables CSI Windows support. Default: `false`. |
+
+## Usage Example
+
+To learn more about how to use vSphere CSI refer to [vSphere CSI website](https://github.com/kubernetes-sigs/vsphere-csi-driver)

--- a/addons/packages/vsphere-csi/2.6.2/bundle/.imgpkg/bundle.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/.imgpkg/bundle.yaml
@@ -1,0 +1,9 @@
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: Bundle
+metadata:
+  name: vsphere-csi
+authors:
+  - name: Akanksha Panse
+    email: pansea@vmware.com
+websites:
+  - url: https://github.com/kubernetes-sigs/vsphere-csi-driver

--- a/addons/packages/vsphere-csi/2.6.2/bundle/.imgpkg/images.yml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/.imgpkg/images.yml
@@ -1,0 +1,84 @@
+---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- annotations:
+    kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.6.2
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v2.6.2
+          url: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.6.2
+  image: gcr.io/cloud-provider-vsphere/csi/release/driver@sha256:df421c7928686d63c46beecfaca26eb53c9a27cdd125ead325e5299abfc961f7
+- annotations:
+    kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.6.2
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v2.6.2
+          url: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.6.2
+  image: gcr.io/cloud-provider-vsphere/csi/release/syncer@sha256:ea067f29bd03e2b366a611acd34f313a4cac7773aaae5a82210864496bcc0cd0
+- annotations:
+    kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v3.4.0
+          url: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-attacher@sha256:8b9c313c05f54fb04f8d430896f5f5904b6cb157df261501b29adc04d2b2dc7b
+  image: k8s.gcr.io/sig-storage/csi-attacher@sha256:8b9c313c05f54fb04f8d430896f5f5904b6cb157df261501b29adc04d2b2dc7b
+- annotations:
+    kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v2.5.0
+          url: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:4fd21f36075b44d1a423dfb262ad79202ce54e95f5cbc4622a6c1c38ab287ad6
+  image: k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:4fd21f36075b44d1a423dfb262ad79202ce54e95f5cbc4622a6c1c38ab287ad6
+- annotations:
+    kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v2.5.1
+          url: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+  image: k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:0103eee7c35e3e0b5cd8cdca9850dc71c793cdeb6669d8be7a89440da2d06ae4
+- annotations:
+    kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v3.2.1
+          url: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+  image: k8s.gcr.io/sig-storage/csi-provisioner@sha256:4ad5fcdbe7e9147b541a863d74e4d1d519bf435ecda4c7bde5abe237a43f7029
+- annotations:
+    kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v1.4.0
+          url: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-resizer@sha256:9ebbf9f023e7b41ccee3d52afe39a89e3ddacdbb69269d583abfc25847cfd9e4
+  image: k8s.gcr.io/sig-storage/csi-resizer@sha256:9ebbf9f023e7b41ccee3d52afe39a89e3ddacdbb69269d583abfc25847cfd9e4
+- annotations:
+    kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v5.0.1
+          url: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-snapshotter@sha256:89e900a160a986a1a7a4eba7f5259e510398fa87ca9b8a729e7dec59e04c7709
+  image: k8s.gcr.io/sig-storage/csi-snapshotter@sha256:89e900a160a986a1a7a4eba7f5259e510398fa87ca9b8a729e7dec59e04c7709
+- annotations:
+    kbld.carvel.dev/id: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v2.6.0
+          url: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/livenessprobe@sha256:406f59599991916d2942d8d02f076d957ed71b541ee19f09fc01723a6e6f5932
+  image: k8s.gcr.io/sig-storage/livenessprobe@sha256:406f59599991916d2942d8d02f076d957ed71b541ee19f09fc01723a6e6f5932
+- annotations:
+    kbld.carvel.dev/id: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: v2.7.0
+          url: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+  image: k8s.gcr.io/sig-storage/livenessprobe@sha256:933940f13b3ea0abc62e656c1aa5c5b47c04b15d71250413a6b821bd0c58b94e
+kind: ImagesLock

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/add-secret.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/add-secret.yaml
@@ -1,0 +1,12 @@
+#@ load("/values.star", "values")
+#@ load("/vsphereconf.lib.txt", "vsphere_conf")
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-config-secret
+  namespace: #@ values.vsphereCSI.namespace
+stringData:
+  csi-vsphere.conf: #@ vsphere_conf(values)
+type: Opaque

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/update-csi-driver.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/update-csi-driver.yaml
@@ -1,0 +1,150 @@
+#@ load("/values.star", "values")
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:sha256", "sha256")
+
+#@overlay/match by=overlay.subset({"kind": "Deployment", "metadata": {"name": "vsphere-csi-controller"}})
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
+    kapp.k14s.io/update-strategy: fallback-on-replace
+    vsphere-csi/data-values-hash: #@ sha256.sum(yaml.encode(values))
+  namespace: #@ values.vsphereCSI.namespace
+
+spec:
+  #@overlay/match
+  replicas: #@ values.vsphereCSI.deployment_replicas
+  template:
+    spec:
+      containers:
+        #@overlay/match by=overlay.subset({"name": "csi-attacher"})
+        - args:
+            #@overlay/match by=lambda index, left, right: "--timeout=" in left, expects=1
+            - #@ "--timeout=" + values.vsphereCSI.attachTimeout
+              #@ if values.vsphereCSI.http_proxy != "" :
+            #@overlay/match by=overlay.subset({"name": "vsphere-csi-controller"})
+        - env:
+            #@overlay/append
+            - name: "HTTP_PROXY"
+              value: #@ values.vsphereCSI.http_proxy
+            - name: "HTTPS_PROXY"
+              value: #@ values.vsphereCSI.https_proxy
+            - name: "NO_PROXY"
+              value: #@ values.vsphereCSI.no_proxy
+        #@ end
+        #@ if values.vsphereCSI.http_proxy != "" :
+        #@overlay/match by=overlay.subset({"name": "vsphere-syncer"})
+        - env:
+            #@overlay/append
+            - name: "HTTP_PROXY"
+              value: #@ values.vsphereCSI.http_proxy
+            - name: "HTTPS_PROXY"
+              value: #@ values.vsphereCSI.https_proxy
+            - name: "NO_PROXY"
+              value: #@ values.vsphereCSI.no_proxy
+        #@ end
+        #@overlay/match by=overlay.subset({"name": "csi-provisioner"})
+        - args:
+            #@overlay/match by=lambda index, left, right: "--timeout=" in left, expects=1
+            - #@ "--timeout=" + values.vsphereCSI.provisionTimeout
+          #@ if values.vsphereCSI.region or values.vsphereCSI.zone:
+            #@overlay/match by=overlay.index(-1), missing_ok=True
+            - "--feature-gates=Topology=true"
+            #@overlay/match by=overlay.index(-1), missing_ok=True
+            - "--strict-topology"
+          #@ end
+        #@ if hasattr(values.vsphereCSI, 'vSphereVersion') and values.vsphereCSI.vSphereVersion.startswith('6'):
+        #@overlay/remove
+        #@overlay/match by="name"
+        - name: csi-resizer
+        #@ end
+
+#@overlay/match by=overlay.subset({"kind": "DaemonSet"}), expects="1+"
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
+    kapp.k14s.io/update-strategy: fallback-on-replace
+    vsphere-csi/data-values-hash: #@ sha256.sum(yaml.encode(values))
+  namespace: #@ values.vsphereCSI.namespace
+spec:
+  template:
+    metadata:
+      labels:
+        #@overlay/match missing_ok=True
+        vsphere-csi/data-values-hash: #@ "h-{}".format(sha256.sum(yaml.encode(values))[:7])
+    spec:
+      containers:
+        #@overlay/match by=overlay.subset({"name": "vsphere-csi-node"})
+        - env:
+            #@overlay/append
+            - name: "VSPHERE_CSI_CONFIG"
+              value: "/etc/cloud/csi-vsphere.conf"
+            #@ if values.vsphereCSI.http_proxy != "" :
+            #@overlay/append
+            - name: "HTTP_PROXY"
+              value: #@ values.vsphereCSI.http_proxy
+            - name: "HTTPS_PROXY"
+              value: #@ values.vsphereCSI.https_proxy
+            - name: "NO_PROXY"
+              value: #@ values.vsphereCSI.no_proxy
+            #@ end
+          volumeMounts:
+            #@overlay/append
+            - name: vsphere-config-volume
+              mountPath: /etc/cloud
+              readOnly: true
+      volumes:
+        #@overlay/append
+        - name: vsphere-config-volume
+          secret:
+            secretName: vsphere-config-secret
+
+#@ service_accounts = overlay.subset({"kind": "ServiceAccount", "metadata": {"namespace": "vmware-system-csi"}})
+#@ roles = overlay.subset({"kind": "Role", "metadata": {"namespace": "vmware-system-csi"}})
+#@ role_bindings = overlay.subset({"kind": "RoleBinding", "metadata": {"namespace": "vmware-system-csi"}})
+#@ services = overlay.subset({"kind": "Service", "metadata": {"namespace": "vmware-system-csi"}})
+
+#@overlay/match by=overlay.or_op(service_accounts, roles, role_bindings, services), expects=5
+---
+metadata:
+  namespace: #@ values.vsphereCSI.namespace
+
+#@overlay/match by=overlay.or_op(overlay.subset({"kind": "ClusterRoleBinding"}), overlay.subset({"kind": "RoleBinding"})), expects=3
+---
+subjects:
+  #@overlay/match by="kind"
+  - kind: ServiceAccount
+    namespace: #@ values.vsphereCSI.namespace
+
+#@ config_maps = overlay.subset({"kind": "ConfigMap", "metadata": {"namespace": "vmware-system-csi"}})
+
+#@overlay/match by=config_maps, expects=1
+---
+metadata:
+  namespace: #@ values.vsphereCSI.namespace
+data:
+#@ if values.vsphereCSI.windows_support:
+  #@overlay/replace
+  "csi-windows-support": "true"
+#@ else:
+  #@overlay/replace
+  "csi-windows-support": "false"
+#@ end
+
+
+#@ if values.vsphereCSI.windows_support:
+#@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "vsphere-csi-node"}})
+---
+#@overlay/remove
+
+#@ else:
+#@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "vsphere-csi-node-windows"}})
+---
+#@overlay/remove
+
+#@ end

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/update-strategy-overlay.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/update-strategy-overlay.yaml
@@ -1,0 +1,50 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#! We are adding this overlay in the package to accommodate the need from vSphere supervisor cluster:
+#! `deployment.spec.strategy.type` is configured to `RollingUpdate`
+#! `deployment.spec.strategy.rollingUpdate.maxUnavailable` is set to `0`.
+#! `deployment.spec.strategy.rollingUpdate.maxSurge` is set to `1`.
+#! `deployment.spec.template.spec.nodeSelector`is set to target only `Nodes`
+#! `daemonset.spec.updateStrategy.type` is configured to `OnDelete`
+#! This overlay makes configuring the above parameters possible
+#! Reference: https://github.com/vmware-tanzu/tanzu-framework/issues/1850
+
+#@overlay/match expects="0+",by=overlay.subset({"kind":"Deployment"})
+---
+kind: Deployment
+spec:
+  #@ if data.values.deployment.updateStrategy != None:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: #@ data.values.deployment.updateStrategy
+    #@overlay/match missing_ok=True
+    #@ if data.values.deployment.updateStrategy == "RollingUpdate":
+    rollingUpdate:
+      #@ if/end data.values.deployment.rollingUpdate.maxUnavailable != None:
+      maxUnavailable: #@ data.values.deployment.rollingUpdate.maxUnavailable
+      #@ if/end data.values.deployment.rollingUpdate.maxSurge != None:
+      maxSurge: #@ data.values.deployment.rollingUpdate.maxSurge
+    #@ end
+  #@ end
+  #@ if data.values.nodeSelector != None:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      nodeSelector:
+        #@ for key in data.values.nodeSelector:
+        #@overlay/match missing_ok=True
+        #@yaml/text-templated-strings
+        (@= key @): #@ data.values.nodeSelector[key]
+        #@ end
+  #@ end
+
+#@overlay/match expects="0+",by=overlay.subset({"kind":"DaemonSet"})
+---
+kind: DaemonSet
+spec:
+  #@ if data.values.daemonset.updateStrategy:
+  #@overlay/match missing_ok=True
+  updateStrategy:
+    type: #@ data.values.daemonset.updateStrategy
+  #@ end

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/upstream/vsphere-csi/LICENSE
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/upstream/vsphere-csi/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/upstream/vsphere-csi/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/upstream/vsphere-csi/manifests/vanilla/vsphere-csi-driver.yaml
@@ -1,0 +1,686 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi.vsphere.vmware.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods", "configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["triggercsifullsyncs"]
+    verbs: ["create", "get", "update", "watch", "list"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvspherevolumemigrations"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvolumeoperationrequests"]
+    verbs: ["create", "get", "list", "update", "delete"]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshots" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotclasses" ]
+    verbs: [ "watch", "get", "list" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotcontents" ]
+    verbs: [ "create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotcontents/status" ]
+    verbs: [ "update", "patch" ]
+  - apiGroups: [ "cns.vmware.com" ]
+    resources: [ "csinodetopologies" ]
+    verbs: ["get", "update", "watch", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: vmware-system-csi
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-node
+  namespace: vmware-system-csi
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-role
+rules:
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["csinodetopologies"]
+    verbs: ["create", "watch", "get", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: vmware-system-csi
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-node-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-role
+  namespace: vmware-system-csi
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-binding
+  namespace: vmware-system-csi
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: vmware-system-csi
+roleRef:
+  kind: Role
+  name: vsphere-csi-node-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+data:
+  "csi-migration": "false"
+  "csi-auth-check": "true"
+  "online-volume-extend": "true"
+  "trigger-csi-fullsync": "false"
+  "async-query-volume": "true"
+  "improved-csi-idempotency": "true"
+  "improved-volume-topology": "true"
+  "block-volume-snapshot": "true"
+  "csi-windows-support": "false"
+  "use-csinode-id": "true"
+  "list-volumes": "false"
+  "pv-to-backingdiskobjectid-mapping": "false"
+  "cnsmgr-suspend-create-volume": "true"
+  "topology-preferential-datastores": "true"
+  "max-pvscsi-targets-per-vm": "false"
+kind: ConfigMap
+metadata:
+  name: internal-feature-states.csi.vsphere.vmware.com
+  namespace: vmware-system-csi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      app: vsphere-csi-controller
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-controller
+        role: vsphere-csi
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - vsphere-csi-controller
+              topologyKey: "kubernetes.io/hostname"
+      serviceAccountName: vsphere-csi-controller
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        # uncomment below toleration if you need an aggressive pod eviction in case when
+        # node becomes not-ready or unreachable. Default is 300 seconds if not specified.
+        #- key: node.kubernetes.io/not-ready
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
+        #- key: node.kubernetes.io/unreachable
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
+      dnsPolicy: "Default"
+      containers:
+        - name: csi-attacher
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: csi-resizer
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--handle-volume-inuse-error=false"
+            - "--csi-address=$(ADDRESS)"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: vsphere-csi-controller
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.6.2
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: X_CSI_MODE
+              value: "controller"
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/cloud/csi-vsphere.conf"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /csi
+              name: socket-dir
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+            - name: prometheus
+              containerPort: 2112
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
+        - name: liveness-probe
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+          args:
+            - "--v=4"
+            - "--csi-address=/csi/csi.sock"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: vsphere-syncer
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.6.2
+          args:
+            - "--leader-election"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
+          env:
+            - name: FULL_SYNC_INTERVAL_MINUTES
+              value: "30"
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/cloud/csi-vsphere.conf"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+        - name: csi-provisioner
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+            - "--leader-election"
+            - "--default-fstype=ext4"
+            # needed only for topology aware setup
+            #- "--feature-gates=Topology=true"
+            #- "--strict-topology"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: csi-snapshotter
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+          args:
+            - "--v=4"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+        - name: vsphere-config-volume
+          secret:
+            secretName: vsphere-config-secret
+        - name: socket-dir
+          emptyDir: {}
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-node
+  namespace: vmware-system-csi
+spec:
+  selector:
+    matchLabels:
+      app: vsphere-csi-node
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-node
+        role: vsphere-csi
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: vsphere-csi-node
+      hostNetwork: true
+      dnsPolicy: "ClusterFirstWithHostNet"
+      containers:
+        - name: node-driver-registrar
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          livenessProbe:
+            exec:
+              command:
+              - /csi-node-driver-registrar
+              - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+              - --mode=kubelet-registration-probe
+            initialDelaySeconds: 3
+        - name: vsphere-csi-node
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.6.2
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: MAX_VOLUMES_PER_NODE
+              value: "59" # Maximum number of volumes that controller can publish to the node. If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
+            - name: X_CSI_MODE
+              value: "node"
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: "false"
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
+              value: "1"
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - name: device-dir
+              mountPath: /dev
+            - name: blocks-dir
+              mountPath: /sys/block
+            - name: sys-devices-dir
+              mountPath: /sys/devices
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+        - name: liveness-probe
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+          args:
+            - "--v=4"
+            - "--csi-address=/csi/csi.sock"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+        - name: blocks-dir
+          hostPath:
+            path: /sys/block
+            type: Directory
+        - name: sys-devices-dir
+          hostPath:
+            path: /sys/devices
+            type: Directory
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-node-windows
+  namespace: vmware-system-csi
+spec:
+  selector:
+    matchLabels:
+      app: vsphere-csi-node-windows
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-node-windows
+        role: vsphere-csi-windows
+    spec:
+      nodeSelector:
+        kubernetes.io/os: windows
+      serviceAccountName: vsphere-csi-node
+      containers:
+        - name: node-driver-registrar
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          env:
+            - name: ADDRESS
+              value: 'unix://C:\\csi\\csi.sock'
+            - name: DRIVER_REG_SOCK_PATH
+              value: 'C:\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock'
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          livenessProbe:
+            exec:
+              command:
+              - /csi-node-driver-registrar.exe
+              - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock
+              - --mode=kubelet-registration-probe
+            initialDelaySeconds: 3
+        - name: vsphere-csi-node
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.6.2
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: 'unix://C:\\csi\\csi.sock'
+            - name: MAX_VOLUMES_PER_NODE
+              value: "0" # Maximum number of volumes that controller can publish to the node. If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: 'false'
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: X_CSI_LOG_LEVEL
+              value: DEBUG
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
+              value: "1"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: 'C:\csi'
+            - name: pods-mount-dir
+              mountPath: 'C:\var\lib\kubelet'
+            - name: csi-proxy-volume-v1
+              mountPath: \\.\pipe\csi-proxy-volume-v1
+            - name: csi-proxy-filesystem-v1
+              mountPath: \\.\pipe\csi-proxy-filesystem-v1
+            - name: csi-proxy-disk-v1
+              mountPath: \\.\pipe\csi-proxy-disk-v1
+            - name: csi-proxy-system-v1alpha1
+              mountPath: \\.\pipe\csi-proxy-system-v1alpha1
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+        - name: liveness-probe
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+          args:
+            - "--v=4"
+            - "--csi-address=/csi/csi.sock"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: 'C:\var\lib\kubelet\plugins_registry\'
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: 'C:\var\lib\kubelet\plugins\csi.vsphere.vmware.com\'
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: \var\lib\kubelet
+            type: Directory
+        - name: csi-proxy-disk-v1
+          hostPath:
+            path: \\.\pipe\csi-proxy-disk-v1
+            type: ''
+        - name: csi-proxy-volume-v1
+          hostPath:
+            path: \\.\pipe\csi-proxy-volume-v1
+            type: ''
+        - name: csi-proxy-filesystem-v1
+          hostPath:
+            path: \\.\pipe\csi-proxy-filesystem-v1
+            type: ''
+        - name: csi-proxy-system-v1alpha1
+          hostPath:
+            path: \\.\pipe\csi-proxy-system-v1alpha1
+            type: ''
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/values.star
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/values.star
@@ -1,0 +1,21 @@
+load("@ytt:data", "data")
+load("@ytt:assert", "assert")
+
+def validate_vsphereCSI():
+   data.values.vsphereCSI.namespace or assert.fail("vsphereCSI namespace should be provided")
+   data.values.vsphereCSI.clusterName or assert.fail("vsphereCSI clusterName should be provided")
+   data.values.vsphereCSI.server or assert.fail("vsphereCSI server should be provided")
+   data.values.vsphereCSI.datacenter or assert.fail("vsphereCSI datacenter should be provided")
+   data.values.vsphereCSI.publicNetwork or assert.fail("vsphereCSI publicNetwork should be provided")
+   data.values.vsphereCSI.username or assert.fail("vsphereCSI username should be provided")
+   data.values.vsphereCSI.password or assert.fail("vsphereCSI password should be provided")
+   if not data.values.vsphereCSI.insecureFlag:
+     data.values.vsphereCSI.tlsThumbprint or assert.fail("vsphereCSI tlsThumbprint should be provided when insecureFlag is False")
+   end
+end
+
+#export
+values = data.values
+
+# validate
+validate_vsphereCSI()

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/values.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/values.yaml
@@ -1,0 +1,34 @@
+#@data/values
+#@overlay/match-child-defaults missing_ok=True
+
+---
+nodeSelector: null
+deployment:
+  updateStrategy: null
+  rollingUpdate:
+    maxUnavailable: null
+    maxSurge: null
+daemonset:
+  updateStrategy: null
+vsphereCSI:
+  tlsThumbprint: ""
+  namespace: kube-system
+  clusterName: null
+  server: null
+  datacenter: null
+  publicNetwork: null
+  username: null
+  password: null
+  region: null
+  zone: null
+  insecureFlag: True
+  useTopologyCategories: false
+  provisionTimeout: 300s
+  attachTimeout: 300s
+  resizerTimeout: 300s
+  vSphereVersion: 6.7.0
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  deployment_replicas: 3
+  windows_support: false

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/vsphereconf.lib.txt
@@ -1,0 +1,51 @@
+
+(@ def vsphere_conf(values): -@)
+[Global]
+(@ if values.vsphereCSI.insecureFlag: -@)
+insecure-flag = true
+(@ else: -@)
+thumbprint = "(@=values.vsphereCSI.tlsThumbprint @)"
+(@ end -@)
+cluster-id = (@=values.vsphereCSI.namespace @)/(@=values.vsphereCSI.clusterName @)
+
+[VirtualCenter "(@=values.vsphereCSI.server @)"]
+user = "(@=values.vsphereCSI.username.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t","\\t") @)"
+password = "(@=values.vsphereCSI.password.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t","\\t") @)"
+datacenters = "(@=values.vsphereCSI.datacenter @)"
+(@ if values.vsphereCSI.insecureFlag: -@)
+insecure-flag = true
+(@ else: -@)
+thumbprint = "(@=values.vsphereCSI.tlsThumbprint @)"
+(@ end -@)
+
+[Network]
+public-network = "(@=values.vsphereCSI.publicNetwork @)"
+(@ if values.vsphereCSI.region or values.vsphereCSI.zone: -@)
+
+[Labels]
+(@ # if useTopologyCategories is set as True, csi config uses topology-categories. Otherwise still use region,zone -@)
+(@ if hasattr(values.vsphereCSI, "useTopologyCategories") and values.vsphereCSI.useTopologyCategories: -@)
+
+(@ if values.vsphereCSI.region and values.vsphereCSI.zone: -@)
+topology-categories = "(@=values.vsphereCSI.region @), (@=values.vsphereCSI.zone @)"
+(@ else: -@)
+(@ if values.vsphereCSI.region: -@)
+topology-categories = "(@=values.vsphereCSI.region @)"
+(@ end -@)
+(@ if values.vsphereCSI.zone: -@)
+topology-categories = "(@=values.vsphereCSI.zone @)"
+(@ end -@)
+(@ end -@)
+
+(@ else: -@)
+
+(@ if values.vsphereCSI.region: -@)
+region = "(@=values.vsphereCSI.region @)"
+(@ end -@)
+(@ if values.vsphereCSI.zone: -@)
+zone = "(@=values.vsphereCSI.zone @)"
+(@ end -@)
+(@ end -@)
+(@- end @)
+
+(@- end @)

--- a/addons/packages/vsphere-csi/2.6.2/bundle/vendir.lock.yml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/vendir.lock.yml
@@ -1,0 +1,11 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - git:
+      commitTitle: tag v2.6.2 release (#2035)
+      sha: cf84f1a0b5cf897099587efd6d0b33866935211c
+      tags:
+      - v2.6.2
+    path: vsphere-csi
+  path: config/upstream
+kind: LockConfig

--- a/addons/packages/vsphere-csi/2.6.2/bundle/vendir.yml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/vendir.yml
@@ -1,0 +1,12 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.12.0
+directories:
+- path: config/upstream
+  contents:
+  - path: vsphere-csi
+    git:
+      url: git@github.com:kubernetes-sigs/vsphere-csi-driver.git
+      ref: cf84f1a0b5cf897099587efd6d0b33866935211c
+    includePaths:
+      - manifests/vanilla/vsphere-csi-driver.yaml

--- a/addons/packages/vsphere-csi/2.6.2/package.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/package.yaml
@@ -1,0 +1,25 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: vsphere-csi.community.tanzu.vmware.com.2.6.2
+spec:
+  refName: vsphere-csi.community.tanzu.vmware.com
+  version: 2.6.2
+  releaseNotes: "vsphere-csi 2.6.2 https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.6.2"
+  licenses:
+    - "Apache 2.0"
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:eac7fa217de0c348dc3a4dc3d83697acd47f12e78fc34d55a241f7f1bb0a55e4
+      template:
+        - ytt:
+            paths:
+              - config/
+        - kbld:
+            paths:
+              - "-"
+              - .imgpkg/images.yml
+      deploy:
+        - kapp: {}


### PR DESCRIPTION
## What this PR does / why we need it
Bump up vsphere-csi version to consume v2.6.2 GA

## Which issue(s) this PR fixes
Fixes: #

## Describe testing done for PR

Created test yaml and verified CSI deployment on test setup

```
$ ytt --ignore-unknown-comments -f bundle/config > test.yaml

# kubectl create -f test.yaml
secret/vsphere-config-secret created
csidriver.storage.k8s.io/csi.vsphere.vmware.com created
serviceaccount/vsphere-csi-controller created
clusterrole.rbac.authorization.k8s.io/vsphere-csi-controller-role created
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-controller-binding created
serviceaccount/vsphere-csi-node created
clusterrole.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role created
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role-binding created
role.rbac.authorization.k8s.io/vsphere-csi-node-role created
rolebinding.rbac.authorization.k8s.io/vsphere-csi-node-binding created
configmap/internal-feature-states.csi.vsphere.vmware.com created
service/vsphere-csi-controller created
deployment.apps/vsphere-csi-controller created
daemonset.apps/vsphere-csi-node created
```
CSI pods are up and running, basic volume provisioning worked fine

 ```
vsphere-csi-controller-8fc44f55f-297z8                        6/6	Running	0             38s
 vsphere-csi-controller-8fc44f55f-7d65n			6/6	Running	0             38s
 vsphere-csi-controller-8fc44f55f-9q9zd			6/6	Running	0             38s
 vsphere-csi-node-2c7n8						3/3	Running	0             38s
 vsphere-csi-node-dtcws						3/3	Running	0             38s
 vsphere-csi-node-hxbjd						3/3	Running	0             38s
 vsphere-csi-node-j7x88						3/3	Running	0             38s
 vsphere-csi-node-jssdq						3/3	Running	0             38s
 vsphere-csi-node-n6dqf						3/3	Running	0             38s
 vsphere-csi-node-p9lkk						3/3	Running	0             38s
 vsphere-csi-node-sbx7t						3/3	Running	0             38s
 vsphere-csi-node-vbk4g						3/3	Running	0             38s
 vsphere-csi-node-xlx96						3/3	Running	0             38s
 
 
# kubectl create -f example-raw-block-sc.yaml
storageclass.storage.k8s.io/example-raw-block-sc created

# kubectl create -f example-raw-block-pvc.yaml
persistentvolumeclaim/example-raw-block-pvc created

# kubectl get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             AGE
example-raw-block-pvc   Bound    pvc-9fae9139-ca99-4be3-bb67-9dcdb8e6a181   1Gi        RWO            example-raw-block-sc   4s

# kubectl create -f example-raw-block-pod.yaml
pod/example-raw-block-pod created

# kubectl get pods
NAME                    READY   STATUS    RESTARTS   AGE
example-raw-block-pod   1/1     Running   0          58s
```

## Special notes for your reviewer

