### PR TITLE
WIP:create custom namespace for vsphere-csi deployment

### DIFF
--- a/addons/packages/vsphere-csi/2.6.2/bundle/.imgpkg/images.yml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/.imgpkg/images.yml
@@ -9,6 +9,8 @@ images:
           url: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.6.2
       - preresolved:
           url: gcr.io/cloud-provider-vsphere/csi/release/driver@sha256:df421c7928686d63c46beecfaca26eb53c9a27cdd125ead325e5299abfc961f7
+      - preresolved:
+          url: gcr.io/cloud-provider-vsphere/csi/release/driver@sha256:df421c7928686d63c46beecfaca26eb53c9a27cdd125ead325e5299abfc961f7
   image: gcr.io/cloud-provider-vsphere/csi/release/driver@sha256:df421c7928686d63c46beecfaca26eb53c9a27cdd125ead325e5299abfc961f7
 - annotations:
     kbld.carvel.dev/id: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.6.2
@@ -16,6 +18,8 @@ images:
       - resolved:
           tag: v2.6.2
           url: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.6.2
+      - preresolved:
+          url: gcr.io/cloud-provider-vsphere/csi/release/syncer@sha256:ea067f29bd03e2b366a611acd34f313a4cac7773aaae5a82210864496bcc0cd0
       - preresolved:
           url: gcr.io/cloud-provider-vsphere/csi/release/syncer@sha256:ea067f29bd03e2b366a611acd34f313a4cac7773aaae5a82210864496bcc0cd0
   image: gcr.io/cloud-provider-vsphere/csi/release/syncer@sha256:ea067f29bd03e2b366a611acd34f313a4cac7773aaae5a82210864496bcc0cd0
@@ -27,6 +31,8 @@ images:
           url: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
       - preresolved:
           url: k8s.gcr.io/sig-storage/csi-attacher@sha256:8b9c313c05f54fb04f8d430896f5f5904b6cb157df261501b29adc04d2b2dc7b
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-attacher@sha256:8b9c313c05f54fb04f8d430896f5f5904b6cb157df261501b29adc04d2b2dc7b
   image: k8s.gcr.io/sig-storage/csi-attacher@sha256:8b9c313c05f54fb04f8d430896f5f5904b6cb157df261501b29adc04d2b2dc7b
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
@@ -34,6 +40,8 @@ images:
       - resolved:
           tag: v2.5.0
           url: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:4fd21f36075b44d1a423dfb262ad79202ce54e95f5cbc4622a6c1c38ab287ad6
       - preresolved:
           url: k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:4fd21f36075b44d1a423dfb262ad79202ce54e95f5cbc4622a6c1c38ab287ad6
   image: k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:4fd21f36075b44d1a423dfb262ad79202ce54e95f5cbc4622a6c1c38ab287ad6
@@ -45,6 +53,8 @@ images:
           url: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
       - preresolved:
           url: k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:0103eee7c35e3e0b5cd8cdca9850dc71c793cdeb6669d8be7a89440da2d06ae4
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:0103eee7c35e3e0b5cd8cdca9850dc71c793cdeb6669d8be7a89440da2d06ae4
   image: k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:0103eee7c35e3e0b5cd8cdca9850dc71c793cdeb6669d8be7a89440da2d06ae4
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
@@ -52,6 +62,8 @@ images:
       - resolved:
           tag: v3.2.1
           url: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-provisioner@sha256:4ad5fcdbe7e9147b541a863d74e4d1d519bf435ecda4c7bde5abe237a43f7029
       - preresolved:
           url: k8s.gcr.io/sig-storage/csi-provisioner@sha256:4ad5fcdbe7e9147b541a863d74e4d1d519bf435ecda4c7bde5abe237a43f7029
   image: k8s.gcr.io/sig-storage/csi-provisioner@sha256:4ad5fcdbe7e9147b541a863d74e4d1d519bf435ecda4c7bde5abe237a43f7029
@@ -63,6 +75,8 @@ images:
           url: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
       - preresolved:
           url: k8s.gcr.io/sig-storage/csi-resizer@sha256:9ebbf9f023e7b41ccee3d52afe39a89e3ddacdbb69269d583abfc25847cfd9e4
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-resizer@sha256:9ebbf9f023e7b41ccee3d52afe39a89e3ddacdbb69269d583abfc25847cfd9e4
   image: k8s.gcr.io/sig-storage/csi-resizer@sha256:9ebbf9f023e7b41ccee3d52afe39a89e3ddacdbb69269d583abfc25847cfd9e4
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
@@ -70,6 +84,8 @@ images:
       - resolved:
           tag: v5.0.1
           url: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/csi-snapshotter@sha256:89e900a160a986a1a7a4eba7f5259e510398fa87ca9b8a729e7dec59e04c7709
       - preresolved:
           url: k8s.gcr.io/sig-storage/csi-snapshotter@sha256:89e900a160a986a1a7a4eba7f5259e510398fa87ca9b8a729e7dec59e04c7709
   image: k8s.gcr.io/sig-storage/csi-snapshotter@sha256:89e900a160a986a1a7a4eba7f5259e510398fa87ca9b8a729e7dec59e04c7709
@@ -81,6 +97,8 @@ images:
           url: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
       - preresolved:
           url: k8s.gcr.io/sig-storage/livenessprobe@sha256:406f59599991916d2942d8d02f076d957ed71b541ee19f09fc01723a6e6f5932
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/livenessprobe@sha256:406f59599991916d2942d8d02f076d957ed71b541ee19f09fc01723a6e6f5932
   image: k8s.gcr.io/sig-storage/livenessprobe@sha256:406f59599991916d2942d8d02f076d957ed71b541ee19f09fc01723a6e6f5932
 - annotations:
     kbld.carvel.dev/id: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
@@ -88,6 +106,8 @@ images:
       - resolved:
           tag: v2.7.0
           url: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+      - preresolved:
+          url: k8s.gcr.io/sig-storage/livenessprobe@sha256:933940f13b3ea0abc62e656c1aa5c5b47c04b15d71250413a6b821bd0c58b94e
       - preresolved:
           url: k8s.gcr.io/sig-storage/livenessprobe@sha256:933940f13b3ea0abc62e656c1aa5c5b47c04b15d71250413a6b821bd0c58b94e
   image: k8s.gcr.io/sig-storage/livenessprobe@sha256:933940f13b3ea0abc62e656c1aa5c5b47c04b15d71250413a6b821bd0c58b94e

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/add-namespace.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/add-namespace.yaml
@@ -1,4 +1,4 @@
-#@ load("/values.star", "values") 
+#@ load("/values.star", "values")
 
 ---
 apiVersion: v1

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/add-namespace.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/add-namespace.yaml
@@ -1,0 +1,7 @@
+#@ load("/values.star", "values") 
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: #@ values.vsphereCSI.namespace

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/upstream/vsphere-csi/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/upstream/vsphere-csi/manifests/vanilla/vsphere-csi-driver.yaml
@@ -596,7 +596,7 @@ spec:
               valueFrom:
                 fieldRef:
                   apiVersion: v1
-                  fieldPath: spec.nodeName
+                  fieldPath: spec.nodeName          
             - name: CSI_ENDPOINT
               value: 'unix://C:\\csi\\csi.sock'
             - name: MAX_VOLUMES_PER_NODE
@@ -621,13 +621,13 @@ spec:
             - name: plugin-dir
               mountPath: 'C:\csi'
             - name: pods-mount-dir
-              mountPath: 'C:\var\lib\kubelet'
+              mountPath: 'C:\var\lib\kubelet'   
             - name: csi-proxy-volume-v1
               mountPath: \\.\pipe\csi-proxy-volume-v1
             - name: csi-proxy-filesystem-v1
               mountPath: \\.\pipe\csi-proxy-filesystem-v1
             - name: csi-proxy-disk-v1
-              mountPath: \\.\pipe\csi-proxy-disk-v1
+              mountPath: \\.\pipe\csi-proxy-disk-v1    
             - name: csi-proxy-system-v1alpha1
               mountPath: \\.\pipe\csi-proxy-system-v1alpha1
           ports:

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/values.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/values.yaml
@@ -13,12 +13,12 @@ daemonset:
 vsphereCSI:
   tlsThumbprint: ""
   namespace: vmware-system-csi
-  clusterName: null
-  server: null
-  datacenter: null
-  publicNetwork: null
-  username: null
-  password: null
+  clusterName: cluster1
+  server: 10.161.140.18
+  datacenter: VSAN-DC
+  publicNetwork: VM Network
+  username: Administrator@vsphere.local
+  password: Admin!23
   region: null
   zone: null
   insecureFlag: True

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/values.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/values.yaml
@@ -13,12 +13,12 @@ daemonset:
 vsphereCSI:
   tlsThumbprint: ""
   namespace: vmware-system-csi
-  clusterName: cluster1
-  server: 10.161.140.18
-  datacenter: VSAN-DC
-  publicNetwork: VM Network
-  username: Administrator@vsphere.local
-  password: Admin!23
+  clusterName: null
+  server: null
+  datacenter: null
+  publicNetwork: null
+  username: null
+  password: null
   region: null
   zone: null
   insecureFlag: True

--- a/addons/packages/vsphere-csi/2.6.2/package.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:539dd4cd84d93182bc478c1f204c3d7eb4d06233acd35f22cfbb68c9d1bd23ae
+            image: sabu-persistence-service-docker-local.artifactory.eng.vmware.com/nbarge/vsphere-csi@sha256:c582844fdb674bab287b2d647f4115b6f792c68116383b0e107fcf6ed8cad1dd
       template:
         - ytt:
             paths:

--- a/addons/packages/vsphere-csi/2.6.2/package.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:6ba0c377505e1b8f37902a3c49ed94c00560d972a5f763d181ab07a00d2d4d54
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:3e3bdfc7324b113559af479c12361a492506583144cc24fbc1a16fce991f3b8a
       template:
         - ytt:
             paths:

--- a/addons/packages/vsphere-csi/2.6.2/package.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: sabu-persistence-service-docker-local.artifactory.eng.vmware.com/nbarge/vsphere-csi@sha256:c582844fdb674bab287b2d647f4115b6f792c68116383b0e107fcf6ed8cad1dd
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:6ba0c377505e1b8f37902a3c49ed94c00560d972a5f763d181ab07a00d2d4d54
       template:
         - ytt:
             paths:


### PR DESCRIPTION
# What this PR does / why we need it

Create namespace vmware-system-csi before csi deployment so TKGm releases would deploy CSI on vmware-system-csi namespace


## Describe testing done for PR

Added overlay to create namespace vmware-system-csi 
Build new Package image and PackageRepository.
verified after installing package that vsphere csi driver deployed under namespace: vmware-system-csi as follow
```
   
```
## Special notes for your reviewer
Create namespace vmware-system-csi before csi deployment so TKGm releases would deploy CSI on vmware-system-csi namespace
