### PR TITLE
Enable TKGm user to configure net permissions

### DIFF
--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/values.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/values.yaml
@@ -32,3 +32,4 @@ vsphereCSI:
   no_proxy: ""
   deployment_replicas: 3
   windows_support: false
+  netpermissions: null

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/vsphereconf.lib.txt
@@ -8,6 +8,34 @@ thumbprint = "(@=values.vsphereCSI.tlsThumbprint @)"
 (@ end -@)
 cluster-id = (@=values.vsphereCSI.namespace @)/(@=values.vsphereCSI.clusterName @)
 
+(@ if hasattr(values.vsphereCSI, "netpermissions"): -@)
+(@ if values.vsphereCSI.netpermissions: -@)
+(@ for np in values.vsphereCSI.netpermissions: -@)
+[NetPermission "(@=np @)"]
+(@ if hasattr(values.vsphereCSI.netpermissions[np], "ips"): -@)
+ips = "(@=values.vsphereCSI.netpermissions[np]["ips"] @)"
+(@ end -@)
+(@ if hasattr(values.vsphereCSI.netpermissions[np], "permissions"): -@)
+permissions = "(@=values.vsphereCSI.netpermissions[np]["permissions"] @)"
+(@ end -@)
+
+(@ if hasattr(values.vsphereCSI.netpermissions[np], "rootsquash"): -@)
+(@ if values.vsphereCSI.netpermissions[np]["rootsquash"]: -@)
+rootsquash = true
+
+(@ else: -@)
+rootsquash = false
+
+(@ end -@)
+(@ else: -@)
+rootsquash = false
+
+(@ end -@)
+
+(@ end -@)
+(@ end -@)
+(@ end -@)
+
 [VirtualCenter "(@=values.vsphereCSI.server @)"]
 user = "(@=values.vsphereCSI.username.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t","\\t") @)"
 password = "(@=values.vsphereCSI.password.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t","\\t") @)"


### PR DESCRIPTION
## What this PR does / why we need it
Enable TKGm users to configure the NetPermission when create the workload clusters with vSphere CSI NFS volumes.

## Describe testing done for PR

Build new Package image and PackageRepository.
verified after installing package that netpermissions are configured.
used values as: 
```
vsphereCSI:
  tlsThumbprint: ""
  ...
  ..
  windows_support: false
  netpermissions:
    A:
      ips: "*"
      permissions: READ_WRITE
      rootsquash: false
    B:
      ips: "10.20.20.0/24"
      permissions: READ_ONLY
      rootsquash: true
    C:
      ips: "10.30.30.0/24"
      permissions: NO_ACCESS
    D:
      ips: "10.30.10.0/24" 
      rootsquash: true
    E:
      ips: "10.30.1.0/24"

```


[values.yaml](https://github.com/vmware-tanzu/community-edition/files/10672305/values.txt)
 
logs:

```
root@k8s-control-514-1675592526:~/carvel# kapp deploy -a sa -f sa.yaml -y
Target cluster 'https://10.43.250.83:6443' (nodes: k8s-control-514-1675592526, 5+)

Changes

Namespace                  Name                                            Kind                Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
(cluster)                  vsphere-csi-install-cluster-admin-role          ClusterRole         -       -    create  -       reconcile  -   -  
^                          vsphere-csi-install-cluster-admin-role-binding  ClusterRoleBinding  -       -    create  -       reconcile  -   -  
tanzu-package-repo-global  vsphere-csi-install-sa                          ServiceAccount      -       -    create  -       reconcile  -   -  

Op:      3 create, 0 delete, 0 update, 0 noop, 0 exists
Wait to: 3 reconcile, 0 delete, 0 noop

6:37:11AM: ---- applying 2 changes [0/3 done] ----
6:37:11AM: create clusterrole/vsphere-csi-install-cluster-admin-role (rbac.authorization.k8s.io/v1) cluster
6:37:11AM: create serviceaccount/vsphere-csi-install-sa (v1) namespace: tanzu-package-repo-global
6:37:11AM: ---- waiting on 2 changes [0/3 done] ----
6:37:12AM: ok: reconcile clusterrole/vsphere-csi-install-cluster-admin-role (rbac.authorization.k8s.io/v1) cluster
6:37:12AM: ok: reconcile serviceaccount/vsphere-csi-install-sa (v1) namespace: tanzu-package-repo-global
6:37:12AM: ---- applying 1 changes [2/3 done] ----
6:37:12AM: create clusterrolebinding/vsphere-csi-install-cluster-admin-role-binding (rbac.authorization.k8s.io/v1) cluster
6:37:12AM: ---- waiting on 1 changes [2/3 done] ----
6:37:12AM: ok: reconcile clusterrolebinding/vsphere-csi-install-cluster-admin-role-binding (rbac.authorization.k8s.io/v1) cluster
6:37:12AM: ---- applying complete [3/3 done] ----
6:37:12AM: ---- waiting complete [3/3 done] ----

Succeeded
root@k8s-control-514-1675592526:~/carvel# kapp deploy -a repo -f repo.yaml -y -n tanzu-package-repo-global
Target cluster 'https://10.43.250.83:6443' (nodes: k8s-control-514-1675592526, 5+)

Changes

Namespace                  Name              Kind               Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
tanzu-package-repo-global  vsphere-pkg-repo  PackageRepository  -       -    create  -       reconcile  -   -  

Op:      1 create, 0 delete, 0 update, 0 noop, 0 exists
Wait to: 1 reconcile, 0 delete, 0 noop

6:37:26AM: ---- applying 1 changes [0/1 done] ----
6:37:26AM: create packagerepository/vsphere-pkg-repo (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
6:37:26AM: ---- waiting on 1 changes [0/1 done] ----
6:37:26AM: ongoing: reconcile packagerepository/vsphere-pkg-repo (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
6:37:26AM:  ^ Waiting for generation 1 to be observed
6:37:27AM: ongoing: reconcile packagerepository/vsphere-pkg-repo (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
6:37:27AM:  ^ Reconciling
6:37:30AM: ok: reconcile packagerepository/vsphere-pkg-repo (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
6:37:30AM: ---- applying complete [1/1 done] ----
6:37:30AM: ---- waiting complete [1/1 done] ----

Succeeded
root@k8s-control-514-1675592526:~/carvel# kapp list -A
Target cluster 'https://10.43.250.83:6443' (nodes: k8s-control-514-1675592526, 5+)

Apps in all namespaces

Namespace                  Name                   Namespaces                             Lcs   Lca  
default                    kc                     (cluster),kapp-controller,kube-system  true  11m  
^                          sa                     (cluster),tanzu-package-repo-global    true  31s  
tanzu-package-repo-global  repo                   tanzu-package-repo-global              true  17s  
^                          vsphere-pkg-repo.pkgr  tanzu-package-repo-global              true  13s  

Lcs: Last Change Successful
Lca: Last Change Age

4 apps

Succeeded
root@k8s-control-514-1675592526:~/carvel# kapp deploy -a pkginstall-vsphere-csi -f packageinstall.yaml -y
Target cluster 'https://10.43.250.83:6443' (nodes: k8s-control-514-1675592526, 5+)

Changes

Namespace                  Name                    Kind            Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
tanzu-package-repo-global  pkginstall-vsphere-csi  PackageInstall  -       -    create  -       reconcile  -   -  

Op:      1 create, 0 delete, 0 update, 0 noop, 0 exists
Wait to: 1 reconcile, 0 delete, 0 noop

6:38:01AM: ---- applying 1 changes [0/1 done] ----
6:38:01AM: create packageinstall/pkginstall-vsphere-csi (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
6:38:01AM: ---- waiting on 1 changes [0/1 done] ----
6:38:01AM: ongoing: reconcile packageinstall/pkginstall-vsphere-csi (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
6:38:01AM:  ^ Waiting for generation 1 to be observed
6:38:02AM: ongoing: reconcile packageinstall/pkginstall-vsphere-csi (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
6:38:02AM:  ^ Reconciling

6:38:30AM: ok: reconcile packageinstall/pkginstall-vsphere-csi (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
6:38:30AM: ---- applying complete [1/1 done] ----
6:38:30AM: ---- waiting complete [1/1 done] ----

Succeeded
root@k8s-control-514-1675592526:~/carvel# 
root@k8s-control-514-1675592526:~/carvel# kubectl get pods -A
NAMESPACE           NAME                                                 READY   STATUS    RESTARTS        AGE
kapp-controller     kapp-controller-7b77b8c49-q7pmt                      2/2     Running   0               12m
kube-flannel        kube-flannel-ds-h68cs                                1/1     Running   0               44h
kube-flannel        kube-flannel-ds-jc22x                                1/1     Running   0               43h
kube-flannel        kube-flannel-ds-ksgdx                                1/1     Running   0               43h
kube-flannel        kube-flannel-ds-mhjx2                                1/1     Running   0               43h
kube-flannel        kube-flannel-ds-mpbw6                                1/1     Running   0               44h
kube-flannel        kube-flannel-ds-zsk5v                                1/1     Running   0               44h
kube-system         coredns-565d847f94-2cw6d                             1/1     Running   0               44h
kube-system         coredns-565d847f94-2lkpf                             1/1     Running   0               44h
kube-system         etcd-k8s-control-406-1675592554                      1/1     Running   0               44h
kube-system         etcd-k8s-control-514-1675592526                      1/1     Running   0               44h
kube-system         etcd-k8s-control-825-1675592579                      1/1     Running   0               44h
kube-system         kube-apiserver-k8s-control-406-1675592554            1/1     Running   2 (10h ago)     44h
kube-system         kube-apiserver-k8s-control-514-1675592526            1/1     Running   3 (10h ago)     44h
kube-system         kube-apiserver-k8s-control-825-1675592579            1/1     Running   2 (10h ago)     44h
kube-system         kube-controller-manager-k8s-control-406-1675592554   1/1     Running   2 (3h35m ago)   44h
kube-system         kube-controller-manager-k8s-control-514-1675592526   1/1     Running   6 (10h ago)     44h
kube-system         kube-controller-manager-k8s-control-825-1675592579   1/1     Running   4 (10h ago)     44h
kube-system         kube-proxy-5k446                                     1/1     Running   0               43h
kube-system         kube-proxy-dqf54                                     1/1     Running   0               44h
kube-system         kube-proxy-h5jgl                                     1/1     Running   0               44h
kube-system         kube-proxy-mbb88                                     1/1     Running   0               44h
kube-system         kube-proxy-vg6gz                                     1/1     Running   0               43h
kube-system         kube-proxy-zmng8                                     1/1     Running   0               43h
kube-system         kube-scheduler-k8s-control-406-1675592554            1/1     Running   3 (10h ago)     44h
kube-system         kube-scheduler-k8s-control-514-1675592526            1/1     Running   4 (24h ago)     44h
kube-system         kube-scheduler-k8s-control-825-1675592579            1/1     Running   4 (10h ago)     44h
kube-system         vsphere-cloud-controller-manager-962ll               1/1     Running   5 (10h ago)     43h
kube-system         vsphere-cloud-controller-manager-hrn5m               1/1     Running   4 (23h ago)     43h
kube-system         vsphere-cloud-controller-manager-ph9bm               1/1     Running   6 (10h ago)     43h
vmware-system-csi   vsphere-csi-controller-5f7fd9bdfc-675p9              6/6     Running   0               44s
vmware-system-csi   vsphere-csi-controller-5f7fd9bdfc-bczz9              6/6     Running   0               43s
vmware-system-csi   vsphere-csi-controller-5f7fd9bdfc-bnqnz              6/6     Running   0               43s
vmware-system-csi   vsphere-csi-node-2wjkf                               3/3     Running   0               44s
vmware-system-csi   vsphere-csi-node-482qt                               3/3     Running   0               43s
vmware-system-csi   vsphere-csi-node-hk6w8                               3/3     Running   0               43s
vmware-system-csi   vsphere-csi-node-jdnbk                               3/3     Running   0               43s
vmware-system-csi   vsphere-csi-node-lfhrq                               3/3     Running   0               43s
vmware-system-csi   vsphere-csi-node-r7jp2                               3/3     Running   0               43s

root@k8s-control-514-1675592526:~/carvel# kubectl get secret vsphere-config-secret -n vmware-system-csi -o jsonpath="{.data.csi-vsphere\.conf}" | base64 -d 
[Global]
insecure-flag = true
cluster-id = vmware-system-csi/cluster1

[NetPermission "A"]
ips = "*"
permissions = "READ_WRITE"
rootsquash = false

[NetPermission "B"]
ips = "10.20.20.0/24"
permissions = "READ_ONLY"
rootsquash = true

[NetPermission "C"]
ips = "10.30.30.0/24"
permissions = "NO_ACCESS"
rootsquash = false

[NetPermission "D"]
ips = "10.30.10.0/24"
rootsquash = true

[NetPermission "E"]
ips = "10.30.1.0/24"
rootsquash = false

[VirtualCenter "10.43.242.170"]
user = "Administrator@vsphere.local"
password = "PMIQc9:IkRtf0fl*"
datacenters = "VSAN-DC"
insecure-flag = true
[Network]
public-network = "VM Network"
root@k8s-control-514-1675592526:~/carvel# 

```
## Special notes for your reviewer
Enable TKGm users to configure the NetPermission when create the workload clusters with vSphere CSI NFS volumes.
