### PR TITLE
Bump Dex to `v2.35.3_vmware.2` in the Pinniped addon

### DIFF
--- a/addons/packages/pinniped/0.12.1/bundle/.imgpkg/images.yml
+++ b/addons/packages/pinniped/0.12.1/bundle/.imgpkg/images.yml
@@ -9,12 +9,12 @@ images:
           url: docker.io/getpinniped/pinniped-server:v0.12.1
   image: index.docker.io/getpinniped/pinniped-server@sha256:8b4ee3b279d8d1d1f1c65d95f8611a99e00c6d2fbb5dbf974ad76ac4ca563d73
 - annotations:
-    kbld.carvel.dev/id: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
+    kbld.carvel.dev/id: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.2
     kbld.carvel.dev/origins: |
       - resolved:
-          tag: v2.35.3_vmware.1
-          url: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
-  image: projects.registry.vmware.com/tce/dex@sha256:7ac6e085ad900eb67b3b59d46a01b280560355b20eec8a75de27e632c379523d
+          tag: v2.35.3_vmware.2
+          url: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.2
+  image: projects.registry.vmware.com/tce/dex@sha256:25d6eb8a4e7676d382cf79675f5eadeda64e1067e343c38670041f4e049b35fe
 - annotations:
     kbld.carvel.dev/id: projects.registry.vmware.com/tce/tanzu_core/addons/tkg-pinniped-post-deploy:v1.3.1
     kbld.carvel.dev/origins: |

--- a/addons/packages/pinniped/0.12.1/bundle/config/overlay/dex-deployment.yaml
+++ b/addons/packages/pinniped/0.12.1/bundle/config/overlay/dex-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-aws-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-aws-v1_3_0.yaml
@@ -165,7 +165,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-azure-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-azure-v1_3_0.yaml
@@ -165,7 +165,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-custom-cluster-issuer.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-custom-cluster-issuer.yaml
@@ -167,7 +167,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-updatestrategyoverlay-v1_5_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-updatestrategyoverlay-v1_5_0.yaml
@@ -156,7 +156,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_3_1.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_3_1.yaml
@@ -165,7 +165,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_4_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_4_0.yaml
@@ -167,7 +167,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_5_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-v1_5_0.yaml
@@ -167,7 +167,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-vsphere-v1_3_0.yaml
+++ b/addons/packages/pinniped/0.12.1/fixtures/expected/mc-ldap-vsphere-v1_3_0.yaml
@@ -165,7 +165,7 @@ spec:
         revision: "1"
     spec:
       containers:
-      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.1
+      - image: projects.registry.vmware.com/tce/dex:v2.35.3_vmware.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex

--- a/addons/packages/pinniped/0.12.1/package.yaml
+++ b/addons/packages/pinniped/0.12.1/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/pinniped@sha256:756fb0c6989510612a75a87908786e6648b44a0fb2bde426f8f8e27c506ddf3a
+            image: projects.registry.vmware.com/tce/pinniped@sha256:6e4227bd3b4d0492c7359224ad7b261dd31ca264f11e9a15a355f52867456563
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it

Bump Dex to `v2.35.3_vmware.2` in the Pinniped addon

## Which issue(s) this PR fixes
Runs Dex on distroless to remove components that introduce CVEs.

## Describe testing done for PR
Ran `make test-v0121` in the `addons/pinniped/test` directory

## Special notes for your reviewer

None