### PR TITLE
fix whereabouts package schema defination issue

### DIFF
--- a/addons/packages/whereabouts/0.5.4/package.yaml
+++ b/addons/packages/whereabouts/0.5.4/package.yaml
@@ -38,7 +38,7 @@ spec:
                           type: string
                           description: Daemonset memory limits.
                           default: 50Mi
-                    request:
+                    requests:
                       type: object
                       description: Daemonset resource request.
                       properties:
@@ -66,7 +66,7 @@ spec:
                   type: object
                   description: CronJob resource related config.
                   properties:
-                    request:
+                    requests:
                       type: object
                       description: CronJob resource request.
                       properties:


### PR DESCRIPTION
the "requests" of resources was wrongly defined as "request".