### PR TITLE
update image for vsphere-csi

### DIFF
--- a/addons/packages/vsphere-csi/2.6.2/package.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:65ef23b1adcf5086d2bc4eaaa7f4abcd15d25c91caa00924cabcba1deef4f3e8
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:0263aa6982f3d36bf94bc0a97b279873e2ab975ed5cbc751ad86acd05e92a5ff
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
Enable TKGm users to configure the NetPermission when create the workload clusters with vSphere CSI NFS volumes.

Build new Package image and PackageRepository.
verified after installing package that netpermissions are configured.

## Special notes for your reviewer
Enable TKGm users to configure the NetPermission when create the workload clusters with vSphere CSI NFS volumes.
