### PR TITLE
Fix incorrect CCM image version in the oracle-cpi package.

### DIFF
--- a/addons/packages/oracle-cpi/1.22.1/bundle/.imgpkg/images.yml
+++ b/addons/packages/oracle-cpi/1.22.1/bundle/.imgpkg/images.yml
@@ -5,9 +5,6 @@ images:
     kbld.carvel.dev/id: ghcr.io/oracle/cloud-provider-oci:v1.22.1
   image: ghcr.io/oracle/cloud-provider-oci@sha256:ed7dfbb03ac859787f390cada1d619ba81ed5053eac2b0e0ce79c24ff102baea
 - annotations:
-    kbld.carvel.dev/id: ghcr.io/oracle/cloud-provider-oci:v1.23.0
-  image: ghcr.io/oracle/cloud-provider-oci@sha256:3ddaf954aa3f01de2a7911ceee1b5408b395f159802f64968821ee647da06711
-- annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
   image: k8s.gcr.io/sig-storage/csi-attacher@sha256:8b9c313c05f54fb04f8d430896f5f5904b6cb157df261501b29adc04d2b2dc7b
 - annotations:

--- a/addons/packages/oracle-cpi/1.22.1/bundle/config/upstream/oci-cloud-controller-manager.yaml
+++ b/addons/packages/oracle-cpi/1.22.1/bundle/config/upstream/oci-cloud-controller-manager.yaml
@@ -52,7 +52,7 @@ spec:
             path: /etc/kubernetes
       containers:
         - name: oci-cloud-controller-manager
-          image: ghcr.io/oracle/cloud-provider-oci:v1.23.0
+          image: ghcr.io/oracle/cloud-provider-oci:v1.22.1
           command: ["/usr/local/bin/oci-cloud-controller-manager"]
           args:
             - --cloud-config=/etc/oci/cloud-provider.yaml

--- a/addons/packages/oracle-cpi/1.22.1/package.yaml
+++ b/addons/packages/oracle-cpi/1.22.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/tce/oracle-cpi@sha256:c701059fbb41c7021fed8c131b809c668b0d12e140734c3ea06fdb1b53690716
+          image: projects.registry.vmware.com/tce/oracle-cpi@sha256:bcb564f23298b8583afa48e2cbcbc344d40e84531ce7b3f121b63dced25d79c8
       template:
       - ytt:
           paths:


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

We were using the incorrect CCM image `cloud-provider-oci:v1.23.0` in the 1.22.1 version of oracle-cpi


## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
