### PR TITLE
Remove vsphere-config-secret mounted in CSI node daemonset from overlay for CSI v2.6.2

### DIFF
--- a/addons/packages/vsphere-csi/2.6.2/bundle/.imgpkg/images.yml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/.imgpkg/images.yml
@@ -7,6 +7,8 @@ images:
       - resolved:
           tag: v2.6.2
           url: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.6.2
+      - preresolved:
+          url: gcr.io/cloud-provider-vsphere/csi/release/driver@sha256:df421c7928686d63c46beecfaca26eb53c9a27cdd125ead325e5299abfc961f7
   image: gcr.io/cloud-provider-vsphere/csi/release/driver@sha256:df421c7928686d63c46beecfaca26eb53c9a27cdd125ead325e5299abfc961f7
 - annotations:
     kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.6.2
@@ -14,6 +16,8 @@ images:
       - resolved:
           tag: v2.6.2
           url: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.6.2
+      - preresolved:
+          url: gcr.io/cloud-provider-vsphere/csi/release/syncer@sha256:ea067f29bd03e2b366a611acd34f313a4cac7773aaae5a82210864496bcc0cd0
   image: gcr.io/cloud-provider-vsphere/csi/release/syncer@sha256:ea067f29bd03e2b366a611acd34f313a4cac7773aaae5a82210864496bcc0cd0
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
@@ -39,6 +43,8 @@ images:
       - resolved:
           tag: v2.5.1
           url: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:0103eee7c35e3e0b5cd8cdca9850dc71c793cdeb6669d8be7a89440da2d06ae4
   image: k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:0103eee7c35e3e0b5cd8cdca9850dc71c793cdeb6669d8be7a89440da2d06ae4
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
@@ -46,6 +52,8 @@ images:
       - resolved:
           tag: v3.2.1
           url: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-provisioner@sha256:4ad5fcdbe7e9147b541a863d74e4d1d519bf435ecda4c7bde5abe237a43f7029
   image: k8s.gcr.io/sig-storage/csi-provisioner@sha256:4ad5fcdbe7e9147b541a863d74e4d1d519bf435ecda4c7bde5abe237a43f7029
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
@@ -80,5 +88,7 @@ images:
       - resolved:
           tag: v2.7.0
           url: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/livenessprobe@sha256:933940f13b3ea0abc62e656c1aa5c5b47c04b15d71250413a6b821bd0c58b94e
   image: k8s.gcr.io/sig-storage/livenessprobe@sha256:933940f13b3ea0abc62e656c1aa5c5b47c04b15d71250413a6b821bd0c58b94e
 kind: ImagesLock

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/update-csi-driver.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/update-csi-driver.yaml
@@ -93,16 +93,6 @@ spec:
             - name: "NO_PROXY"
               value: #@ values.vsphereCSI.no_proxy
             #@ end
-          volumeMounts:
-            #@overlay/append
-            - name: vsphere-config-volume
-              mountPath: /etc/cloud
-              readOnly: true
-      volumes:
-        #@overlay/append
-        - name: vsphere-config-volume
-          secret:
-            secretName: vsphere-config-secret
 
 #@ service_accounts = overlay.subset({"kind": "ServiceAccount", "metadata": {"namespace": "vmware-system-csi"}})
 #@ roles = overlay.subset({"kind": "Role", "metadata": {"namespace": "vmware-system-csi"}})

--- a/addons/packages/vsphere-csi/2.6.2/package.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:eac7fa217de0c348dc3a4dc3d83697acd47f12e78fc34d55a241f7f1bb0a55e4
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:539dd4cd84d93182bc478c1f204c3d7eb4d06233acd35f22cfbb68c9d1bd23ae
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
We found a bug in TKGm deployment of CSI where vsphere-config-secret gets mounted in CSI node daemonset, which exposes  vsphere confidential information on worker nodes, causing security breach.
For these security concerns raised. we have removed vsphere-config-secret from CSI node daemonset from CSI manifest file since v2.4.0 but manifest generated in TKGm deployment was still mounting the secret due to overlay files adding vsphere secret explicitly to CSI manifest file during packaging.
Hence removed the secret from overlay file to avoid it being added to final CSI manifest file that gets deployed in TKGm.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
Generated test.yaml and found that vsphere-config-secret was NOT mounted to CSI node daemonset in CSI driver deployment YAML

test.yaml

```
...
kind: DaemonSet
apiVersion: apps/v1
metadata:
  name: vsphere-csi-node
  namespace: kube-system
...
      - name: vsphere-csi-node
        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.6.2
        args:
        - --fss-name=internal-feature-states.csi.vsphere.vmware.com
        - --fss-namespace=$(CSI_NAMESPACE)
        imagePullPolicy: Always
        env:
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        - name: CSI_ENDPOINT
          value: unix:///csi/csi.sock
        - name: MAX_VOLUMES_PER_NODE
          value: "59"
        - name: X_CSI_MODE
          value: node
        - name: X_CSI_SPEC_REQ_VALIDATION
          value: "false"
        - name: X_CSI_SPEC_DISABLE_LEN_CHECK
          value: "true"
        - name: LOGGER_LEVEL
          value: PRODUCTION
        - name: CSI_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
          value: "1"
        - name: VSPHERE_CSI_CONFIG
          value: /etc/cloud/csi-vsphere.conf
        securityContext:
          privileged: true
          capabilities:
            add:
            - SYS_ADMIN
          allowPrivilegeEscalation: true
        volumeMounts:
        - name: plugin-dir
          mountPath: /csi
        - name: pods-mount-dir
          mountPath: /var/lib/kubelet
          mountPropagation: Bidirectional
        - name: device-dir
          mountPath: /dev
        - name: blocks-dir
          mountPath: /sys/block
        - name: sys-devices-dir
          mountPath: /sys/devices
          
```

Deployed CSI driver on local setup using test.yaml and verified basic volume provisioning, pod creation

```
# kubectl get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
example-raw-block-pvc-1   Bound    pvc-bde91829-5c1e-4f95-b22d-286c7027c868   1Gi        RWO            example-raw-block-sc   2s

# kubectl get pods
NAME                      READY   STATUS    RESTARTS   AGE
example-raw-block-pod-1   1/1     Running   0          5s
```


## Special notes for your reviewer

