### PR TITLE
configuration for netpermission

### DIFF
--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/values.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/values.yaml
@@ -32,3 +32,4 @@ vsphereCSI:
   no_proxy: ""
   deployment_replicas: 3
   windows_support: false
+  netpermissions: null

--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/vsphereconf.lib.txt
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/vsphereconf.lib.txt
@@ -8,6 +8,34 @@ thumbprint = "(@=values.vsphereCSI.tlsThumbprint @)"
 (@ end -@)
 cluster-id = (@=values.vsphereCSI.namespace @)/(@=values.vsphereCSI.clusterName @)
 
+(@ if hasattr(values.vsphereCSI, "netpermissions"): -@)
+(@ if values.vsphereCSI.netpermissions: -@)
+(@ for np in values.vsphereCSI.netpermissions: -@)
+[NetPermission "(@=np @)"]
+(@ if hasattr(values.vsphereCSI.netpermissions[np], "ips"): -@)
+ips = "(@=values.vsphereCSI.netpermissions[np]["ips"] @)"
+(@ end -@)
+(@ if hasattr(values.vsphereCSI.netpermissions[np], "permissions"): -@)
+permissions = "(@=values.vsphereCSI.netpermissions[np]["permissions"] @)"
+(@ end -@)
+
+(@ if hasattr(values.vsphereCSI.netpermissions[np], "rootsquash"): -@)
+(@ if values.vsphereCSI.netpermissions[np]["rootsquash"]: -@)
+rootsquash = true
+
+(@ else: -@)
+rootsquash = false
+
+(@ end -@)
+(@ else: -@)
+rootsquash = false
+
+(@ end -@)
+
+(@ end -@)
+(@ end -@)
+(@ end -@)
+
 [VirtualCenter "(@=values.vsphereCSI.server @)"]
 user = "(@=values.vsphereCSI.username.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t","\\t") @)"
 password = "(@=values.vsphereCSI.password.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t","\\t") @)"

--- a/addons/packages/vsphere-csi/2.6.2/package.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:65ef23b1adcf5086d2bc4eaaa7f4abcd15d25c91caa00924cabcba1deef4f3e8
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:0263aa6982f3d36bf94bc0a97b279873e2ab975ed5cbc751ad86acd05e92a5ff
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
Enable TKGm users to configure the NetPermission when create the workload clusters with vSphere CSI NFS volumes.

Build new Package image and PackageRepository.
verified after installing package that netpermissions are configured.

## Special notes for your reviewer
Enable TKGm users to configure the NetPermission when create the workload clusters with vSphere CSI NFS volumes.
