### PR TITLE
Avoid create system namespace

### DIFF
--- a/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/add-namespace.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/bundle/config/overlays/add-namespace.yaml
@@ -1,7 +1,10 @@
 #@ load("/values.star", "values")
 
+#@ if values.vsphereCSI.namespace != "kube-system":
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: #@ values.vsphereCSI.namespace
+
+#@ end

--- a/addons/packages/vsphere-csi/2.6.2/package.yaml
+++ b/addons/packages/vsphere-csi/2.6.2/package.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:0263aa6982f3d36bf94bc0a97b279873e2ab975ed5cbc751ad86acd05e92a5ff
+            image: projects.registry.vmware.com/tce/vsphere-csi@sha256:3e7be80c0ada667312d0c41d5abefebfbbd7662933437468d0c5b687d2f0084a
       template:
         - ytt:
             paths:


### PR DESCRIPTION
## What this PR does / why we need it
add validation to avoid creating system namespace "kube-system"

## Which issue(s) this PR fixes

## Describe testing done for PR
update overlay to create namespace custom namespace
Build new Package image and PackageRepository.
verified after installing package that vsphere csi driver deployed under namespace: vmware-system-csi 
and if kube-system namespace is provided in values avoid creating the namespace
as follow

```
root@k8s-control-144-1676464005:~# kapp deploy -a repo -f repo.yaml -y -n tanzu-package-repo-global
Target cluster 'https://10.212.30.82:6443' (nodes: k8s-control-144-1676464005, 5+)

Changes

Namespace                  Name              Kind               Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
tanzu-package-repo-global  vsphere-pkg-repo  PackageRepository  -       -    create  -       reconcile  -   -  

Op:      1 create, 0 delete, 0 update, 0 noop, 0 exists
Wait to: 1 reconcile, 0 delete, 0 noop

2:36:41PM: ---- applying 1 changes [0/1 done] ----
2:36:42PM: create packagerepository/vsphere-pkg-repo (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
2:36:42PM: ---- waiting on 1 changes [0/1 done] ----
2:36:42PM: ongoing: reconcile packagerepository/vsphere-pkg-repo (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
2:36:42PM:  ^ Reconciling
2:36:44PM: ok: reconcile packagerepository/vsphere-pkg-repo (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
2:36:44PM: ---- applying complete [1/1 done] ----
2:36:44PM: ---- waiting complete [1/1 done] ----

Succeeded
root@k8s-control-144-1676464005:~#   kubectl get packagerepository -A 
NAMESPACE                   NAME               AGE   DESCRIPTION
tanzu-package-repo-global   vsphere-pkg-repo   37s   Reconcile succeeded
root@k8s-control-144-1676464005:~# kapp ls -A
Target cluster 'https://10.212.30.82:6443' (nodes: k8s-control-144-1676464005, 5+)

Apps in all namespaces

Namespace                  Name                   Namespaces                             Lcs   Lca  
default                    kc                     (cluster),kapp-controller,kube-system  true  23m  
^                          sa                     (cluster),tanzu-package-repo-global    true  15m  
tanzu-package-repo-global  repo                   tanzu-package-repo-global              true  44s  
^                          vsphere-pkg-repo.pkgr  tanzu-package-repo-global              true  41s  

Lcs: Last Change Successful
Lca: Last Change Age

4 apps

Succeeded
root@k8s-control-144-1676464005:~# kapp deploy -a pkginstall-vsphere-csi -f packageinstall.yaml -y
Target cluster 'https://10.212.30.82:6443' (nodes: k8s-control-144-1676464005, 5+)

Changes

Namespace                  Name                    Kind            Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
tanzu-package-repo-global  pkginstall-vsphere-csi  PackageInstall  -       -    create  -       reconcile  -   -  

Op:      1 create, 0 delete, 0 update, 0 noop, 0 exists
Wait to: 1 reconcile, 0 delete, 0 noop

2:37:39PM: ---- applying 1 changes [0/1 done] ----
2:37:39PM: create packageinstall/pkginstall-vsphere-csi (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
2:37:39PM: ---- waiting on 1 changes [0/1 done] ----
2:37:39PM: ongoing: reconcile packageinstall/pkginstall-vsphere-csi (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
2:37:39PM:  ^ Waiting for generation 1 to be observed
2:37:40PM: ongoing: reconcile packageinstall/pkginstall-vsphere-csi (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
2:37:40PM:  ^ Reconciling
2:38:00PM: ok: reconcile packageinstall/pkginstall-vsphere-csi (packaging.carvel.dev/v1alpha1) namespace: tanzu-package-repo-global
2:38:00PM: ---- applying complete [1/1 done] ----
2:38:00PM: ---- waiting complete [1/1 done] ----

Succeeded
root@k8s-control-144-1676464005:~# kubectl get pods -A
NAMESPACE           NAME                                                 READY   STATUS    RESTARTS       AGE
kapp-controller     kapp-controller-69cfd7b5fb-g7g8l                     2/2     Running   0              24m
kube-flannel        kube-flannel-ds-4klpj                                1/1     Running   0              108m
kube-flannel        kube-flannel-ds-79jdh                                1/1     Running   0              117m
kube-flannel        kube-flannel-ds-cbzqh                                1/1     Running   0              109m
kube-flannel        kube-flannel-ds-mtpfz                                1/1     Running   0              110m
kube-flannel        kube-flannel-ds-qx942                                1/1     Running   0              112m
kube-flannel        kube-flannel-ds-sb5jv                                1/1     Running   0              122m
kube-system         coredns-565d847f94-74d4h                             1/1     Running   0              123m
kube-system         coredns-565d847f94-9wp8k                             1/1     Running   0              123m
kube-system         etcd-k8s-control-144-1676464005                      1/1     Running   0              123m
kube-system         etcd-k8s-control-39-1676464043                       1/1     Running   0              116m
kube-system         etcd-k8s-control-802-1676464085                      1/1     Running   0              112m
kube-system         kube-apiserver-k8s-control-144-1676464005            1/1     Running   1 (101m ago)   123m
kube-system         kube-apiserver-k8s-control-39-1676464043             1/1     Running   1 (101m ago)   116m
kube-system         kube-apiserver-k8s-control-802-1676464085            1/1     Running   1 (100m ago)   112m
kube-system         kube-controller-manager-k8s-control-144-1676464005   1/1     Running   5 (13m ago)    123m
kube-system         kube-controller-manager-k8s-control-39-1676464043    1/1     Running   3 (15m ago)    116m
kube-system         kube-controller-manager-k8s-control-802-1676464085   1/1     Running   1 (14m ago)    112m
kube-system         kube-proxy-2cc5r                                     1/1     Running   0              110m
kube-system         kube-proxy-5r4mz                                     1/1     Running   0              117m
kube-system         kube-proxy-8xqh8                                     1/1     Running   0              109m
kube-system         kube-proxy-f8v8c                                     1/1     Running   0              123m
kube-system         kube-proxy-jfqbd                                     1/1     Running   0              112m
kube-system         kube-proxy-phpn9                                     1/1     Running   0              108m
kube-system         kube-scheduler-k8s-control-144-1676464005            1/1     Running   5 (13m ago)    123m
kube-system         kube-scheduler-k8s-control-39-1676464043             1/1     Running   2 (14m ago)    116m
kube-system         kube-scheduler-k8s-control-802-1676464085            1/1     Running   1 (100m ago)   112m
kube-system         vsphere-cloud-controller-manager-5fv68               1/1     Running   2 (13m ago)    107m
kube-system         vsphere-cloud-controller-manager-jn42q               1/1     Running   2 (14m ago)    107m
kube-system         vsphere-cloud-controller-manager-l29rl               1/1     Running   2 (15m ago)    107m
vmware-system-csi   vsphere-csi-controller-85fc89b5d4-dnvvm              6/6     Running   0              25s
vmware-system-csi   vsphere-csi-controller-85fc89b5d4-wv67v              6/6     Running   0              25s
vmware-system-csi   vsphere-csi-controller-85fc89b5d4-z9sjk              6/6     Running   0              25s
vmware-system-csi   vsphere-csi-node-2bm6r                               3/3     Running   0              25s
vmware-system-csi   vsphere-csi-node-49cwb                               3/3     Running   0              24s
vmware-system-csi   vsphere-csi-node-cmrbc                               3/3     Running   0              25s
vmware-system-csi   vsphere-csi-node-jgwfg                               3/3     Running   0              24s
vmware-system-csi   vsphere-csi-node-vkgff                               3/3     Running   0              24s
vmware-system-csi   vsphere-csi-node-zh2cq                               3/3     Running   0              25s

```
## Special notes for your reviewer
if kube-system namespace is provided by user avoid creating the namespace