### PR TITLE
Update vSphere version check for CSI version 2.3.0

### DIFF
--- a/addons/packages/vsphere-csi/2.3.0/bundle/config/overlays/update-csi-driver.yaml
+++ b/addons/packages/vsphere-csi/2.3.0/bundle/config/overlays/update-csi-driver.yaml
@@ -54,7 +54,7 @@ spec:
             #@overlay/match by=overlay.index(-1), missing_ok=True
             - "--strict-topology"
           #@ end
-        #@ if hasattr(values.vsphereCSI, 'vSphereVersion') and not values.vsphereCSI.vSphereVersion.startswith('7'):
+        #@ if hasattr(values.vsphereCSI, 'vSphereVersion') and values.vsphereCSI.vSphereVersion.startswith('6'):
         #@overlay/remove
         #@overlay/match by="name"
         - name: csi-resizer


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
We need to omit adding CSI resizer container to vSphere CSI driver deployment YAML for vSphere version < v7.0 however current version check also omits adding this container to CSI driver YAML for vSphere version > v7.*
Hence corrected the check to omit CSI resizer for vSphere version starting with v6.*

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Generated test.yaml for vSphere version 8.0.0 and found CSI resizer container was added successfully to CSI driver deployment YAML

values.yaml


```
#@data/values
#@overlay/match-child-defaults missing_ok=True

---
...
  vSphereVersion: 8.0.0
...
```
test.yaml

```
...
      - name: csi-resizer
        image: quay.io/k8scsi/csi-resizer:v1.1.0
        args:
        - --v=4
        - --timeout=300s
        - --handle-volume-inuse-error=false
        - --csi-address=$(ADDRESS)
        - --kube-api-qps=100
        - --kube-api-burst=100
        - --leader-election
        env:
        - name: ADDRESS
          value: /csi/csi.sock
        volumeMounts:
        - mountPath: /csi
          name: socket-dir
...
```


## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
