### PR TITLE
allow envoy to be run as deployment

### DIFF
--- a/addons/packages/contour/1.22.0/README.md
+++ b/addons/packages/contour/1.22.0/README.md
@@ -76,6 +76,8 @@ You can configure the following in the data values file:
 | `envoy.hostNetwork` | `false` | Whether to enable host networking for the Envoy pods. |
 | `envoy.terminationGracePeriodSeconds` | `300` | The termination grace period, in seconds, for the Envoy pods. |
 | `envoy.logLevel` | `info` | The Envoy log level. Valid values are `trace`, `debug`, `info`, `warn`, `error`, `critical`, and `off`. |
+| `envoy.workload.type` | The type of Kubernetes workload Envoy is deployed as. Options are 'Deployment' or 'DaemonSet'. If not specified, will default to 'DaemonSet'. |
+| `envoy.workload.replicas` | The number of Envoy replicas to deploy when 'type' is set to 'Deployment'. If not specified, it will default to '2'. |
 | `certificates.useCertManager` | `false` | Whether to use cert-manager to provision TLS certificates for securing communication between Contour and Envoy. If false, the upstream Contour certgen job will be used to provision certificates. If true, the `cert-manager` addon must be installed in the cluster. |
 | `certificates.duration` | `8760h` |  If using cert-manager, how long the certificates should be valid for. If useCertManager is false, this field is ignored. |
 | `certificates.renewBefore` | `360h` |  If using cert-manager, how long before expiration the certificates should be renewed. If useCertManager is false, this field is ignored. |

--- a/addons/packages/contour/1.22.0/bundle/config/contour.star
+++ b/addons/packages/contour/1.22.0/bundle/config/contour.star
@@ -87,6 +87,7 @@ def validate_contour():
                     validate_contour_deployment,
                     validate_contour_certificate,
                     validate_envoy_deployment,
+                    validate_envoy_workload,
                     validate_envoy_service]
    for validate_func in validate_funcs:
      validate_func()
@@ -123,6 +124,14 @@ def validate_envoy_deployment():
   data.values.envoy.logLevel in ("trace", "debug", "info", "warning", "warn", "error", "critical", "off") or assert.fail("envoy.logLevel must be one of trace|debug|info|warning/warn|error|critical|off")
 
   data.values.envoy.terminationGracePeriodSeconds or assert.fail("envoy.terminationGracePeriodSeconds must be provided")
+end
+
+def validate_envoy_workload():
+  data.values.envoy.workload.type in ("Deployment", "DaemonSet") or assert.fail("envoy.workload.type must be one of Deployment|DaemonSet")
+  if data.values.envoy.workload.type == "Deployment":
+    data.values.envoy.workload.replicas > 0 or assert.fail("envoy.workload.replicas must be greater than 0 when envoy.workload.type is Deployment")
+  end
+
 end
 
 def validate_envoy_service():

--- a/addons/packages/contour/1.22.0/bundle/config/overlays/update-envoy-daemonset.yaml
+++ b/addons/packages/contour/1.22.0/bundle/config/overlays/update-envoy-daemonset.yaml
@@ -4,7 +4,19 @@
 
 #@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "envoy"}})
 ---
+kind: #@ data.values.envoy.workload.type
 spec:
+  #@ if data.values.envoy.workload.type == "Deployment":
+  #@overlay/match missing_ok=True
+  replicas: #@ data.values.envoy.workload.replicas
+  #@overlay/remove
+  updateStrategy:
+  #@overlay/match missing_ok=True
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  #@ end
   template:
     spec:
       containers:

--- a/addons/packages/contour/1.22.0/bundle/config/overlays/update-envoy-daemonset.yaml
+++ b/addons/packages/contour/1.22.0/bundle/config/overlays/update-envoy-daemonset.yaml
@@ -15,7 +15,9 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 10%
+      #! This value of maxSurge means that during a rolling update
+      #! the new ReplicaSet will be created first.
+      maxSurge: 10%
   #@ end
   template:
     spec:

--- a/addons/packages/contour/1.22.0/bundle/config/overlays/update-envoy-daemonset.yaml
+++ b/addons/packages/contour/1.22.0/bundle/config/overlays/update-envoy-daemonset.yaml
@@ -19,6 +19,19 @@ spec:
   #@ end
   template:
     spec:
+      #@ if data.values.envoy.workload.type == "Deployment":
+      #@overlay/match missing_ok=True
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - envoy
+              topologyKey: "kubernetes.io/hostname"
+      #@ end
       containers:
       #@overlay/match by=overlay.subset({"name": "envoy"})
       - args:

--- a/addons/packages/contour/1.22.0/bundle/config/schema.yaml
+++ b/addons/packages/contour/1.22.0/bundle/config/schema.yaml
@@ -25,6 +25,13 @@ contour:
 
 #@schema/desc "Settings for the Envoy component."
 envoy:
+  #@schema/desc "Envoy workload settings."
+  workload:
+    #@schema/desc "The type of Kubernetes workload Envoy is deployed as. Options are 'Deployment' or 'DaemonSet'. If not specified, will default to 'DaemonSet'."
+    type: DaemonSet
+    #@schema/desc "The number of Envoy replicas to deploy when 'type' is set to 'Deployment'. If not specified, it will default to '2'."
+    replicas: 2
+
   #@schema/desc "Envoy service settings."
   service:
     #@schema/desc "The type of Kubernetes service to provision for Envoy. If not specified, will default to 'NodePort' for docker and vsphere and 'LoadBalancer' for others."

--- a/addons/packages/contour/1.22.0/package.yaml
+++ b/addons/packages/contour/1.22.0/package.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/contour@sha256:4b01d102e78cdd7c99d2dae3a4e8108e09b87bbbef75cef9265394d75972fc1e
+          image: projects.registry.vmware.com/tce/contour@sha256:b68ad8ec3012db7d2a2e84f8544685012e2dca09d28d54dce8735fb60f0d05bf1
       template:
       - ytt:
           paths:

--- a/addons/packages/contour/1.22.0/package.yaml
+++ b/addons/packages/contour/1.22.0/package.yaml
@@ -65,6 +65,19 @@ spec:
           additionalProperties: false
           description: Settings for the Envoy component.
           properties:
+            workload:
+              type: object
+              additionalProperties: false
+              description: Envoy workload settings.
+              properties:
+                type:
+                  type: string
+                  description: The type of Kubernetes workload Envoy is deployed as. Options are 'Deployment' or 'DaemonSet'. If not specified, will default to 'DaemonSet'.
+                  default: DaemonSet
+                replicas:
+                  type: integer
+                  description: The number of Envoy replicas to deploy when 'type' is set to 'Deployment'. If not specified, it will default to '2'.
+                  default: 2
             service:
               type: object
               additionalProperties: false

--- a/addons/packages/contour/1.22.0/test/go.mod
+++ b/addons/packages/contour/1.22.0/test/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/gomega v1.18.1
 	github.com/vmware-tanzu/community-edition/addons/packages/test/pkg v0.0.0-00010101000000-000000000000
 	k8s.io/api v0.23.4
+	k8s.io/apimachinery v0.23.4
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/addons/packages/contour/1.22.0/test/unittest/contour_test.go
+++ b/addons/packages/contour/1.22.0/test/unittest/contour_test.go
@@ -637,7 +637,6 @@ var _ = Describe("Contour Ytt Templates", func() {
 
 		Context("Envoy replicas specified", func() {
 			BeforeEach(func() {
-				values = envoyServiceAnnotationsAWSNLB
 				values = envoyDeploymentWithReplicas
 			})
 

--- a/addons/packages/contour/1.22.0/test/unittest/contour_test.go
+++ b/addons/packages/contour/1.22.0/test/unittest/contour_test.go
@@ -617,7 +617,7 @@ var _ = Describe("Contour Ytt Templates", func() {
 				IntVal: 0,
 				StrVal: "10%",
 			}
-			Expect(deployment.Spec.Strategy.RollingUpdate.MaxUnavailable).To(Equal(percentage))
+			Expect(deployment.Spec.Strategy.RollingUpdate.MaxSurge).To(Equal(percentage))
 			Expect(*deployment.Spec.Replicas).To(Equal(int32(2)))
 			affinity := corev1.PodAffinityTerm{
 				LabelSelector: &metav1.LabelSelector{

--- a/addons/packages/contour/1.22.0/test/unittest/contour_test.go
+++ b/addons/packages/contour/1.22.0/test/unittest/contour_test.go
@@ -9,6 +9,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/yaml"
 
@@ -618,6 +619,19 @@ var _ = Describe("Contour Ytt Templates", func() {
 			}
 			Expect(deployment.Spec.Strategy.RollingUpdate.MaxUnavailable).To(Equal(percentage))
 			Expect(*deployment.Spec.Replicas).To(Equal(int32(2)))
+			affinity := corev1.PodAffinityTerm{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"envoy"},
+						},
+					},
+				},
+				TopologyKey: "kubernetes.io/hostname",
+			}
+			Expect(deployment.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(ContainElement(affinity))
 
 		})
 

--- a/addons/packages/contour/1.22.0/test/unittest/fixtures_test.go
+++ b/addons/packages/contour/1.22.0/test/unittest/fixtures_test.go
@@ -83,6 +83,27 @@ envoy:
   terminationGracePeriodSeconds: 0
 `
 
+// envoyDeploymentDefaultReplicas has envoy.workload_options.type set to Deployment and
+// an empty envoy.workload_options.replicas value.
+const envoyDeploymentDefaultReplicas string = `
+#@data/values
+---
+envoy:
+  workload:
+    type: Deployment
+`
+
+// envoyDeploymentWithReplicas has envoy.workload_options.type set to Deployment and
+// a number for envoy.workload_options.replicas value.
+const envoyDeploymentWithReplicas string = `
+#@data/values
+---
+envoy:
+  workload:
+    type: Deployment
+    replicas: 5
+`
+
 // invalidEnvoyServiceType has an invalid envoy.service.type value.
 const invalidEnvoyServiceType string = `
 #@data/values


### PR DESCRIPTION
## What this PR does / why we need it
This change allows users to configure Contour so that they can deploy Envoy as a DaemonSet OR a Deployment, and choose the number of replicas when Deployment is used.

## Which issue(s) this PR fixes

Fixes: # N/A

## Describe testing done for PR
* unit tests
* I've deployed Contour package with these changes and have seen Envoy successfully run as a Deployment.

## Special notes for your reviewer

