### PR TITLE
package/pinniped/0.12.1: bump dex to 2.35.3

### DIFF
--- a/addons/packages/pinniped/0.12.1/bundle/.imgpkg/bundle.yml
+++ b/addons/packages/pinniped/0.12.1/bundle/.imgpkg/bundle.yml
@@ -3,11 +3,7 @@ kind: Bundle
 metadata:
   name: pinniped
 authors:
-- name: Andrew Keesler
-  email: akeesler@vmware.com
 - name: Ben Petersen
   email: petersenbe@vmware.com
-- name: Sarah Abbey
-  email: sabbey@vmware.com
 websites:
 - url: https://github.com/vmware-tanzu/pinniped

--- a/addons/packages/pinniped/0.12.1/bundle/.imgpkg/images.yml
+++ b/addons/packages/pinniped/0.12.1/bundle/.imgpkg/images.yml
@@ -9,12 +9,12 @@ images:
           url: docker.io/getpinniped/pinniped-server:v0.12.1
   image: index.docker.io/getpinniped/pinniped-server@sha256:8b4ee3b279d8d1d1f1c65d95f8611a99e00c6d2fbb5dbf974ad76ac4ca563d73
 - annotations:
-    kbld.carvel.dev/id: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+    kbld.carvel.dev/id: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
     kbld.carvel.dev/origins: |
       - resolved:
-          tag: v2.30.2_vmware.1
-          url: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
-  image: projects.registry.vmware.com/tce/dex@sha256:b9e2f32b864f83a5f3e7b555b876c40665576bc09b20de745b3675238fd7657d
+          tag: v2.35.3_vmware.1
+          url: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
+  image: projects.registry.vmware.com/tce/dex@sha256:7ac6e085ad900eb67b3b59d46a01b280560355b20eec8a75de27e632c379523d
 - annotations:
     kbld.carvel.dev/id: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
     kbld.carvel.dev/origins: |

--- a/addons/packages/pinniped/0.12.1/bundle/config/overlay/dex-deployment.yaml
+++ b/addons/packages/pinniped/0.12.1/bundle/config/overlay/dex-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-aws-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-aws-v1_3_0.yaml
@@ -165,7 +165,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-azure-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-azure-v1_3_0.yaml
@@ -165,7 +165,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-custom-cluster-issuer.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-custom-cluster-issuer.yaml
@@ -167,7 +167,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-updatestrategyoverlay-v1_5_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-updatestrategyoverlay-v1_5_0.yaml
@@ -156,7 +156,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_3_1.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_3_1.yaml
@@ -165,7 +165,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_4_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_4_0.yaml
@@ -167,7 +167,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_5_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_5_0.yaml
@@ -167,7 +167,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-vsphere-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-vsphere-v1_3_0.yaml
@@ -165,7 +165,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.30.2_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/package.yaml
+++ b/addons/packages/pinniped/0.12.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/pinniped@sha256:211bbc5be32137ca0ec71202855894387ee3b78bacad9f04e27e579d3a6e43ed
+            image: projects.registry.vmware.com/tce/pinniped@sha256:756fb0c6989510612a75a87908786e6648b44a0fb2bde426f8f8e27c506ddf3a
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it

Bump the dex image from 2.30.1 to 2.35.2 (latest).

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR

Templating works.
Opening BOLT MRs to run automated tests for this change.

