### PR TITLE
Remove the default empty value from configMap of kube-vip-cloud-provider

### DIFF
--- a/addons/packages/kube-vip-cloud-provider/0.0.4/bundle/config/upstream/kube-vip-cloud-provider/configmap.yaml
+++ b/addons/packages/kube-vip-cloud-provider/0.0.4/bundle/config/upstream/kube-vip-cloud-provider/configmap.yaml
@@ -5,5 +5,3 @@ metadata:
   name: kubevip
   namespace: kube-system
 data:
-  cidr-global: ""
-  range-global: ""


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
kube-vip-cloud-provider can't handle empty string

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
